### PR TITLE
fix: Don't show a misleading message when test fails with AppMaps

### DIFF
--- a/packages/cli/src/cmds/record/state/testCasesComplete.ts
+++ b/packages/cli/src/cmds/record/state/testCasesComplete.ts
@@ -9,7 +9,8 @@ export default async function testCasesComplete(recordContext: RecordContext): P
   // Handle command failures here, rather than in a separate state, so we maintain compatibility
   // with the Azure Function that processes telemetry events.
   if (recordContext.failures > 0 || recordContext.appMapsCreated === 0) {
-    UI.warn(`\n${chalk.yellow('!')} The test commands failed to create AppMaps\n`);
+    if (recordContext.appMapsCreated === 0)
+      UI.warn(`\n${chalk.yellow('!')} The test commands failed to create AppMaps\n`);
 
     const errors: string | string[] =
       recordContext.output?.join('\n').length > 0

--- a/packages/cli/tests/unit/record/testCasesComplete.spec.ts
+++ b/packages/cli/tests/unit/record/testCasesComplete.spec.ts
@@ -4,6 +4,7 @@ import RecordContext from '../../../src/cmds/record/recordContext';
 import testCasesComplete from '../../../src/cmds/record/state/testCasesComplete';
 import * as openTicket from '../../../src/lib/ticket/openTicket';
 import Configuration from '../../../src/cmds/record/configuration';
+import UI from '../../../src/cmds/userInteraction';
 
 describe('testCasesComplete', () => {
   afterEach(() => {
@@ -22,10 +23,33 @@ describe('testCasesComplete', () => {
 
     it('opens a ticket when test commands fail', async () => {
       sinon.stub(rc, 'failures').value(1);
+      sinon.stub(rc, 'appMapsCreated').value(42);
 
       await testCasesComplete(rc);
 
       expect(openTicketStub).toBeCalledOnce();
+    });
+
+    it('warns when a failed run did not produce appmaps', async () => {
+      const warn = sinon.stub(UI, 'warn');
+
+      sinon.stub(rc, 'failures').value(1);
+      sinon.stub(rc, 'appMapsCreated').value(0);
+
+      await testCasesComplete(rc);
+
+      expect(warn).toBeCalledWithMatch(/AppMaps/);
+    });
+
+    it('does not show a misleading message when failed run produces appmaps', async () => {
+      const warn = sinon.stub(UI, 'warn');
+
+      sinon.stub(rc, 'failures').value(1);
+      sinon.stub(rc, 'appMapsCreated').value(42);
+
+      await testCasesComplete(rc);
+
+      expect(warn).not.toBeCalledWithMatch(/AppMaps/);
     });
 
     describe('when test commands succeed', () => {


### PR DESCRIPTION
When running `appmap record` if a test run failed a message was
shown suggesting no maps were created even if some, in fact, were.
We're not showing that message anymore (unless maps were indeed
not created).

Fixes #728 