### PR TITLE
fix: replace python with python3, use -m

### DIFF
--- a/packages/cli/src/cmds/agentInstaller/pythonAgentInstaller.ts
+++ b/packages/cli/src/cmds/agentInstaller/pythonAgentInstaller.ts
@@ -28,9 +28,9 @@ abstract class PythonInstaller extends AgentInstaller {
   async environment(): Promise<Record<string, string>> {
     // Python version is returned as a string similar to:
     // Python 3.7.0
-    const version = await getOutput('python', ['--version'], this.path);
+    const version = await getOutput('python3', ['--version'], this.path);
     const pythonPath = await getOutput(
-      'python',
+      'python3',
       ['-c', 'import sys; print(sys.prefix)'],
       this.path
     );
@@ -158,11 +158,11 @@ export class PipInstaller extends PythonInstaller {
   }
 
   async checkConfigCommand(): Promise<CommandStruct | undefined> {
-    let commandArgs = ['install', '-r', this.buildFile];
+    let commandArgs = ['-m', 'pip', 'install', '-r', this.buildFile];
     let supportsDryRun: boolean;
 
     try {
-      const pipVersionOutput = await getOutput('pip', ['--version'], this.path);
+      const pipVersionOutput = await getOutput('python3', ['-m', 'pip', '--version'], this.path);
       const pipVersion = semver.coerce(pipVersionOutput.output);
 
       if (!pipVersion) {
@@ -178,7 +178,7 @@ export class PipInstaller extends PythonInstaller {
       commandArgs.push('--dry-run');
     }
 
-    return new CommandStruct('pip', commandArgs, this.path);
+    return new CommandStruct('python3', commandArgs, this.path);
   }
 
   async installAgent(): Promise<void> {
@@ -198,12 +198,16 @@ export class PipInstaller extends PythonInstaller {
 
     encodedFile.write(requirements);
 
-    const cmd = new CommandStruct('pip', ['install', '-r', this.buildFile], this.path);
+    const cmd = new CommandStruct(
+      'python3',
+      ['-m', 'pip', 'install', '-r', this.buildFile],
+      this.path
+    );
     await run(cmd);
   }
 
   async initCommand(): Promise<CommandStruct> {
-    return new CommandStruct('appmap-agent-init', [], this.path);
+    return new CommandStruct('python3', ['-m', 'appmap.command.appmap_agent_init'], this.path);
   }
 
   async verifyCommand() {

--- a/packages/cli/tests/unit/agentInstall/installCommand.spec.ts
+++ b/packages/cli/tests/unit/agentInstall/installCommand.spec.ts
@@ -466,13 +466,13 @@ packages:
 
   describe('A Python project', () => {
     const pythonVersion = (cmdStruct: CommandStruct) => {
-      expect(cmdStruct.program).toEqual('python');
+      expect(cmdStruct.program).toEqual('python3');
       expect(cmdStruct.args).toEqual(['--version']);
       return Promise.resolve({ stdout: 'Python 3.7.0', stderr: '' });
     };
 
     const pythonPath = (cmdStruct: CommandStruct) => {
-      expect(cmdStruct.program).toEqual('python');
+      expect(cmdStruct.program).toEqual('python3');
       expect(cmdStruct.args).toEqual(['-c', "'import sys; print(sys.prefix)'"]);
       return Promise.resolve({ stdout: '/usr/local', stderr: '' });
     };
@@ -521,15 +521,15 @@ packages:
       });
 
       const installAgent = (cmdStruct: CommandStruct) => {
-        expect(cmdStruct.program).toEqual('pip');
-        expect(cmdStruct.args).toEqual(['install', '-r', 'requirements.txt']);
+        expect(cmdStruct.program).toEqual('python3');
+        expect(cmdStruct.args).toEqual(['-m', 'pip', 'install', '-r', 'requirements.txt']);
         const ret = { stdout: '', stderr: '' };
         return Promise.resolve(ret);
       };
 
       const initAgent = (cmdStruct: CommandStruct) => {
-        expect(cmdStruct.program).toEqual('appmap-agent-init');
-        expect(cmdStruct.args.length).toEqual(0);
+        expect(cmdStruct.program).toEqual('python3');
+        expect(cmdStruct.args).toEqual(['-m', 'appmap.command.appmap_agent_init']);
         const fakeConfig = `
 {
   "configuration": {
@@ -542,8 +542,8 @@ packages:
 
       describe('below version 22.2.0', () => {
         const pipVersion = (cmdStruct: CommandStruct) => {
-          expect(cmdStruct.program).toEqual('pip');
-          expect(cmdStruct.args).toEqual(['--version']);
+          expect(cmdStruct.program).toEqual('python3');
+          expect(cmdStruct.args).toEqual(['-m', 'pip', '--version']);
           return Promise.resolve({
             stdout:
               'pip 22.0 from /home/user/.pyenv/versions/3.7.0/lib/python3.7/site-packages/pip (python 3.7)',
@@ -552,9 +552,9 @@ packages:
         };
 
         const checkCurrentConfig = (cmdStruct: CommandStruct) => {
-          expect(cmdStruct.program).toEqual('pip');
+          expect(cmdStruct.program).toEqual('python3');
           const args = cmdStruct.args;
-          expect(args).toEqual(['install', '-r', 'requirements.txt']);
+          expect(args).toEqual(['-m', 'pip', 'install', '-r', 'requirements.txt']);
           const ret = { stdout: '', stderr: '' };
           return Promise.resolve(ret);
         };
@@ -583,14 +583,14 @@ packages:
 
       describe('above version 22.2.0', () => {
         const pythonVersion = (cmdStruct: CommandStruct) => {
-          expect(cmdStruct.program).toEqual('python');
+          expect(cmdStruct.program).toEqual('python3');
           expect(cmdStruct.args).toEqual(['--version']);
           return Promise.resolve({ stdout: 'Python 3.10.7', stderr: '' });
         };
 
         const pipVersion = (cmdStruct: CommandStruct) => {
-          expect(cmdStruct.program).toEqual('pip');
-          expect(cmdStruct.args).toEqual(['--version']);
+          expect(cmdStruct.program).toEqual('python3');
+          expect(cmdStruct.args).toEqual(['-m', 'pip', '--version']);
           return Promise.resolve({
             stdout:
               'pip 22.2.2 from /home/user/.pyenv/versions/3.10.7/lib/python3.7/site-packages/pip (python 3.10)',
@@ -599,9 +599,9 @@ packages:
         };
 
         const checkCurrentConfig = (cmdStruct: CommandStruct) => {
-          expect(cmdStruct.program).toEqual('pip');
+          expect(cmdStruct.program).toEqual('python3');
           const args = cmdStruct.args;
-          expect(args).toEqual(['install', '-r', 'requirements.txt', '--dry-run']);
+          expect(args).toEqual(['-m', 'pip', 'install', '-r', 'requirements.txt', '--dry-run']);
           const ret = { stdout: '', stderr: '' };
           return Promise.resolve(ret);
         };
@@ -658,7 +658,7 @@ packages:
       };
 
       const pythonVersion = (cmdStruct: CommandStruct) => {
-        expect(cmdStruct.program).toEqual('python');
+        expect(cmdStruct.program).toEqual('python3');
         expect(cmdStruct.args).toEqual(['--version']);
         return Promise.resolve({ stdout: 'Python 3.7.0', stderr: '' });
       };

--- a/packages/cli/tests/unit/agentInstall/python.spec.ts
+++ b/packages/cli/tests/unit/agentInstall/python.spec.ts
@@ -92,8 +92,8 @@ describe('Python Agent Installation', () => {
 
     it('provides the correct init command', async () => {
       const cmdStruct = await btInstaller.initCommand();
-      expect(cmdStruct.program).toBe('appmap-agent-init');
-      expect(cmdStruct.args).toEqual([]);
+      expect(cmdStruct.program).toBe('python3');
+      expect(cmdStruct.args).toEqual(['-m', 'appmap.command.appmap_agent_init']);
     });
   });
 


### PR DESCRIPTION
**This must be merged after https://github.com/getappmap/appmap-python/pull/195**


`appmap-python` requires python 3, so invoke the interpreter as `python3`. Also, use `python3 -m` to run some commands, instead of relying on the user to have their PATH set correctly.

Fixes #839 . Fixes #840 .