### PR TITLE
fix: More reliable polling in index --watch

### DIFF
--- a/packages/cli/src/fingerprint/globber.ts
+++ b/packages/cli/src/fingerprint/globber.ts
@@ -1,0 +1,86 @@
+import { EventEmitter } from 'stream';
+import { Glob, IGlob } from 'glob';
+import { assert } from 'console';
+import { stat } from 'fs/promises';
+import { Stats } from 'fs-extra';
+
+class Globber extends EventEmitter {
+  constructor(private pattern: string, public interval = 1000) {
+    super();
+  }
+
+  private currentGlob?: IGlob;
+
+  public scanNow() {
+    assert(!this.currentGlob);
+    this.timeout = undefined;
+    this.currentGlob = new Glob(this.pattern, { ignore: ['**/node_modules/**', '**/.git/**'] })
+      .on('end', this.scanEnd.bind(this))
+      .on('match', this.matchFound.bind(this));
+  }
+
+  private running = false;
+  public start() {
+    this.running = true;
+    this.scanNow();
+  }
+
+  public close() {
+    if (this.currentGlob) this.currentGlob.abort();
+    if (this.timeout) clearTimeout(this.timeout);
+
+    this.running = false;
+    this.currentGlob = undefined;
+    this.timeout = undefined;
+  }
+
+  timeout?: NodeJS.Timeout;
+  private scanEnd(found: string[]) {
+    this.currentGlob = undefined;
+
+    const files = new Set(found);
+    for (const f of this.mtimes.keys()) {
+      if (!files.has(f)) this.remove(f);
+    }
+
+    this.emit('end');
+
+    if (this.running) this.timeout = setTimeout(this.scanNow.bind(this), this.interval);
+  }
+
+  private matchFound(file: string) {
+    stat(file).then(
+      (stat) => this.update(file, stat),
+      () => this.remove(file)
+    );
+  }
+
+  private mtimes = new Map<string, number>();
+
+  private update(file: string, { mtimeMs }: Stats) {
+    const oldTime = this.mtimes.get(file);
+
+    if (oldTime === mtimeMs) return;
+
+    this.mtimes.set(file, mtimeMs);
+
+    const event = oldTime ? 'change' : 'add';
+    this.emit(event, file);
+  }
+
+  private remove(file: string) {
+    {
+      this.mtimes.delete(file);
+      this.emit('unlink', file);
+    }
+  }
+}
+
+interface Globber {
+  on(event: 'end', listener: () => void): this;
+  on(event: 'add' | 'change' | 'unlink', listener: (path: string) => void): this;
+  emit(event: 'end'): boolean;
+  emit(event: 'add' | 'change' | 'unlink', path: string): boolean;
+}
+
+export default Globber;

--- a/packages/cli/tests/unit/fingerprint/fingerprinter.spec.ts
+++ b/packages/cli/tests/unit/fingerprint/fingerprinter.spec.ts
@@ -21,8 +21,8 @@ describe(Fingerprinter, () => {
     withTempDir(async (dir) => {
       const filePath = path.join(dir, 'too-large.appmap.json');
       const file = await open(filePath, 'w');
-      file.write('{}', 500 * 1000 * 1000);
-      file.close();
+      await file.write('{}', 500 * 1000 * 1000);
+      await file.close();
       const fingerprinter = new Fingerprinter(false);
       await expect(fingerprinter.fingerprint(filePath)).rejects.toThrow(FileTooLargeError);
     })


### PR DESCRIPTION
Instead of using chokidar polling mode, periodically rescan the directory with glob to find appmaps. This is more reliable and avoids many corner cases of chokidar.