### PR TITLE
Allow and show warnings from agents

### DIFF
--- a/packages/cli/doc/appmap-agent-validate.md
+++ b/packages/cli/doc/appmap-agent-validate.md
@@ -1,0 +1,47 @@
+# appmap-agent-validate protocol
+
+Validates the project configuration.
+
+Output:
+
+    {
+      "errors": [
+        {
+          "level":  "warning" | "error",
+          "setting": "configuration", (logical setting name, if known)
+          "filename": <path to file>, (if known)
+          "message": <error message>,
+          "detailed_message": <error message details, if known>,
+          "help_urls": [ <url to FAQ, troubleshooting, etc, if known> ]
+        },
+        ...
+      ],
+      "schema": {
+        ... JSON schema ... 
+      }
+    }
+
+The "schema" attribute contains the JSON schema for the agent configuration (usually found in a project's appmap.yml). For example, appmap-ruby's schema is here: https://github.com/applandinc/appmap-ruby/blob/master/config-schema.yml.
+
+Example
+
+    {
+      "errors": [
+        {
+          "level": "warning",
+          "filename": "Gemfile",
+          "message": "appmap gem should precede other gems in the Gemfile",
+          "help_urls": [ "https://appland.com/docs/faq/ruby#some-header" ]
+        },
+        {
+          "level": "error",
+          "setting": "configuration",
+          "filename": "appmap.yml",
+          "message": "AppMap configuration is not valid YAML",
+          "detailed_message": "Parse error at line 5: <whatever>"
+        }
+      ],
+      "schema": {
+        ... JSON schema ...
+      }
+    }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -57,6 +57,7 @@
     "ts-node": "^10.2.1",
     "ts-sinon": "^2.0.2",
     "tsc": "^2.0.3",
+    "type-fest": "^3.1.0",
     "typescript": "^4.3.5",
     "webpack": "5",
     "webpack-cli": "^4.8.0"

--- a/packages/cli/src/cmds/agentInstaller/ValidationResult.ts
+++ b/packages/cli/src/cmds/agentInstaller/ValidationResult.ts
@@ -1,0 +1,31 @@
+import { AnySchema } from 'ajv';
+import { PartialDeep } from 'type-fest';
+import { ValidationError } from '../errors';
+
+type ValidationErrorDescription = {
+  level: 'warning' | 'error';
+  message: string;
+  setting?: string;
+  filename?: string;
+  detailed_message?: string;
+  help_urls?: string[];
+};
+
+export type ValidationResult = {
+  errors?: ValidationErrorDescription[];
+  schema?: AnySchema | AnySchema[];
+};
+
+function normalizeErrorDescription(raw: Partial<ValidationErrorDescription>): ValidationErrorDescription {
+  return { level: raw.level || 'error', message: raw.message || '', ...raw }
+}
+
+export function parseValidationResult(json: string): ValidationResult {
+  try {
+    const raw: PartialDeep<ValidationResult> | Partial<ValidationErrorDescription>[] = JSON.parse(json);
+    if (Array.isArray(raw)) return { errors: raw.map(normalizeErrorDescription) };
+    return { ...raw, errors: raw.errors?.map(normalizeErrorDescription) };
+  } catch (e) {
+    throw new ValidationError(`Unable to parse validation output.\n${e}\nOutput:\n${json}`);
+  }
+}

--- a/packages/cli/src/cmds/agentInstaller/ValidationResult.ts
+++ b/packages/cli/src/cmds/agentInstaller/ValidationResult.ts
@@ -29,3 +29,13 @@ export function parseValidationResult(json: string): ValidationResult {
     throw new ValidationError(`Unable to parse validation output.\n${e}\nOutput:\n${json}`);
   }
 }
+
+export function formatValidationError(e: ValidationErrorDescription): string {
+  const m = [e.level.charAt(0).toUpperCase(), e.level.slice(1), ': ', e.message];
+  if (e.filename) m.push(' in ', e.filename);
+  if (e.setting) m.push(' at ', e.setting);
+  if (e.detailed_message) m.push('\n', e.detailed_message);
+  if (e.help_urls) m.push('\n', 'See: ', e.help_urls.join('\n\t'));
+
+  return m.join('');
+}

