### PR TITLE
fix: OpenAPI accepts either relative or absolute `--appmap-dir` paths

### DIFF
--- a/packages/cli/tests/unit/openapi.spec.ts
+++ b/packages/cli/tests/unit/openapi.spec.ts
@@ -1,12 +1,15 @@
 import { verbose } from '../../src/utils';
 import { default as openapi } from '../../src/cmds/openapi';
 import assert from 'assert';
+import path from 'path';
 
 describe('OpenAPI', () => {
+  const fixtureDirectory = 'tests/unit/fixtures/malformedHTTPServerRequest';
+
   beforeAll(async () => verbose(process.env.DEBUG === 'true'));
 
   it('handles valid and malformed HTTP server requests', async () => {
-    const cmd = new openapi.OpenAPICommand('tests/unit/fixtures/malformedHTTPServerRequest');
+    const cmd = new openapi.OpenAPICommand(fixtureDirectory);
     const result = await cmd.execute();
     assert.deepStrictEqual(result, {
       paths: {
@@ -24,5 +27,17 @@ describe('OpenAPI', () => {
       securitySchemes: {},
     });
     assert.deepStrictEqual(cmd.errors, []);
+  });
+
+  it('accepts a relative --appmap-dir path', async () => {
+    const cmd = new openapi.OpenAPICommand(fixtureDirectory);
+    const result = await cmd.execute();
+    assert(Object.keys(result.paths).length);
+  });
+
+  it('accepts an absolute --appmap-dir path', async () => {
+    const cmd = new openapi.OpenAPICommand(path.resolve(fixtureDirectory));
+    const result = await cmd.execute();
+    assert(Object.keys(result.paths).length);
   });
 });


### PR DESCRIPTION
Fixes an issue where absolute `--appmap-dir` paths would be appended to the current working directory, leading to an invalid path.

Resolves #860 