### PR TITLE
feat: trace-data command

### DIFF
--- a/packages/cli/smoketest.sh
+++ b/packages/cli/smoketest.sh
@@ -15,7 +15,7 @@ yarn add ./package.tgz
 yarn run appmap index --appmap-dir ruby
 yarn run appmap depends --appmap-dir ruby
 yarn run appmap inventory --appmap-dir ruby
-yarn run appmap openapi -d ruby -o /dev/null
+yarn run appmap openapi --appmap-dir ruby -o /dev/null
 
 
 cd "$PKGDIR"

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -27,6 +27,7 @@ const RecordCommand = require('./cmds/record/record');
 import InstallCommand from './cmds/agentInstaller/install-agent';
 import StatusCommand from './cmds/agentInstaller/status';
 import PruneCommand from './cmds/prune/prune';
+import * as TraceDataCommand from './cmds/traceData/traceData';
 import { handleWorkingDirectory } from './lib/handleWorkingDirectory';
 import { locateAppMapDir } from './lib/locateAppMapDir';
 
@@ -451,6 +452,7 @@ yargs(process.argv.slice(2))
   .command(RecordCommand)
   .command(StatusCommand)
   .command(InspectCommand)
+  .command(TraceDataCommand)
   .command(PruneCommand)
   .strict()
   .demandCommand()

