### PR TITLE
fix: Prevent EPERM/EACCES errors while watching AppMaps if a directory cannot be read

### DIFF
--- a/packages/cli/src/fingerprint/fingerprintWatchCommand.ts
+++ b/packages/cli/src/fingerprint/fingerprintWatchCommand.ts
@@ -64,6 +64,7 @@ export default class FingerprintWatchCommand {
     this.watcher = watch(glob, {
       ignoreInitial: true,
       ignored: ['**/node_modules/**', '**/.git/**'],
+      ignorePermissionErrors: true,
     })
       .on('add', this.added.bind(this))
       .on('change', this.changed.bind(this))

--- a/packages/cli/src/fingerprint/globber.ts
+++ b/packages/cli/src/fingerprint/globber.ts
@@ -3,6 +3,7 @@ import { Glob, IGlob } from 'glob';
 import { assert } from 'console';
 import { stat } from 'fs/promises';
 import { Stats } from 'fs-extra';
+import { verbose } from '../utils';
 
 class Globber extends EventEmitter {
   constructor(private pattern: string, public interval = 1000) {
@@ -14,7 +15,11 @@ class Globber extends EventEmitter {
   public scanNow() {
     assert(!this.currentGlob);
     this.timeout = undefined;
-    this.currentGlob = new Glob(this.pattern, { ignore: ['**/node_modules/**', '**/.git/**'] })
+    this.currentGlob = new Glob(this.pattern, {
+      ignore: ['**/node_modules/**', '**/.git/**'],
+      strict: false,
+      silent: !verbose(),
+    })
       .on('end', this.scanEnd.bind(this))
       .on('match', this.matchFound.bind(this));
   }

--- a/packages/cli/tests/unit/fingerprint/fingerprintWatchCommand.spec.ts
+++ b/packages/cli/tests/unit/fingerprint/fingerprintWatchCommand.spec.ts
@@ -10,6 +10,7 @@ import OriginalTelemetry from '../../../src/telemetry';
 import { once } from 'events';
 import Fingerprinter from '../../../src/fingerprint/fingerprinter';
 import { MaxMSBetween } from '../../../src/lib/eventAggregator';
+import { mkdir } from 'fs/promises';
 
 jest.mock('../../../src/telemetry');
 const Telemetry = jest.mocked(OriginalTelemetry);
@@ -71,6 +72,14 @@ describe(FingerprintWatchCommand, () => {
       cmd = new FingerprintWatchCommand(appMapDir);
       await cmd.execute();
       cmd.watcher?.removeAllListeners();
+      placeMap();
+      return verifyIndexSuccess(200, 20);
+    });
+
+    it('does not raise if it encounters an unreadable directory', async () => {
+      await mkdir(join(appMapDir, 'eacces'), { mode: 0 });
+      cmd = new FingerprintWatchCommand(appMapDir);
+      await cmd.execute();
       placeMap();
       return verifyIndexSuccess(200, 20);
     });


### PR DESCRIPTION
If the user does not have permissions to read a directory under `--appmap-dir`, an `EPERM`/`EACCES` error would panic the process (even in `--watch` mode).

Instead, these errors will be ignored and we'll continue scanning what we can.

I wasn't sure of an easy way to test an `EPERM` without involving other OS users, so I've omitted the test for now. Behavior should otherwise be the same.

Resolves #880 