### PR TITLE
fix: Install `@appland/appmap-agent-js`, not `appmap-agent-js`

### DIFF
--- a/packages/cli/src/cmds/agentInstaller/javaScriptAgentInstaller.ts
+++ b/packages/cli/src/cmds/agentInstaller/javaScriptAgentInstaller.ts
@@ -27,11 +27,11 @@ abstract class JavaScriptInstaller extends AgentInstaller {
   }
 
   async initCommand(): Promise<CommandStruct> {
-    return new CommandStruct('npx', ['appmap-agent-js', 'init', this.path], this.path);
+    return new CommandStruct('npx', ['@appland/appmap-agent-js', 'init', this.path], this.path);
   }
 
   async validateAgentCommand(): Promise<CommandStruct> {
-    return new CommandStruct('npx', ['appmap-agent-js', 'status', this.path], this.path);
+    return new CommandStruct('npx', ['@appland/appmap-agent-js', 'status', this.path], this.path);
   }
 }
 

--- a/packages/cli/tests/unit/agentInstall/installCommand.spec.ts
+++ b/packages/cli/tests/unit/agentInstall/installCommand.spec.ts
@@ -756,7 +756,7 @@ packages:
     const initAgent = (cmdStruct: CommandStruct) => {
       expect(cmdStruct.program).toEqual('npx');
       const args = cmdStruct.args;
-      expect(args).toEqual(['appmap-agent-js', 'init', projectDir]);
+      expect(args).toEqual(['@appland/appmap-agent-js', 'init', projectDir]);
       const fakeConfig = `
     {
        "configuration": {
@@ -770,7 +770,7 @@ packages:
     const validateAgent = (cmdStruct: CommandStruct) => {
       expect(cmdStruct.program).toEqual('npx');
       const args = cmdStruct.args;
-      expect(args).toEqual(['appmap-agent-js', 'status', projectDir]);
+      expect(args).toEqual(['@appland/appmap-agent-js', 'status', projectDir]);
       const ret = { stdout: '[]', stderr: '' };
       return Promise.resolve(ret);
     };


### PR DESCRIPTION
Fixes https://github.com/getappmap/appmap-js/issues/784

```
https://registry.npmjs.org/appmap-agent-js               doesn't exist.
https://registry.npmjs.org/@appland/appmap-agent-js              exists.
```

Before
```
$ npx appmap-agent-js init ~/src/sample_app_6th_ed/
npm ERR! code E404
npm ERR! 404 Not Found - GET https://registry.npmjs.org/appmap-agent-js - Not found
npm ERR! 404 
npm ERR! 404  'appmap-agent-js@latest' is not in this registry.
npm ERR! 404 
npm ERR! 404 Note that you can also install from a
npm ERR! 404 tarball, folder, http url, or git url.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/test/.npm/_logs/2022-10-14T14_56_38_907Z-debug-0.log
```
After
```
$ npx @appland/appmap-agent-js init ~/src/sample_app_6th_ed/
Need to install the following packages:
  @appland/appmap-agent-js@11.5.3
Ok to proceed? (y)
```

It's probably also the root cause of https://github.com/getappmap/appmap-js/issues/770. The text error from the `status` command probably doesn't get parsed as JSON.