### PR TITLE
feat: Add `public` flag to create AppMap

### DIFF
--- a/packages/client/src/appMap.ts
+++ b/packages/client/src/appMap.ts
@@ -33,6 +33,7 @@ export type UploadCreateAppMapResponse = {
 export type CreateAppMapOptions = {
   app?: string;
   metadata?: MetadataDataType;
+  public?: boolean;
 };
 
 type PerformUploadOptions = {
@@ -91,6 +92,9 @@ export default class AppMap {
       }
       if (options.app) {
         form.append('app', options.app);
+      }
+      if (options.public) {
+        form.append('link_sharing', 'true');
       }
       const request = await buildRequest(performOptions.path, performOptions.requireApiKey);
       return new Promise<IncomingMessage>((resolve, reject) => {

--- a/packages/client/test/appMap.create.spec.ts
+++ b/packages/client/test/appMap.create.spec.ts
@@ -13,6 +13,7 @@ interface TestOptions {
   data?: Buffer;
   app?: string;
   metadata?: Metadata;
+  public?: boolean;
   requestBodyHandler?: (body: RequestBodyMatcher) => boolean;
 }
 
@@ -21,6 +22,7 @@ async function createAppMap(options: TestOptions): Promise<void> {
   const createOptions = {
     app: options.app || test.AppId,
     metadata: options.metadata,
+    public: options.public,
   };
 
   nock('http://localhost:3000')
@@ -53,6 +55,18 @@ describe('appMap', () => {
         requestBodyHandler(body: RequestBodyMatcher) {
           expect(body).toMatch(/Content-Disposition: form-data; name="data"/);
           expect(body).not.toMatch(/Content-Disposition: form-data; name="metadata"/);
+          expect(body).not.toMatch(/Content-Disposition: form-data; name="link_sharing"/);
+          return true;
+        },
+      });
+    });
+
+    it('succeeds with the public flag on', async () => {
+      await createAppMap({
+        public: true,
+        requestBodyHandler(body: RequestBodyMatcher) {
+          expect(body).toMatch(/Content-Disposition: form-data; name="data"/);
+          expect(body).toMatch(/Content-Disposition: form-data; name="link_sharing"/);
           return true;
         },
       });


### PR DESCRIPTION
This will be used by the VS Code extension (and is, in the latest RC).