### PR TITLE
fix: Don't let scanner crash on "ENOSPC: System limit for number of file watchers reached" error

### DIFF
--- a/packages/cli/src/fingerprint/fingerprintWatchCommand.ts
+++ b/packages/cli/src/fingerprint/fingerprintWatchCommand.ts
@@ -52,6 +52,13 @@ export default class FingerprintWatchCommand {
       await this.watcher?.close();
       this.watcher = undefined;
       console.warn("File watching disabled.");
+      Telemetry.sendEvent({
+          name: `index:watcher_error:enospc`,
+          properties: {
+            errorMessage: error.message,
+            errorStack: error.stack,
+          },
+        });
     } else {
       // let it crash if it's some other error, to learn what the error is
       throw error;

--- a/packages/scanner/src/cli/scan/watchScan.ts
+++ b/packages/scanner/src/cli/scan/watchScan.ts
@@ -106,8 +106,27 @@ export class Watcher {
 
     const enqueue = (filePath: string) =>
       path.basename(filePath) === 'mtime' && this.enqueue(filePath);
-    for (const ch of [this.appmapWatcher, this.appmapPoller])
-      ch.on('add', enqueue).on('change', enqueue);
+    this.appmapPoller.on('add', enqueue).on('change', enqueue);
+    this.appmapWatcher
+      .on('add', enqueue)
+      .on('change', enqueue)
+      .on('error', this.watcherErrorFunction.bind(this));
+  }
+
+  async watcherErrorFunction(error: Error) {
+    if (
+      this.appmapWatcher &&
+      error.message.includes('ENOSPC: System limit for number of file watchers reached')
+    ) {
+      console.warn(error.stack);
+      console.warn('Will disable file watching. File polling will stay enabled.');
+      await this.appmapWatcher?.close();
+      this.appmapWatcher = undefined;
+      console.warn('File watching disabled.');
+    } else {
+      // let it crash if it's some other error, to learn what the error is
+      throw error;
+    }
   }
 
   async close(): Promise<void> {

--- a/packages/scanner/src/cli/scan/watchScan.ts
+++ b/packages/scanner/src/cli/scan/watchScan.ts
@@ -123,6 +123,13 @@ export class Watcher {
       await this.appmapWatcher?.close();
       this.appmapWatcher = undefined;
       console.warn('File watching disabled.');
+      Telemetry.sendEvent({
+        name: `scan:watcher_error:enospc`,
+        properties: {
+          errorMessage: error.message,
+          errorStack: error.stack,
+        },
+      });
     } else {
       // let it crash if it's some other error, to learn what the error is
       throw error;


### PR DESCRIPTION
Before this change, running the scanner with a directory that contains many files crashes with an `ENOSPC` error
![scanner_ENOSPC_main](https://user-images.githubusercontent.com/111290954/207674316-5c8b24c1-29b2-4850-9361-0f95a5174fe5.png)

After this change, the `ENOSPC` error is captured so the scanner doesn't crash and file watching is disabled.

![scanner_ENOSPC_file_watching_disabled](https://user-images.githubusercontent.com/111290954/207698437-83504523-7e07-4495-8aab-1fe77f16e935.png)

Send a `scan:watcher_error:enospc` event.  To stay consistent also send a `index:watcher_error:enospc` in the scanner.

Fixes https://github.com/getappmap/appmap-js/issues/904.

This is similar to https://github.com/getappmap/appmap-js/pull/895.