### PR TITLE
feat: Collect git metadata

### DIFF
--- a/packages/cli/src/fingerprint/collectGitMetadata.ts
+++ b/packages/cli/src/fingerprint/collectGitMetadata.ts
@@ -1,0 +1,56 @@
+import { exec } from 'child_process';
+import sanitizeURL from '../lib/repositoryInfo';
+
+type MetadataHandlerFn = (value: string) => string | string[] | undefined;
+
+type MetadataSource = {
+  command: string;
+  handler?: MetadataHandlerFn;
+};
+
+const GitCommands: Record<string, string | MetadataSource> = {
+  repository: `git config --get remote.origin.url`,
+  user_name: `git config --get user.name`,
+  user_email: `git config --get user.email`,
+  branch: `git rev-parse --abbrev-ref HEAD`,
+  commit: `git rev-parse HEAD`,
+  status: {
+    command: `git status -s`,
+    handler: (value: string) => value.split('\n').map((line) => line.trim()),
+  },
+};
+
+export default async function collectGitMetadata(properties: Record<string, string | string[]>) {
+  const gitKeys = Object.keys(GitCommands);
+  const commandErrors = new Map<string, Error>();
+  await Promise.all(
+    gitKeys.map(async (key) => {
+      return new Promise<void>((resolve) => {
+        const source = GitCommands[key];
+        let command: string;
+        let handler: MetadataHandlerFn | undefined;
+        if (typeof source === 'string') {
+          command = source as string;
+        } else {
+          command = (source as MetadataSource).command;
+          handler = (source as MetadataSource).handler;
+        }
+        exec(command, (error, stdout, _stderr) => {
+          if (error) {
+            commandErrors.set(key, error);
+            resolve();
+          }
+          let value: string | string[] | undefined = stdout.trim();
+          if (handler) {
+            value = handler(value);
+          }
+          if (value !== undefined) {
+            properties[['git', key].join('.')] =
+              typeof value === 'string' ? sanitizeURL(value) : value;
+          }
+          resolve();
+        });
+      });
+    })
+  );
+}

--- a/packages/cli/src/fingerprint/fingerprintWatchCommand.ts
+++ b/packages/cli/src/fingerprint/fingerprintWatchCommand.ts
@@ -11,6 +11,7 @@ import { FingerprintEvent } from './fingerprinter';
 import FingerprintQueue from './fingerprintQueue';
 import Globber from './globber';
 import path from 'path';
+import collectGitMetadata from './collectGitMetadata';
 
 export default class FingerprintWatchCommand {
   private pidfilePath: string | undefined;
@@ -245,10 +246,11 @@ export default class FingerprintWatchCommand {
     this.fpQueue.push(file);
   }
 
-  private sendTelemetry(metadata: Metadata[]) {
+  private async sendTelemetry(metadata: Metadata[]) {
     const properties = Object.fromEntries(
       intersectMaps(...metadata.map(flattenMetadata)).entries()
     );
+    await collectGitMetadata(properties);
     Telemetry.sendEvent({
       name: 'appmap:index',
       properties,

--- a/packages/cli/src/lib/flattenMetadata.ts
+++ b/packages/cli/src/lib/flattenMetadata.ts
@@ -2,7 +2,7 @@ import { Metadata } from '@appland/models';
 import sanitizeURL from './repositoryInfo';
 
 /** Flattens metadata into a string-string map suitable for use in telemetry.
- * Ignores git, exception and fingerprints.
+ * Ignores exception and fingerprints.
  */
 export default function flattenMetadata(metadata: Metadata): Map<string, string> {
   const result = new Map<string, string>();
@@ -26,8 +26,14 @@ export default function flattenMetadata(metadata: Metadata): Map<string, string>
     if (metadata.language.engine) result.set('language.engine', metadata.language.engine);
   }
 
-  if (metadata.git?.repository) {
-    result.set('git.repository', sanitizeURL(metadata.git.repository));
+  if (metadata.git) {
+    Object.keys(metadata.git as any).forEach((key) => {
+      const saveKey = key.replace(/^git_/, '');
+      const value = (metadata.git as any)[key];
+      if (value !== null && value !== undefined) {
+        result.set(`git.${saveKey}`, sanitizeURL(value));
+      }
+    });
   }
 
   if (metadata.name) result.set('name', metadata.name);

--- a/packages/cli/tests/unit/util.ts
+++ b/packages/cli/tests/unit/util.ts
@@ -25,3 +25,34 @@ export async function indexDirectory(dir: string): Promise<void> {
     await fingerprinter.fingerprint(fileName);
   });
 }
+
+export async function waitFor(test: () => void | Promise<void>, timeout = 100): Promise<void> {
+  const startTime = Date.now();
+  let delay = 10;
+  let error: Error | undefined;
+
+  const attempt = (): boolean => {
+    try {
+      test();
+      return true;
+    } catch (err) {
+      console.warn(err);
+      error = err as any as Error;
+      return false;
+    }
+  };
+  while (!attempt()) {
+    const elapsed = Date.now() - startTime;
+    if (elapsed > timeout) {
+      throw error;
+    }
+
+    console.log(`Waiting ${delay}ms`);
+    await wait(delay);
+    delay = delay * 2;
+  }
+}
+
+async function wait(delay: number) {
+  await new Promise<void>((resolve) => setTimeout(resolve, delay));
+}

--- a/packages/models/types/index.d.ts
+++ b/packages/models/types/index.d.ts
@@ -260,10 +260,12 @@ declare module '@appland/models' {
       branch: string;
       commit: string;
       status: string[];
+      user_name?: string;
+      user_email?: string;
       tag?: string;
       annotated_tag?: string;
       commits_since_tag?: number;
-      commits_since_annotated_tag: number;
+      commits_since_annotated_tag?: number;
     }
 
     export class Language extends Framework {


### PR DESCRIPTION
Collect and emit git metadata in the Fingerprint watcher. So, for anyone who has `git` and runs a current indexer, we should get the git telemetry. 

The `git` commands are borrowed from appmap-ruby.