--- a/packages/cli/src/cmds/traceData/traceData.ts
+++ b/packages/cli/src/cmds/traceData/traceData.ts
@@ -1,0 +1,242 @@
+import { buildAppMap, Event as AppMapEvent } from '@appland/models';
+import cliProgress from 'cli-progress';
+import assert from 'assert';
+import { readFile, writeFile } from 'fs/promises';
+import { basename } from 'path';
+import yargs from 'yargs';
+import { handleWorkingDirectory } from '../../lib/handleWorkingDirectory';
+import { locateAppMapDir } from '../../lib/locateAppMapDir';
+import FindCodeObjects from '../../search/findCodeObjects';
+import FindEvents from '../../search/findEvents';
+import { verbose } from '../../utils';
+import { ValidationError } from '../errors';
+
+export const command = 'trace-data [data-item]';
+export const describe = 'Trace data ancestry';
+
+type SearchItem = {
+  codeObjectPattern: string;
+  param: string;
+};
+
+function parseSearchItem(dataItem: string): SearchItem {
+  const tokens = dataItem.match(/(.*)\((.*)\)/);
+  if (!tokens || !tokens[1] || !tokens[2])
+    throw new ValidationError(`Unable to parse data-item ${dataItem}`);
+
+  return {
+    codeObjectPattern: tokens[1],
+    param: tokens[2],
+  };
+}
+
+export const builder = (args: yargs.Argv) => {
+  args.positional('data-item', {
+    describe: 'identifies a data item to trace',
+    required: true,
+  });
+
+  args.option('directory', {
+    describe: 'program working directory',
+    type: 'string',
+    alias: 'd',
+  });
+  args.option('appmap-dir', {
+    describe: 'directory to recursively inspect for AppMaps',
+  });
+  args.option('appmap-file', {
+    describe: 'AppMap file to inspect',
+  });
+
+  return args.strict();
+};
+
+export const handler = async (argv: any) => {
+  verbose(argv.verbose);
+  handleWorkingDirectory(argv.directory);
+
+  console.log(`Searching AppMaps for ${argv.dataItem}`);
+
+  const searchItem = parseSearchItem(argv.dataItem);
+
+  let findCodeObjects: FindCodeObjects;
+  if (argv.appmapFile) {
+    console.warn(`Searching AppMap ${argv.appmapFile}`);
+    findCodeObjects = new FindCodeObjects(
+      searchItem.codeObjectPattern,
+      undefined,
+      [argv.appmapFile]
+    );
+  } else {
+    const appmapDir = await locateAppMapDir(argv.appmapDir);
+    console.warn(`Finding matching AppMaps in ${appmapDir}`);
+    findCodeObjects = new FindCodeObjects(
+      searchItem.codeObjectPattern,
+      appmapDir
+    );
+  }
+
+  let progress = new cliProgress.SingleBar(
+    {},
+    cliProgress.Presets.shades_classic
+  );
+  const codeObjectMatches = await findCodeObjects.find(
+    (count) => progress.start(count, 0),
+    progress.increment.bind(progress)
+  );
+  progress.stop();
+
+  console.warn(
+    `Found ${codeObjectMatches.length} AppMaps containing ${searchItem.codeObjectPattern}`
+  );
+
+  const appmaps = new Set<string>();
+  for (let index = 0; index < codeObjectMatches.length; index++) {
+    const codeObjectMatch = codeObjectMatches[index];
+    if (appmaps.has(codeObjectMatch.appmap)) continue;
+
+    appmaps.add(codeObjectMatch.appmap);
+
+    const eventsByData = new Map<string, Set<AppMapEvent>>();
+    const appmap = buildAppMap(
+      await readFile([codeObjectMatch.appmap, 'appmap.json'].join('.'), 'utf-8')
+    ).build();
+
+    {
+      const collectParameters = (
+        event: AppMapEvent,
+        values: Set<string>
+      ): void => {
+        if (!event.parameters) return;
+
+        event.parameters.map((m) => values.add(m.value));
+      };
+
+      const collectMessage = (
+        event: AppMapEvent,
+        values: Set<string>
+      ): void => {
+        if (!event.message) return;
+
+        event.message.map((m) => values.add(m.value));
+      };
+
+      const collectReceiver = (event: AppMapEvent, values: Set<string>): void => {
+        if (!event.receiver) return;
+
+        values.add(event.receiver.value);
+      };
+
+      const collectReturnValue = (
+        event: AppMapEvent,
+        values: Set<string>
+      ): void => {
+        if (!event.returnValue) return;
+
+        values.add(event.returnValue.value);
+      };
+
+      const collectEventData = (event: AppMapEvent): Set<string> => {
+        const result = new Set<string>();
+        collectParameters(event, result);
+        collectMessage(event, result);
+        collectReceiver(event, result);
+        collectReturnValue(event, result);
+        return result;
+      };
+
+      appmap.events.forEach((event) => {
+        const eventData = collectEventData(event);
+        eventData.delete('');
+        for (const value of eventData) {
+          if (!eventsByData.get(value))
+            eventsByData.set(value, new Set<AppMapEvent>());
+
+          eventsByData.get(value)!.add(event);
+        }
+      });
+    }
+
+    const findEvents = new FindEvents(
+      codeObjectMatch.appmap,
+      codeObjectMatch.codeObject
+    );
+    findEvents.filter([{ name: 'hasParameter', value: searchItem.param }]);
+    const eventMatches = await findEvents.matches();
+    console.warn(
+      `Matches ${eventMatches.length} events in ${codeObjectMatch.appmap}`
+    );
+
+    const valuesOfInterest = new Set<string>();
+    const collectParameterValueOfEventMatch = (event?: AppMapEvent) => {
+      if (!event) return;
+      if (!event.parameters) return;
+
+      const param = event.parameters.find((p) => p.name === searchItem.param);
+      assert(param, `No ${searchItem.param} found on event ${event}`);
+      const value = param.value;
+      if (!value || value === '') return;
+
+      valuesOfInterest.add(value);
+    };
+
+    // For each event match, collect the value of the target parameter
+    eventMatches.forEach((match) =>
+      collectParameterValueOfEventMatch(
+        appmap.events.find((e) => e.id === match.event.id)
+      )
+    );
+
+    // Find all events whose return value is a value of interest.
+    // Add parameter values for that event to the values of interest.
+    // Terminate when no values of interest are found.
+    const collectParameterValuesOfValueReturningEvent = (
+      event: AppMapEvent
+    ) => {
+      if (!event.returnValue) return;
+      if (!valuesOfInterest.has(event.returnValue.value)) return;
+
+      if (event.parameters)
+        event.parameters
+          .filter((param) => param.value && param.value !== '')
+          .forEach((param) => valuesOfInterest.add(param.value));
+      if (event.receiver?.value && event.receiver.value !== '')
+        valuesOfInterest.add(event.receiver.value);
+    };
+
+    // Collect parameter values that lead to values of interest
+    let valuesOfInterestCount: number;
+    do {
+      valuesOfInterestCount = valuesOfInterest.size;
+      for (let index = 0; index < appmap.events.length; index++) {
+        const event = appmap.events[index];
+        collectParameterValuesOfValueReturningEvent(event);
+      }
+    } while (valuesOfInterest.size > valuesOfInterestCount);
+
+    // Collect all events which are related to a value of interest.
+    const eventIds = new Set<number>();
+    for (const value of valuesOfInterest) {
+      const events = eventsByData.get(value);
+      if (!events)
+        assert(events, `No events found for parameter value ${value}`);
+
+      for (const event of events) {
+        eventIds.add(event.id);
+      }
+    }
+
+    const ancestorEvents = appmap.events.filter(
+      (event) => eventIds.has(event.id) || eventIds.has(event.linkedEvent.id)
+    );
+
+    await writeFile(
+      [basename(codeObjectMatch.appmap), 'data_trace.appmap.json'].join('_'),
+      JSON.stringify({
+        metadata: appmap.metadata,
+        classMap: appmap.classMap,
+        events: ancestorEvents,
+      })
+    );
+  }
+};

