### PR TITLE
fix: Don't crash indexer on an "UNKNOWN: unknown error, lstat" error

### DIFF
--- a/packages/cli/src/fingerprint/fingerprintWatchCommand.ts
+++ b/packages/cli/src/fingerprint/fingerprintWatchCommand.ts
@@ -59,6 +59,8 @@ export default class FingerprintWatchCommand {
             errorStack: error.stack,
           },
         });
+    } else if (error.message.includes("UNKNOWN: unknown error, lstat")) {
+      console.warn(error.stack);
     } else {
       // let it crash if it's some other error, to learn what the error is
       throw error;

--- a/packages/cli/src/fingerprint/fingerprintWatchCommand.ts
+++ b/packages/cli/src/fingerprint/fingerprintWatchCommand.ts
@@ -61,6 +61,13 @@ export default class FingerprintWatchCommand {
         });
     } else if (error.message.includes("UNKNOWN: unknown error, lstat")) {
       console.warn(error.stack);
+      Telemetry.sendEvent({
+          name: `index:watcher_error:unknown`,
+          properties: {
+            errorMessage: error.message,
+            errorStack: error.stack,
+          },
+        });
     } else {
       // let it crash if it's some other error, to learn what the error is
       throw error;

--- a/packages/cli/src/fingerprint/fingerprintWatchCommand.ts
+++ b/packages/cli/src/fingerprint/fingerprintWatchCommand.ts
@@ -10,6 +10,7 @@ import { verbose } from '../utils';
 import { FingerprintEvent } from './fingerprinter';
 import FingerprintQueue from './fingerprintQueue';
 import Globber from './globber';
+import path from 'path';
 
 export default class FingerprintWatchCommand {
   private pidfilePath: string | undefined;
@@ -17,6 +18,7 @@ export default class FingerprintWatchCommand {
   public watcher?: FSWatcher;
   private poller?: Globber;
   private _numProcessed = 0;
+  public unreadableFiles = new Set();
 
   public get numProcessed() {
     return this._numProcessed;
@@ -45,6 +47,15 @@ export default class FingerprintWatchCommand {
     }
   }
 
+  getFilenameFromErrorMessage(errorMessage: string): string {
+    // The errorMessage must contain the filename within single quotes
+    // and looks like this:
+    // Error: UNKNOWN: unknown error, lstat 'c:\Users\Test\Programming\MyProject'
+    let quoteStartIndex = errorMessage.indexOf(`'`);
+    let quoteEndIndex = errorMessage.indexOf(`'`, quoteStartIndex + 1);
+    return errorMessage.substring(quoteStartIndex + 1, quoteEndIndex);
+  }
+
   async watcherErrorFunction (error: Error) {
     if (this.watcher && error.message.includes("ENOSPC: System limit for number of file watchers reached")) {
       console.warn(error.stack);
@@ -67,12 +78,34 @@ export default class FingerprintWatchCommand {
             errorMessage: error.message,
             errorStack: error.stack,
           },
-        });
+      });
+      const filename = this.getFilenameFromErrorMessage(error.message);
+      this.unreadableFiles.add(filename);
+      console.warn("Will not read this file again.");
     } else {
       // let it crash if it's some other error, to learn what the error is
       throw error;
     }
   };
