### PR TITLE
feat: When recording tests, don't crash if directory path is invalid.

### DIFF
--- a/packages/cli/src/cmds/record/record.ts
+++ b/packages/cli/src/cmds/record/record.ts
@@ -15,6 +15,7 @@ import openTicket from '../../lib/ticket/openTicket';
 import UI from '../userInteraction';
 import { RemoteRecordingError } from './makeRequest';
 import chalk from 'chalk';
+import { existsSync as fsExistsSync, constants as fsConstants, statSync as fsStatSync } from 'fs';
 
 export default {
   command: 'record [mode]',
@@ -48,6 +49,18 @@ export default {
       const { directory, appmapConfig } = argv;
       if (directory) {
         if (verbose()) console.log(`Using working directory ${directory}`);
+
+        if (fsExistsSync(directory)) {
+          // statSync follows symlinks
+          if (!fsStatSync(directory).isDirectory()) {
+            UI.error(`${directory} is not a directory.`);
+            return null;
+          }
+        } else {
+          UI.error(`Directory ${directory} does not exist.`);
+          return null;
+        }
+
         chdir(directory);
       }
 

--- a/packages/cli/tests/unit/record/record.test.spec.ts
+++ b/packages/cli/tests/unit/record/record.test.spec.ts
@@ -83,8 +83,6 @@ describe('record test', () => {
     it('shows error if directory parameter is file instead of directory', async () => {
       const dirPrefix = tmpdir();
       const directoryParam = `${dirPrefix}/file_not_dir`;
-      // ensuring the file doesn't exist breaks after trying it a few times
-      // await unlink(directoryParam, (err) => {});
       closeSync(openSync(directoryParam, 'w'));
       expect(existsSync(directoryParam)).toEqual(true);
 

--- a/packages/cli/tests/unit/record/record.test.spec.ts
+++ b/packages/cli/tests/unit/record/record.test.spec.ts
@@ -80,7 +80,7 @@ describe('record test', () => {
   });
 
   describe('record test with invalid directory parameter', () => {
-    it('shows error if directory parameter is file instead of directory', async () => {
+    it('stops if directory parameter is file instead of directory', async () => {
       const dirPrefix = tmpdir();
       const directoryParam = `${dirPrefix}/file_not_dir`;
       closeSync(openSync(directoryParam, 'w'));
@@ -99,7 +99,7 @@ describe('record test', () => {
       await unlink(directoryParam, (err) => {});
     });
 
-    it('shows error if directory parameter is invalid symlink', async () => {
+    it('stops if directory parameter is invalid symlink', async () => {
       const dirPrefix = tmpdir();
       const symlinkDst = `${dirPrefix}/symlink_dst`;
       const symlinkSrc = `${dirPrefix}/symlink_src`;


### PR DESCRIPTION
If the directory path supplied as input doesn't exist or isn't a directory, let the user know.

Fixes https://github.com/getappmap/board/issues/202

![record_test_file_does_not_exist](https://user-images.githubusercontent.com/111290954/199304887-eda02023-1af3-4da2-8de4-93f6a9f6b69d.png)
