### PR TITLE
fix: Fix a bug preventing 'Update in GET request' rule from working

### DIFF
--- a/packages/scanner/src/rules/updateInGetRequest.ts
+++ b/packages/scanner/src/rules/updateInGetRequest.ts
@@ -74,6 +74,7 @@ export default {
   id: 'update-in-get-request',
   title: 'Data update performed in GET or HEAD request',
   scope: 'http_server_request',
+  enumerateScope: true,
   labels: [Audit],
   impactDomain: 'Maintainability',
   description: parseRuleDescription('updateInGetRequest'),

--- a/packages/scanner/test/scanner/updateInGetRequest.spec.ts
+++ b/packages/scanner/test/scanner/updateInGetRequest.spec.ts
@@ -1,28 +1,20 @@
 import updateInGetRequest from '../../src/rules/updateInGetRequest';
-import testRule from '../support/testRule';
+import describeRule from '../support/describeRule';
 
-describe(updateInGetRequest.title, () => {
-  it('correctly recognizes an update in a GET request', async () => {
-    const findings = await testRule(updateInGetRequest, [
-      { http: 'GET /foobar' },
-      [{ sql: 'UPDATE things SET col=4' }],
-    ]);
-    expect(findings[0].checkId).toEqual(updateInGetRequest.id);
-  });
-
-  it('correctly recognizes an update deeper in a GET request', async () => {
-    const findings = await testRule(updateInGetRequest, [
-      { http: 'GET /foobar' },
-      [[{ fn: 'Foo.check' }, [{ sql: 'UPDATE things SET col=4' }]]],
-    ]);
-    expect(findings[0].checkId).toEqual(updateInGetRequest.id);
-  });
-
-  it('does not flag an update in a POST request', async () => {
-    const findings = await testRule(updateInGetRequest, [
-      { http: 'POST /foobar' },
-      [{ sql: 'UPDATE things SET col=4' }],
-    ]);
-    expect(findings.length).toEqual(0);
-  });
-});
+describeRule(updateInGetRequest, [
+  [
+    'correctly recognizes an update in a GET request',
+    [{ http: 'GET /foobar' }, [{ sql: 'UPDATE things SET col=4' }]],
+    1,
+  ],
+  [
+    'correctly recognizes an update deeper in a GET request',
+    [{ http: 'GET /foobar' }, [[{ fn: 'Foo.check' }, [{ sql: 'UPDATE things SET col=4' }]]]],
+    1,
+  ],
+  [
+    'does not flag an update in a POST request',
+    [{ http: 'POST /foobar' }, [{ sql: 'UPDATE things SET col=4' }]],
+    0,
+  ],
+]);

--- a/packages/scanner/test/scanner/updateInGetRequest.spec.ts
+++ b/packages/scanner/test/scanner/updateInGetRequest.spec.ts
@@ -1,0 +1,28 @@
+import updateInGetRequest from '../../src/rules/updateInGetRequest';
+import testRule from '../support/testRule';
+
+describe(updateInGetRequest.title, () => {
+  it('correctly recognizes an update in a GET request', async () => {
+    const findings = await testRule(updateInGetRequest, [
+      { http: 'GET /foobar' },
+      [{ sql: 'UPDATE things SET col=4' }],
+    ]);
+    expect(findings[0].checkId).toEqual(updateInGetRequest.id);
+  });
+
+  it('correctly recognizes an update deeper in a GET request', async () => {
+    const findings = await testRule(updateInGetRequest, [
+      { http: 'GET /foobar' },
+      [[{ fn: 'Foo.check' }, [{ sql: 'UPDATE things SET col=4' }]]],
+    ]);
+    expect(findings[0].checkId).toEqual(updateInGetRequest.id);
+  });
+
+  it('does not flag an update in a POST request', async () => {
+    const findings = await testRule(updateInGetRequest, [
+      { http: 'POST /foobar' },
+      [{ sql: 'UPDATE things SET col=4' }],
+    ]);
+    expect(findings.length).toEqual(0);
+  });
+});

--- a/packages/scanner/test/support/describeRule.ts
+++ b/packages/scanner/test/support/describeRule.ts
@@ -1,0 +1,17 @@
+import { Rule } from '../../src/types';
+import { TestMap } from './testMap';
+import testRule from './testRule';
+
+type RuleTestCase = [string, TestMap, number];
+
+export default function describeRule(rule: Rule, cases: RuleTestCase[]): void {
+  return describe(rule.title, () => {
+    cases.map(([title, map, findingCount]) => {
+      it(title, async () => {
+        const findings = await testRule(rule, map);
+        expect(findings.length).toEqual(findingCount);
+        for (const { checkId } of findings) expect(checkId).toEqual(rule.id);
+      });
+    });
+  });
+}

--- a/packages/scanner/test/support/testMap.ts
+++ b/packages/scanner/test/support/testMap.ts
@@ -1,0 +1,90 @@
+import { AppMap, buildAppMap, HttpServerRequest, SqlQuery } from '@appland/models';
+
+type NodeInfo = { http: string } | { sql: string } | { fn: string };
+type MapNode = [NodeInfo, MapNode[]] | NodeInfo;
+export type TestMap = MapNode;
+
+type BaseEvent = { id: number };
+
+type BaseCallEvent = BaseEvent & {
+  event: 'call';
+};
+
+type HttpEvent = BaseCallEvent & {
+  http_server_request: HttpServerRequest;
+};
+
+type SqlEvent = BaseCallEvent & {
+  sql_query: SqlQuery;
+};
+
+type FunctionCallEvent = BaseCallEvent & {
+  defined_class: string;
+  method_id: string;
+};
+
+type CallEvent = FunctionCallEvent | HttpEvent | SqlEvent;
+
+type ReturnEvent = BaseEvent & {
+  event: 'return';
+  parent_id: Event['id'];
+};
+
+type Event = CallEvent | ReturnEvent;
+
+function testEvents(node: MapNode): Event[] {
+  const [info, children] = node instanceof Array ? node : [node, []];
+  const call = makeEvent(info);
+  const childEvents = children.flatMap(testEvents);
+  return [call, ...childEvents, makeReturn(call)];
+}
+
+export default function testMap(root: MapNode): AppMap {
+  return buildAppMap({ events: testEvents(root) })
+    .normalize()
+    .build();
+}
+
+const nextId = (() => {
+  let eventId = 0;
+  return () => {
+    eventId += 1;
+    return eventId;
+  };
+})();
+
+function makeEvent(info: NodeInfo): CallEvent {
+  const ev = { id: nextId(), event: 'call' } as const;
+
+  if ('http' in info) {
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    const [request_method, path_info] = info.http.split(' ', 2);
+    return {
+      ...ev,
+      http_server_request: {
+        request_method,
+        path_info,
+      },
+    };
+  }
+
+  if ('sql' in info) {
+    return { ...ev, sql_query: { sql: info.sql, database_type: 'test' } };
+  }
+
+  if ('fn' in info) {
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    const [defined_class, method_id] = info.fn.split('.');
+    return { ...ev, defined_class, method_id };
+  }
+
+  throw new TypeError(`invalid node info`);
+}
+
+function makeReturn(call: CallEvent): ReturnEvent {
+  return {
+    id: nextId(),
+    event: 'return',
+    parent_id: call.id,
+  };
+}

--- a/packages/scanner/test/support/testRule.ts
+++ b/packages/scanner/test/support/testRule.ts
@@ -1,0 +1,8 @@
+import { scan } from '../util';
+import Check from '../../src/check';
+import testMap, { TestMap } from './testMap';
+import { Finding, Rule } from '../../src/types';
+
+export default async function testRule(rule: Rule, map: TestMap): Promise<Finding[]> {
+  return (await scan(new Check(rule), 'test', testMap(map))).findings;
+}


### PR DESCRIPTION
The rule was missing a correct `enumerateScope` setting.