### PR TITLE
feat: appmap_dir and language in appmap.yml

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -271,12 +271,16 @@ yargs(process.argv.slice(2))
     'depends [files]',
     'Compute a list of AppMaps that are out of date',
     (args) => {
+      args.option('directory', {
+        describe: 'program working directory',
+        type: 'string',
+        alias: 'd',
+      });
       args.positional('files', {
         describe: 'provide an explicit list of dependency files',
       });
       args.option('appmap-dir', {
         describe: 'directory to recursively inspect for AppMaps',
-        default: 'tmp/appmap',
       });
       args.option('base-dir', {
         describe: 'directory to prepend to each dependency source file',
@@ -293,6 +297,8 @@ yargs(process.argv.slice(2))
     },
     async (argv) => {
       verbose(argv.verbose);
+      handleWorkingDirectory(argv.directory);
+      const appmapDir = await locateAppMapDir(argv.appmapDir);
 
       let { files } = argv;
       if (argv.stdinFiles) {
@@ -305,10 +311,10 @@ yargs(process.argv.slice(2))
       }
 
       if (verbose()) {
-        console.warn(`Testing AppMaps in ${argv.appmapDir}`);
+        console.warn(`Testing AppMaps in ${appmapDir}`);
       }
 
-      const depends = new Depends(argv.appmapDir);
+      const depends = new Depends(appmapDir);
       if (argv.baseDir) {
         depends.baseDir = argv.baseDir;
       }
@@ -343,21 +349,27 @@ yargs(process.argv.slice(2))
     'index',
     'Compute fingerprints and update index files for all appmaps in a directory',
     (args) => {
+      args.option('directory', {
+        describe: 'program working directory',
+        type: 'string',
+        alias: 'd',
+      });
       args.option('watch', {
         describe: 'watch the directory for changes to appmaps',
         boolean: true,
       });
       args.option('appmap-dir', {
         describe: 'directory to recursively inspect for AppMaps',
-        default: 'tmp/appmap',
       });
       return args.strict();
     },
     async (argv) => {
       verbose(argv.verbose);
+      handleWorkingDirectory(argv.directory);
+      const appmapDir = await locateAppMapDir(argv.appmapDir);
 
       if (argv.watch) {
-        const cmd = new FingerprintWatchCommand(argv.appmapDir);
+        const cmd = new FingerprintWatchCommand(appmapDir);
         await cmd.execute();
 
         if (!argv.verbose && process.stdout.isTTY) {
@@ -374,7 +386,7 @@ yargs(process.argv.slice(2))
           });
         }
       } else {
-        const cmd = new FingerprintDirectoryCommand(argv.appmapDir);
+        const cmd = new FingerprintDirectoryCommand(appmapDir);
         await cmd.execute();
       }
     }

--- a/packages/cli/src/cmds/agentInstaller/agentInstaller.ts
+++ b/packages/cli/src/cmds/agentInstaller/agentInstaller.ts
@@ -13,6 +13,8 @@ export default abstract class AgentInstaller {
     this.path = resolve(path);
   }
 
+  abstract get language(): string;
+  abstract get appmap_dir(): string;
   abstract installAgent(): Promise<void>;
 
   abstract checkConfigCommand(): Promise<CommandStruct | undefined>;

--- a/packages/cli/src/cmds/agentInstaller/gradleInstaller.ts
+++ b/packages/cli/src/cmds/agentInstaller/gradleInstaller.ts
@@ -18,6 +18,14 @@ export default class GradleInstaller extends JavaBuildToolInstaller {
     super(GradleInstaller.identifier, path);
   }
 
+  get language(): string {
+    return 'java';
+  }
+
+  get appmap_dir(): string {
+    return 'build/appmap';
+  }
+
   private get buildGradleFileName(): string {
     return 'build.gradle';
   }

--- a/packages/cli/src/cmds/agentInstaller/javaScriptAgentInstaller.ts
+++ b/packages/cli/src/cmds/agentInstaller/javaScriptAgentInstaller.ts
@@ -14,6 +14,14 @@ abstract class JavaScriptInstaller extends AgentInstaller {
     super(name, path);
   }
 
+  get language(): string {
+    return 'javascript';
+  }
+
+  get appmap_dir(): string {
+    return 'tmp/appmap';
+  }
+
   get documentation() {
     return 'https://appland.com/docs/reference/appmap-agent-js';
   }

--- a/packages/cli/src/cmds/agentInstaller/mavenInstaller.ts
+++ b/packages/cli/src/cmds/agentInstaller/mavenInstaller.ts
@@ -5,7 +5,6 @@ import { JSDOM } from 'jsdom';
 import xmlSerializer from 'w3c-xmlserializer';
 import chalk from 'chalk';
 import CommandStruct from './commandStruct';
-import AgentInstaller from './agentInstaller';
 import { verbose, exists } from '../../utils';
 import JavaBuildToolInstaller from './javaBuildToolInstaller';
 import EncodedFile from '../../encodedFile';
@@ -15,6 +14,14 @@ export default class MavenInstaller extends JavaBuildToolInstaller {
 
   constructor(path: string) {
     super(MavenInstaller.identifier, path);
+  }
+
+  get language(): string {
+    return 'java';
+  }
+
+  get appmap_dir(): string {
+    return 'target/appmap';
   }
 
   get buildFile(): string {

--- a/packages/cli/src/cmds/agentInstaller/pythonAgentInstaller.ts
+++ b/packages/cli/src/cmds/agentInstaller/pythonAgentInstaller.ts
@@ -21,6 +21,14 @@ abstract class PythonInstaller extends AgentInstaller {
     super(name, path);
   }
 
+  get language(): string {
+    return 'python';
+  }
+
+  get appmap_dir(): string {
+    return 'tmp/appmap';
+  }
+
   get documentation() {
     return 'https://appland.com/docs/reference/appmap-python';
   }

--- a/packages/cli/src/cmds/agentInstaller/rubyAgentInstaller.ts
+++ b/packages/cli/src/cmds/agentInstaller/rubyAgentInstaller.ts
@@ -24,6 +24,14 @@ export class BundleInstaller extends AgentInstaller {
     super('Bundler', path);
   }
 
+  get language(): string {
+    return 'ruby';
+  }
+
+  get appmap_dir(): string {
+    return 'tmp/appmap';
+  }
+
   get buildFile(): string {
     return 'Gemfile';
   }

--- a/packages/cli/src/cmds/openapi.ts
+++ b/packages/cli/src/cmds/openapi.ts
@@ -121,7 +121,7 @@ export default {
   async handler(argv: Arguments | any) {
     verbose(argv.verbose);
     handleWorkingDirectory(argv.directory);
-
+    const appmapDir = await locateAppMapDir(argv.appmapDir);
     const { openapiTitle, openapiVersion } = argv;
 
     function tryConfigure(path: string, fn: () => void) {
@@ -131,7 +131,7 @@ export default {
         console.warn(`Warning: unable to configure OpenAPI field ${path}`);
       }
     }
-    const appmapDir = await locateAppMapDir(argv.appmapDir);
+
     const appmapConfigFile = await locateAppMapConfigFile(appmapDir);
 
     const cmd = new OpenAPICommand(appmapDir);

--- a/packages/cli/tests/unit/agentInstall/TestAgentProcedure.ts
+++ b/packages/cli/tests/unit/agentInstall/TestAgentProcedure.ts
@@ -17,11 +17,18 @@ export class TestAgentInstaller extends AgentInstaller {
   public buildFile = 'test build file';
   public documentation = 'test documentation';
 
+  get language(): string {
+    return 'pig-latin';
+  }
+  get appmap_dir(): string {
+    return 'tmp/appmap';
+  }
+
   async validateAgentCommand(): Promise<commandStruct | undefined> {
     return new commandStruct('test validate agent command', [], '/test/validate/agent/command');
   }
 
-  async installAgent(): Promise<void> { }
+  async installAgent(): Promise<void> {}
 
   async checkConfigCommand(): Promise<commandStruct | undefined> {
     return undefined;

--- a/packages/cli/tests/unit/agentInstall/agentInstaller.spec.ts
+++ b/packages/cli/tests/unit/agentInstall/agentInstaller.spec.ts
@@ -9,6 +9,12 @@ class FakeInstaller extends AgentInstaller {
     super('Fake', path);
   }
 
+  get language(): string {
+    return 'Method not implemented';
+  }
+  get appmap_dir(): string {
+    return 'Method not implemented';
+  }
   installAgent(): Promise<void> {
     throw new Error('Method not implemented.');
   }


### PR DESCRIPTION
Include `appmap_dir` and `language` in the generated _appmap.yml_ file.

If the _appmap.yml_ does not contain these settings, the installer will add them on a subsequent run.

## Demo

https://asciinema.org/a/5ZFuGNXeBxGPPQQlUO82or2Z4