### PR TITLE
fix: Fix a panic condition when indexing in watch mode

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -17,7 +17,7 @@ const { algorithms, canonicalize } = require('./fingerprint');
 const { verbose, loadAppMap } = require('./utils');
 const appMapCatalog = require('./appMapCatalog');
 const FingerprintDirectoryCommand = require('./fingerprint/fingerprintDirectoryCommand');
-const FingerprintWatchCommand = require('./fingerprint/fingerprintWatchCommand');
+const FingerprintWatchCommand = require('./fingerprint/fingerprintWatchCommand').default;
 const Depends = require('./depends');
 import * as OpenAPICommand from './cmds/openapi';
 const InventoryCommand = require('./inventoryCommand');
@@ -371,7 +371,7 @@ yargs(process.argv.slice(2))
           setInterval(() => {
             readline.cursorTo(process.stdout, consoleLabel.length - 1);
             process.stdout.write(`${cmd.numProcessed}`);
-          }, 200);
+          }, 1000);
 
           process.on('beforeExit', (/* _code */) => {
             process.stdout.write(`\x1B[?25h`);

--- a/packages/cli/src/fingerprint/fingerprintWatchCommand.ts
+++ b/packages/cli/src/fingerprint/fingerprintWatchCommand.ts
@@ -15,6 +15,15 @@ export default class FingerprintWatchCommand {
   public fpQueue: FingerprintQueue;
   public watcher?: FSWatcher;
   private poller?: FSWatcher;
+  private _numProcessed = 0;
+
+  public get numProcessed() {
+    return this._numProcessed;
+  }
+
+  private set numProcessed(value) {
+    this._numProcessed = value;
+  }
 
   constructor(private directory: string) {
     this.pidfilePath = process.env.APPMAP_WRITE_PIDFILE && join(this.directory, 'index.pid');
@@ -23,6 +32,7 @@ export default class FingerprintWatchCommand {
     new EventAggregator((events) => {
       const indexEvents = events.map(({ args: [event] }) => event) as FingerprintEvent[];
       this.sendTelemetry(indexEvents.map(({ metadata }) => metadata));
+      this.numProcessed += events.length;
     }).attach(this.fpQueue.handler, 'index');
   }
 


### PR DESCRIPTION
Found via IntelliJ:
```sh
$ /home/db/dev/applandinc/appmap-intellij-plugin/build/idea-sandbox/system/tmp/appland-downloads/appmap/3.43.1/appmap-linux-x64 index --watch --appmap-dir /home/db/dev/applandinc/appmap-ruby/spec/fixtures/rails6_users_app    
TypeError: FingerprintWatchCommand is not a constructor
    at Object.handler (/snapshot/appmap-js/packages/cli/built/cli.js:316:21)
    at /snapshot/appmap-js/node_modules/yargs/build/index.cjs:1:9114
    at j (/snapshot/appmap-js/node_modules/yargs/build/index.cjs:1:4993)
    at M.applyMiddlewareAndGetResult (/snapshot/appmap-js/node_modules/yargs/build/index.cjs:1:9083)
    at M.runCommand (/snapshot/appmap-js/node_modules/yargs/build/index.cjs:1:7268)
    at Jt.[runYargsParserAndExecuteCommands] (/snapshot/appmap-js/node_modules/yargs/build/index.cjs:1:56059)
    at Jt.parse (/snapshot/appmap-js/node_modules/yargs/build/index.cjs:1:38312)
    at Jt.get [as argv] (/snapshot/appmap-js/node_modules/yargs/build/index.cjs:1:59548)
    at Object.<anonymous> (/snapshot/appmap-js/packages/cli/built/cli.js:386:12)
    at Module._compile (pkg/prelude/bootstrap.js:1930:22)
```