### PR TITLE
chore: remove git commit post-hook to lint commit messages [skip ci]

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
   "husky": {
     "hooks": {
       "pre-commit": "lint-staged",
-      "pre-push": "npm run lint && npm test",
-      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
+      "pre-push": "npm run lint && npm test"
     }
   },
   "files": [
@@ -41,8 +40,6 @@
     "@babel/core": "^7.12.10",
     "@babel/plugin-proposal-nullish-coalescing-operator": "^7.12.1",
     "@babel/preset-env": "^7.9.5",
-    "@commitlint/cli": "^11.0.0",
-    "@commitlint/config-conventional": "^11.0.0",
     "@rollup/plugin-alias": "^2.2.0",
     "@rollup/plugin-commonjs": "^11.1.0",
     "@rollup/plugin-image": "^2.0.6",


### PR DESCRIPTION
instead opt for enforcement before merging pull requests