### PR TITLE
fix: Don't attempt to render external service routes

### DIFF
--- a/packages/diagrams/src/componentDiagram/index.js
+++ b/packages/diagrams/src/componentDiagram/index.js
@@ -8,6 +8,16 @@ import Graph from './graph/index';
 
 export const DEFAULT_TARGET_COUNT = 1;
 
+// Types which have render support within the diagram
+const renderableTypes = [
+  CodeObjectType.DATABASE,
+  CodeObjectType.HTTP,
+  CodeObjectType.EXTERNAL_SERVICE,
+  CodeObjectType.ROUTE,
+  CodeObjectType.PACKAGE,
+  CodeObjectType.CLASS,
+];
+
 function codeObjectFromElement(element, classMap) {
   const { id, type } = element.dataset;
   return classMap.codeObjects.find((obj) => obj.id === id && obj.type === type);
@@ -227,11 +237,7 @@ export default class ComponentDiagram extends EventSource {
       .reduce((objects, obj) => {
         const children = obj.childLeafs();
 
-        if (
-          children.length === 1 &&
-          children[0].type !== CodeObjectType.QUERY &&
-          children[0].type !== CodeObjectType.FUNCTION
-        ) {
+        if (children.length === 1 && renderableTypes.includes(children[0].type)) {
           // Make sure this object isn't empty
           const eventCount = obj.allEvents.length;
           if (eventCount > 0) {


### PR DESCRIPTION
If an external service has once child, do not expand the service into its route. There's no rendering support for that type. This change also prevents future issues of this type.

![image](https://user-images.githubusercontent.com/8737782/208946460-aca35f62-2ae8-4cad-a8d0-88754c4a2743.png)
