### PR TITLE
fix: Don't encourage `git commit` for `pip`

### DIFF
--- a/packages/cli/tests/unit/agentInstall/TestAgentProcedure.ts
+++ b/packages/cli/tests/unit/agentInstall/TestAgentProcedure.ts
@@ -3,15 +3,15 @@ import AgentProcedure from '../../../src/cmds/agentInstaller/agentProcedure';
 import commandStruct from '../../../src/cmds/agentInstaller/commandStruct';
 
 export class TestAgentProcedure extends AgentProcedure {
-  constructor() {
-    const installer = new TestAgentInstaller();
+  constructor(name: string) {
+    const installer = new TestAgentInstaller(name);
     super(installer, '/test/agent/procedure/path');
   }
 }
 
 export class TestAgentInstaller extends AgentInstaller {
-  constructor() {
-    super('test agent', '/test/agent/installer/path');
+  constructor(name: string) {
+    super(name, '/test/agent/installer/path');
   }
 
   public buildFile = 'test build file';

--- a/packages/cli/tests/unit/agentInstall/agentInstallerProcedure.spec.ts
+++ b/packages/cli/tests/unit/agentInstall/agentInstallerProcedure.spec.ts
@@ -13,15 +13,23 @@ jest.mock('../../../src/cmds/agentInstaller/commandRunner');
 const { prompt, success, warn } = jest.mocked(UI);
 const { run } = jest.mocked(CommandRunner);
 
-const procedure = new AgentInstallerProcedure(new TestAgentInstaller(), '/test/path');
+const procedure = new AgentInstallerProcedure(new TestAgentInstaller('test agent'), '/test/path');
 
 describe(AgentInstallerProcedure, () => {
   withStubbedTelemetry(sinon);
   it('prints any warnings from the validator', async () => {
     prompt.mockResolvedValue({ confirm: true });
-    jest.spyOn(procedure, 'validateProject').mockResolvedValue(
-      { errors: [{ level: 'warning', message: 'Remember to foo the bar.', help_urls: ['test:///help/url'] }] }
-    );
+    jest
+      .spyOn(procedure, 'validateProject')
+      .mockResolvedValue({
+        errors: [
+          {
+            level: 'warning',
+            message: 'Remember to foo the bar.',
+            help_urls: ['test:///help/url'],
+          },
+        ],
+      });
     run.mockResolvedValue({ stdout: '{"configuration": {"contents": ""}}', stderr: '' });
     jest.spyOn(fs, 'writeFileSync').mockImplementation();
 

--- a/packages/cli/tests/unit/agentInstall/agentProcedure.spec.ts
+++ b/packages/cli/tests/unit/agentInstall/agentProcedure.spec.ts
@@ -6,7 +6,7 @@ import { withStubbedTelemetry } from '../../helper';
 
 jest.mock('../../../src/cmds/userInteraction');
 
-const procedure = new TestAgentProcedure();
+const procedure = new TestAgentProcedure('test agent');
 
 const { prompt } = jest.mocked(UI);
 
@@ -87,6 +87,12 @@ describe(AgentProcedure, () => {
         jest.spyOn(procedure, 'gitStatus').mockResolvedValue(filesAfter);
         prompt.mockResolvedValue({ commit: false });
         return expect(procedure.commitConfiguration(filesBefore)).resolves.toBe(false);
+      });
+
+      it('there is a diff but it is pip; it would enable AppMap in production', () => {
+        const filesBefore = [];
+        const procedurePip = new TestAgentProcedure('pip');
+        return expect(procedurePip.commitConfiguration(filesBefore)).resolves.toBe(false);
       });
     });
 

--- a/packages/cli/tests/unit/agentInstall/agentStatusProcedure.spec.ts
+++ b/packages/cli/tests/unit/agentInstall/agentStatusProcedure.spec.ts
@@ -6,13 +6,24 @@ import { TestAgentInstaller } from './TestAgentProcedure';
 jest.mock('../../../src/cmds/userInteraction');
 const { success, warn } = jest.mocked(UI);
 
-const procedure = new AgentStatusProcedure(new TestAgentInstaller(), '/test/project/path');
+const procedure = new AgentStatusProcedure(
+  new TestAgentInstaller('test agent'),
+  '/test/project/path'
+);
 
 describe(AgentStatusProcedure, () => {
   it('prints any warnings from the validator', async () => {
-    jest.spyOn(procedure, 'validateProject').mockResolvedValue(
-      { errors: [{ level: 'warning', message: 'Remember to foo the bar.', help_urls: ['test:///help/url'] }] }
-    );
+    jest
+      .spyOn(procedure, 'validateProject')
+      .mockResolvedValue({
+        errors: [
+          {
+            level: 'warning',
+            message: 'Remember to foo the bar.',
+            help_urls: ['test:///help/url'],
+          },
+        ],
+      });
 
     await procedure.run();
 


### PR DESCRIPTION
When adding AppMap with the installer to a project that uses `pip`, don't prompt the user to commit the changes to git. It would affect production because `appmap-python` will soon [record by default](https://github.com/getappmap/appmap-python/pull/208) in production.  Affecting production is not what the user would want.

For `pipenv` and `poetry` this isn't necessary because they provide a way to add AppMap to a development configuration.

In general the installers go out of their way to ensure their respective agents don't get installed in production.

Before this change, installing in a `pip` project prompted the user to commit to git.
![installer_pip_before](https://user-images.githubusercontent.com/111290954/209003914-a6412cdb-a8dd-472e-b2fa-bd99d41e27eb.png)

After this change, installing in a `pip` project doesn't prompt the user to commit to git.
![installer_pip_after](https://user-images.githubusercontent.com/111290954/209003941-efddc59b-0de1-4ce4-a142-45b22fd3dfbc.png)

Tested with repo [`git@github.com:symwell/try_appmap_python.git`](https://github.com/symwell/try_appmap_python)