### PR TITLE
Optimize DOM manipulations to faster render huge amount of node connections

### DIFF
--- a/src/components/DiagramFlow.vue
+++ b/src/components/DiagramFlow.vue
@@ -85,7 +85,7 @@ export default {
         const { id } = selectedObject;
         this.flowView.highlight(id);
 
-        const element = this.$el.querySelector(`.node[data-node-id="${id}"]`);
+        const element = this.$el.querySelector(`#traceNode${id}`);
         panToNode(this.flowView.container.containerController, element);
       } else {
         this.flowView.highlight(null);


### PR DESCRIPTION
Before: click on "Trace" tab took 35sec
![image](https://user-images.githubusercontent.com/17301016/106946696-2c7a9e00-6775-11eb-8cec-4947be43b6c6.png)

After: 3sec
![image](https://user-images.githubusercontent.com/17301016/106946822-55029800-6775-11eb-86f3-ff8ec1fe9873.png)

