### PR TITLE
fix: prompt user for name to open a ticket

### DIFF
--- a/packages/cli/src/lib/ticket/openTicket.ts
+++ b/packages/cli/src/lib/ticket/openTicket.ts
@@ -53,17 +53,23 @@ If you change your mind, you can always reach us by email: support@appmap.io
     }
   }
 
-  const { email } = await UI.prompt([
+  UI.progress(`The AppMap team will respond to you by email. Please provide your name and email address to open the support request:
+`);
+  const { name, email } = await UI.prompt([
+    {
+      name: 'name',
+      message: `Your name`,
+      validate: (v) => v.trim().length > 0 || 'Please enter your name',
+    },
     {
       name: 'email',
-      message: `The AppMap team will respond to you by email. 
-Please provide your email address to open the support request:`,
+      message: `Your email address`,
       validate: (v) => v.trim().length > 0 || 'Please enter your email address',
     },
   ]);
 
   try {
-    const id = await createZendeskRequest(errors, email);
+    const id = await createZendeskRequest(errors, name, email);
     Telemetry.sendEvent({
       name: 'open-ticket:success',
     });

--- a/packages/cli/src/lib/ticket/zendesk.ts
+++ b/packages/cli/src/lib/ticket/zendesk.ts
@@ -31,7 +31,8 @@ const debugAdapter = async (config: AxiosRequestConfig): Promise<any> => {
 
 export default async function createRequest(
   errors: string | string[],
-  email: any
+  name: string,
+  email: string
 ): Promise<number> {
   errors = !Array.isArray(errors) ? [errors] : errors;
   const body = JSON.stringify({
@@ -42,6 +43,7 @@ ${errors.map((e) => `===\n${stripAnsi(e)}\n===`).join('\n')}`,
       },
       subject: `CLI command failure`,
       requester: {
+        name,
         email,
       },
     },

--- a/packages/cli/tests/unit/lib/openTicket.spec.ts
+++ b/packages/cli/tests/unit/lib/openTicket.spec.ts
@@ -58,7 +58,7 @@ describe('openTicket', () => {
       await openTicket('error');
       expect(prompt).toBeCalledTwice();
       expect(getNthCallArgs(prompt, 0)).toMatchObject({ name: 'openTicket' });
-      expect(getNthCallArgs(prompt, 1)).toMatchObject([{ name: 'email' }]);
+      expect(getNthCallArgs(prompt, 1)).toMatchObject([{ name: 'name' }, { name: 'email' }]);
     });
 
     it("doesn't prompt when the user declines", async () => {


### PR DESCRIPTION
Zendesk requires the user's name when opening a ticket request. These changes prompt them for it before prompting for their email address.

Old prompt:
```
? Would you like to open a support request? Yes
? The AppMap team will respond to you by email.
Please provide your email address to open the support request: ajp@example.com
```

New prompt:
```
? Would you like to open a support request? Yes
The AppMap team will respond to you by email. Please provide your name and email address to open the support request:

? Your name ajp
? Your email address ajp@example.com
```

Fixes getappmap/board#207.