### PR TITLE
fix: Listing AppMap files will now ignore non-permissioned directories

### DIFF
--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -90,11 +90,20 @@ export async function processFiles(
  * Lists all appmap.json files in a directory, and passes them to a function.
  * With `await`, `listAppMapFiles` blocks until all the files have been processed.
  */
-export async function listAppMapFiles(directory: string, fn: (path: string) => (Promise<void> | void)) {
-  if (verbose()) {
+export async function listAppMapFiles(
+  directory: string,
+  fn: (path: string) => Promise<void> | void
+) {
+  const printDebug = verbose();
+  if (printDebug) {
     console.warn(`Scanning ${directory} for AppMaps`);
   }
-  await Promise.all((await promisify(glob)(`${directory}/**/*.appmap.json`)).map(fn));
+
+  const opts = {
+    strict: false,
+    silent: !printDebug,
+  };
+  await Promise.all((await promisify(glob)(`${directory}/**/*.appmap.json`, opts)).map(fn));
 }
 
 export function exists(path: PathLike): Promise<boolean> {


### PR DESCRIPTION
Glob would raise an error while searching for AppMap files if it encountered a directory it could not read due to permission errors. By specifying `strict: false`, the errors will be ignored and the search will continue on.

Resolves #803 