### PR TITLE
fix: Fix unresolved type in Rule.Options

### DIFF
--- a/packages/scanner/src/types.d.ts
+++ b/packages/scanner/src/types.d.ts
@@ -148,7 +148,7 @@ interface Rule {
   impactDomain?: ImpactDomain;
   references?: Record<string, URL>;
   // User-defined options for the rule.
-  Options?: Class;
+  Options?: any; // FIXME
   // Function to instantiate the rule logic from configured options.
   build: (options: this['Options']) => RuleLogic;
 }


### PR DESCRIPTION
Set to `any` which is suboptimal but at least doesn't cause dependents to break. It would be good to enable proper type checking for the options.