### PR TITLE
fix: Disable file watching on "ENOSPC: System limit for number of file watchers reached" error

### DIFF
--- a/packages/cli/src/fingerprint/fingerprintWatchCommand.ts
+++ b/packages/cli/src/fingerprint/fingerprintWatchCommand.ts
@@ -46,7 +46,7 @@ export default class FingerprintWatchCommand {
   }
 
   async watcherErrorFunction (error: Error) {
-    if (error.message.includes("ENOSPC: System limit for number of file watchers reached")) {
+    if (this.watcher && error.message.includes("ENOSPC: System limit for number of file watchers reached")) {
       console.warn(error.stack);
       console.warn("Will disable file watching. File polling will stay enabled.");
       await this.watcher?.close();
@@ -82,7 +82,7 @@ export default class FingerprintWatchCommand {
       .on('add', this.added.bind(this))
       .on('change', this.changed.bind(this))
       .on('unlink', this.removed.bind(this))
-      .on('error', error => this.watcherErrorFunction(error));
+      .on('error', this.watcherErrorFunction.bind(this));
 
     const watchReady = new Promise<void>((r) => this.watcher?.once('ready', r));
 

--- a/packages/cli/tests/unit/fingerprint/fingerprintWatchCommand.spec.ts
+++ b/packages/cli/tests/unit/fingerprint/fingerprintWatchCommand.spec.ts
@@ -11,6 +11,7 @@ import { once } from 'events';
 import Fingerprinter from '../../../src/fingerprint/fingerprinter';
 import { MaxMSBetween } from '../../../src/lib/eventAggregator';
 import { mkdir } from 'fs/promises';
+import { FSWatcher } from 'chokidar';
 
 jest.mock('../../../src/telemetry');
 const Telemetry = jest.mocked(OriginalTelemetry);
@@ -83,6 +84,14 @@ describe(FingerprintWatchCommand, () => {
       placeMap();
       return verifyIndexSuccess(200, 20);
     });
+
+    it('does not raise if it hits the limit of the number of file watchers', async () => {
+      cmd = new FingerprintWatchCommand(appMapDir);
+      cmd.watcher = new FSWatcher();
+      expect(cmd.watcher).not.toBeUndefined();
+      await cmd.watcherErrorFunction(new Error("ENOSPC: System limit for number of file watchers reached"));
+      expect(cmd.watcher).toBeUndefined();
+     });
 
     describe('telemetry', () => {
       let handler: Fingerprinter;


### PR DESCRIPTION
When the indexer processes an appmap_dir that has more files than the OS limit for watching files, FSWatch raises an ENOSPC error.  Catch this specific type of ENOSPC error and disable file watching.  File changes continue to be detected through file polling.

Output of manual test. After disabling file watching, file polling continues to run.
![file_watching_disabled](https://user-images.githubusercontent.com/111290954/206763259-c0dd62eb-ebcb-414e-9ee8-d57bdbfa4a0f.png)

Fixes https://github.com/getappmap/appmap-js/issues/894

If the reason for watching too many files was that the directory monitored wasn't precisely the `appmap_dir` but something more general, like `.` monitoring two parent directories up, then saving the `appmap_dir` in `appmap.yml` through [this pr](https://github.com/getappmap/appmap-js/pull/896) may be enough to make this ENOSPC error disappear without this fix.

This fix should still be applied because choosing to discard error messages instead of crash is still needed, as shown in https://github.com/getappmap/appmap-js/pull/898