### PR TITLE
Send telemetry events on indexing

### DIFF
--- a/packages/cli/src/fingerprint/fingerprintQueue.ts
+++ b/packages/cli/src/fingerprint/fingerprintQueue.ts
@@ -7,7 +7,7 @@ function isNodeError(error: unknown, code?: string): error is NodeJS.ErrnoExcept
 }
 
 export default class FingerprintQueue {
-  private handler: Fingerprinter;
+  public handler: Fingerprinter;
   private queue: QueueObject<string>;
   private pending = new Set<string>();
 
@@ -23,10 +23,6 @@ export default class FingerprintQueue {
       this.pending.delete(appmapFileName);
     }, this.size);
     this.queue.pause();
-  }
-
-  setCounterFn(counterFn: () => void) {
-    this.handler.setCounterFn(counterFn);
   }
 
   async process() {

--- a/packages/cli/src/fingerprint/fingerprintWatchCommand.js
+++ b/packages/cli/src/fingerprint/fingerprintWatchCommand.js
@@ -8,8 +8,8 @@ class FingerprintWatchCommand {
   constructor(directory) {
     this.directory = directory;
     this.print = true;
-    this.numProcessed = 0;
     this.pidfilePath = process.env.APPMAP_WRITE_PIDFILE && path.join(this.directory, 'index.pid');
+    this.fpQueue = new FingerprintQueue();
   }
 
   removePidfile() {
@@ -21,11 +21,6 @@ class FingerprintWatchCommand {
   }
 
   async execute() {
-    this.fpQueue = new FingerprintQueue();
-    this.fpQueue.setCounterFn(() => {
-      this.numProcessed += 1;
-    });
-
     // Index existing AppMap files
     await listAppMapFiles(this.directory, (file) => this.fpQueue.push(file));
     this.fpQueue.process();

--- a/packages/cli/src/fingerprint/index.js
+++ b/packages/cli/src/fingerprint/index.js
@@ -1,7 +1,7 @@
 const { verbose } = require('../utils');
 const { algorithms, canonicalize } = require('./canonicalize');
 const FingerprintDirectoryCommand = require('./fingerprintDirectoryCommand');
-const FingerprintWatchCommand = require('./fingerprintWatchCommand');
+const FingerprintWatchCommand = require('./fingerprintWatchCommand').default;
 
 async function fingerprintDirectory(dir, watch = false) {
   if (verbose) {

--- a/packages/cli/src/lib/eventAggregator.ts
+++ b/packages/cli/src/lib/eventAggregator.ts
@@ -1,0 +1,33 @@
+import { EventEmitter } from 'events';
+
+export type PendingEvent = {
+  emitter: EventEmitter;
+  event: string;
+  args: any[];
+};
+
+export default class EventAggregator {
+  constructor(private callback: (events: PendingEvent[]) => void, private maxMsBetween = 1000) {}
+
+  private pending: PendingEvent[] = [];
+  private push(emitter: EventEmitter, event: string, args: any[]) {
+    this.pending.push({ emitter, event, args });
+    this.refresh();
+  }
+
+  private timeout?: NodeJS.Timeout;
+  private refresh() {
+    if (this.timeout) clearTimeout(this.timeout);
+    this.timeout = setTimeout(this.emitPending.bind(this), this.maxMsBetween);
+  }
+
+  private emitPending() {
+    this.callback(this.pending);
+    this.timeout = undefined;
+    this.pending = [];
+  }
+
+  attach(emitter: EventEmitter, event: string) {
+    emitter.on(event, (...args) => this.push(emitter, event, args));
+  }
+}

--- a/packages/cli/src/lib/flattenMetadata.ts
+++ b/packages/cli/src/lib/flattenMetadata.ts
@@ -1,0 +1,37 @@
+import { Metadata } from '@appland/models';
+
+/** Flattens metadata into a string-string map suitable for use in telemetry.
+ * Ignores git, exception and fingerprints.
+ */
+export default function flattenMetadata(metadata: Metadata): Map<string, string> {
+  const result = new Map<string, string>();
+
+  if (metadata.app) result.set('app', metadata.app);
+
+  if (metadata.client) {
+    result.set('client.name', metadata.client.name);
+    result.set('client.url', metadata.client.url);
+    if (metadata.client.version) result.set('client.version', metadata.client.version);
+  }
+
+  if (metadata.frameworks)
+    for (const { name, version } of metadata.frameworks) result.set(`framework.${name}`, version);
+
+  if (metadata.labels) result.set('labels', metadata.labels.join(', '));
+
+  if (metadata.language) {
+    result.set('language.name', metadata.language.name);
+    result.set('language.version', metadata.language.version);
+    if (metadata.language.engine) result.set('language.engine', metadata.language.engine);
+  }
+
+  if (metadata.name) result.set('name', metadata.name);
+  if (metadata.recorder) {
+    result.set('recorder.name', metadata.recorder.name);
+    if (metadata.recorder.type) result.set('recorder.type', metadata.recorder.type);
+  }
+
+  if (metadata.testStatus) result.set('testStatus', metadata.testStatus);
+
+  return result;
+}

--- a/packages/cli/src/lib/intersectMaps.ts
+++ b/packages/cli/src/lib/intersectMaps.ts
@@ -1,0 +1,12 @@
+/** Creates a map that only contains entries that exist in all arguments. */
+export function intersectMaps<K, V>(...maps: Map<K, V>[]): Map<K, V> {
+  const first = maps.shift();
+  if (!first) return new Map();
+
+  const result = new Map(first.entries());
+
+  for (const map of maps)
+    for (const [k, v] of map.entries()) if (result.get(k) !== v) result.delete(k);
+
+  return result;
+}

--- a/packages/cli/tests/unit/fingerprint/fingerprintWatchCommand.spec.ts
+++ b/packages/cli/tests/unit/fingerprint/fingerprintWatchCommand.spec.ts
@@ -67,7 +67,7 @@ describe(FingerprintWatchCommand, () => {
       await cmd.execute();
       cmd.watcher?.removeAllListeners();
       placeMap();
-      return verifyIndexSuccess(200);
+      return verifyIndexSuccess(200, 20);
     });
   });
 });

--- a/packages/cli/tests/unit/fingerprint/fingerprintWatchCommand.spec.ts
+++ b/packages/cli/tests/unit/fingerprint/fingerprintWatchCommand.spec.ts
@@ -1,11 +1,17 @@
 import { retry } from 'async';
 import { existsSync, copyFileSync } from 'fs';
 import { stat } from 'fs/promises';
-import { join } from 'path';
+import { basename, join } from 'path';
 import { restore, stub } from 'sinon';
 import { dirSync } from 'tmp';
 import FingerprintWatchCommand from '../../../src/fingerprint/fingerprintWatchCommand';
 import { verbose } from '../../../src/utils';
+import OriginalTelemetry from '../../../src/telemetry';
+import { once } from 'events';
+import Fingerprinter from '../../../src/fingerprint/fingerprinter';
+
+jest.mock('../../../src/telemetry');
+const Telemetry = jest.mocked(OriginalTelemetry);
 
 describe(FingerprintWatchCommand, () => {
   let cmd: FingerprintWatchCommand | null;
@@ -43,11 +49,9 @@ describe(FingerprintWatchCommand, () => {
   });
 
   describe('indexing', () => {
-    function placeMap() {
-      copyFileSync(
-        join(__dirname, '../fixtures/ruby/revoke_api_key.appmap.json'),
-        join(appMapDir, 'revoke_api_key.appmap.json')
-      );
+    function placeMap(path = '../fixtures/ruby/revoke_api_key.appmap.json', name?: string) {
+      name ||= basename(path);
+      copyFileSync(join(__dirname, path), join(appMapDir, name));
     }
 
     async function verifyIndexSuccess(interval = 100, times = 10) {
@@ -68,6 +72,57 @@ describe(FingerprintWatchCommand, () => {
       cmd.watcher?.removeAllListeners();
       placeMap();
       return verifyIndexSuccess(200, 20);
+    });
+
+    describe('telemetry', () => {
+      let handler: Fingerprinter;
+
+      beforeEach(async () => {
+        cmd = new FingerprintWatchCommand(appMapDir);
+        handler = cmd.fpQueue.handler;
+        await cmd.execute();
+        jest.useFakeTimers();
+        Telemetry.sendEvent.mockClear();
+      });
+
+      afterEach(() => {
+        jest.runAllTimers();
+        jest.useRealTimers();
+      });
+
+      it('aggregates indexes that occur less than one second apart', async () => {
+        placeMap();
+        await once(handler, 'index');
+        jest.advanceTimersByTime(512);
+        placeMap('../fixtures/ruby/user_page_scenario.appmap.json');
+        await once(handler, 'index');
+        jest.advanceTimersByTime(2048);
+
+        expect(Telemetry.sendEvent).toHaveBeenCalledTimes(1);
+        const data = Telemetry.sendEvent.mock.calls[0][0];
+        expect(data).toMatchObject({
+          name: 'appmap:index',
+          properties: {
+            app: 'appland/AppLand',
+            'language.name': 'ruby',
+          },
+          metrics: { appmaps: 2 },
+        });
+        expect(data.properties?.name).toBeUndefined();
+      });
+
+      it('send separate events for indexes that occur more than one second apart', async () => {
+        placeMap();
+        await once(handler, 'index');
+        jest.advanceTimersByTime(1024);
+        placeMap('../fixtures/ruby/user_page_scenario.appmap.json');
+        await once(handler, 'index');
+        jest.advanceTimersByTime(2048);
+
+        expect(Telemetry.sendEvent).toHaveBeenCalledTimes(2);
+        for (const [data] of Telemetry.sendEvent.mock.calls)
+          expect(data).toMatchObject({ name: 'appmap:index', metrics: { appmaps: 1 } });
+      });
     });
   });
 });

--- a/packages/cli/tests/unit/lib/eventAggregator.spec.ts
+++ b/packages/cli/tests/unit/lib/eventAggregator.spec.ts
@@ -1,0 +1,53 @@
+import EventEmitter from 'events';
+import EventAggregator from '../../../src/lib/eventAggregator';
+jest.useFakeTimers();
+
+describe(EventAggregator, () => {
+  const emitter = new EventEmitter();
+  const fn = jest.fn();
+  const aggregator = new EventAggregator(fn);
+  aggregator.attach(emitter, 'sing');
+  aggregator.attach(emitter, 'dance');
+
+  beforeEach(() => {
+    fn.mockReset();
+  });
+
+  it('aggregates events in the given timeframe', () => {
+    emitter.emit('sing', 80, 'song');
+    jest.advanceTimersByTime(512);
+    emitter.emit('dance', 'like there is no tomorrow');
+    jest.advanceTimersByTime(512);
+    emitter.emit('sing', 'in the rain');
+    jest.advanceTimersByTime(1024);
+
+    expect(fn.mock.calls).toEqual([
+      [
+        [
+          { emitter, event: 'sing', args: [80, 'song'] },
+          { emitter, event: 'dance', args: ['like there is no tomorrow'] },
+          { emitter, event: 'sing', args: ['in the rain'] },
+        ],
+      ],
+    ]);
+  });
+
+  it('calls the callback separately between timeframes', () => {
+    emitter.emit('sing', 80, 'song');
+    jest.advanceTimersByTime(512);
+    emitter.emit('dance', 'like there is no tomorrow');
+    jest.advanceTimersByTime(1024);
+    emitter.emit('sing', 'in the rain');
+    jest.advanceTimersByTime(1024);
+
+    expect(fn.mock.calls).toEqual([
+      [
+        [
+          { emitter, event: 'sing', args: [80, 'song'] },
+          { emitter, event: 'dance', args: ['like there is no tomorrow'] },
+        ],
+      ],
+      [[{ emitter, event: 'sing', args: ['in the rain'] }]],
+    ]);
+  });
+});

--- a/packages/models/types/index.d.ts
+++ b/packages/models/types/index.d.ts
@@ -271,6 +271,9 @@ declare module '@appland/models' {
 
     export class Recorder {
       name: string;
+
+      /** Optional in AppMaps versions < 1.9.0. */
+      type?: 'tests' | 'requests' | 'remote';
     }
   }
 


### PR DESCRIPTION
The telemetry data sent includes number of AppMaps seen and some common metadata about them. An event is not sent more often than once per second.

Note this only applies to watch mode. The intention is to let us see when our users are succeeding with AppMap creation, and as live indexing automatically happens when using IDEs, this solution avoids having to call home from every agent. Telemetry can also be easily disabled in the editors.

Example event:
```json
    {
      "name": "appmap:index",
      "properties": {
        "app": "appland/AppLand",
        "client.name": "appmap",
        "client.url": "https://github.com/applandinc/appmap-ruby",
        "framework.rails": "5.2.4.2",
        "framework.rspec": "3.9.1",
        "labels": "api key, api",
        "language.name": "ruby",
        "language.version": "2.6.6",
        "language.engine": "ruby",
        "recorder.name": "rspec"
      },
      "metrics": {
        "appmaps": 2
      }
    }
```

Fixes https://github.com/getappmap/board/issues/167