### PR TITLE
refactor: add org name in guess test commands

### DIFF
--- a/packages/cli/src/cmds/record/action/guessTestCommands.ts
+++ b/packages/cli/src/cmds/record/action/guessTestCommands.ts
@@ -34,14 +34,14 @@ const TestCommands: TestCommandGuess[] = [
   {
     paths: ['package.json', 'node_modules/mocha'],
     command: {
-      command: 'npx appmap-agent-js --recorder=mocha -- npx mocha',
+      command: 'npx @appland/appmap-agent-js --recorder=mocha -- npx mocha',
       env: {},
     },
   },
   {
     paths: ['package.json', 'node_modules'],
     command: {
-      command: 'npx appmap-agent-js --recorder=process -- npm run test',
+      command: 'npx @appland/appmap-agent-js --recorder=process -- npm run test',
       env: {},
     },
   },


### PR DESCRIPTION
Normally, the user should have installed the js agent at this point. But we still see failures about https://registry.npmjs.org/appmap-agent-js not existing in telemetry. I'm not sure what to think about this.