### PR TITLE
`scan --watch` works correctly even when the appmap dir doesn't initially exist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,9 @@ jobs:
       script: |
         yarn workspace @appland/appmap jest --runTestsByPath \
           tests/unit/agentInstall/commandRunner.spec.ts \
-          tests/unit/agentInstall/gradleInstaller.spec.ts
+          tests/unit/agentInstall/gradleInstaller.spec.ts \
+        && yarn workspace @appland/scanner jest --runTestsByPath \
+          test/cli/scan.spec.ts
 
     - stage: deploy
       if: branch != main

--- a/packages/scanner/src/cli/scan/command.ts
+++ b/packages/scanner/src/cli/scan/command.ts
@@ -80,10 +80,10 @@ export default {
       );
     }
 
+    if (appmapDir) await validateFile('directory', appmapDir);
     if (!appmapFile && !appmapDir) {
       appmapDir = (await appmapDirFromConfig()) || '.';
     }
-    if (appmapDir) await validateFile('directory', appmapDir);
 
     let appId = appIdArg;
     if (!watch && !reportAllFindings) appId = await resolveAppId(appIdArg, appmapDir);

--- a/packages/scanner/src/cli/scan/watchScan.ts
+++ b/packages/scanner/src/cli/scan/watchScan.ts
@@ -121,7 +121,7 @@ export class Watcher {
   protected async scan(mtimePath: string): Promise<void> {
     assert(this.config, `config should always be loaded before appmapWatcher triggers a scan`);
 
-    const appmapFile = mtimePath.replace(/\/mtime$/, '.appmap.json');
+    const appmapFile = [path.dirname(mtimePath), 'appmap.json'].join('.');
     const reportFile = mtimePath.replace(/mtime$/, 'appmap-findings.json');
 
     const [appmapStats, reportStats] = await Promise.all(

--- a/packages/scanner/test/cli/commands.spec.ts
+++ b/packages/scanner/test/cli/commands.spec.ts
@@ -1,38 +1,39 @@
-import sinon from 'sinon';
+import { Arguments } from 'yargs';
 import * as resolveAppId from '../../src/cli/resolveAppId';
 import ScanCommand from '../../src/cli/scan/command';
+import CommandOptions from '../../src/cli/scan/options';
 import * as watchScan from '../../src/cli/scan/watchScan';
+
+const defaultArguments: Arguments<CommandOptions> = {
+  _: [],
+  $0: 'scan',
+  all: false,
+  interactive: false,
+  watch: false,
+  config: 'appmap-scanner.yml',
+  reportFile: 'appmap-findings.json',
+};
 
 describe('commands', () => {
   afterEach(() => {
-    sinon.restore();
+    jest.restoreAllMocks();
   });
 
   describe('scan --watch', () => {
-    beforeEach(() => {
-      // Prevent the watcher from running indefinitely
-      sinon.stub(watchScan, 'default').resolves();
-    });
-
     it('does not attempt to resolve an app ID', async () => {
-      const spy = sinon.spy(resolveAppId, 'default');
+      // Prevent the watcher from running indefinitely
+      jest.spyOn(watchScan, 'default').mockResolvedValue();
+
+      const spy = jest.spyOn(resolveAppId, 'default');
 
       try {
-        await ScanCommand.handler({
-          _: [],
-          $0: 'scan',
-          interactive: false,
-          config: 'appmap-scanner.yml',
-          all: false,
-          watch: true,
-          reportFile: 'appmap-findings.json',
-        });
+        await ScanCommand.handler({ ...defaultArguments, watch: true });
       } catch {
         // Do nothing.
         // We don't want exceptions, we just want to know if our stub was called.
       }
 
-      expect(spy.called).toBe(false);
+      expect(spy).not.toBeCalled();
     });
   });
 });

--- a/packages/scanner/test/cli/commands.spec.ts
+++ b/packages/scanner/test/cli/commands.spec.ts
@@ -2,7 +2,11 @@ import { Arguments } from 'yargs';
 import * as resolveAppId from '../../src/cli/resolveAppId';
 import ScanCommand from '../../src/cli/scan/command';
 import CommandOptions from '../../src/cli/scan/options';
+import * as scanner from '../../src/cli/scan/scanner';
 import * as watchScan from '../../src/cli/scan/watchScan';
+import tmp from 'tmp-promise';
+import { copyFile, mkdir, writeFile } from 'node:fs/promises';
+import path, { basename } from 'node:path';
 
 const defaultArguments: Arguments<CommandOptions> = {
   _: [],
@@ -15,8 +19,11 @@ const defaultArguments: Arguments<CommandOptions> = {
 };
 
 describe('commands', () => {
+  const cwd = process.cwd();
+
   afterEach(() => {
     jest.restoreAllMocks();
+    process.chdir(cwd);
   });
 
   describe('scan --watch', () => {
@@ -35,5 +42,46 @@ describe('commands', () => {
 
       expect(spy).not.toBeCalled();
     });
+
+    it('work correctly even if the appmap directory does not initially exist', () =>
+      tmp.withDir(
+        async ({ path: tmpDir }) => {
+          let watcher: watchScan.Watcher | undefined;
+          jest.spyOn(watchScan, 'default').mockImplementation((opts) => {
+            watcher = new watchScan.Watcher(opts);
+            return watcher.watch();
+          });
+
+          await writeFile(path.join(tmpDir, 'appmap.yml'), 'appmap_dir: tmp/appmap\n');
+          await ScanCommand.handler({
+            ...defaultArguments,
+            watch: true,
+            directory: tmpDir,
+          });
+
+          const originalScanner = scanner.default;
+          const scanned = new Promise<void>((resolve) =>
+            jest.spyOn(scanner, 'default').mockImplementation((...args) => {
+              resolve();
+              return originalScanner(...args);
+            })
+          );
+
+          const appmapDir = path.join(tmpDir, 'tmp', 'appmap');
+          const appmapSrc = path.join(
+            __dirname,
+            '../fixtures/appmaps/JWT.decode_no_validation.appmap.json'
+          );
+          const indexDir = path.join(appmapDir, basename(appmapSrc, '.appmap.json'));
+          await mkdir(indexDir, { recursive: true });
+          await copyFile(appmapSrc, path.join(appmapDir, basename(appmapSrc)));
+          await writeFile(path.join(indexDir, 'mtime'), Date.now().toString());
+
+          await scanned;
+
+          await watcher?.close();
+        },
+        { unsafeCleanup: true }
+      ));
   });
 });


### PR DESCRIPTION
Also, fix paths handling for windows.

Fixes #753 .