### PR TITLE
Modify the condition in which AppMaps are depicted as being successfully recorded

### DIFF
--- a/packages/components/src/pages/InstallGuide.vue
+++ b/packages/components/src/pages/InstallGuide.vue
@@ -100,9 +100,6 @@ export default {
   },
 
   computed: {
-    hasRecorded() {
-      return this.selectedProject && this.selectedProject.appMapsRecorded;
-    },
     hasFindings() {
       return this.selectedProject && this.selectedProject.analysisPerformed;
     },
@@ -117,6 +114,9 @@ export default {
     },
     numHttpRequests() {
       return this.selectedProject && this.selectedProject.numHttpRequests;
+    },
+    hasRecorded() {
+      return this.selectedProject && this.selectedProject.numAppMaps > 0;
     },
     path() {
       return this.selectedProject && this.selectedProject.path;


### PR DESCRIPTION
The `appMapsRecorded` flag indicates the user has, at any point, recorded AppMaps. This doesn't guarantee that there are any AppMaps currently available as the user could have since deleted them. By looking at the AppMap count, this indicator is more reflective of the actual current state.

![image](https://user-images.githubusercontent.com/8737782/198315784-4f4b56c0-ec21-446c-8725-e617cb06b1dc.png)
