### PR TITLE
ci: Add "feature" as a supported commit type

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -3,7 +3,18 @@ const { join } = require('path');
 module.exports = {
   branches: ['main'],
   plugins: [
-    '@semantic-release/commit-analyzer',
+    [
+      '@semantic-release/commit-analyzer',
+      {
+        preset: 'angular',
+        releaseRules: [
+          {
+            type: 'feature',
+            release: 'minor'
+          }
+        ]
+      }
+    ],
     '@semantic-release/release-notes-generator',
     '@semantic-release/changelog',
     [


### PR DESCRIPTION
Add "feature" to the config for @semantic-release/commit-analyzer so the
latest version of the CLI will get released.