### PR TITLE
feat: appmap_dir and language in appmap.yml

### DIFF
--- a/packages/cli/smoketest.sh
+++ b/packages/cli/smoketest.sh
@@ -11,12 +11,10 @@ cd "$TESTDIR"
 echo '{}' > package.json
 yarn add ./package.tgz
 
-
 yarn run appmap index --appmap-dir ruby
 yarn run appmap depends --appmap-dir ruby
 yarn run appmap inventory --appmap-dir ruby
-yarn run appmap openapi -d ruby -o /dev/null
-
+yarn run appmap openapi --appmap-dir ruby -o /dev/null
 
 cd "$PKGDIR"
 rm -rf "$TESTDIR"

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -31,8 +31,8 @@ const RecordCommand = require('./cmds/record/record');
 import InstallCommand from './cmds/agentInstaller/install-agent';
 import StatusCommand from './cmds/agentInstaller/status';
 import PruneCommand from './cmds/prune/prune';
-import { appmapDirFromConfig } from './lib/appmapDirFromConfig';
-import assert from 'assert';
+import { locateAppMapDir } from './lib/locateAppMapDir';
+import { handleWorkingDirectory } from './lib/handleWorkingDirectory';
 
 class DiffCommand {
   public appMapNames: any;
@@ -185,6 +185,11 @@ yargs(process.argv.slice(2))
     'diff',
     'Compute the difference between two mapsets',
     (args) => {
+      args.option('directory', {
+        describe: 'program working directory',
+        type: 'string',
+        alias: 'd',
+      });
       args.option('name', {
         describe: 'indicate a specific AppMap to of compare',
       });
@@ -202,6 +207,7 @@ yargs(process.argv.slice(2))
     },
     async function (argv) {
       verbose(argv.verbose);
+      handleWorkingDirectory(argv.directory);
 
       let baseDir;
       let workingDir;
@@ -290,9 +296,13 @@ yargs(process.argv.slice(2))
       args.positional('files', {
         describe: 'provide an explicit list of dependency files',
       });
+      args.option('directory', {
+        describe: 'program working directory',
+        type: 'string',
+        alias: 'd',
+      });
       args.option('appmap-dir', {
         describe: 'directory to recursively inspect for AppMaps',
-        alias: 'd',
       });
       args.option('base-dir', {
         describe: 'directory to prepend to each dependency source file',
@@ -310,15 +320,8 @@ yargs(process.argv.slice(2))
     },
     async (argv) => {
       verbose(argv.verbose);
-
-      let { appmapDir } = argv;
-      if (!appmapDir) {
-        appmapDir = await appmapDirFromConfig();
-      }
-      assert(
-        appmapDir,
-        'appmapDir must be provided as a command option, or available in appmap.yml'
-      );
+      handleWorkingDirectory(argv.directory);
+      const appmapDir = await locateAppMapDir(argv.appmapDir);
 
       let { files } = argv;
       if (argv.stdinFiles) {
@@ -374,9 +377,13 @@ yargs(process.argv.slice(2))
       args.positional('code-object', {
         describe: 'identifies the code-object to inspect',
       });
+      args.option('directory', {
+        describe: 'program working directory',
+        type: 'string',
+        alias: 'd',
+      });
       args.option('appmap-dir', {
         describe: 'directory to recursively inspect for AppMaps',
-        alias: 'd',
       });
       args.option('interactive', {
         describe: 'interact with the output via CLI',
@@ -387,15 +394,8 @@ yargs(process.argv.slice(2))
     },
     async (argv) => {
       verbose(argv.verbose);
-
-      let { appmapDir } = argv;
-      if (!appmapDir) {
-        appmapDir = await appmapDirFromConfig();
-      }
-      assert(
-        appmapDir,
-        'appmapDir must be provided as a command option, or available in appmap.yml'
-      );
+      handleWorkingDirectory(argv.directory);
+      const appmapDir = await locateAppMapDir(argv.appmapDir);
 
       const newProgress = () => {
         if (argv.interactive) {
@@ -534,23 +534,20 @@ yargs(process.argv.slice(2))
         describe: 'watch the directory for changes to appmaps',
         boolean: true,
       });
+      args.option('directory', {
+        describe: 'program working directory',
+        type: 'string',
+        alias: 'd',
+      });
       args.option('appmap-dir', {
         describe: 'directory to recursively inspect for AppMaps',
-        alias: 'd',
       });
       return args.strict();
     },
     async (argv) => {
       verbose(argv.verbose);
-
-      let { appmapDir } = argv;
-      if (!appmapDir) {
-        appmapDir = await appmapDirFromConfig();
-      }
-      assert(
-        appmapDir,
-        'appmapDir must be provided as a command option, or available in appmap.yml'
-      );
+      handleWorkingDirectory(argv.directory);
+      const appmapDir = await locateAppMapDir(argv.appmapDir);
 
       if (argv.watch) {
         const cmd = new FingerprintWatchCommand(appmapDir);
@@ -579,23 +576,20 @@ yargs(process.argv.slice(2))
     'inventory',
     'Generate canonical lists of the application code object inventory',
     (args) => {
+      args.option('directory', {
+        describe: 'program working directory',
+        type: 'string',
+        alias: 'd',
+      });
       args.option('appmap-dir', {
         describe: 'directory to recursively inspect for AppMaps',
-        alias: 'd',
       });
       return args.strict();
     },
     async (argv) => {
       verbose(argv.verbose);
-
-      let { appmapDir } = argv;
-      if (!appmapDir) {
-        appmapDir = await appmapDirFromConfig();
-      }
-      assert(
-        appmapDir,
-        'appmapDir must be provided as a command option, or available in appmap.yml'
-      );
+      handleWorkingDirectory(argv.directory);
+      const appmapDir = await locateAppMapDir(argv.appmapDir);
 
       await new FingerprintDirectoryCommand(appmapDir).execute();
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -31,6 +31,8 @@ const RecordCommand = require('./cmds/record/record');
 import InstallCommand from './cmds/agentInstaller/install-agent';
 import StatusCommand from './cmds/agentInstaller/status';
 import PruneCommand from './cmds/prune/prune';
+import { appmapDirFromConfig } from './lib/appmapDirFromConfig';
+import assert from 'assert';
 
 class DiffCommand {
   public appMapNames: any;
@@ -290,6 +292,7 @@ yargs(process.argv.slice(2))
       });
       args.option('appmap-dir', {
         describe: 'directory to recursively inspect for AppMaps',
+        alias: 'd',
       });
       args.option('base-dir', {
         describe: 'directory to prepend to each dependency source file',
@@ -312,7 +315,10 @@ yargs(process.argv.slice(2))
       if (!appmapDir) {
         appmapDir = await appmapDirFromConfig();
       }
-      assertAppMapDir(appmapDir);
+      assert(
+        appmapDir,
+        'appmapDir must be provided as a command option, or available in appmap.yml'
+      );
 
       let { files } = argv;
       if (argv.stdinFiles) {
@@ -370,7 +376,7 @@ yargs(process.argv.slice(2))
       });
       args.option('appmap-dir', {
         describe: 'directory to recursively inspect for AppMaps',
-        default: 'tmp/appmap',
+        alias: 'd',
       });
       args.option('interactive', {
         describe: 'interact with the output via CLI',
@@ -386,7 +392,10 @@ yargs(process.argv.slice(2))
       if (!appmapDir) {
         appmapDir = await appmapDirFromConfig();
       }
-      assertAppMapDir(appmapDir);
+      assert(
+        appmapDir,
+        'appmapDir must be provided as a command option, or available in appmap.yml'
+      );
 
       const newProgress = () => {
         if (argv.interactive) {
@@ -527,7 +536,7 @@ yargs(process.argv.slice(2))
       });
       args.option('appmap-dir', {
         describe: 'directory to recursively inspect for AppMaps',
-        default: 'tmp/appmap',
+        alias: 'd',
       });
       return args.strict();
     },
@@ -538,7 +547,10 @@ yargs(process.argv.slice(2))
       if (!appmapDir) {
         appmapDir = await appmapDirFromConfig();
       }
-      assertAppMapDir(appmapDir);
+      assert(
+        appmapDir,
+        'appmapDir must be provided as a command option, or available in appmap.yml'
+      );
 
       if (argv.watch) {
         const cmd = new FingerprintWatchCommand(appmapDir);
@@ -569,7 +581,7 @@ yargs(process.argv.slice(2))
     (args) => {
       args.option('appmap-dir', {
         describe: 'directory to recursively inspect for AppMaps',
-        default: 'tmp/appmap',
+        alias: 'd',
       });
       return args.strict();
     },
@@ -580,7 +592,10 @@ yargs(process.argv.slice(2))
       if (!appmapDir) {
         appmapDir = await appmapDirFromConfig();
       }
-      assertAppMapDir(appmapDir);
+      assert(
+        appmapDir,
+        'appmapDir must be provided as a command option, or available in appmap.yml'
+      );
 
       await new FingerprintDirectoryCommand(appmapDir).execute();
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -290,7 +290,6 @@ yargs(process.argv.slice(2))
       });
       args.option('appmap-dir', {
         describe: 'directory to recursively inspect for AppMaps',
-        default: 'tmp/appmap',
       });
       args.option('base-dir', {
         describe: 'directory to prepend to each dependency source file',
@@ -309,6 +308,12 @@ yargs(process.argv.slice(2))
     async (argv) => {
       verbose(argv.verbose);
 
+      let { appmapDir } = argv;
+      if (!appmapDir) {
+        appmapDir = await appmapDirFromConfig();
+      }
+      assertAppMapDir(appmapDir);
+
       let { files } = argv;
       if (argv.stdinFiles) {
         const stdinFileStr = readFileSync(0).toString();
@@ -320,10 +325,10 @@ yargs(process.argv.slice(2))
       }
 
       if (verbose()) {
-        console.warn(`Testing AppMaps in ${argv.appmapDir}`);
+        console.warn(`Testing AppMaps in ${appmapDir}`);
       }
 
-      const depends = new Depends(argv.appmapDir);
+      const depends = new Depends(appmapDir);
       if (argv.baseDir) {
         depends.baseDir = argv.baseDir;
       }
@@ -377,6 +382,12 @@ yargs(process.argv.slice(2))
     async (argv) => {
       verbose(argv.verbose);
 
+      let { appmapDir } = argv;
+      if (!appmapDir) {
+        appmapDir = await appmapDirFromConfig();
+      }
+      assertAppMapDir(appmapDir);
+
       const newProgress = () => {
         if (argv.interactive) {
           return new cliProgress.SingleBar(
@@ -393,12 +404,12 @@ yargs(process.argv.slice(2))
       };
 
       console.warn('Indexing the AppMap database');
-      await new FingerprintDirectoryCommand(argv.appmapDir).execute();
+      await new FingerprintDirectoryCommand(appmapDir).execute();
 
       console.warn('Finding matching AppMaps');
       let progress = newProgress();
       const codeObjectId = argv.codeObject;
-      const finder = new FindCodeObjects(argv.appmapDir, codeObjectId);
+      const finder = new FindCodeObjects(appmapDir, codeObjectId);
       const codeObjectMatches = await finder.find(
         (count) => progress.start(count, 0),
         progress.increment.bind(progress)
@@ -523,8 +534,14 @@ yargs(process.argv.slice(2))
     async (argv) => {
       verbose(argv.verbose);
 
+      let { appmapDir } = argv;
+      if (!appmapDir) {
+        appmapDir = await appmapDirFromConfig();
+      }
+      assertAppMapDir(appmapDir);
+
       if (argv.watch) {
-        const cmd = new FingerprintWatchCommand(argv.appmapDir);
+        const cmd = new FingerprintWatchCommand(appmapDir);
         await cmd.execute();
 
         if (!argv.verbose && process.stdout.isTTY) {
@@ -541,7 +558,7 @@ yargs(process.argv.slice(2))
           });
         }
       } else {
-        const cmd = new FingerprintDirectoryCommand(argv.appmapDir);
+        const cmd = new FingerprintDirectoryCommand(appmapDir);
         await cmd.execute();
       }
     }
@@ -559,9 +576,15 @@ yargs(process.argv.slice(2))
     async (argv) => {
       verbose(argv.verbose);
 
-      await new FingerprintDirectoryCommand(argv.appmapDir).execute();
+      let { appmapDir } = argv;
+      if (!appmapDir) {
+        appmapDir = await appmapDirFromConfig();
+      }
+      assertAppMapDir(appmapDir);
 
-      const inventory = await new InventoryCommand(argv.appmapDir).execute();
+      await new FingerprintDirectoryCommand(appmapDir).execute();
+
+      const inventory = await new InventoryCommand(appmapDir).execute();
       console.log(yaml.dump(inventory));
     }
   )

--- a/packages/cli/src/cmds/agentInstaller/agentInstaller.ts
+++ b/packages/cli/src/cmds/agentInstaller/agentInstaller.ts
@@ -11,6 +11,8 @@ export default abstract class AgentInstaller {
     this.path = resolve(path);
   }
 
+  abstract get language(): string;
+  abstract get appmap_dir(): string;
   abstract installAgent(): Promise<void>;
   abstract validateAgentCommand(): Promise<CommandStruct | undefined>;
   abstract initCommand(): Promise<CommandStruct>;

--- a/packages/cli/src/cmds/agentInstaller/gradleInstaller.ts
+++ b/packages/cli/src/cmds/agentInstaller/gradleInstaller.ts
@@ -11,11 +11,17 @@ import JavaBuildToolInstaller from './javaBuildToolInstaller';
 import { GradleParser, GradleParseResult } from './gradleParser';
 import EncodedFile from '../../encodedFile';
 
-export default class GradleInstaller
-  extends JavaBuildToolInstaller
-{
+export default class GradleInstaller extends JavaBuildToolInstaller {
   constructor(path: string) {
     super('Gradle', path);
+  }
+
+  get language(): string {
+    return 'java';
+  }
+
+  get appmap_dir(): string {
+    return 'build/appmap';
   }
 
   private get buildGradleFileName(): string {
@@ -40,8 +46,12 @@ export default class GradleInstaller
    * If not, the installer will pick the build.gradle.
    */
   get identifyGradleFile(): string {
-    const buildGradleKtsExists: boolean = fs.existsSync(join(this.path, this.buildGradleKtsFileName));
-    return buildGradleKtsExists ? this.buildGradleKtsFileName : this.buildGradleFileName;
+    const buildGradleKtsExists: boolean = fs.existsSync(
+      join(this.path, this.buildGradleKtsFileName)
+    );
+    return buildGradleKtsExists
+      ? this.buildGradleKtsFileName
+      : this.buildGradleFileName;
   }
 
   async printJarPathCommand(): Promise<CommandStruct> {
@@ -171,7 +181,7 @@ ${whitespace.padLine(pluginSpec)}
     const updatedSrc = [
       buildFileSource.substring(0, parseResult.plugins.lbrace + 1),
       lines.map((l) => whitespace.padLine(l)).join(os.EOL),
-      '}'
+      '}',
     ].join(os.EOL);
     const offset = parseResult.plugins.rbrace + 1;
 
@@ -181,7 +191,9 @@ ${whitespace.padLine(pluginSpec)}
   private selectPluginSpec() {
     const pluginSpecKotlinSyntax = `id("com.appland.appmap") version "1.1.0"`;
     const pluginSpecGroovySyntax = `id 'com.appland.appmap' version '1.1.0'`;
-    return this.identifyGradleFile.endsWith('.gradle.kts') ? pluginSpecKotlinSyntax : pluginSpecGroovySyntax;
+    return this.identifyGradleFile.endsWith('.gradle.kts')
+      ? pluginSpecKotlinSyntax
+      : pluginSpecGroovySyntax;
   }
 
   /**

--- a/packages/cli/src/cmds/agentInstaller/javaScriptAgentInstaller.ts
+++ b/packages/cli/src/cmds/agentInstaller/javaScriptAgentInstaller.ts
@@ -13,6 +13,14 @@ abstract class JavaScriptInstaller extends AgentInstaller {
     super(name, path);
   }
 
+  get language(): string {
+    return 'javascript';
+  }
+
+  get appmap_dir(): string {
+    return 'tmp/appmap';
+  }
+
   get documentation() {
     return 'https://appland.com/docs/reference/appmap-agent-js';
   }
@@ -44,9 +52,7 @@ abstract class JavaScriptInstaller extends AgentInstaller {
   }
 }
 
-export class NpmInstaller
-  extends JavaScriptInstaller
-{
+export class NpmInstaller extends JavaScriptInstaller {
   constructor(path: string) {
     super('npm', path);
   }
@@ -66,7 +72,11 @@ export class NpmInstaller
   async installAgent(): Promise<void> {
     const cmd = new CommandStruct(
       'npm',
-      ['install', '--saveDev', process.env.APPMAP_AGENT_PACKAGE || AGENT_PACKAGE],
+      [
+        'install',
+        '--saveDev',
+        process.env.APPMAP_AGENT_PACKAGE || AGENT_PACKAGE,
+      ],
       this.path
     );
 
@@ -78,9 +88,7 @@ export class NpmInstaller
   }
 }
 
-export class YarnInstaller
-  extends JavaScriptInstaller
-{
+export class YarnInstaller extends JavaScriptInstaller {
   constructor(path: string) {
     super('yarn', path);
   }
@@ -107,7 +115,7 @@ export class YarnInstaller
     await run(cmd);
   }
 
-  async verifyCommand() { 
+  async verifyCommand() {
     return undefined;
   }
 }

--- a/packages/cli/src/cmds/agentInstaller/mavenInstaller.ts
+++ b/packages/cli/src/cmds/agentInstaller/mavenInstaller.ts
@@ -5,7 +5,6 @@ import { JSDOM } from 'jsdom';
 import xmlSerializer from 'w3c-xmlserializer';
 import chalk from 'chalk';
 import CommandStruct from './commandStruct';
-import AgentInstaller from './agentInstaller';
 import { verbose, exists } from '../../utils';
 import JavaBuildToolInstaller from './javaBuildToolInstaller';
 import EncodedFile from '../../encodedFile';
@@ -13,6 +12,14 @@ import EncodedFile from '../../encodedFile';
 export default class MavenInstaller extends JavaBuildToolInstaller {
   constructor(path: string) {
     super('Maven', path);
+  }
+
+  get language(): string {
+    return 'java';
+  }
+
+  get appmap_dir(): string {
+    return 'target/appmap';
   }
 
   get buildFile(): string {

--- a/packages/cli/src/cmds/agentInstaller/pythonAgentInstaller.ts
+++ b/packages/cli/src/cmds/agentInstaller/pythonAgentInstaller.ts
@@ -15,8 +15,16 @@ const REGEX_PKG_DEPENDENCY = /^\s*appmap\s*[=>~]+=.*$/m;
 const PKG_DEPENDENCY = 'appmap>=1.1.0.dev0';
 
 abstract class PythonInstaller extends AgentInstaller {
-  constructor(name:string, path: string) {
+  constructor(name: string, path: string) {
     super(name, path);
+  }
+
+  get language(): string {
+    return 'python';
+  }
+
+  get appmap_dir(): string {
+    return 'tmp/appmap';
   }
 
   get documentation() {
@@ -85,7 +93,7 @@ export class PoetryInstaller extends PythonInstaller {
 
   async validateAgentCommand() {
     return undefined;
-  }  
+  }
 }
 
 export class PipInstaller extends PythonInstaller {

--- a/packages/cli/src/cmds/agentInstaller/rubyAgentInstaller.ts
+++ b/packages/cli/src/cmds/agentInstaller/rubyAgentInstaller.ts
@@ -21,6 +21,14 @@ export class BundleInstaller extends AgentInstaller {
     super('Bundler', path);
   }
 
+  get language(): string {
+    return 'ruby';
+  }
+
+  get appmap_dir(): string {
+    return 'tmp/appmap';
+  }
+
   get buildFile(): string {
     return 'Gemfile';
   }
@@ -47,7 +55,10 @@ export class BundleInstaller extends AgentInstaller {
 
       if (gemExists) {
         // Replace the existing gem declaration entirely
-        gemfile = gemfile.replace(REGEX_GEM_DEPENDENCY, `${os.EOL}${GEM_DEPENDENCY}`);
+        gemfile = gemfile.replace(
+          REGEX_GEM_DEPENDENCY,
+          `${os.EOL}${GEM_DEPENDENCY}`
+        );
       } else {
         // Insert a new gem declaration
         const chars = gemfile.split('');
@@ -57,9 +68,7 @@ export class BundleInstaller extends AgentInstaller {
 
       encodedFile.write(gemfile);
     } else {
-      encodedFile.write(
-        `${gemfile}${os.EOL}${GEM_DEPENDENCY}${os.EOL}`
-      );
+      encodedFile.write(`${gemfile}${os.EOL}${GEM_DEPENDENCY}${os.EOL}`);
     }
 
     await run(new CommandStruct('bundle', ['install'], this.path));

--- a/packages/cli/src/cmds/openapi.ts
+++ b/packages/cli/src/cmds/openapi.ts
@@ -4,7 +4,13 @@ import { promises as fsp, statSync } from 'fs';
 import { queue } from 'async';
 import { glob } from 'glob';
 import yaml from 'js-yaml';
-import { Model, parseHTTPServerRequests, rpcRequestForEvent, SecuritySchemes, verbose } from '@appland/openapi';
+import {
+  Model,
+  parseHTTPServerRequests,
+  rpcRequestForEvent,
+  SecuritySchemes,
+  verbose,
+} from '@appland/openapi';
 import { Event } from '@appland/models';
 import { Arguments, Argv } from 'yargs';
 
@@ -95,7 +101,14 @@ module.exports = {
   },
   async handler(argv: Arguments | any) {
     verbose(argv.verbose);
+
+    let { appmapDir } = argv;
     const { openapiTitle, openapiVersion } = argv;
+
+    if (!appmapDir) {
+      appmapDir = await appmapDirFromConfig();
+    }
+    assertAppMapDir(appmapDir);
 
     function tryConfigure(path: string, fn: () => void) {
       try {
@@ -105,7 +118,7 @@ module.exports = {
       }
     }
 
-    const openapi = await new OpenAPICommand(argv.appmapDir).execute();
+    const openapi = await new OpenAPICommand(appmapDir).execute();
 
     const template = await loadTemplate(argv.openapiTemplate);
     template.paths = openapi.paths;

--- a/packages/cli/src/cmds/openapi.ts
+++ b/packages/cli/src/cmds/openapi.ts
@@ -13,6 +13,8 @@ import {
 } from '@appland/openapi';
 import { Event } from '@appland/models';
 import { Arguments, Argv } from 'yargs';
+import { appmapDirFromConfig } from '../lib/appmapDirFromConfig';
+import assert from 'assert';
 
 export class OpenAPICommand {
   directory: string;
@@ -108,7 +110,10 @@ module.exports = {
     if (!appmapDir) {
       appmapDir = await appmapDirFromConfig();
     }
-    assertAppMapDir(appmapDir);
+    assert(
+      appmapDir,
+      'appmapDir must be provided as a command option, or available in appmap.yml'
+    );
 
     function tryConfigure(path: string, fn: () => void) {
       try {

--- a/packages/cli/src/lib/appmapDirFromConfig.ts
+++ b/packages/cli/src/lib/appmapDirFromConfig.ts
@@ -1,0 +1,23 @@
+import assert from 'assert';
+import { exists } from 'fs';
+import { readFile } from 'fs/promises';
+import { load } from 'js-yaml';
+import { promisify } from 'util';
+
+export async function appmapDirFromConfig(): Promise<string | undefined> {
+  const appMapConfigExists = await promisify(exists)('appmap.yml');
+  if (appMapConfigExists) {
+    const appMapConfigData = load((await readFile('appmap.yml')).toString());
+    if (appMapConfigData && typeof appMapConfigData === 'object') {
+      const configData: { appmap_dir?: string } = appMapConfigData;
+      return configData['appmap_dir'];
+    }
+  }
+}
+
+export function assertAppMapDir(appmapDir: string) {
+  assert(
+    appmapDir,
+    'appmapDir must be provided as a command option, or available in appmap.yml'
+  );
+}

--- a/packages/cli/src/lib/handleWorkingDirectory.ts
+++ b/packages/cli/src/lib/handleWorkingDirectory.ts
@@ -1,0 +1,3 @@
+export function handleWorkingDirectory(directory?: string) {
+  if (directory) process.chdir(directory);
+}

--- a/packages/cli/src/lib/locateAppMapDir.ts
+++ b/packages/cli/src/lib/locateAppMapDir.ts
@@ -1,0 +1,12 @@
+import { appmapDirFromConfig } from './appmapDirFromConfig';
+
+export async function locateAppMapDir(appmapDir?: string): Promise<string> {
+  if (appmapDir) return appmapDir;
+
+  const result = await appmapDirFromConfig();
+  if (!result)
+    throw new Error(
+      'appmapDir must be provided as a command option, or available in appmap.yml'
+    );
+  return result;
+}

--- a/packages/cli/tests/unit/agentInstall/agentInstaller.spec.ts
+++ b/packages/cli/tests/unit/agentInstall/agentInstaller.spec.ts
@@ -1,6 +1,6 @@
-import path from "path";
-import AgentInstaller from "../../../src/cmds/agentInstaller/agentInstaller";
-import commandStruct from "../../../src/cmds/agentInstaller/commandStruct";
+import path from 'path';
+import AgentInstaller from '../../../src/cmds/agentInstaller/agentInstaller';
+import commandStruct from '../../../src/cmds/agentInstaller/commandStruct';
 
 class FakeInstaller extends AgentInstaller {
   public buildFile: string = 'bf';
@@ -9,23 +9,29 @@ class FakeInstaller extends AgentInstaller {
     super('Fake', path);
   }
 
+  get language(): string {
+    return 'Method not implemented';
+  }
+  get appmap_dir(): string {
+    return 'Method not implemented';
+  }
   installAgent(): Promise<void> {
-    throw new Error("Method not implemented.");
+    throw new Error('Method not implemented.');
   }
   validateAgentCommand(): Promise<commandStruct> {
-    throw new Error("Method not implemented.");
+    throw new Error('Method not implemented.');
   }
   initCommand(): Promise<commandStruct> {
-    throw new Error("Method not implemented.");
+    throw new Error('Method not implemented.');
   }
   verifyCommand(): Promise<commandStruct> {
-    throw new Error("Method not implemented.");
+    throw new Error('Method not implemented.');
   }
   environment(): Promise<Record<string, string>> {
-    throw new Error("Method not implemented.");
+    throw new Error('Method not implemented.');
   }
   available(): Promise<boolean> {
-    throw new Error("Method not implemented.");
+    throw new Error('Method not implemented.');
   }
 }
 

--- a/packages/scanner/src/cli/appmapDirFromConfig.ts
+++ b/packages/scanner/src/cli/appmapDirFromConfig.ts
@@ -1,0 +1,20 @@
+import assert from 'assert';
+import { exists } from 'fs';
+import { readFile } from 'fs/promises';
+import { load } from 'js-yaml';
+import { promisify } from 'util';
+
+export async function appmapDirFromConfig(): Promise<string | undefined> {
+  const appMapConfigExists = await promisify(exists)('appmap.yml');
+  if (appMapConfigExists) {
+    const appMapConfigData = load((await readFile('appmap.yml')).toString());
+    if (appMapConfigData && typeof appMapConfigData === 'object') {
+      const configData: { appmap_dir?: string } = appMapConfigData;
+      return configData['appmap_dir'];
+    }
+  }
+}
+
+export function assertAppMapDir(appmapDir: string): void {
+  assert(appmapDir, 'appmapDir must be provided as a command option, or available in appmap.yml');
+}

--- a/packages/scanner/src/cli/ci/command.ts
+++ b/packages/scanner/src/cli/ci/command.ts
@@ -7,7 +7,7 @@ import { FindingStatusListItem } from '@appland/client/dist/src';
 
 import { parseConfigFile } from '../../configuration/configurationProvider';
 import { ScanResults } from '../../report/scanResults';
-import { appmapDirFromConfig, verbose } from '../../rules/lib/util';
+import { verbose } from '../../rules/lib/util';
 import { newFindings } from '../../findings';
 import findingsReport from '../../report/findingsReport';
 import summaryReport from '../../report/summaryReport';
@@ -22,7 +22,8 @@ import updateCommitStatus from '../updateCommitStatus';
 import reportUploadURL from '../reportUploadURL';
 import fail from '../fail';
 import codeVersionArgs from '../codeVersionArgs';
-import assert from 'assert';
+import { locateAppMapDir } from '../locateAppMapDir';
+import { handleWorkingDirectory } from '../handleWorkingDirectory';
 
 export default {
   command: 'ci',
@@ -53,9 +54,10 @@ export default {
     return args.strict();
   },
   async handler(options: Arguments): Promise<void> {
-    let { appmapDir } = options as unknown as CommandOptions;
     const {
       config,
+      directory,
+      appmapDir: appmapDirOption,
       verbose: isVerbose,
       fail: failOption,
       app: appIdArg,
@@ -71,11 +73,8 @@ export default {
     if (isVerbose) {
       verbose(true);
     }
-
-    if (!appmapDir) {
-      appmapDir = await appmapDirFromConfig();
-    }
-    assert(appmapDir, 'appmapDir must be provided as a command option, or available in appmap.yml');
+    handleWorkingDirectory(directory);
+    const appmapDir = await locateAppMapDir(appmapDirOption);
 
     const appId = await resolveAppId(appIdArg, appmapDir);
 

--- a/packages/scanner/src/cli/ci/command.ts
+++ b/packages/scanner/src/cli/ci/command.ts
@@ -6,7 +6,6 @@ import { Arguments, Argv } from 'yargs';
 import { FindingStatusListItem } from '@appland/client/dist/src';
 
 import { parseConfigFile } from '../../configuration/configurationProvider';
-import { ValidationError } from '../../errors';
 import { ScanResults } from '../../report/scanResults';
 import { appmapDirFromConfig, verbose } from '../../rules/lib/util';
 import { newFindings } from '../../findings';
@@ -14,7 +13,6 @@ import findingsReport from '../../report/findingsReport';
 import summaryReport from '../../report/summaryReport';
 
 import resolveAppId from '../resolveAppId';
-import validateFile from '../validateFile';
 import upload from '../upload';
 import { default as buildScanner } from '../scan/scanner';
 
@@ -24,6 +22,7 @@ import updateCommitStatus from '../updateCommitStatus';
 import reportUploadURL from '../reportUploadURL';
 import fail from '../fail';
 import codeVersionArgs from '../codeVersionArgs';
+import assert from 'assert';
 
 export default {
   command: 'ci',
@@ -76,12 +75,8 @@ export default {
     if (!appmapDir) {
       appmapDir = await appmapDirFromConfig();
     }
-    if (!appmapDir) {
-      appmapDir = await appmapDirFromConfig();
-      throw new ValidationError('--appmap-dir is required');
-    }
+    assert(appmapDir, 'appmapDir must be provided as a command option, or available in appmap.yml');
 
-    await validateFile('directory', appmapDir!);
     const appId = await resolveAppId(appIdArg, appmapDir);
 
     const glob = promisify(globCallback);

--- a/packages/scanner/src/cli/handleWorkingDirectory.ts
+++ b/packages/scanner/src/cli/handleWorkingDirectory.ts
@@ -1,0 +1,3 @@
+export function handleWorkingDirectory(directory?: string): void {
+  if (directory) process.chdir(directory);
+}

--- a/packages/scanner/src/cli/locateAppMapDir.ts
+++ b/packages/scanner/src/cli/locateAppMapDir.ts
@@ -1,0 +1,10 @@
+import { appmapDirFromConfig } from './appmapDirFromConfig';
+
+export async function locateAppMapDir(appmapDir?: string): Promise<string> {
+  if (appmapDir) return appmapDir;
+
+  const result = await appmapDirFromConfig();
+  if (!result)
+    throw new Error('appmapDir must be provided as a command option, or available in appmap.yml');
+  return result;
+}

--- a/packages/scanner/src/cli/merge/command.ts
+++ b/packages/scanner/src/cli/merge/command.ts
@@ -5,11 +5,17 @@ import { merge as mergeScannerJob } from '../../integration/appland/scannerJob/m
 import resolveAppId from '../resolveAppId';
 import updateCommitStatus from '../updateCommitStatus';
 import fail from '../fail';
+import { handleWorkingDirectory } from '../handleWorkingDirectory';
 
 export default {
   command: 'merge <merge-key>',
   describe: 'Merge scan results from parallel scans',
   builder(args: Argv): Argv {
+    args.option('directory', {
+      describe: 'program working directory',
+      type: 'string',
+      alias: 'd',
+    });
     args.option('app', {
       describe:
         'name of the app to publish the findings for. By default, this is determined by looking in appmap.yml',
@@ -35,6 +41,7 @@ export default {
   async handler(options: Arguments): Promise<void> {
     const {
       verbose: isVerbose,
+      directory,
       app: appIdArg,
       fail: failOption,
       updateCommitStatus: updateCommitStatusOption,
@@ -44,6 +51,7 @@ export default {
     if (isVerbose) {
       verbose(true);
     }
+    handleWorkingDirectory(directory);
 
     const appId = await resolveAppId(appIdArg, '.');
 

--- a/packages/scanner/src/cli/merge/options.ts
+++ b/packages/scanner/src/cli/merge/options.ts
@@ -1,5 +1,6 @@
 export default interface CommandOptions {
   verbose?: boolean;
+  directory?: string;
   mergeKey: string;
   app?: string;
   fail?: boolean;

--- a/packages/scanner/src/cli/scan/command.ts
+++ b/packages/scanner/src/cli/scan/command.ts
@@ -3,13 +3,13 @@ import { Arguments, Argv } from 'yargs';
 import { ValidationError } from '../../errors';
 import { appmapDirFromConfig, verbose } from '../../rules/lib/util';
 
-import validateFile from '../validateFile';
 import CommandOptions from './options';
 import scanArgs from '../scanArgs';
 import resolveAppId from '../resolveAppId';
 import singleScan from './singleScan';
 import watchScan from './watchScan';
 import { parseConfigFile } from '../../configuration/configurationProvider';
+import assert from 'assert';
 
 export default {
   command: 'scan',
@@ -74,9 +74,12 @@ export default {
       );
     }
     if (!appmapFile && !appmapDir) {
-      appmapDir = (await appmapDirFromConfig()) || '.';
+      appmapDir = await appmapDirFromConfig();
+      assert(
+        appmapDir,
+        'appmapDir must be provided as a command option, or available in appmap.yml'
+      );
     }
-    if (appmapDir) await validateFile('directory', appmapDir);
 
     if (watch) {
       const watchAppMapDir = appmapDir!;

--- a/packages/scanner/src/cli/scan/singleScan.ts
+++ b/packages/scanner/src/cli/scan/singleScan.ts
@@ -32,6 +32,7 @@ export default async function singleScan(options: SingleScanOptions): Promise<vo
     const glob = promisify(globCallback);
     files = await glob(`${appmapDir}/**/*.appmap.json`);
   }
+
   if (appmapFile) {
     files = typeof appmapFile === 'string' ? [appmapFile] : appmapFile;
     await Promise.all(files.map(async (file) => validateFile('file', file)));

--- a/packages/scanner/src/cli/scanArgs.ts
+++ b/packages/scanner/src/cli/scanArgs.ts
@@ -1,9 +1,13 @@
 import { Argv } from 'yargs';
 
 export default function (args: Argv): void {
+  args.option('directory', {
+    describe: 'program working directory',
+    type: 'string',
+    alias: 'd',
+  });
   args.option('appmap-dir', {
     describe: 'directory to recursively inspect for AppMaps',
-    alias: 'd',
   });
   args.option('config', {
     describe:

--- a/packages/scanner/src/cli/scanOptions.ts
+++ b/packages/scanner/src/cli/scanOptions.ts
@@ -1,6 +1,7 @@
 export default interface ScanOptions {
   app?: string;
   apiKey?: string;
+  directory: string;
   appmapDir?: string;
   config: string;
   reportFile: string;

--- a/packages/scanner/src/cli/upload/options.ts
+++ b/packages/scanner/src/cli/upload/options.ts
@@ -1,6 +1,7 @@
 export default interface CommandOptions {
   verbose?: boolean;
   reportFile: string;
+  directory?: string;
   appmapDir?: string;
   app?: string;
   mergeKey?: string;

--- a/packages/scanner/src/cli/upload/options.ts
+++ b/packages/scanner/src/cli/upload/options.ts
@@ -1,7 +1,7 @@
 export default interface CommandOptions {
   verbose?: boolean;
   reportFile: string;
-  appmapDir: string;
+  appmapDir?: string;
   app?: string;
   mergeKey?: string;
   branch?: string;


### PR DESCRIPTION
Include appmap_dir and language in generated config file.

Use appmap_dir setting as the default AppMap dir for all commands, instead of having no default or using a hard coded default like tmp/appmap. 