### PR TITLE
fix: Change copy in prompt and commit message used when configuring AppMap for a project.

### DIFF
--- a/packages/cli/src/cmds/agentInstaller/agentProcedure.ts
+++ b/packages/cli/src/cmds/agentInstaller/agentProcedure.ts
@@ -226,8 +226,9 @@ export default abstract class AgentProcedure {
       type: 'confirm',
       name: 'commit',
       message: [
-        `AppMap recommends you have the installer commit in Git for you the following`,
-        `  files, to not have to install AppMap again in this repository:`,
+        `Commit these files to your repo so that everyone on your team can use AppMap`,
+        `  without them having to repeat the setup process. Bring runtime code analysis`,
+        `  to your whole team!`,
         filesMessages,
         '  ',
         '  Commit?',
@@ -251,7 +252,14 @@ export default abstract class AgentProcedure {
         UI.error(addGitReturn.errorMessage);
       }
 
-      const commitGitReturn = await this.gitCommit(filesDiff, 'feat: Install AppMap.');
+      const commitGitReturn = await this.gitCommit(filesDiff, `Configure AppMap for this project
+
+AppMap is a free and open-source runtime code analysis tool.
+
+AppMap has been installed and configured using the installation instructions at:
+https://appmap.io/docs/install-appmap-agent.html using the automated
+installer tool:
+        npx @appland/appmap@latest install`);
       if (!commitGitReturn.success) {
         UI.error(commitGitReturn.errorMessage);
       }


### PR DESCRIPTION
Addresses https://github.com/getappmap/board/issues/220

![copy_new_prompt](https://user-images.githubusercontent.com/111290954/202565885-0774117e-b84a-4078-ac8a-b9ee29b60d04.png)

![copy_new_commit](https://user-images.githubusercontent.com/111290954/202565883-c7fcbff7-5a1d-4ffb-80ec-c6325e99babf.png)
