### PR TITLE
feat: Don't crash if validateProject fails to JSON.parse(stdout)

### DIFF
--- a/packages/cli/src/cmds/agentInstaller/agentProcedure.ts
+++ b/packages/cli/src/cmds/agentInstaller/agentProcedure.ts
@@ -77,22 +77,28 @@ export default abstract class AgentProcedure {
 
     let { stdout } = await this.validateAgent(validateCmd);
 
-    const validationResult = JSON.parse(stdout);
+    try {
+      const validationResult = JSON.parse(stdout);
 
-    const errors = Array.isArray(validationResult) ? validationResult : validationResult.errors;
-    // if there were no errors then there's no "errors" key
-    if (errors && errors.length > 0) {
-      throw new ValidationError(
-        errors
-          .map((e) => {
-            let msg = e.message;
-            if (e.detailed_message) {
-              msg += `, ${e.detailed_message}`;
-            }
-            return msg;
-          })
-          .join('\n')
-      );
+      const errors = Array.isArray(validationResult) ? validationResult : validationResult.errors;
+      // if there were no errors then there's no "errors" key
+      if (errors && errors.length > 0) {
+        throw new ValidationError(
+          errors
+            .map((e) => {
+              let msg = e.message;
+              if (e.detailed_message) {
+                msg += `, ${e.detailed_message}`;
+              }
+              return msg;
+            })
+            .join('\n')
+        );
+      }
+    } catch (e) {
+      UI.error('Output from validateAgent was: ' + stdout);
+      UI.error('Failed to validate the installation.');
+      throw e;
     }
 
     const schema = JSON.parse(stdout)['schema'];

--- a/packages/cli/tests/unit/agentInstall/installCommand.spec.ts
+++ b/packages/cli/tests/unit/agentInstall/installCommand.spec.ts
@@ -1056,6 +1056,51 @@ packages:
     });
   });
 
+  describe('when appmap-agent-validate returns an invalid schema', () => {
+    it('does not crash when the config syntax is invalid', async () => {
+      // all this is mostly the same as beforeEach of 'returns a schema'
+      const installer = new BundleInstaller('.');
+
+      sinon.stub(ProjectConfiguration, 'getProjects').resolves([
+        {
+          path: projectDir,
+          name: 'test',
+          availableInstallers: [installer],
+          selectedInstaller: installer,
+        },
+      ]);
+
+      sinon.stub(installer, 'environment').resolves({});
+
+      sinon.stub(inquirer, 'prompt').resolves({
+        installerName: 'ruby',
+        confirm: true,
+        overwriteAppMapYml: 'Use existing',
+      });
+
+      sinon.stub(BundleInstaller.prototype, 'checkCurrentConfig').resolves();
+      sinon.stub(BundleInstaller.prototype, 'installAgent').resolves();
+
+      sinon.stub(AgentInstallerProcedure.prototype, 'configExists').value(true);
+      sinon.stub(AgentInstallerProcedure.prototype, 'loadConfig').returns({});
+
+      // NOTE: stdout produced invalid JSON
+      sinon
+        .stub(AgentInstallerProcedure.prototype, 'validateAgent')
+        .resolves({ stdout: '[ }', stderr: '' });
+
+      const uiError = sinon
+        .stub(UI, 'error')
+        .withArgs('Failed to validate the installation.')
+        .resolves();
+
+      const validateConfig = sinon.stub(validator, 'validateConfig').returns({ valid: true });
+
+      await invokeCommand(projectDir, () => {});
+      expect(uiError).toBeCalled();
+    });
+  });
+
   describe('Multi-project install flow', () => {
     let expectedStubs: SinonStub[];
 


### PR DESCRIPTION
If validateProject fails to JSON.parse(stdout), print out the stdout that failed to be parsed and display an error message.

Fixes https://github.com/getappmap/board/issues/193.

This is basically https://github.com/getappmap/appmap-js/pull/772 rebased to integrate the recent `error` [fix](https://github.com/getappmap/appmap-js/pull/787).