### PR TITLE
feat: keyboard navigation for Trace

### DIFF
--- a/src/components/Container.vue
+++ b/src/components/Container.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="container">
+  <div class="container" tabindex="0">
     <div ref="containerContent" style="transform: translate(0px, 0px)">
       <slot />
     </div>
@@ -48,5 +48,6 @@ export default {
   overflow: hidden;
   height: 100%;
   width: 100%;
+  outline: none;
 }
 </style>


### PR DESCRIPTION
You can navigate through Trace nodes with keyboard arrows:

- **up** and **down** - iterate through siblings
- **right** - select first child event (if exists)
- **left** - select parent event

Fixes: #83 