### PR TITLE
fix: Fix TypeError: Cannot read properties of undefined

### DIFF
--- a/packages/cli/src/cmds/agentInstaller/agentProcedure.ts
+++ b/packages/cli/src/cmds/agentInstaller/agentProcedure.ts
@@ -77,21 +77,27 @@ export default abstract class AgentProcedure {
 
     let { stdout } = await this.validateAgent(validateCmd);
 
-    const validationResult = JSON.parse(stdout);
+    try {
+      const validationResult = JSON.parse(stdout);
 
-    const errors = Array.isArray(validationResult) ? validationResult : validationResult.errors;
-    if (errors.length > 0) {
-      throw new ValidationError(
-        errors
-          .map((e) => {
-            let msg = e.message;
-            if (e.detailed_message) {
-              msg += `, ${e.detailed_message}`;
-            }
-            return msg;
-          })
-          .join('\n')
-      );
+      const errors = Array.isArray(validationResult) ? validationResult : validationResult.errors;
+      if (errors.length > 0) {
+        throw new ValidationError(
+          errors
+            .map((e) => {
+              let msg = e.message;
+              if (e.detailed_message) {
+                msg += `, ${e.detailed_message}`;
+              }
+              return msg;
+            })
+            .join('\n')
+        );
+      }
+    } catch (e) {
+      UI.error('Output from validateAgent was: ' + stdout);
+      UI.error('Failed to validate the installation.');
+      throw e;
     }
 
     const schema = JSON.parse(stdout)['schema'];


### PR DESCRIPTION
If validateProject fails to `JSON.parse(stdout)`, print out the stdout that failed to be parsed and display an error message.

Fixes https://github.com/getappmap/appmap-js/issues/770