### PR TITLE
Update the links shown when the AppMap has no data to display

### DIFF
--- a/packages/components/src/pages/VsCodeExtension.vue
+++ b/packages/components/src/pages/VsCodeExtension.vue
@@ -238,13 +238,11 @@
         </ul>
         <p class="no-data-notice__text">
           Check our
-          <a href="https://github.com/getappmap/appmap" target="_blank" rel="noopener noreferrer">
+          <a href="https://appmap.io/docs" target="_blank" rel="noopener noreferrer">
             documentation</a
           >,<br />
           or ask for help in
-          <a href="https://discord.com/invite/N9VUap6" target="_blank" rel="noopener noreferrer">
-            Discord</a
-          >.
+          <a href="https://appmap.io/slack" target="_blank" rel="noopener noreferrer"> Slack</a>.
         </p>
       </div>
       <DiagramGray class="empty-state-diagram" />


### PR DESCRIPTION
- Point the user towards the appmap.io documentation. 
- Update the Discord Link to point to Slack instead