### PR TITLE
fix: Don't fail if there were no testcases in Ruby.

### DIFF
--- a/packages/cli/src/cmds/record/state/testCasesComplete.ts
+++ b/packages/cli/src/cmds/record/state/testCasesComplete.ts
@@ -8,7 +8,18 @@ import RecordContext from '../recordContext';
 export default async function testCasesComplete(recordContext: RecordContext): Promise<undefined> {
   // Handle command failures here, rather than in a separate state, so we maintain compatibility
   // with the Azure Function that processes telemetry events.
-  if (recordContext.failures > 0 || recordContext.appMapsCreated === 0) {
+
+  // If the reason test recording generated no appmaps is that there
+  // were no testcases, then this isn't a failure.
+  let isRubyWithNoTestcases = false;
+  if (recordContext.output && recordContext.output.length > 0) {
+    isRubyWithNoTestcases = /^No examples found./.test(recordContext.output[0]);
+  }
+
+  if (
+    !isRubyWithNoTestcases &&
+    (recordContext.failures > 0 || recordContext.appMapsCreated === 0)
+  ) {
     if (recordContext.appMapsCreated === 0)
       UI.warn(`\n${chalk.yellow('!')} The test commands failed to create AppMaps\n`);
 

--- a/packages/cli/tests/unit/record/testCasesComplete.spec.ts
+++ b/packages/cli/tests/unit/record/testCasesComplete.spec.ts
@@ -41,6 +41,23 @@ describe('testCasesComplete', () => {
       expect(warn).toBeCalledWithMatch(/AppMaps/);
     });
 
+    it("is not a failure if 'No examples found.' from rspec", async () => {
+      sinon.stub(rc, 'output').value([
+        `No examples found.
+
+
+Finished in 0.00025 seconds (files took 0.03966 seconds to load)
+0 examples, 0 failures
+
+`,
+      ]);
+      sinon.stub(rc, 'failures').value(1);
+
+      await testCasesComplete(rc);
+
+      expect(openTicketStub).not.toBeCalled();
+    });
+
     it('does not show a misleading message when failed run produces appmaps', async () => {
       const warn = sinon.stub(UI, 'warn');
 


### PR DESCRIPTION
Fixes https://github.com/getappmap/appmap-js/issues/754