### PR TITLE
fix: Don't let scanner crash on `EACCES: permission denied` error

### DIFF
--- a/packages/scanner/src/cli/scan/watchScan.ts
+++ b/packages/scanner/src/cli/scan/watchScan.ts
@@ -94,6 +94,7 @@ export class Watcher {
     this.appmapWatcher = chokidar.watch(watchDir, {
       ignoreInitial: true,
       ignored,
+      ignorePermissionErrors: true,
     });
 
     this.appmapPoller = chokidar.watch(watchDir, {

--- a/packages/scanner/test/cli/scan.spec.ts
+++ b/packages/scanner/test/cli/scan.spec.ts
@@ -294,10 +294,10 @@ describe('scan', () => {
       const permissionDeniedDir = join(tmpDir, 'permission_denied_dir');
       await mkdir(permissionDeniedDir);
       await fsextra.copy(secretInLogMap, join(permissionDeniedDir, basename(secretInLogMap)));
-      chmod(permissionDeniedDir, 0o000);
+      await chmod(permissionDeniedDir, 0o000);
       await createWatcher();
       await waitForSingleFinding();
-      chmod(permissionDeniedDir, 0o777); // else the next testcase fails
+      await chmod(permissionDeniedDir, 0o777); // else the next testcase fails
     });
 
     it('reloads the scanner configuration automatically', async () => {


### PR DESCRIPTION
Before this change, the scanner crashed when it encountered a directory that didn't have read permission.
![scanner_EACCESS_before](https://user-images.githubusercontent.com/111290954/207939983-ef1d0f7b-8f8b-410e-9655-6b06b4108cdc.png)

After this change, the scanner doesn't crash.
![scanner_EACCES_after](https://user-images.githubusercontent.com/111290954/207940021-e6ea5e40-4637-4e61-8b1b-47284021bf91.png)

This crash is probably caused by using a general path for `appmap_dir` instead of the expected `tmp/appmap`, along with the scanner not handling this exception.  The fix is to set `ignorePermissionErrors: true` in chokidar's options.

There's a testcase.  When `ignorePermissionErrors` is commented out the testcase fails, as expected.

Fixes https://github.com/getappmap/appmap-js/issues/899.