--- a/packages/cli/src/depends.js
+++ b/packages/cli/src/depends.js
@@ -167,6 +167,7 @@ class Depends {
 
     await processFiles(
       `${this.appMapDir}/**/classMap.json`,
+      undefined,
       async (fileName) => {
         try {
           await checkClassMap(fileName);

--- a/packages/cli/src/inspect/context.ts
+++ b/packages/cli/src/inspect/context.ts
@@ -30,7 +30,7 @@ export default class Context extends EventEmitter {
   }
 
   async findCodeObjects() {
-    const finder = new FindCodeObjects(this.appmapDir, this.codeObjectId);
+    const finder = new FindCodeObjects(this.codeObjectId, this.appmapDir);
     this.codeObjectMatches = await finder.find(
       (count) => this.emit('start', count),
       () => this.emit('increment')

--- a/packages/cli/src/search/findCodeObjects.ts
+++ b/packages/cli/src/search/findCodeObjects.ts
@@ -162,8 +162,12 @@ function buildCodeObjectMatcher(codeObjectId: string): CodeObjectMatcher[] {
 export default class FindCodeObjects {
   matchers: CodeObjectMatcher[];
 
-  constructor(public appMapDir: string, public codeObjectId: string) {
-    this.matchers = buildCodeObjectMatcher(codeObjectId);
+  constructor(
+    public codeObjectPattern: string,
+    public appmapDir?: string,
+    public appmapFiles?: string[]
+  ) {
+    this.matchers = buildCodeObjectMatcher(codeObjectPattern);
     if (verbose()) {
       console.warn(`Searching for: ${inspect(this.matchers)}`);
     }
@@ -248,7 +252,8 @@ export default class FindCodeObjects {
     };
 
     await processFiles(
-      `${this.appMapDir}/**/classMap.json`,
+      this.appmapDir ? `${this.appmapDir}/**/classMap.json` : undefined,
+      this.appmapFiles,
       checkClassMap.bind(this),
       fileCountFn
     );

--- a/packages/cli/src/search/matchFilter.js
+++ b/packages/cli/src/search/matchFilter.js
@@ -1,7 +1,16 @@
 const { formatValue, formatHttpServerRequest } = require('../utils');
 
 /** @typedef {import('./types').Event} Event */
+/** @typedef {import('./types').ParameterObject} ParameterObject */
 /** @typedef {function(string,Event[],string):boolean} Matcher */
+
+/** @type {Matcher} */
+const hasParameter = (expectedValue, stack) => {
+  const event = stack[stack.length - 1];
+  return event.parameters?.find(
+    (/** @type {ParameterObject} */ param) => param.name === expectedValue
+  );
+};
 
 /** @type {Matcher} */
 const returnValue = (expectedValue, stack) => {
@@ -35,6 +44,7 @@ function defaultMatcher(expectedValue, stack, fieldName) {
 }
 
 const MATCHERS = {
+  hasParameter,
   returnValue,
   httpServerRequest,
   ancestor,

--- a/packages/cli/tests/unit/inspect.spec.ts
+++ b/packages/cli/tests/unit/inspect.spec.ts
@@ -44,8 +44,8 @@ describe('Inspect', () => {
 
   test('finds a named function', async () => {
     const fn = new FindCodeObjects(
-      appMapDir,
-      'function:app/models/ApiKey.issue'
+      'function:app/models/ApiKey.issue',
+      appMapDir
     );
     const result = await fn.find();
     expect(JSON.stringify(stripCodeObjectParents(result), null, 2)).toEqual(
@@ -70,7 +70,7 @@ describe('Inspect', () => {
   });
 
   test('finds a named class', async () => {
-    const fn = new FindCodeObjects(appMapDir, 'class:app/models/ApiKey');
+    const fn = new FindCodeObjects('class:app/models/ApiKey', appMapDir);
     const result = await fn.find();
     expect(JSON.stringify(stripCodeObjectParents(result), null, 2)).toEqual(
       JSON.stringify(
@@ -91,7 +91,7 @@ describe('Inspect', () => {
   });
 
   test('finds a named package', async () => {
-    const fn = new FindCodeObjects(appMapDir, 'package:app/models');
+    const fn = new FindCodeObjects('package:app/models', appMapDir);
     const result = await fn.find();
     // FindCodeObjects.find may return appmaps in any order. Sort them so they'll match.
     result.sort((o1, o2) => o1.appmap.localeCompare(o2.appmap));


### PR DESCRIPTION
Add function `appmap trace-data [data-item]`.

* `data-item` a specifier of the form `code-object-type:code-object-id-or-pattern(param-name)`. Example: `function:psych/Psych.load(yaml)`.

data-item is parsed into a code object id or pattern, and a parameter name. So in the above example, we want to trace the `yaml` parameter to `Psych.load`. Example AppMap is attached.

This command finds all AppMaps that match the code object id or pattern. Then, for each AppMap, it finds the value of the specified parameter across all matching events. It also traces the value backwards through other events that have this value as a return value. And it finds events whose return value matches a parameter value of those events, and so on.

Once this set of "events of interest" is built, the command prints a new AppMap for each matching AppMap, which includes only the events of interest. 

## Example command invocation

```sh-session
$ yarn start trace-data -d ~/source/land-of-apps/sample_app_6th_ed "function:psych/Psych.load(yaml)"
```

## Example of the unfiltered AppMap

[Password_resets_password_reset_attack.appmap.json.zip](https://github.com/applandinc/appmap-js/files/9096567/Password_resets_password_reset_attack.appmap.json.zip)

## Example of a filtered AppMap showing "events of interest"

[Password_resets_password_reset_attack_data_trace.appmap.json.zip](https://github.com/applandinc/appmap-js/files/9096561/Password_resets_password_reset_attack_data_trace.appmap.json.zip)

