### PR TITLE
feat: Send telemetry for the Stats command only when it's called manually

### DIFF
--- a/packages/cli/src/cmds/record/record.ts
+++ b/packages/cli/src/cmds/record/record.ts
@@ -119,7 +119,7 @@ export default {
         await showAppMap(state as FileName);
       }
 
-      await StatsCommand.handler(argv);
+      await StatsCommand.handler(argv, 'from_record');
     };
 
     return runCommand('record', commandFn);

--- a/packages/cli/src/cmds/stats/stats.ts
+++ b/packages/cli/src/cmds/stats/stats.ts
@@ -39,7 +39,7 @@ export const builder = (args: yargs.Argv) => {
   return args.strict();
 };
 
-export async function handler(argv: any) {
+export async function handler(argv: any, handlerCaller: string = 'from_stats') {
   verbose(argv.verbose);
 
   const commandFn = async () => {
@@ -302,7 +302,7 @@ export async function handler(argv: any) {
         });
 
         Telemetry.sendEvent({
-          name: 'stats:success',
+          name: `stats:${handlerCaller}:success`,
           properties: {
             path: appMapDir,
           },
@@ -312,7 +312,7 @@ export async function handler(argv: any) {
         let errorMessage: string | undefined = (err as any).toString();
         if (err instanceof Error) {
           Telemetry.sendEvent({
-            name: 'stats:error',
+            name: `stats:${handlerCaller}:error`,
             properties: {
               errorMessage,
               errorStack: err.stack,


### PR DESCRIPTION
Fixes https://github.com/getappmap/appmap-js/issues/749

Ran manually:
```
$ npm start stats -- /home/test/src/sample_app_6th_ed --limit 20

> @appland/appmap@3.41.0 start
> ts-node src/cli.ts stats /home/test/src/sample_app_6th_ed --limit 20

✔ Computing AppMap stats...

Largest AppMaps (which are bigger than 1024kb)
1.2MB tmp/appmap/minitest/Microposts_interface_micropost_interface.appmap.json

✔ Computing functions with highest AppMap overhead...

No "elapsed_instrumentation" data in the AppMaps.
would have sent telemetry !!!                                        <================ debugging statement
```

Ran from Record command:
```
$ rm -rf  /home/test/src/sample_app_6th_ed/tmp/appmap > /dev/null 2>&1; npm start record test -- -d /home/test/src/sample_app_6th_ed

> @appland/appmap@3.41.0 start
> ts-node src/cli.ts record test -d /home/test/src/sample_app_6th_ed

The following test commands were provided by your AppMap configuration (appmap.yml):

APPMAP=true DISABLE_SPRING=true bundle exec rails test

? Use these test commands? Yes
? Enter the maximum time (in seconds) to allow test cases to run (-1 to run forever): 30
Running test command: APPMAP=true DISABLE_SPRING=true bundle exec rails test
Started with run options --seed 54431


Progress: |============================================================================================================================================================|

Finished in 5.82800s
67 tests, 282 assertions, 0 failures, 0 errors, 0 skips

   ╭───────────────────────────────────────────────────────────────────────────────────────╮
   │                                                                                       │
   │           Success! There are now 67 AppMap files in directory 'tmp/appmap'.           │
   │                                                                                       │
   │                                NEXT STEP: Open AppMaps                                │
   │                                                                                       │
   │   Return to the AppMap extension in your code editor to open and view your AppMaps.   │
   │                                                                                       │
   ╰───────────────────────────────────────────────────────────────────────────────────────╯

✔ Computing AppMap stats...

Largest AppMaps (which are bigger than 1024kb)
1.2MB tmp/appmap/minitest/Microposts_interface_micropost_interface.appmap.json

✔ Computing functions with highest AppMap overhead...

No "elapsed_instrumentation" data in the AppMaps.
```
^^ No debugging statement.