+
+  // Custom ignore function needed to skip unreadableFiles because
+  // attempting to read them can block reading all files. It also
+  // cuts down the watch tree to just what we need.
+  ignored (targetPath: string) {
+    ['/node_modules/', '/.git/'].forEach((pattern) => {
+      if (targetPath.includes(pattern)) {
+        return true;
+       }
+    });
+
+    if (this.unreadableFiles.has(targetPath)) {
+      return true;
+    }
+
+    // Also make sure to not try to recurse down node_modules or .git
+    const basename = path.basename(targetPath);
+    return basename === 'node_modules' || basename === '.git';
+  }
 
   async execute() {
     this.fpQueue.process().then(() => {
@@ -92,7 +125,7 @@ export default class FingerprintWatchCommand {
 
     this.watcher = watch(glob, {
       ignoreInitial: true,
-      ignored: ['**/node_modules/**', '**/.git/**'],
+      ignored: this.ignored.bind(this),
       ignorePermissionErrors: true,
     })
       .on('add', this.added.bind(this))

--- a/packages/cli/tests/unit/fingerprint/fingerprintWatchCommand.spec.ts
+++ b/packages/cli/tests/unit/fingerprint/fingerprintWatchCommand.spec.ts
@@ -93,6 +93,18 @@ describe(FingerprintWatchCommand, () => {
       expect(cmd.watcher).toBeUndefined();
      });
 
+     it('does not raise on unknown error lstat', async () => {
+      cmd = new FingerprintWatchCommand(appMapDir);
+      cmd.watcher = new FSWatcher();
+      expect(cmd.watcher).not.toBeUndefined();
+      console.warn = jest.fn();
+      const errorMessage = "UNKNOWN: unknown error, lstat";
+      await cmd.watcherErrorFunction(new Error(errorMessage));
+      expect(cmd.watcher).not.toBeUndefined();
+      expect(console.warn).toBeCalledTimes(1);
+      expect(console.warn).toHaveBeenCalledWith(expect.stringContaining(errorMessage));
+    });
+
     describe('telemetry', () => {
       let handler: Fingerprinter;
 

--- a/packages/cli/tests/unit/fingerprint/fingerprintWatchCommand.spec.ts
+++ b/packages/cli/tests/unit/fingerprint/fingerprintWatchCommand.spec.ts
@@ -91,18 +91,29 @@ describe(FingerprintWatchCommand, () => {
       expect(cmd.watcher).not.toBeUndefined();
       await cmd.watcherErrorFunction(new Error("ENOSPC: System limit for number of file watchers reached"));
       expect(cmd.watcher).toBeUndefined();
-     });
+    });
 
-     it('does not raise on unknown error lstat', async () => {
+    it('gets filenames from error messages', async () => {
+      cmd = new FingerprintWatchCommand(appMapDir);
+      expect(cmd.getFilenameFromErrorMessage(`Error: UNKNOWN: unknown error, lstat 'c:\\Users\\Test\\Programming\\MyProject'`)).toBe('c:\\Users\\Test\\Programming\\MyProject');
+    });
+
+    it('does not raise on unknown error lstat', async () => {
       cmd = new FingerprintWatchCommand(appMapDir);
       cmd.watcher = new FSWatcher();
       expect(cmd.watcher).not.toBeUndefined();
+      expect(cmd.unreadableFiles.size).toBe(0);
       console.warn = jest.fn();
-      const errorMessage = "UNKNOWN: unknown error, lstat";
+      const errorMessage = `Error: UNKNOWN: unknown error, lstat 'c:\\Users\\Test\\Programming\\MyProject'`;
       await cmd.watcherErrorFunction(new Error(errorMessage));
       expect(cmd.watcher).not.toBeUndefined();
-      expect(console.warn).toBeCalledTimes(1);
+      expect(console.warn).toBeCalledTimes(2);
       expect(console.warn).toHaveBeenCalledWith(expect.stringContaining(errorMessage));
+      expect(cmd.unreadableFiles.size).toBe(1);
+      expect(cmd.unreadableFiles.has('c:\\Users\\Test\\Programming\\MyProject')).toBe(true);
+      // ignoring this file or directory works correctly
+      expect(cmd.ignored('c:\\Users\\Test\\Programming\\MyProject')).toBe(true);
+      expect(cmd.ignored('c:\\Users\\Test\\Programming\\MyProject\\some.appmap.json')).toBe(false);
     });
 
     describe('telemetry', () => {


### PR DESCRIPTION
Attempts to fix https://github.com/getappmap/appmap-js/issues/897. Created from branch `sw/disable_watching_on_ENOSPC_error`

This error is an exception thrown by chokidar while file watching.

I wasn't able to reproduce this error.  I created symlinks and deleted them programmatically when the queue processes the file but this produced an ENOENT error.
```
File /home/test/tmp/too_many_open_files/minitest/Static_pages_controller_should_get_help.appmap.json does not exist or is not a file.
Deleted File successfully.
[Error: ENOENT: no such file or directory, lstat '/home/test/tmp/too_many_open_files/minitest/Static_pages_controller_should_get_home.appmap.json'] {
  errno: -2,
  code: 'ENOENT',
  syscall: 'lstat',
  path: '/home/test/tmp/too_many_open_files/minitest/Static_pages_controller_should_get_home.appmap.json'
}
```

There's a claim this `UNKNOWN: unknown error, lstat` error is the result of file corruption down at the NTFS level.
https://github.com/nodejs/node/issues/43439