### PR TITLE
feat: add guess test command for the js agent

### DIFF
--- a/packages/cli/src/cmds/record/action/guessTestCommands.ts
+++ b/packages/cli/src/cmds/record/action/guessTestCommands.ts
@@ -31,6 +31,20 @@ const TestCommands: TestCommandGuess[] = [
       env: {},
     },
   },
+  {
+    paths: ['package.json', 'node_modules/mocha'],
+    command: {
+      command: 'npx appmap-agent-js --recorder=mocha -- npx mocha',
+      env: {},
+    },
+  },
+  {
+    paths: ['package.json', 'node_modules'],
+    command: {
+      command: 'npx appmap-agent-js --recorder=process -- npm run test',
+      env: {},
+    },
+  },
 ];
 
 export default async function guessTestCommands(): Promise<TestCommand[] | undefined> {


### PR DESCRIPTION
```
 > node ../appmap-js/packages/cli/built/cli.js record test

In order to record test cases, you need to provide a command that I can use to run the tests. If your project has many test cases, enter a command that will run integration, functional, system or request tests, as opposed to unit tests. Don't worry about how long the tests will take to run, you will specify a maximum runtime in an upcoming step.

Here's a suggested test command for your project:

npx appmap-agent-js --recorder=mocha -- npx mocha

? Use this suggested test command? Yes

I've written this test command to your AppMap configuration file (appmap.yml). The next time you run this program, it will be used automatically. You can change it in the appmap.yml if you want to. You can also delete it, in which case you'll be prompted again next time. And, you can also add additional test commands to that file.

? Press enter to continue 
? Enter the maximum time (in seconds) to allow test cases to run (-1 to run forever): 30
Running test command: npx appmap-agent-js --recorder=mocha -- npx mocha
(node:56478) ExperimentalWarning: Custom ESM Loaders is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
(node:56478) DeprecationWarning: Obsolete loader hook(s) supplied and will be ignored: transformSource


  Array
    #indexOf()
      ✔ should return -1 when the value is not present


  1 passing (7ms)


   ╭───────────────────────────────────────────────────────────────────────────────────────╮
   │                                                                                       │
   │                Success! There are now 1 AppMap files in directory '.'.                │
   │                                                                                       │
   │                                NEXT STEP: Open AppMaps                                │
   │                                                                                       │
   │   Return to the AppMap extension in your code editor to open and view your AppMaps.   │
   │                                                                                       │
   ╰───────────────────────────────────────────────────────────────────────────────────────╯
```