### PR TITLE
feat: remove fonky default test command

### DIFF
--- a/packages/cli/src/cmds/record/action/guessTestCommands.ts
+++ b/packages/cli/src/cmds/record/action/guessTestCommands.ts
@@ -45,13 +45,6 @@ const TestCommands: TestCommandGuess[] = [
       env: {},
     },
   },
-  {
-    paths: ['package.json', 'node_modules'],
-    command: {
-      command: 'npx @appland/appmap-agent-js --recorder=process -- npm run test',
-      env: {},
-    },
-  },
 ];
 
 export default async function guessTestCommands(): Promise<TestCommand[] | undefined> {


### PR DESCRIPTION
The default js test command seems to record 0 appmaps in many cases. It  could be that there is no tests or that the project is not using node to  run tests. Also, the command is confusing because it mixes  `--recorder=process` with a test command whereas we want to push ad-hoc  recorders for tests.