--- a/packages/cli/src/cmds/agentInstaller/agentInstallerProcedure.ts
+++ b/packages/cli/src/cmds/agentInstaller/agentInstallerProcedure.ts
@@ -8,6 +8,7 @@ import UI from '../userInteraction';
 import AgentProcedure from './agentProcedure';
 import Telemetry from '../../telemetry';
 import CommandStruct from './commandStruct';
+import { formatValidationError } from './ValidationResult';
 
 export default class AgentInstallerProcedure extends AgentProcedure {
   async run(): Promise<void> {
@@ -76,7 +77,7 @@ export default class AgentInstallerProcedure extends AgentProcedure {
         fs.writeFileSync(appMapYml, json.configuration.contents);
       }
 
-      await this.validateProject(useExistingAppMapYml);
+      const result = await this.validateProject(useExistingAppMapYml);
 
       const successMessage = [
         chalk.green('Success! AppMap has finished installing.'),
@@ -88,6 +89,9 @@ export default class AgentInstallerProcedure extends AgentProcedure {
       ];
 
       UI.success(successMessage.join('\n'));
+
+      if (result?.errors) for (const warning of result.errors.filter((e) => e.level === 'warning'))
+        UI.warn(formatValidationError(warning));
     } catch (e) {
       const error = e as Error;
       console.log(error?.message);

--- a/packages/cli/src/cmds/agentInstaller/agentProcedure.ts
+++ b/packages/cli/src/cmds/agentInstaller/agentProcedure.ts
@@ -9,7 +9,7 @@ import { run, runSync } from './commandRunner';
 import { validateConfig } from '../../service/config/validator';
 import CommandStruct from './commandStruct';
 import Telemetry from '../../telemetry';
-import { parseValidationResult, ValidationResult } from './ValidationResult';
+import { formatValidationError, parseValidationResult, ValidationResult } from './ValidationResult';
 
 export default abstract class AgentProcedure {
   constructor(readonly installer: AgentInstaller, readonly path: string) {}
@@ -83,15 +83,7 @@ export default abstract class AgentProcedure {
     const errors = (validationResult.errors || []).filter((e) => e.level === 'error');
     if (errors.length > 0) {
       throw new ValidationError(
-        errors
-          .map((e) => {
-            let msg = e.message;
-            if (e.detailed_message) {
-              msg += `, ${e.detailed_message}`;
-            }
-            return msg;
-          })
-          .join('\n')
+        errors.map(formatValidationError).join('\n')
       );
     }
 

--- a/packages/cli/src/cmds/agentInstaller/agentProcedure.ts
+++ b/packages/cli/src/cmds/agentInstaller/agentProcedure.ts
@@ -9,6 +9,7 @@ import { run, runSync } from './commandRunner';
 import { validateConfig } from '../../service/config/validator';
 import CommandStruct from './commandStruct';
 import Telemetry from '../../telemetry';
+import { parseValidationResult, ValidationResult } from './ValidationResult';
 
 export default abstract class AgentProcedure {
   constructor(readonly installer: AgentInstaller, readonly path: string) {}
@@ -67,7 +68,7 @@ export default abstract class AgentProcedure {
     }
   }
 
-  async validateProject(checkSyntax: boolean) {
+  async validateProject(checkSyntax: boolean): Promise<ValidationResult | undefined> {
     const validateCmd = await this.installer.validateAgentCommand();
     if (!validateCmd) {
       return;
@@ -77,31 +78,24 @@ export default abstract class AgentProcedure {
 
     let { stdout } = await this.validateAgent(validateCmd);
 
-    try {
-      const validationResult = JSON.parse(stdout);
+    const validationResult = parseValidationResult(stdout);
 
-      const errors = Array.isArray(validationResult) ? validationResult : validationResult.errors;
-      // if there were no errors then there's no "errors" key
-      if (errors && errors.length > 0) {
-        throw new ValidationError(
-          errors
-            .map((e) => {
-              let msg = e.message;
-              if (e.detailed_message) {
-                msg += `, ${e.detailed_message}`;
-              }
-              return msg;
-            })
-            .join('\n')
-        );
-      }
-    } catch (e) {
-      UI.error('Output from validateAgent was: ' + stdout);
-      UI.error('Failed to validate the installation.');
-      throw e;
+    const errors = (validationResult.errors || []).filter((e) => e.level === 'error');
+    if (errors.length > 0) {
+      throw new ValidationError(
+        errors
+          .map((e) => {
+            let msg = e.message;
+            if (e.detailed_message) {
+              msg += `, ${e.detailed_message}`;
+            }
+            return msg;
+          })
+          .join('\n')
+      );
     }
 
-    const schema = JSON.parse(stdout)['schema'];
+    const { schema } = validationResult;
     // If appmap-agent-validate returned a schema, and we're using an
     // existing appmap.yml, verify that the config matches the schema.
     if (schema && checkSyntax) {
@@ -118,6 +112,8 @@ export default abstract class AgentProcedure {
         throw new ValidationError(`\n${this.configPath}:\n${lines.join('\n')}`);
       }
     }
+
+    return validationResult;
   }
 
   loadConfig(): Record<string, unknown> {

--- a/packages/cli/src/cmds/agentInstaller/agentStatusProcedure.ts
+++ b/packages/cli/src/cmds/agentInstaller/agentStatusProcedure.ts
@@ -1,5 +1,6 @@
 import UI from '../userInteraction';
 import AgentProcedure from './agentProcedure';
+import { formatValidationError } from './ValidationResult';
 
 export default class AgentStatusProcedure extends AgentProcedure {
   async run(): Promise<void> {
@@ -8,8 +9,11 @@ export default class AgentStatusProcedure extends AgentProcedure {
     console.log(`${env.join('\n')}\n`);
 
     await this.verifyProject();
-    await this.validateProject(true);
+    const result = await this.validateProject(true);
 
     UI.success('Success!');
+
+    if (result?.errors) for (const warning of result.errors.filter((e) => e.level === 'warning'))
+      UI.warn(formatValidationError(warning));
   }
 }

--- a/packages/cli/src/service/config/validator.ts
+++ b/packages/cli/src/service/config/validator.ts
@@ -1,4 +1,4 @@
-import Ajv from 'ajv';
+import Ajv, { AnySchema } from 'ajv';
 import betterAjvErrors from '@sidvind/better-ajv-errors';
 
 type ValidationResult = {
@@ -15,7 +15,7 @@ export class ConfigValidationError extends Error {
   }
 }
 
-export function validateConfig(schema: object, config: object): ValidationResult {
+export function validateConfig(schema: AnySchema | AnySchema[], config: object): ValidationResult {
   const ajv = new Ajv();
   // If schema is an array, it's actually a collection of schemas, and the
   // 'config' schema will be found within it (i.e. will have '"$id"' set to

--- a/packages/cli/tests/unit/agentInstall/TestAgentProcedure.ts
+++ b/packages/cli/tests/unit/agentInstall/TestAgentProcedure.ts
@@ -9,7 +9,7 @@ export class TestAgentProcedure extends AgentProcedure {
   }
 }
 
-class TestAgentInstaller extends AgentInstaller {
+export class TestAgentInstaller extends AgentInstaller {
   constructor() {
     super('test agent', '/test/agent/installer/path');
   }
@@ -21,21 +21,24 @@ class TestAgentInstaller extends AgentInstaller {
     return new commandStruct('test validate agent command', [], '/test/validate/agent/command');
   }
 
-  installAgent(): Promise<void> {
-    throw new Error('Method not implemented.');
+  async installAgent(): Promise<void> { }
+
+  async checkConfigCommand(): Promise<commandStruct | undefined> {
+    return undefined;
   }
-  checkConfigCommand(): Promise<commandStruct | undefined> {
-    throw new Error('Method not implemented.');
+
+  async initCommand(): Promise<commandStruct> {
+    return new commandStruct('test init agent command', [], '/test/validate/init/command');
   }
-  initCommand(): Promise<commandStruct> {
-    throw new Error('Method not implemented.');
+
+  async verifyCommand(): Promise<commandStruct | undefined> {
+    return undefined;
   }
-  verifyCommand(): Promise<commandStruct | undefined> {
-    throw new Error('Method not implemented.');
+
+  async environment(): Promise<Record<string, string>> {
+    return { test: 'environment' };
   }
-  environment(): Promise<Record<string, string>> {
-    throw new Error('Method not implemented.');
-  }
+
   available(): Promise<boolean> {
     throw new Error('Method not implemented.');
   }

--- a/packages/cli/tests/unit/agentInstall/agentInstallerProcedure.spec.ts
+++ b/packages/cli/tests/unit/agentInstall/agentInstallerProcedure.spec.ts
@@ -1,0 +1,36 @@
+import AgentInstallerProcedure from '../../../src/cmds/agentInstaller/agentInstallerProcedure';
+import * as CommandRunner from '../../../src/cmds/agentInstaller/commandRunner';
+
+import fs from 'fs';
+import { TestAgentInstaller } from './TestAgentProcedure';
+import UI from '../../../src/cmds/userInteraction';
+
+jest.mock('../../../src/cmds/userInteraction');
+jest.mock('../../../src/cmds/agentInstaller/commandRunner');
+
+const { prompt, success, warn } = jest.mocked(UI);
+const { run } = jest.mocked(CommandRunner);
+
+const procedure = new AgentInstallerProcedure(new TestAgentInstaller(), '/test/path');
+
+describe(AgentInstallerProcedure, () => {
+  it('prints any warnings from the validator', async () => {
+    prompt.mockResolvedValue({ confirm: true });
+    jest.spyOn(procedure, 'validateProject').mockResolvedValue(
+      { errors: [{ level: 'warning', message: 'Remember to foo the bar.', help_urls: ['test:///help/url'] }] }
+    );
+    run.mockResolvedValue({ stdout: '{"configuration": {"contents": ""}}', stderr: '' });
+    jest.spyOn(fs, 'writeFileSync').mockImplementation();
+
+    await procedure.run();
+
+    expect(success).toBeCalled();
+
+    expect(warn).toBeCalled();
+    const [message] = warn.mock.calls[0];
+    expect(message).toContain('Warning: Remember to foo the bar.');
+    expect(message).toContain('test:///help/url');
+  });
+
+  beforeEach(jest.restoreAllMocks);
+});

--- a/packages/cli/tests/unit/agentInstall/agentProcedure.spec.ts
+++ b/packages/cli/tests/unit/agentInstall/agentProcedure.spec.ts
@@ -26,6 +26,16 @@ describe(AgentProcedure, () => {
       }`});
       return expect(procedure.validateProject(false)).resolves.not.toThrow();
     });
+
+    it('fails if there are errors', () => {
+      jest.spyOn(procedure, 'validateAgent').mockResolvedValue({ stderr: '', stdout: `{
+        "errors": [{
+          "level": "error",
+          "message": "test error"
+        }]
+      }`});
+      return expect(procedure.validateProject(false)).rejects.toThrowError(/test error/);
+    });
   });
 
   beforeEach(jest.restoreAllMocks);

--- a/packages/cli/tests/unit/agentInstall/agentProcedure.spec.ts
+++ b/packages/cli/tests/unit/agentInstall/agentProcedure.spec.ts
@@ -3,17 +3,28 @@ import { TestAgentProcedure } from './TestAgentProcedure';
 
 jest.mock('../../../src/cmds/userInteraction');
 
+const procedure = new TestAgentProcedure();
+
 describe(AgentProcedure, () => {
   describe('validateProject', () => {
     it('works correctly even if there are no errors', () => {
-      const procedure = new TestAgentProcedure();
       jest.spyOn(procedure, 'validateAgent').mockResolvedValue({ stderr: '', stdout: `{
         "filename": "appmap.yml",
         "configuration": {
           "contents": "name: js-project\\npackages: []\\n"
         }
       }`});
-      expect(() => procedure.validateProject(false)).not.toThrowError();
+      return expect(procedure.validateProject(false)).resolves.not.toThrow();
+    });
+
+    it('does not fail if there are only warnings', () => {
+      jest.spyOn(procedure, 'validateAgent').mockResolvedValue({ stderr: '', stdout: `{
+        "errors": [{
+          "level": "warning",
+          "message": "test warning"
+        }]
+      }`});
+      return expect(procedure.validateProject(false)).resolves.not.toThrow();
     });
   });
 

--- a/packages/cli/tests/unit/agentInstall/agentStatusProcedure.spec.ts
+++ b/packages/cli/tests/unit/agentInstall/agentStatusProcedure.spec.ts
@@ -1,0 +1,28 @@
+import AgentStatusProcedure from '../../../src/cmds/agentInstaller/agentStatusProcedure';
+
+import UI from '../../../src/cmds/userInteraction';
+import { TestAgentInstaller } from './TestAgentProcedure';
+
+jest.mock('../../../src/cmds/userInteraction');
+const { success, warn } = jest.mocked(UI);
+
+const procedure = new AgentStatusProcedure(new TestAgentInstaller(), '/test/project/path');
+
+describe(AgentStatusProcedure, () => {
+  it('prints any warnings from the validator', async () => {
+    jest.spyOn(procedure, 'validateProject').mockResolvedValue(
+      { errors: [{ level: 'warning', message: 'Remember to foo the bar.', help_urls: ['test:///help/url'] }] }
+    );
+
+    await procedure.run();
+
+    expect(success).toBeCalled();
+
+    expect(warn).toBeCalled();
+    const [message] = warn.mock.calls[0];
+    expect(message).toContain('Warning: Remember to foo the bar.');
+    expect(message).toContain('test:///help/url');
+  });
+
+  beforeEach(jest.restoreAllMocks);
+});

--- a/packages/cli/tests/unit/agentInstall/installCommand.spec.ts
+++ b/packages/cli/tests/unit/agentInstall/installCommand.spec.ts
@@ -1089,15 +1089,11 @@ packages:
         .stub(AgentInstallerProcedure.prototype, 'validateAgent')
         .resolves({ stdout: '[ }', stderr: '' });
 
-      const uiError = sinon
-        .stub(UI, 'error')
-        .withArgs('Failed to validate the installation.')
-        .resolves();
-
       const validateConfig = sinon.stub(validator, 'validateConfig').returns({ valid: true });
 
-      await invokeCommand(projectDir, () => {});
-      expect(uiError).toBeCalled();
+      await invokeCommand(projectDir, (err) => {
+        expect(err?.message).toMatch('Error');
+      });
     });
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -145,6 +145,7 @@ __metadata:
     ts-node: ^10.2.1
     ts-sinon: ^2.0.2
     tsc: ^2.0.3
+    type-fest: ^3.1.0
     typescript: ^4.3.5
     w3c-xmlserializer: ^2.0.0
     webpack: 5
@@ -28542,6 +28543,13 @@ resolve@1.1.7:
   version: 1.4.0
   resolution: "type-fest@npm:1.4.0"
   checksum: b011c3388665b097ae6a109a437a04d6f61d81b7357f74cbcb02246f2f5bd72b888ae33631b99871388122ba0a87f4ff1c94078e7119ff22c70e52c0ff828201
+  languageName: node
+  linkType: hard
+
+"type-fest@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "type-fest@npm:3.1.0"
+  checksum: 22a0402afafab05edb7b45456d6ebfdcfc616f84a98266857e89bd656a14b5007e86d1a50b12746624b6aafb17dad3f437065df8adfa1b04bb970894db1fe940
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Our appmap-agent-validate protocol supports the notion of warnings, ie. messages from the validator that aren't fatal. 
These changes add support for this:
- don't fail the validation if validator only returns warnings,
- print any warnings when the relevant commands (ie. *install* and *status*) are executed.

This is needed for a proper fix for https://github.com/getappmap/appmap-ruby/issues/292

(Also, add the documentation for the protocol to the repository for easy reference (it used to be in an internal google doc).)