### PR TITLE
Lint and build before running tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ install:
 - npm install
 
 script:
+- npm run lint --no-fix
+- npm run build
 - npm run test:unit
 - npm run test:e2e -- --headless
 


### PR DESCRIPTION
This should fail the build early if build or linting errors are present. Otherwise, the development server will hang, waiting for the linting errors to resolve:
https://github.com/vuejs/vue-cli/issues/3401