### PR TITLE
fix: Use correct wrapper name on Windows

### DIFF
--- a/packages/cli/src/cmds/agentInstaller/gradleInstaller.ts
+++ b/packages/cli/src/cmds/agentInstaller/gradleInstaller.ts
@@ -40,10 +40,7 @@ export default class GradleInstaller
   }
 
   async postInstallMessage(): Promise<string> {
-    let gradleBin = 'gradle';
-    if (await exists(join(this.path, 'gradlew'))) {
-      gradleBin = `.${sep}gradlew`;
-    }
+    let gradleBin = await this.runCommand();
 
     return [
       `Record your tests by running ${chalk.blue(`${gradleBin} appmap test`)}`,
@@ -58,15 +55,16 @@ export default class GradleInstaller
   }
 
   async runCommand(): Promise<string> {
-    const wrapperExists = await exists(join(this.path, 'gradlew'));
+    const ext = os.platform() === 'win32' ? '.bat' : '';
+    const wrapperExists = await exists(join(this.path, `gradlew${ext}`));
 
     if (wrapperExists) {
-      return `.${sep}gradlew`;
+      return `.${sep}gradlew${ext}`;
     } else if (verbose()) {
       console.warn(
         `${chalk.yellow(
-          'gradlew wrapper'
-        )} not located, falling back to ${chalk.yellow('gradle')}`
+          `gradlew${ext} wrapper`
+        )} not located, falling back to ${chalk.yellow(`gradle${ext}`)}`
       );
     }
 

--- a/packages/cli/src/cmds/agentInstaller/mavenInstaller.ts
+++ b/packages/cli/src/cmds/agentInstaller/mavenInstaller.ts
@@ -30,10 +30,7 @@ export default class MavenInstaller
   }
 
   async postInstallMessage(): Promise<string> {
-    let mvnBin = 'mvn';
-    if (await exists(join(this.path, 'mvnw'))) {
-      mvnBin = `.${sep}mvnw`;
-    }
+    let mvnBin = await this.runCommand();
 
     return [
       `The AppMap agent will automatically record your tests when you run ${chalk.blue(
@@ -50,15 +47,16 @@ export default class MavenInstaller
   }
 
   async runCommand(): Promise<string> {
-    const wrapperExists = await exists(join(this.path, 'mvnw'));
+    const ext = os.platform() === 'win32' ? '.cmd' : '';
+    const wrapperExists = await exists(join(this.path, `mvnw${ext}`));
 
     if (wrapperExists) {
-      return `.${sep}mvnw`;
+      return `.${sep}mvnw${ext}`;
     } else if (verbose()) {
       console.warn(
         `${chalk.yellow(
-          'mvnw wrapper'
-        )} not located, falling back to ${chalk.yellow('mvn')}`
+          `mvnw${ext} wrapper`
+        )} not found, falling back to ${chalk.yellow(`mvn${ext}`)}`
       );
     }
 


### PR DESCRIPTION
Use the correct names for the gradle and maven wrappers when running on
Windows.