### PR TITLE
feat: Support for displaying installation notes from language agents

### DIFF
--- a/packages/cli/src/cmds/agentInstaller/agentInstallerProcedure.ts
+++ b/packages/cli/src/cmds/agentInstaller/agentInstallerProcedure.ts
@@ -76,7 +76,7 @@ export default class AgentInstallerProcedure extends AgentProcedure {
         fs.writeFileSync(appMapYml, json.configuration.contents);
       }
 
-      await this.validateProject(useExistingAppMapYml);
+      const validationResult = await this.validateProject(useExistingAppMapYml);
 
       const successMessage = [
         chalk.green('Success! AppMap has finished installing.'),
@@ -86,6 +86,9 @@ export default class AgentInstallerProcedure extends AgentProcedure {
         'You can consult the AppMap documentation, or continue with the ',
         'instructions provided in the AppMap code editor extension.',
       ];
+
+      for (const note of validationResult?.notes || [])
+        successMessage.push('', `NOTE: ${note}`);
 
       UI.success(successMessage.join('\n'));
     } catch (e) {

--- a/packages/cli/src/cmds/agentInstaller/agentStatusProcedure.ts
+++ b/packages/cli/src/cmds/agentInstaller/agentStatusProcedure.ts
@@ -8,8 +8,13 @@ export default class AgentStatusProcedure extends AgentProcedure {
     console.log(`${env.join('\n')}\n`);
 
     await this.verifyProject();
-    await this.validateProject(true);
+    const validationResult = await this.validateProject(true);
 
-    UI.success('Success!');
+    const message = ['Success!'];
+
+    for (const note of validationResult?.notes || [])
+      message.push('', `NOTE: ${note}`);
+
+    UI.success(message.join('\n'));
   }
 }

--- a/packages/cli/src/service/config/validator.ts
+++ b/packages/cli/src/service/config/validator.ts
@@ -1,4 +1,4 @@
-import Ajv from 'ajv';
+import Ajv, { AnySchema } from 'ajv';
 import betterAjvErrors from '@sidvind/better-ajv-errors';
 
 type ValidationResult = {
@@ -15,7 +15,7 @@ export class ConfigValidationError extends Error {
   }
 }
 
