### PR TITLE
fix: Don't run test commands that contain only whitespace

### DIFF
--- a/packages/cli/src/cmds/record/prompt/obtainTestCommands.ts
+++ b/packages/cli/src/cmds/record/prompt/obtainTestCommands.ts
@@ -49,6 +49,8 @@ export default async function obtainTestCommands({ configuration }: RecordContex
           message: 'Test command (without env vars):',
         })
       )['testCommand'];
+      if (testCommand)
+        testCommand = testCommand.trim();
     } while (!testCommand);
 
     const { envVars } = await UI.prompt({

--- a/packages/cli/tests/unit/record/prompt/obtainTestCommands.spec.ts
+++ b/packages/cli/tests/unit/record/prompt/obtainTestCommands.spec.ts
@@ -67,7 +67,7 @@ describe('record.prompt.obtainTestCommands', () => {
       const stubPrompt = sinon.stub(UI, 'prompt');
 
       stubPrompt.onFirstCall().resolves({ testCommand: null });
-      stubPrompt.onSecondCall().resolves({ testCommand: '' });
+      stubPrompt.onSecondCall().resolves({ testCommand: ' ' });
       stubPrompt.onThirdCall().resolves({ testCommand: testCommand.command });
       stubPrompt.onCall(3).resolves({ envVars: '' });
 


### PR DESCRIPTION
Fixes https://github.com/getappmap/appmap-js/issues/802