### PR TITLE
Don't use node:crypto in @appmap/models

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,6 @@ git:
   # required to enable symlinks on windows
   symlinks: true
 
-addons:
-  apt:
-    packages:
-      # Ubuntu 16+ does not install this dependency by default, so we need to install it ourselves
-      - libgconf-2-4
-
 install:
   - yarn && yarn run build
 script: yarn run ci

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -38,7 +38,6 @@
     "@types/tmp": "^0.2.3",
     "@types/validator": "^13.7.10",
     "@types/w3c-xmlserializer": "^2.0.2",
-    "crypto": "^1.0.1",
     "css-loader": "^6.2.0",
     "eslint": "^7.25.0",
     "eslint-config-airbnb-base": "^14.2.1",

--- a/packages/cli/webpack.config.js
+++ b/packages/cli/webpack.config.js
@@ -36,7 +36,6 @@ module.exports = {
   resolve: {
     fallback: {
       buffer: require.resolve('buffer'),
-      crypto: require.resolve('crypto-browserify'),
       stream: require.resolve('stream-browserify'),
     },
   },

--- a/packages/models/src/hashBuilder.js
+++ b/packages/models/src/hashBuilder.js
@@ -1,4 +1,4 @@
-import { createHash } from 'crypto';
+import sha256 from 'crypto-js/sha256.js';
 
 export default class HashBuilder {
   constructor(algorithmVersion) {
@@ -14,9 +14,7 @@ export default class HashBuilder {
   }
 
   digest() {
-    const hash = createHash('sha256');
-    this.hashEntries.forEach((row) => hash.update(row.join('=')));
-    return hash.digest('hex');
+    return sha256(this.hashEntries.map((r) => r.join('=')).join('')).toString();
   }
 
   static buildHash(algorithmName, properties) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -107,7 +107,6 @@ __metadata:
     cli-progress: ^3.9.0
     conf: ^10.0.2
     console-table-printer: ^2.9.0
-    crypto: ^1.0.1
     crypto-js: ^4.0.0
     css-loader: ^6.2.0
     detect-indent: ^6.1.0
@@ -11336,13 +11335,6 @@ __metadata:
   version: 2.0.0
   resolution: "crypto-random-string@npm:2.0.0"
   checksum: 0283879f55e7c16fdceacc181f87a0a65c53bc16ffe1d58b9d19a6277adcd71900d02bb2c4843dd55e78c51e30e89b0fec618a7f170ebcc95b33182c28f05fd6
-  languageName: node
-  linkType: hard
-
-"crypto@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "crypto@npm:1.0.1"
-  checksum: 087fe3165bd94c333a49e6ed66a0193911f63eac38a24f379b3001a5fe260a59c413646e53a0f67875ba13902b2686d81dc703cb2c147a4ec727dcdc04e5645e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
@appmap/models package is also used in the browser. Using node:crypto requires using crypto-browserify implementation which bloats the build unnecessarily. We're already using crypto-js in other places, it can be used instead.

This improves compilation time and size of the appmap.html bundle in cli by a third:
```sh-session
$ yarn build # before
asset main.js.map 3.88 MiB [emitted] [dev] (auxiliary name: main)
asset appmap.html 1.23 MiB [emitted] [big]
asset main.js.LICENSE.txt 607 bytes [emitted]
orphan modules 278 KiB [orphan] 197 modules
runtime modules 1.25 KiB 6 modules
modules by path ../../node_modules/ 1.85 MiB
  javascript modules 1.83 MiB 497 modules
  json modules 12.7 KiB 6 modules
modules by path ./ 9.43 KiB
  modules by path ./node_modules/style-loader/dist/runtime/*.js 5.75 KiB 6 modules
  modules by path ./node_modules/css-loader/dist/runtime/*.js 2.94 KiB 2 modules
  ./src/html/page.js 764 bytes [built] [code generated]
modules by path ../diagrams/dist/*.css 28.2 KiB
  ../diagrams/dist/style.css 1.17 KiB [built] [code generated]
  ./node_modules/css-loader/dist/cjs.js!../diagrams/dist/style.css 27.1 KiB [built] [code generated]
+ 12 modules

WARNING in asset size limit: The following asset(s) exceed the recommended size limit (244 KiB).
This can impact web performance.
Assets: 
  appmap.html (1.23 MiB)

WARNING in webpack performance recommendations: 
You can limit the size of your bundles by using import() or require.ensure to lazy load some parts of your application.
For more info visit https://webpack.js.org/guides/code-splitting/

webpack 5.68.0 compiled with 2 warnings in 15411 ms

$ yarn build # after
asset main.js.map 2.38 MiB [emitted] [dev] (auxiliary name: main)
asset appmap.html 832 KiB [emitted] [big]
asset main.js.LICENSE.txt 521 bytes [emitted]
orphan modules 278 KiB [orphan] 197 modules
runtime modules 1.25 KiB 6 modules
modules by path ../../node_modules/ 987 KiB 321 modules
modules by path ./ 9.43 KiB
  modules by path ./node_modules/style-loader/dist/runtime/*.js 5.75 KiB 6 modules
  modules by path ./node_modules/css-loader/dist/runtime/*.js 2.94 KiB
    ./node_modules/css-loader/dist/runtime/sourceMaps.js 688 bytes [built] [code generated]
    ./node_modules/css-loader/dist/runtime/api.js 2.26 KiB [built] [code generated]
  ./src/html/page.js 764 bytes [built] [code generated]
modules by path ../diagrams/dist/*.css 28.2 KiB
  ../diagrams/dist/style.css 1.17 KiB [built] [code generated]
  ./node_modules/css-loader/dist/cjs.js!../diagrams/dist/style.css 27.1 KiB [built] [code generated]
../components/dist/index.js + 112 modules 509 KiB [built] [code generated]
crypto (ignored) 15 bytes [optional] [built] [code generated]

WARNING in asset size limit: The following asset(s) exceed the recommended size limit (244 KiB).
This can impact web performance.
Assets: 
  appmap.html (832 KiB)

WARNING in webpack performance recommendations: 
You can limit the size of your bundles by using import() or require.ensure to lazy load some parts of your application.
For more info visit https://webpack.js.org/guides/code-splitting/

webpack 5.68.0 compiled with 2 warnings in 10610 ms
```