### PR TITLE
feat: Encourage users to commit their AppMap config.

### DIFF
--- a/packages/cli/src/cmds/agentInstaller/agentInstallerProcedure.ts
+++ b/packages/cli/src/cmds/agentInstaller/agentInstallerProcedure.ts
@@ -9,6 +9,7 @@ import AgentProcedure from './agentProcedure';
 import Telemetry from '../../telemetry';
 import CommandStruct from './commandStruct';
 import { formatValidationError } from './ValidationResult';
+import { GitStatus } from './types/state';
 
 export default class AgentInstallerProcedure extends AgentProcedure {
   async run(): Promise<void> {
@@ -62,7 +63,11 @@ export default class AgentInstallerProcedure extends AgentProcedure {
     UI.status = 'Installing AppMap...';
 
     try {
-      const filesBefore = await this.filesLocallyModified();
+      const filesBeforeGitStatus: GitStatus[] = await this.gitStatus();
+      const filesBefore: string[] = [];
+      for (const file of filesBeforeGitStatus) {
+        filesBefore.push(file.file);
+      }
       await this.installer.checkCurrentConfig();
       await this.installer.installAgent();
 

--- a/packages/cli/src/cmds/agentInstaller/agentInstallerProcedure.ts
+++ b/packages/cli/src/cmds/agentInstaller/agentInstallerProcedure.ts
@@ -62,6 +62,7 @@ export default class AgentInstallerProcedure extends AgentProcedure {
     UI.status = 'Installing AppMap...';
 
     try {
+      const filesBefore = await this.filesLocallyModified();
       await this.installer.checkCurrentConfig();
       await this.installer.installAgent();
 
@@ -79,6 +80,8 @@ export default class AgentInstallerProcedure extends AgentProcedure {
 
       const result = await this.validateProject(useExistingAppMapYml);
 
+      await this.commitConfiguration(filesBefore);
+
       const successMessage = [
         chalk.green('Success! AppMap has finished installing.'),
         '',
@@ -90,8 +93,9 @@ export default class AgentInstallerProcedure extends AgentProcedure {
 
       UI.success(successMessage.join('\n'));
 
-      if (result?.errors) for (const warning of result.errors.filter((e) => e.level === 'warning'))
-        UI.warn(formatValidationError(warning));
+      if (result?.errors)
+        for (const warning of result.errors.filter((e) => e.level === 'warning'))
+          UI.warn(formatValidationError(warning));
     } catch (e) {
       const error = e as Error;
       console.log(error?.message);

--- a/packages/cli/src/cmds/agentInstaller/agentProcedure.ts
+++ b/packages/cli/src/cmds/agentInstaller/agentProcedure.ts
@@ -10,6 +10,7 @@ import { validateConfig } from '../../service/config/validator';
 import CommandStruct from './commandStruct';
 import Telemetry from '../../telemetry';
 import { formatValidationError, parseValidationResult, ValidationResult } from './ValidationResult';
+import { GitStatus } from './types/state';
 
 export default abstract class AgentProcedure {
   constructor(readonly installer: AgentInstaller, readonly path: string) {}
@@ -82,9 +83,7 @@ export default abstract class AgentProcedure {
 
     const errors = (validationResult.errors || []).filter((e) => e.level === 'error');
     if (errors.length > 0) {
-      throw new ValidationError(
-        errors.map(formatValidationError).join('\n')
-      );
+      throw new ValidationError(errors.map(formatValidationError).join('\n'));
     }
 
     const { schema } = validationResult;
@@ -106,6 +105,146 @@ export default abstract class AgentProcedure {
     }
 
     return validationResult;
+  }
+
+  async filesLocallyModified(): Promise<string[]> {
+    let files: GitStatus[] = await this.gitStatus();
+    let filesModified: string[] = [];
+    files.filter((file) => {
+      if (file.status[0] !== '?') {
+        filesModified.push(file.file);
+      }
+    });
+    return filesModified;
+  }
+
+  async gitStatus(file?: string): Promise<GitStatus[]> {
+    let files: GitStatus[] = [];
+    let params: string[] = ['status', '-s'];
+    if (file !== undefined) {
+      params.push(file);
+    }
+    let stdout = '';
+    try {
+      stdout = runSync(new CommandStruct('git', params, this.installer.path));
+    } catch (e) {
+      const gitError = (e as Error).message.split('\n')[1];
+      const gitStatus = `[git status failed, ${gitError}]`;
+      // may want to print the error
+    }
+
+    if (stdout && stdout.length > 0) {
+      // git status output looks like this:
+      //  M Gemfile
+      //  M Gemfile.lock
+      // ?? appmap.yml
+      const lines = stdout.split('\n');
+      for (const line of lines) {
+        const gitStatus = line.substring(0, 2);
+        const file = line.substring(3);
+        files.push({
+          file: file,
+          status: gitStatus,
+        });
+      }
+    }
+
+    return files;
+  }
+
+  async gitCommit(files: string[], commitMessage: string): Promise<boolean> {
+    let params: string[] = ['commit', '-m', commitMessage];
+    for (const file of files) {
+      params.push(file);
+    }
+    try {
+      const stdout = runSync(new CommandStruct('git', params, this.installer.path));
+      return true;
+    } catch (e) {
+      const gitError = (e as Error).message.split('\n')[1];
+      const gitCommit = `[git commit failed, ${gitError}]`;
+      // may want to print the error
+    }
+
+    return false;
+  }
+
+  async commitConfiguration(filesBefore: string[]) {
+    Telemetry.sendEvent({
+      name: `install-agent:commit_config:commit_start`,
+      properties: {},
+    });
+
+    const filesAfter = await this.filesLocallyModified();
+    let filesDiff: string[] = filesAfter.filter((file) => !filesBefore.includes(file));
+    filesDiff.sort();
+    let filesDiffText = filesDiff.flat().join('__');
+    if (filesDiff.length == 0) {
+      Telemetry.sendEvent({
+        name: `install-agent:commit_config:should_not_commit`,
+        properties: {
+          filesDiffText,
+        },
+      });
+
+      return false;
+    }
+
+    Telemetry.sendEvent({
+      name: `install-agent:commit_config:should_commit`,
+      properties: {
+        filesDiffText,
+      },
+    });
+
+    let filesMessages: string[] = [];
+    for (const file of filesDiff) {
+      filesMessages.push(`  ${chalk.blue(file)}`);
+    }
+    const { commit } = await UI.prompt({
+      type: 'confirm',
+      name: 'commit',
+      message: [
+        `AppMap recommends you have the installer commit in Git for you the following`,
+        `  files, to not have to install AppMap again in this repository:`,
+        filesMessages,
+        '  ',
+        '  Commit?',
+      ]
+        .flat()
+        .join('\n'),
+    });
+
+    if (commit) {
+      Telemetry.sendEvent({
+        name: `install-agent:commit_config:commit_yes`,
+        properties: {
+          filesDiffText,
+        },
+      });
+
+      const commitSuccess = await this.gitCommit(filesDiff, 'feat: Install AppMap.');
+
+      Telemetry.sendEvent({
+        name: commitSuccess
+          ? `install-agent:commit_config:commit_success`
+          : `install-agent:commit_config:commit_failure`,
+        properties: {
+          filesDiffText,
+        },
+      });
+
+      return commitSuccess;
+    } else {
+      Telemetry.sendEvent({
+        name: `install-agent:commit_config:commit_no`,
+        properties: {
+          filesDiffText,
+        },
+      });
+    }
+
+    return false;
   }
 
   loadConfig(): Record<string, unknown> {

--- a/packages/cli/src/cmds/agentInstaller/types/state.ts
+++ b/packages/cli/src/cmds/agentInstaller/types/state.ts
@@ -1,0 +1,4 @@
+export type GitStatus = {
+  file: string;
+  status: string;
+};

--- a/packages/cli/tests/unit/agentInstall/agentInstallerProcedure.spec.ts
+++ b/packages/cli/tests/unit/agentInstall/agentInstallerProcedure.spec.ts
@@ -4,6 +4,8 @@ import * as CommandRunner from '../../../src/cmds/agentInstaller/commandRunner';
 import fs from 'fs';
 import { TestAgentInstaller } from './TestAgentProcedure';
 import UI from '../../../src/cmds/userInteraction';
+import sinon, { SinonStub } from 'sinon';
+import { withStubbedTelemetry } from '../../helper';
 
 jest.mock('../../../src/cmds/userInteraction');
 jest.mock('../../../src/cmds/agentInstaller/commandRunner');
@@ -14,6 +16,7 @@ const { run } = jest.mocked(CommandRunner);
 const procedure = new AgentInstallerProcedure(new TestAgentInstaller(), '/test/path');
 
 describe(AgentInstallerProcedure, () => {
+  withStubbedTelemetry(sinon);
   it('prints any warnings from the validator', async () => {
     prompt.mockResolvedValue({ confirm: true });
     jest.spyOn(procedure, 'validateProject').mockResolvedValue(

--- a/packages/cli/tests/unit/agentInstall/agentProcedure.spec.ts
+++ b/packages/cli/tests/unit/agentInstall/agentProcedure.spec.ts
@@ -95,7 +95,10 @@ describe(AgentProcedure, () => {
         const filesBefore = [];
         jest.spyOn(procedure, 'gitStatus').mockResolvedValue(filesAfter);
         prompt.mockResolvedValue({ commit: true });
-        jest.spyOn(procedure, 'gitCommit').mockResolvedValue(true);
+        jest.spyOn(procedure, 'gitCommit').mockResolvedValue({
+          success: true,
+          errorMessage: '',
+        });
         return expect(procedure.commitConfiguration(filesBefore)).resolves.toBe(true);
       });
     });

--- a/packages/cli/tests/unit/agentInstall/agentProcedure.spec.ts
+++ b/packages/cli/tests/unit/agentInstall/agentProcedure.spec.ts
@@ -1,6 +1,8 @@
 import AgentProcedure from '../../../src/cmds/agentInstaller/agentProcedure';
 import { TestAgentProcedure } from './TestAgentProcedure';
 import UI from '../../../src/cmds/userInteraction';
+import sinon, { SinonStub } from 'sinon';
+import { withStubbedTelemetry } from '../../helper';
 
 jest.mock('../../../src/cmds/userInteraction');
 
@@ -9,6 +11,7 @@ const procedure = new TestAgentProcedure();
 const { prompt } = jest.mocked(UI);
 
 describe(AgentProcedure, () => {
+  withStubbedTelemetry(sinon);
   describe('validateProject', () => {
     it('works correctly even if there are no errors', () => {
       jest.spyOn(procedure, 'validateAgent').mockResolvedValue({
@@ -54,6 +57,7 @@ describe(AgentProcedure, () => {
 });
 
 describe(AgentProcedure, () => {
+  withStubbedTelemetry(sinon);
   describe('commitConfiguration', () => {
     const filesAfter = ['Gemfile', 'Gemfile.lock', 'appmap.yml'];
 

--- a/packages/cli/tests/unit/agentInstall/agentProcedure.spec.ts
+++ b/packages/cli/tests/unit/agentInstall/agentProcedure.spec.ts
@@ -59,19 +59,32 @@ describe(AgentProcedure, () => {
 describe(AgentProcedure, () => {
   withStubbedTelemetry(sinon);
   describe('commitConfiguration', () => {
-    const filesAfter = ['Gemfile', 'Gemfile.lock', 'appmap.yml'];
+    const filesAfter = [
+      {
+        file: 'Gemfile',
+        status: ' M',
+      },
+      {
+        file: 'Gemfile.lock',
+        status: ' M',
+      },
+      {
+        file: 'appmap.yml',
+        status: '??',
+      },
+    ];
 
     describe('does not commit', () => {
       it('there is no diff', () => {
         const filesBefore = [];
         const filesAfter = [];
-        jest.spyOn(procedure, 'filesLocallyModified').mockResolvedValue(filesAfter);
+        jest.spyOn(procedure, 'gitStatus').mockResolvedValue(filesAfter);
         return expect(procedure.commitConfiguration(filesBefore)).resolves.toBe(false);
       });
 
       it('there is a diff and user selected to not commit', () => {
         const filesBefore = [];
-        jest.spyOn(procedure, 'filesLocallyModified').mockResolvedValue(filesAfter);
+        jest.spyOn(procedure, 'gitStatus').mockResolvedValue(filesAfter);
         prompt.mockResolvedValue({ commit: false });
         return expect(procedure.commitConfiguration(filesBefore)).resolves.toBe(false);
       });
@@ -80,7 +93,7 @@ describe(AgentProcedure, () => {
     describe('commits', () => {
       it('there is a diff and user selected to commit', () => {
         const filesBefore = [];
-        jest.spyOn(procedure, 'filesLocallyModified').mockResolvedValue(filesAfter);
+        jest.spyOn(procedure, 'gitStatus').mockResolvedValue(filesAfter);
         prompt.mockResolvedValue({ commit: true });
         jest.spyOn(procedure, 'gitCommit').mockResolvedValue(true);
         return expect(procedure.commitConfiguration(filesBefore)).resolves.toBe(true);

--- a/packages/cli/tests/unit/agentInstall/installCommand.spec.ts
+++ b/packages/cli/tests/unit/agentInstall/installCommand.spec.ts
@@ -1141,15 +1141,15 @@ packages:
 
       expectedStubs.forEach((stub) => expect(stub.called).toBe(true));
       const sendEventStub = Telemetry.sendEvent as sinon.SinonStub;
-      expect(sendEventStub).toBeCalledTimes(3);
+      expect(sendEventStub).toBeCalledTimes(7);
       expect(sendEventStub.getCall(0)).toBeCalledWithMatch({
         name: 'install-agent:start',
       });
-      expect(sendEventStub.getCall(1)).toBeCalledWithMatch({
+      expect(sendEventStub.getCall(3)).toBeCalledWithMatch({
         name: 'install-agent:success',
         properties: { installer: 'Maven' },
       });
-      expect(sendEventStub.getCall(2)).toBeCalledWithMatch({
+      expect(sendEventStub.getCall(6)).toBeCalledWithMatch({
         name: 'install-agent:success',
         properties: { installer: 'Gradle' },
       });


### PR DESCRIPTION
Add a prompt in the command-line installer that commits in Git any configuration files changed by appmap.

Addresses https://github.com/getappmap/board/issues/220

If the directory isn't a valid git repo, or if there's no valid `git` tool, the tool doesn't display this prompt.  There isn't any code that checks for the directory being valid or for git being present.  The calls to `git status -s` fail, the installer thinks nothing changed, and so it doesn't display the prompt.

Don't attempt to `git add appmap.yml` the first time the install runs.

Screenshots:

1) Installing in a directory that is a valid git repo

![commit_hasgit](https://user-images.githubusercontent.com/111290954/200913029-b15eb1fe-761a-4615-99ec-e45f24676f78.png)

2) Installing in a directory that isn't a valid git repo. (I manually `rm -rf .git` in this dir.)

![commit_doesnothavegit](https://user-images.githubusercontent.com/111290954/200858785-928eaab0-e87b-49b2-93af-0024d58c96fe.png)

3) Installing in a sub-directory.

![commit_subdirectory](https://user-images.githubusercontent.com/111290954/200942077-fed7111f-5aad-4954-89fb-cd4f033c9b96.png)

To test this:

```
git clone git@github.com:getappmap/appmap-js.git
cd appmap-js
git checkout sw/encourage_users_to_commit_their_appmap_config
yarn
yarn run build
cd packages/cli
npm start install -- -d ~/src/sample_app_6th_ed
```