### PR TITLE
fix: Don't let indexer crash on `EMFILE: too many open files` error

### DIFF
--- a/packages/cli/src/fingerprint/fingerprintWatchCommand.ts
+++ b/packages/cli/src/fingerprint/fingerprintWatchCommand.ts
@@ -82,6 +82,10 @@ export default class FingerprintWatchCommand {
       const filename = this.getFilenameFromErrorMessage(error.message);
       this.unreadableFiles.add(filename);
       console.warn("Will not read this file again.");
+    } else if (error.message.includes("EMFILE: too many open files")) {
+      // Don't crash if too many files are open. When the files close
+      // the indexer will pick them up.
+      console.warn(error.stack);
     } else {
       // let it crash if it's some other error, to learn what the error is
       throw error;

--- a/packages/cli/src/fingerprint/fingerprintWatchCommand.ts
+++ b/packages/cli/src/fingerprint/fingerprintWatchCommand.ts
@@ -86,6 +86,13 @@ export default class FingerprintWatchCommand {
       // Don't crash if too many files are open. When the files close
       // the indexer will pick them up.
       console.warn(error.stack);
+      Telemetry.sendEvent({
+          name: `index:watcher_error:emfile`,
+          properties: {
+            errorMessage: error.message,
+            errorStack: error.stack,
+          },
+        });
     } else {
       // let it crash if it's some other error, to learn what the error is
       throw error;

--- a/packages/cli/tests/unit/fingerprint/fingerprintWatchCommand.spec.ts
+++ b/packages/cli/tests/unit/fingerprint/fingerprintWatchCommand.spec.ts
@@ -116,6 +116,21 @@ describe(FingerprintWatchCommand, () => {
       expect(cmd.ignored('c:\\Users\\Test\\Programming\\MyProject\\some.appmap.json')).toBe(false);
     });
 
+    it('does not raise if it hits the limit of the number of open files', async () => {
+      cmd = new FingerprintWatchCommand(appMapDir);
+      await cmd.watcherErrorFunction(new Error("EMFILE: too many open files"));
+      expect(cmd.watcher).toBeUndefined();
+
+      cmd.watcher = new FSWatcher();
+      expect(cmd.watcher).not.toBeUndefined();
+      console.warn = jest.fn();
+      const errorMessage = "EMFILE: too many open files";
+      await cmd.watcherErrorFunction(new Error(errorMessage));
+      expect(cmd.watcher).not.toBeUndefined();
+      expect(console.warn).toBeCalledTimes(1);
+      expect(console.warn).toHaveBeenCalledWith(expect.stringContaining(errorMessage));
+    });
+
     describe('telemetry', () => {
       let handler: Fingerprinter;
 

--- a/packages/scanner/src/cli/scan/watchScan.ts
+++ b/packages/scanner/src/cli/scan/watchScan.ts
@@ -115,11 +115,13 @@ export class Watcher {
       .on('error', this.watcherErrorFunction.bind(this));
   }
 
+  isError(error: unknown, code: string): boolean {
+    const err = error as NodeJS.ErrnoException;
+    return err.code === code;
+  }
+
   async watcherErrorFunction(error: Error) {
-    if (
-      this.appmapWatcher &&
-      error.message.includes('ENOSPC: System limit for number of file watchers reached')
-    ) {
+    if (this.appmapWatcher && this.isError(error, 'ENOSPC')) {
       console.warn(error.stack);
       console.warn('Will disable file watching. File polling will stay enabled.');
       await this.appmapWatcher?.close();

--- a/packages/scanner/test/cli/scan.spec.ts
+++ b/packages/scanner/test/cli/scan.spec.ts
@@ -272,13 +272,15 @@ describe('scan', () => {
 
     it('does not raise if it hits the limit of the number of file watchers', async () => {
       await createWatcher();
-      if (watcher) { // without the if it doesn't compile; it could be undefined
+      if (watcher) {
+        // without the if it doesn't compile; it could be undefined
         watcher.appmapWatcher = new FSWatcher();
         expect(watcher.appmapWatcher).not.toBeUndefined();
-        await watcher.watcherErrorFunction(new Error("ENOSPC: System limit for number of file watchers reached"));
+        const err = new Error('ENOSPC: System limit for number of file watchers reached');
+        (err as NodeJS.ErrnoException).code = 'ENOSPC';
+        await watcher.watcherErrorFunction(err);
         expect(watcher.appmapWatcher).toBeUndefined();
-      } else
-        throw new Error("watcher should have been defined");
+      } else throw new Error('watcher should have been defined');
     });
 
     it('eventually rescans even if file watching is flaky', async () => {


### PR DESCRIPTION
The original plan to address this was to increase the number of open files limit.  It didn't work on Windows.

To address this problem on Windows, and as a side effect address it in all operating systems, catch the `EMFILE` error.

It may be possible to get the [original pr](https://github.com/getappmap/appmap-js/pull/893) to compile for all operating systems, just as [it did ](https://app.travis-ci.com/github/getappmap/appmap-js/jobs/591181921) when it was first opened at https://github.com/getappmap/appmap-js/pull/893/commits/2ab7dd5ac182829cd2a4423c4e518eb376191aa4, but have it not call `setrlimit` on Windows.

This happens in the [indexer](https://github.com/getappmap/appmap-js/issues/881) as a `ProcessFailure` in the [logs](https://portal.azure.com/#view/Microsoft_OperationsManagementSuite_Workspace/Logs.ReactView/resourceId/%2Fsubscriptions%2Fa4af4729-21ee-4e0a-953c-33cc9db5295c%2Fresourcegroups%2Fvscode-extension%2Fproviders%2Fmicrosoft.insights%2Fcomponents%2Fvscode-extension-analytics/source/AIExtension.SearchV2/query/union%20customEvents%20%7C%20where%20timestamp%20%3E%3D%20datetime(%222022-11-30T13%3A58%3A41.776Z%22)%20and%20timestamp%20%3C%3D%20(datetime(%222022-11-30T13%3A58%3A41.776Z%22))%20and%20session_Id%20%3D%3D%20%22d48953ca-a1c8-4e66-a861-182479b7692d1669816485794%22%7C%20extend%20logLen%3Dstrlen(customDimensions%5B%22appmap.cli.log%22%5D)%2Clog%3DcustomDimensions%5B%22appmap.cli.log%22%5D%2Cexception%3DcustomDimensions%5B%22appmap.debug.exception%22%5D%7C%20project-reorder%20timestamp%2Cname%2Cuser_Id%2ClogLen%2Clog%2Cexception).

Something similar happens in [vscode-appland](https://github.com/getappmap/vscode-appland/blob/88f3df8a7c8c80249ec7ee92f790aa118e40fb77/src/extension.ts#L296) as an `InitializationFailure` error in [the logs](https://portal.azure.com/#view/Microsoft_OperationsManagementSuite_Workspace/Logs.ReactView/resourceId/%2Fsubscriptions%2Fa4af4729-21ee-4e0a-953c-33cc9db5295c%2Fresourcegroups%2Fvscode-extension%2Fproviders%2Fmicrosoft.insights%2Fcomponents%2Fvscode-extension-analytics/source/AIExtension.SearchV2/query/union%20customEvents%20%7C%20where%20timestamp%20%3E%3D%20datetime(%222022-12-14T13%3A17%3A07.061Z%22)%20and%20timestamp%20%3C%3D%20(datetime(%222022-12-14T13%3A17%3A07.061Z%22))%20and%20session_Id%20%3D%3D%20%2268865943-23ca-4bb1-8be8-4ce05fc9eade1671023703959%22%7C%20extend%20logLen%3Dstrlen(customDimensions%5B%22appmap.cli.log%22%5D)%2Clog%3DcustomDimensions%5B%22appmap.cli.log%22%5D%2Cexception%3DcustomDimensions%5B%22appmap.debug.exception%22%5D%7C%20project-reorder%20timestamp%2Cname%2Cuser_Id%2ClogLen%2Clog%2Cexception)  but it's tracked as a [different issue](https://github.com/getappmap/vscode-appland/issues/511).

Fixes https://github.com/getappmap/appmap-js/issues/892