### PR TITLE
fix: Scan-watching directories on other than the current drive

### DIFF
--- a/packages/scanner/src/cli/scan/watchScan.ts
+++ b/packages/scanner/src/cli/scan/watchScan.ts
@@ -14,6 +14,7 @@ import {
 import Telemetry from '../../telemetry';
 import EventEmitter from 'events';
 import { WatchScanTelemetry } from './watchScanTelemetry';
+import isAncestorPath from '../../lib/isAncestorPath';
 
 export type WatchScanOptions = {
   appId?: string;
@@ -42,10 +43,6 @@ async function existingParent(targetPath: string): Promise<string> {
     targetPath = path.dirname(targetPath);
   }
   return targetPath;
-}
-
-function isAncestorPath(ancestor: string, descendant: string): boolean {
-  return !path.relative(ancestor, descendant).startsWith('..');
 }
 
 export class Watcher {

--- a/packages/scanner/src/lib/isAncestorPath.ts
+++ b/packages/scanner/src/lib/isAncestorPath.ts
@@ -1,0 +1,6 @@
+import path from 'path';
+
+export default function isAncestorPath(ancestor: string, descendant: string): boolean {
+  const relative = path.relative(ancestor, descendant);
+  return !relative.startsWith('..') && !path.isAbsolute(relative);
+}

--- a/packages/scanner/test/lib/isAncestorPath.spec.ts
+++ b/packages/scanner/test/lib/isAncestorPath.spec.ts
@@ -1,0 +1,37 @@
+import { win32, posix } from 'path';
+
+jest.setMock('path', win32);
+
+import isAncestorPath from '../../src/lib/isAncestorPath';
+
+describe(isAncestorPath, () => {
+  it.each([
+    ['C:\\Foo', 'C:\\Foo\\Bar', true],
+    ['C:\\Foo', 'C:\\Bar', false],
+    ['C:\\Foo', 'D:\\Foo\\Bar', false],
+    [
+      'D:\\a\\appmap-js\\appmap-js\\packages\\scanner',
+      'C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\pMITIo',
+      false,
+    ],
+  ])('isAncestorPath(%s, %s) = %s', (ancestor, descendant, expected) => {
+    expect(isAncestorPath(ancestor, descendant)).toBe(expected);
+  });
+});
+
+jest.setMock('path', posix);
+
+describe(isAncestorPath, () => {
+  it.each([
+    ['/foo', '/foo', true],
+    ['/foo', '/bar', false],
+    ['/foo', '/foobar', false],
+    ['/foo', '/foo/bar', true],
+    ['/foo', '/foo/../bar', false],
+    ['/foo', '/foo/./bar', true],
+    ['/bar/../foo', '/foo/bar', true],
+    ['/foo', './bar', false],
+  ])('isAncestorPath(%s, %s) = %s', (ancestor, descendant, expected) => {
+    expect(isAncestorPath(ancestor, descendant)).toBe(expected);
+  });
+});


### PR DESCRIPTION
Fix the problem where on Windows, if the appmap directory was located on a different drive, scan --watch command would erronously watch the current directory instead.