### PR TITLE
fix: Don't crash in the installation if there were no validation errors.

### DIFF
--- a/packages/cli/src/cmds/agentInstaller/agentProcedure.ts
+++ b/packages/cli/src/cmds/agentInstaller/agentProcedure.ts
@@ -80,7 +80,8 @@ export default abstract class AgentProcedure {
     const validationResult = JSON.parse(stdout);
 
     const errors = Array.isArray(validationResult) ? validationResult : validationResult.errors;
-    if (errors.length > 0) {
+    // if there were no errors then there's no "errors" key
+    if (errors && errors.length > 0) {
       throw new ValidationError(
         errors
           .map((e) => {

--- a/packages/cli/tests/unit/agentInstall/TestAgentProcedure.ts
+++ b/packages/cli/tests/unit/agentInstall/TestAgentProcedure.ts
@@ -1,0 +1,42 @@
+import AgentInstaller from '../../../src/cmds/agentInstaller/agentInstaller';
+import AgentProcedure from '../../../src/cmds/agentInstaller/agentProcedure';
+import commandStruct from '../../../src/cmds/agentInstaller/commandStruct';
+
+export class TestAgentProcedure extends AgentProcedure {
+  constructor() {
+    const installer = new TestAgentInstaller();
+    super(installer, '/test/agent/procedure/path');
+  }
+}
+
+class TestAgentInstaller extends AgentInstaller {
+  constructor() {
+    super('test agent', '/test/agent/installer/path');
+  }
+
+  public buildFile = 'test build file';
+  public documentation = 'test documentation';
+
+  async validateAgentCommand(): Promise<commandStruct | undefined> {
+    return new commandStruct('test validate agent command', [], '/test/validate/agent/command');
+  }
+
+  installAgent(): Promise<void> {
+    throw new Error('Method not implemented.');
+  }
+  checkConfigCommand(): Promise<commandStruct | undefined> {
+    throw new Error('Method not implemented.');
+  }
+  initCommand(): Promise<commandStruct> {
+    throw new Error('Method not implemented.');
+  }
+  verifyCommand(): Promise<commandStruct | undefined> {
+    throw new Error('Method not implemented.');
+  }
+  environment(): Promise<Record<string, string>> {
+    throw new Error('Method not implemented.');
+  }
+  available(): Promise<boolean> {
+    throw new Error('Method not implemented.');
+  }
+}

--- a/packages/cli/tests/unit/agentInstall/agentProcedure.spec.ts
+++ b/packages/cli/tests/unit/agentInstall/agentProcedure.spec.ts
@@ -1,0 +1,21 @@
+import AgentProcedure from '../../../src/cmds/agentInstaller/agentProcedure';
+import { TestAgentProcedure } from './TestAgentProcedure';
+
+jest.mock('../../../src/cmds/userInteraction');
+
+describe(AgentProcedure, () => {
+  describe('validateProject', () => {
+    it('works correctly even if there are no errors', () => {
+      const procedure = new TestAgentProcedure();
+      jest.spyOn(procedure, 'validateAgent').mockResolvedValue({ stderr: '', stdout: `{
+        "filename": "appmap.yml",
+        "configuration": {
+          "contents": "name: js-project\\npackages: []\\n"
+        }
+      }`});
+      expect(() => procedure.validateProject(false)).not.toThrowError();
+    });
+  });
+
+  beforeEach(jest.restoreAllMocks);
+});


### PR DESCRIPTION
Fixes https://github.com/getappmap/appmap-js/issues/770

It's not easy to write a testcase for this.

```
$ mkdir js-project
$ cd js-project
$ yarn init
   (enter enter enter...)
$ yarn
$ npx @appland/appmap install
Installing AppMap agent for ....
? AppMap is about to be installed. Confirm the details below.
  !!! Telemetry disabled !!!: true
  Project type: yarn
  Project directory: /home/test/tmp/js-project
  Git remote: [git remote failed, fatal: not a git repository (or any of the parent directories): .git]

  Is this correct? Yes
? An appmap.yml configuration file already exists. How should the conflict be resolved? Use existing
✔ Installing the AppMap agent...
⠋ Validating the AppMap agent...
  Validating the AppMap agent...
✔ Validating the AppMap agent...

   ╭─────────────────────────────────────────────────────────────────────╮
   │                                                                     │
   │            Success! The AppMap agent has been installed.            │
   │                                                                     │
   │                      NEXT STEP: Record AppMaps                      │
   │                                                                     │
   │   You can consult the AppMap documentation, or continue with the    │
   │     instructions provided in the AppMap code editor extension.      │
   │                                                                     │
   ╰─────────────────────────────────────────────────────────────────────╯

```