### PR TITLE
fix: bump @appland dependency versions

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -27,8 +27,8 @@
     "dist/index.js"
   ],
   "dependencies": {
-    "@appland/diagrams": "workspace:^1.5.1",
-    "@appland/models": "workspace:^1.9.0",
+    "@appland/diagrams": "workspace:^1.6.0",
+    "@appland/models": "workspace:^1.23.0",
     "buffer": "^6.0.3",
     "highlight.js": "^10.7.2",
     "sql-formatter": "^4.0.2",

--- a/packages/diagrams/package.json
+++ b/packages/diagrams/package.json
@@ -29,7 +29,7 @@
     "dist/style.css"
   ],
   "dependencies": {
-    "@appland/models": "workspace:^1.9.0",
+    "@appland/models": "workspace:^1.23.0",
     "d3-interpolate": "^1.4.0",
     "d3-selection": "^1.4.2",
     "d3-shape": "^1.3.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -191,8 +191,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@appland/components@workspace:packages/components"
   dependencies:
-    "@appland/diagrams": "workspace:^1.5.1"
-    "@appland/models": "workspace:^1.9.0"
+    "@appland/diagrams": "workspace:^1.6.0"
+    "@appland/models": "workspace:^1.23.0"
     "@babel/core": ^7.13.1
     "@babel/node": ^7.13.0
     "@babel/preset-env": ^7.9.5
@@ -258,11 +258,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@appland/diagrams@workspace:^1, @appland/diagrams@workspace:^1.5.1, @appland/diagrams@workspace:packages/diagrams":
+"@appland/diagrams@workspace:^1, @appland/diagrams@workspace:^1.6.0, @appland/diagrams@workspace:packages/diagrams":
   version: 0.0.0-use.local
   resolution: "@appland/diagrams@workspace:packages/diagrams"
   dependencies:
-    "@appland/models": "workspace:^1.9.0"
+    "@appland/models": "workspace:^1.23.0"
     "@rollup/plugin-commonjs": ^18.1.0
     "@rollup/plugin-node-resolve": ^13.0.0
     "@rollup/plugin-replace": ^2.4.2
@@ -290,7 +290,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@appland/models@workspace:*, @appland/models@workspace:^1, @appland/models@workspace:^1.18.1, @appland/models@workspace:^1.9.0, @appland/models@workspace:packages/models":
+"@appland/models@workspace:*, @appland/models@workspace:^1, @appland/models@workspace:^1.18.1, @appland/models@workspace:^1.23.0, @appland/models@workspace:packages/models":
   version: 0.0.0-use.local
   resolution: "@appland/models@workspace:packages/models"
   dependencies:


### PR DESCRIPTION
Ensure that @appland/models version ^1.23.0 is used in @appland/components.