### PR TITLE
appland.appmap 0.44.0-rc fixes

### DIFF
--- a/packages/components/src/components/install-guide/ProjectPickerRow.vue
+++ b/packages/components/src/components/install-guide/ProjectPickerRow.vue
@@ -230,7 +230,6 @@ $brightblue: rgba(255, 255, 255, 0.1);
 
 .header {
   display: flex;
-  overflow: hidden;
 
   &__title {
     font-size: 1.2rem;

--- a/packages/components/src/components/install-guide/ProjectPickerRow.vue
+++ b/packages/components/src/components/install-guide/ProjectPickerRow.vue
@@ -5,7 +5,6 @@
     :disabled="!supported"
     class="project-picker-row"
     :open="selected"
-    @toggle="onToggle"
     :data-supported="supported"
   >
     <template #header>
@@ -185,9 +184,6 @@ export default {
   methods: {
     performInstall() {
       this.$root.$emit('perform-install', this.path, this.language && this.language.name);
-    },
-    onToggle(isOpen) {
-      if (isOpen) this.$emit('select-project', this.path);
     },
     featureDescription(feature) {
       if (typeof feature.description === 'function') {

--- a/packages/components/src/components/install-guide/ProjectPickerTable.vue
+++ b/packages/components/src/components/install-guide/ProjectPickerTable.vue
@@ -31,6 +31,13 @@ export default {
     };
   },
 
+  watch: {
+    projects(newVal) {
+      if (!this.selectedProject || !this.selectedProject.name) return;
+      this.selectedProject = newVal.find((p) => p.name === this.selectedProject.name);
+    },
+  },
+
   computed: {
     sortedProjects() {
       return [...this.projects].sort((a, b) => {

--- a/packages/components/src/pages/InstallGuide.vue
+++ b/packages/components/src/pages/InstallGuide.vue
@@ -10,7 +10,7 @@
       :editor="editor"
       :project="selectedProject"
       :complete="hasRecorded"
-      :disabled-languages="disabledLanguages"
+      :feature-flags="featureFlags"
     />
     <v-open-app-maps
       id="open-appmaps"
@@ -58,9 +58,9 @@ export default {
       default: 'vscode',
       type: String,
     },
-    disabledLanguages: {
-      type: Array,
-      default: () => [],
+    featureFlags: {
+      type: Set,
+      default: () => new Set(),
     },
     findingsEnabled: {
       type: Boolean,

--- a/packages/components/src/pages/install-guide/ProjectPicker.vue
+++ b/packages/components/src/pages/install-guide/ProjectPicker.vue
@@ -70,34 +70,6 @@ export default {
     },
   },
 
-  computed: {
-    quality() {
-      const { selectedProject: project } = this;
-      if (!project) return undefined;
-      if (!project.score || project.score < 1) return 'empty';
-      if (!project.score || project.score < 2) return 'bad';
-      if (project.score < 3) return 'ok';
-      return 'good';
-    },
-    installCommand() {
-      return [
-        'npx @appland/appmap install',
-        this.selectedProject && `-d ${this.selectedProject.path}`,
-      ]
-        .filter(Boolean)
-        .join(' ');
-    },
-    projectLanguage() {
-      return this.selectedProject && this.selectedProject.language;
-    },
-  },
-
-  data() {
-    return {
-      selectedProject: null,
-    };
-  },
-
   mounted() {
     if (this.projects.length === 1) {
       this.$refs.projectTable.selectProject(this.projects[0]);
@@ -112,7 +84,6 @@ export default {
     },
     selectProject(project) {
       this.$nextTick(() => {
-        this.selectedProject = project;
         this.$root.$emit('select-project', project);
       });
     },

--- a/packages/components/src/pages/install-guide/RecordAppMaps.vue
+++ b/packages/components/src/pages/install-guide/RecordAppMaps.vue
@@ -98,9 +98,9 @@ export default {
       default: 'vscode',
       validator: (value) => ['vscode', 'jetbrains'].indexOf(value) !== -1,
     },
-    disabledLanguages: {
-      type: Array,
-      default: () => [],
+    featureFlags: {
+      type: Set,
+      default: () => new Set(),
     },
   },
 
@@ -117,9 +117,14 @@ export default {
     supported() {
       return isProjectSupported(this.project);
     },
+    automaticRecordingLanguages() {
+      const languages = ['ruby'];
+      if (this.featureFlags.has('ar-python')) languages.push('python');
+      return languages;
+    },
     automaticRecording() {
       return (
-        ['ruby', 'python'].includes((this.language || '').toLowerCase()) &&
+        this.automaticRecordingLanguages.includes((this.language || '').toLowerCase()) &&
         (this.webFrameworkSupported || this.testFrameworkSupported)
       );
     },

--- a/packages/components/src/stories/install-guide/RecordAppMaps.stories.js
+++ b/packages/components/src/stories/install-guide/RecordAppMaps.stories.js
@@ -32,7 +32,7 @@ automatedRecording.args = {
     },
   },
   editor: 'vscode',
-  complete: 'true',
+  complete: true,
 };
 
 export const noTestFramework = Template.bind({});
@@ -55,7 +55,7 @@ noTestFramework.args = {
     },
   },
   editor: 'vscode',
-  complete: 'true',
+  complete: true,
 };
 
 export const noWebFramework = Template.bind({});
@@ -78,7 +78,7 @@ noWebFramework.args = {
     },
   },
   editor: 'vscode',
-  complete: 'true',
+  complete: true,
 };
 
 export const javascriptOrJava = Template.bind({});
@@ -101,7 +101,7 @@ javascriptOrJava.args = {
     },
   },
   editor: 'vscode',
-  complete: 'true',
+  complete: true,
 };
 
 export const noWebOrTestFramework = Template.bind({});
@@ -124,7 +124,7 @@ noWebOrTestFramework.args = {
     },
   },
   editor: 'vscode',
-  complete: 'true',
+  complete: true,
 };
 
 export const unsupportedLanguage = Template.bind({});
@@ -147,5 +147,5 @@ unsupportedLanguage.args = {
     },
   },
   editor: 'vscode',
-  complete: 'true',
+  complete: true,
 };


### PR DESCRIPTION
This change:
- Adds a toggle for Python where recording by default is documented or not
- Fixes hover tooltips being cut off
- Fixes an issue where a project would be unselected if VSCode was still initializing
- Removes some dead code and resolves other non-user facing errors 

Resolves #476