### PR TITLE
fix: class can be at the the root of classmap

### DIFF
--- a/packages/validate/src/macro.yml
+++ b/packages/validate/src/macro.yml
@@ -27,7 +27,9 @@ properties:
   classMap:
     type: array
     items:
-      $ref: "#/definitions/package"
+      anyOf:
+        - $ref: "#/definitions/package"
+        - $ref: "#/definitions/class"
   events:
     type: array
     items:


### PR DESCRIPTION
When I read the [spec](https://github.com/getappmap/appmap#classmap), I don't see that `class` code objects are forbidden from being at the root of classmap. I updated the JSON schema to let them be there.