-export function validateConfig(schema: object, config: object): ValidationResult {
+export function validateConfig(schema: AnySchema | AnySchema[], config: object): ValidationResult {
   const ajv = new Ajv();
   // If schema is an array, it's actually a collection of schemas, and the
   // 'config' schema will be found within it (i.e. will have '"$id"' set to

--- a/packages/cli/tests/unit/agentInstall/TestAgentProcedure.ts
+++ b/packages/cli/tests/unit/agentInstall/TestAgentProcedure.ts
@@ -9,7 +9,7 @@ export class TestAgentProcedure extends AgentProcedure {
   }
 }
 
-class TestAgentInstaller extends AgentInstaller {
+export class TestAgentInstaller extends AgentInstaller {
   constructor() {
     super('test agent', '/test/agent/installer/path');
   }
@@ -21,21 +21,24 @@ class TestAgentInstaller extends AgentInstaller {
     return new commandStruct('test validate agent command', [], '/test/validate/agent/command');
   }
 
-  installAgent(): Promise<void> {
-    throw new Error('Method not implemented.');
+  async installAgent(): Promise<void> { }
+
+  async checkConfigCommand(): Promise<commandStruct | undefined> {
+    return undefined;
   }
-  checkConfigCommand(): Promise<commandStruct | undefined> {
-    throw new Error('Method not implemented.');
+
+  async initCommand(): Promise<commandStruct> {
+    return new commandStruct('test init agent command', [], '/test/validate/init/command');
   }
-  initCommand(): Promise<commandStruct> {
-    throw new Error('Method not implemented.');
+
+  async verifyCommand(): Promise<commandStruct | undefined> {
+    return undefined;
   }
-  verifyCommand(): Promise<commandStruct | undefined> {
-    throw new Error('Method not implemented.');
+
+  async environment(): Promise<Record<string, string>> {
+    return { test: 'environment' };
   }
-  environment(): Promise<Record<string, string>> {
-    throw new Error('Method not implemented.');
-  }
+
   available(): Promise<boolean> {
     throw new Error('Method not implemented.');
   }

--- a/packages/cli/tests/unit/agentInstall/agentInstallerProcedure.spec.ts
+++ b/packages/cli/tests/unit/agentInstall/agentInstallerProcedure.spec.ts
@@ -1,0 +1,32 @@
+import AgentInstallerProcedure from '../../../src/cmds/agentInstaller/agentInstallerProcedure';
+import * as CommandRunner from '../../../src/cmds/agentInstaller/commandRunner';
+
+import fs from 'fs';
+import { TestAgentInstaller } from './TestAgentProcedure';
+import UI from '../../../src/cmds/userInteraction';
+
+jest.mock('../../../src/cmds/userInteraction');
+jest.mock('../../../src/cmds/agentInstaller/commandRunner');
+
+const { prompt, success } = jest.mocked(UI);
+const { run } = jest.mocked(CommandRunner);
+
+const procedure = new AgentInstallerProcedure(new TestAgentInstaller(), '/test/path');
+
+describe(AgentInstallerProcedure, () => {
+  it('prints any notes from the validator', async () => {
+    prompt.mockResolvedValue({ confirm: true });
+    jest.spyOn(procedure, 'validateProject').mockResolvedValue({ notes: ['Remember to foo the bar.'] });
+    run.mockResolvedValue({ stdout: '{"configuration": {"contents": ""}}', stderr: '' });
+    jest.spyOn(fs, 'writeFileSync').mockImplementation();
+
+    await procedure.run();
+
+    expect(success).toBeCalled();
+
+    const [message] = success.mock.calls[0];
+    expect(message).toContain('NOTE: Remember to foo the bar.');
+  });
+
+  beforeEach(jest.restoreAllMocks);
+});

--- a/packages/cli/tests/unit/agentInstall/agentStatusProcedure.spec.ts
+++ b/packages/cli/tests/unit/agentInstall/agentStatusProcedure.spec.ts
@@ -1,0 +1,24 @@
+import AgentStatusProcedure from '../../../src/cmds/agentInstaller/agentStatusProcedure';
+
+import UI from '../../../src/cmds/userInteraction';
+import { TestAgentInstaller } from './TestAgentProcedure';
+
+jest.mock('../../../src/cmds/userInteraction');
+const { success } = jest.mocked(UI);
+
+const procedure = new AgentStatusProcedure(new TestAgentInstaller(), '/test/project/path');
+
+describe(AgentStatusProcedure, () => {
+  it('prints any notes from the validator', async () => {
+    jest.spyOn(procedure, 'validateProject').mockResolvedValue({ notes: ['Remember to foo the bar.'] });
+
+    await procedure.run();
+
+    expect(success).toBeCalled();
+
+    const [message] = success.mock.calls[0];
+    expect(message).toContain('NOTE: Remember to foo the bar.');
+  });
+
+  beforeEach(jest.restoreAllMocks);
+});


### PR DESCRIPTION
This makes it possible for the language agents to communicate further information and steps for the user to take.
Example output (note `NOTE`):
```
packages/cli❯ yarn start install /home/user/projects/io-grab                                                                                   appmap-js/git/feat/allow-notes-from-agents 
Installing AppMap agent for io-grab...
? AppMap is about to be installed. Confirm the details below.
  !!! Telemetry disabled !!!: true
  Project type: Bundler
  Project directory: /home/user/projects/io-grab
  Git remote: origin    git@github.com:dividedmind/io-grab.git (fetch)
  Ruby version: 3.0.2p107
  Gem home: /home/user/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0

  Is this correct? Yes
? An appmap.yml configuration file already exists. How should the conflict be resolved? Use existing
✔ Installing AppMap...
✔ Validating the AppMap agent...
✔ Checking the syntax of AppMap agent configuration...

   ╭───────────────────────────────────────────────────────────────────────────────────────╮
   │                                                                                       │
   │                       Success! AppMap has finished installing.                        │
   │                                                                                       │
   │                               NEXT STEP: Record AppMaps                               │
   │                                                                                       │
   │            You can consult the AppMap documentation, or continue with the             │
   │              instructions provided in the AppMap code editor extension.               │
   │                                                                                       │
   │          NOTE: This is not a rails project. AppMap won't load automatically.          │
   │      Please ensure you load it with "require 'appmap'" in your test environment.      │
   │   Consult https://appmap.io/docs/reference/appmap-ruby#tests-recording for details.   │
   │                                                                                       │
   │                                                                                       │
   ╰───────────────────────────────────────────────────────────────────────────────────────╯

packages/cli❯ yarn start status /home/user/projects/io-grab                                                                                    appmap-js/git/feat/allow-notes-from-agents 

Agent environment:
  !!! Telemetry disabled !!!: true
  Project type: Bundler
  Project directory: /home/user/projects/io-grab
  Git remote: origin	git@github.com:dividedmind/io-grab.git (fetch)
  Ruby version: 3.0.2p107
  Gem home: /home/user/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0

✔ Validating the AppMap agent...
✔ Checking the syntax of AppMap agent configuration...

   ╭───────────────────────────────────────────────────────────────────────────────────────╮
   │                                                                                       │
   │                                       Success!                                        │
   │                                                                                       │
   │          NOTE: This is not a rails project. AppMap won't load automatically.          │
   │      Please ensure you load it with "require 'appmap'" in your test environment.      │
   │   Consult https://appmap.io/docs/reference/appmap-ruby#tests-recording for details.   │
   │                                                                                       │
   │                                                                                       │
   ╰───────────────────────────────────────────────────────────────────────────────────────╯
```