### PR TITLE
feat: Populate openapi path.summary from x-openapi-summary header

### DIFF
--- a/packages/openapi/src/path.ts
+++ b/packages/openapi/src/path.ts
@@ -5,15 +5,15 @@ import { RPCRequest } from './rpcRequest';
 export default class Path {
   methods: Record<string, Method> = {};
 
-  openapi(): Record<OpenAPIV3.HttpMethods, OpenAPIV3.OperationObject> {
+  openapi(): OpenAPIV3.PathItemObject {
     return Object.keys(this.methods)
       .sort()
-      .reduce((memo, method: string) => {
+      .reduce((memo, methodName: string) => {
+        const method = this.methods[methodName as OpenAPIV3.HttpMethods];
         // eslint-disable-next-line no-param-reassign
-        memo[method as OpenAPIV3.HttpMethods] =
-          this.methods[method as OpenAPIV3.HttpMethods].openapi();
+        memo[methodName as OpenAPIV3.HttpMethods] = method.openapi();
         return memo;
-      }, {} as Record<OpenAPIV3.HttpMethods, OpenAPIV3.OperationObject>);
+      }, {} as Record<OpenAPIV3.HttpMethods, OpenAPIV3.OperationObject>) as OpenAPIV3.PathItemObject;
   }
 
   addRpcRequest(rpcRequest: RPCRequest): void {

--- a/packages/openapi/src/rpcRequest.ts
+++ b/packages/openapi/src/rpcRequest.ts
@@ -113,6 +113,12 @@ function isClientEvent(event: Event): event is ClientRpcEvent {
   return !!event.httpClientRequest && !!event.httpClientResponse && !!event.httpClientRequest.url;
 }
 
+export function headerValue(headers: Record<string, string>, name: string): string | undefined {
+  const nameLower = name.toLowerCase();
+  const key = Object.keys(headers).find((header) => header.toLowerCase() === nameLower);
+  if (key) return headers[key];
+}
+
 export function rpcRequestForEvent(event: Event): RPCRequest | undefined {
   if (isServerEvent(event)) return new ServerRPCRequest(event);
   if (isClientEvent(event)) return new ClientRPCRequest(event);

--- a/packages/openapi/test/data/Users_signup_invalid_signup_information.appmap.json
+++ b/packages/openapi/test/data/Users_signup_invalid_signup_information.appmap.json
@@ -2379,7 +2379,8 @@
           "X-Download-Options": "noopen",
           "X-Permitted-Cross-Domain-Policies": "none",
           "Referrer-Policy": "strict-origin-when-cross-origin",
-          "Content-Type": "text/html; charset=utf-8"
+          "Content-Type": "text/html; charset=utf-8",
+          "X-OpenAPI-Summary": "Signup"
         }
       }
     },

--- a/packages/openapi/test/openapi.spec.ts
+++ b/packages/openapi/test/openapi.spec.ts
@@ -65,6 +65,7 @@ describe('openapi', () => {
               description: 'OK',
             },
           },
+          summary: 'Signup',
         },
       },
       '/users': {

--- a/packages/openapi/test/response.spec.ts
+++ b/packages/openapi/test/response.spec.ts
@@ -1,4 +1,4 @@
-import { load, YAMLException } from 'js-yaml';
+import { load } from 'js-yaml';
 import { readFileSync } from 'fs';
 import Response from '../src/response';
 import { Event } from '@appland/models';


### PR DESCRIPTION
Code example:

```
class AccountActivationsController < ApplicationController

  def edit
    response.headers['X-OpenAPI-Summary'] = 'Activate the account of an existing user'
```

Generated OpenAPI:

```
/account_activations/{id}/edit:
    get:
      responses:
        '302':
          content: {}
          description: Found
      parameters:
        - name: email
          in: query
          schema:
            type: string
        - name: id
          in: path
          schema:
            type: string
          required: true
      summary: Activate the account of an existing user
```