### PR TITLE
Style updates for project picker

### DIFF
--- a/packages/components/src/components/Accordion.vue
+++ b/packages/components/src/components/Accordion.vue
@@ -37,10 +37,8 @@ export default {
 <style lang="scss">
 .accordion {
   &--open {
-    border: 1px solid rgba(200, 200, 255, 0.1);
-
     .accordion__header {
-      background-color: rgba(200, 200, 255, 0.1);
+      border-bottom: 0;
     }
   }
 
@@ -48,10 +46,6 @@ export default {
     .accordion__header {
       cursor: default;
       color: $gray4;
-
-      &:hover {
-        background-color: rgba(200, 200, 255, 0.05);
-      }
     }
   }
 
@@ -60,16 +54,12 @@ export default {
     user-select: none;
     width: 100%;
     display: block;
-    padding: 1em;
+    padding: 0.2rem 2rem;
     text-align: left;
-
-    &:hover {
-      background-color: rgba(200, 200, 255, 0.1);
-    }
   }
 
   &__body {
-    margin-top: 1em;
+    padding: 0 2rem;
   }
 }
 </style>

--- a/packages/components/src/components/Button.vue
+++ b/packages/components/src/components/Button.vue
@@ -96,7 +96,7 @@ export default {
   padding: 0.75em 1.5em;
   text-align: center;
   cursor: pointer;
-  transition: 0.25s ease background-color;
+  transition: $transition;
   user-select: none;
 
   &:disabled {
@@ -145,7 +145,7 @@ export default {
     background-color: inherit;
     border: 1px solid $gray4;
     border-style: solid;
-    color: $gray4;
+    color: $white;
 
     &:disabled {
       background-color: inherit;
@@ -154,13 +154,13 @@ export default {
     }
 
     &:hover {
-      color: rgba(255, 255, 255, 0.9);
-      border-color: rgba(255, 255, 255, 0.9);
+      border-color: $white;
+      background-color: $black;
     }
 
     &:active {
-      color: rgba(255, 255, 255, 0.9);
-      border-color: rgba(255, 255, 255, 0.65);
+      color: $white;
+      border-color: $white;
     }
   }
 

--- a/packages/components/src/components/CodeSnippet.vue
+++ b/packages/components/src/components/CodeSnippet.vue
@@ -87,11 +87,10 @@ export default {
 .code-snippet {
   margin: 1rem 0;
   border-radius: $border-radius;
-  border: 1px solid $brightblue;
   display: flex;
   align-items: stretch;
   color: white;
-  background-color: rgba(0, 0, 0, 0.25);
+  background-color: $black;
   max-width: 100%;
 
   &__line {
@@ -105,12 +104,11 @@ export default {
     padding: 0.75rem 1.25rem;
     margin: 0;
     border: none;
-    border-right: 1px solid $brightblue;
     border-radius: 0;
     background: transparent;
     outline: none;
     appearance: none;
-    font-size: 1rem;
+    font-size: 0.9rem;
   }
 
   &__btn {
@@ -120,12 +118,12 @@ export default {
     border: none;
     border-radius: 0 6px 6px 0;
     color: #fff;
-    background-color: $brightblue;
-    opacity: 0.85;
+    background-color: $white;
+    opacity: 1;
     outline: none;
     appearance: none;
     cursor: pointer;
-    transition: 0.25s ease opacity;
+    transition: $transition;
 
     &[disabled] {
       opacity: 0.5;
@@ -133,8 +131,7 @@ export default {
     }
 
     &:hover {
-      color: rgba(255, 255, 255, 0.9);
-      opacity: 1;
+      opacity: 0.5;
     }
 
     &:active {
@@ -142,8 +139,8 @@ export default {
     }
 
     &-icon {
-      width: 1em;
-      fill: currentColor;
+      width: 1.2rem;
+      fill: $black;
     }
   }
 }

--- a/packages/components/src/components/DetailsPanelStackTrace.vue
+++ b/packages/components/src/components/DetailsPanelStackTrace.vue
@@ -90,15 +90,14 @@ export default {
       }
     }
     a {
-      color: $blue;
+      color: $powderblue;
       text-decoration: none;
       line-height: 1.5rem;
       width: 100%;
       word-break: break-all;
       transition: $transition;
       &:hover {
-        text-decoration: underline;
-        color: lighten($blue, 20);
+        color: $white;
       }
     }
   }

--- a/packages/components/src/components/install-guide/ProjectPickerRow.vue
+++ b/packages/components/src/components/install-guide/ProjectPickerRow.vue
@@ -232,7 +232,7 @@ $brightblue: rgba(255, 255, 255, 0.1);
   }
   &__body {
     padding: 1rem 0;
-    border-top: 1px solid $gray4;
+    border-top: 1px solid lighten($gray2, 15);
   }
   &__nav {
     display: flex;
@@ -257,6 +257,7 @@ $brightblue: rgba(255, 255, 255, 0.1);
     font-size: 0.9rem;
     justify-content: left;
     flex-grow: 1;
+    font-weight: 800;
   }
 
   &__support {
@@ -315,13 +316,13 @@ $brightblue: rgba(255, 255, 255, 0.1);
   display: flex;
   justify-content: center;
   margin: 2em auto;
-  color: $color;
+  color: lighten($gray2, 25);
 
   &::before {
     content: ' ';
     margin: auto 1em auto 0;
     width: 100%;
-    background-color: $color;
+    background-color: lighten($gray2, 15);
     height: 1px;
   }
 
@@ -329,7 +330,7 @@ $brightblue: rgba(255, 255, 255, 0.1);
     content: ' ';
     margin: auto 0 auto 1em;
     width: 100%;
-    background-color: $color;
+    background-color: lighten($gray2, 15);
     height: 1px;
   }
 }

--- a/packages/components/src/components/install-guide/ProjectPickerRow.vue
+++ b/packages/components/src/components/install-guide/ProjectPickerRow.vue
@@ -47,7 +47,7 @@
         You're almost done! Install AppMap as a development dependency in your project. Click the
         button below to perform an automated installation.
         <div class="center-block" data-cy="automated-install">
-          <v-button kind="primary" @click.native="performInstall" :timeout="2000">
+          <v-button kind="ghost" @click.native="performInstall" :timeout="2000">
             Automated install via AppMap CLI
           </v-button>
         </div>
@@ -222,15 +222,17 @@ export default {
 $brightblue: rgba(255, 255, 255, 0.1);
 
 .project-picker-row {
-  border-width: 0.5px 0;
-  border-style: solid;
-  border-color: rgba(0, 0, 0, 0.1);
+  border-bottom: 1px solid lighten($gray2, 15);
+  padding: 0;
 
   &.accordion--open {
-    background-color: rgba(200, 200, 255, 0.075);
+    background-color: #171d2d;
+    border-radius: 0;
+    border-bottom: 1px solid lighten($gray2, 15);
   }
   &__body {
-    padding: 1rem;
+    padding: 1rem 0;
+    border-top: 1px solid $gray4;
   }
   &__nav {
     display: flex;
@@ -239,58 +241,62 @@ $brightblue: rgba(255, 255, 255, 0.1);
       flex-grow: 1;
       margin: auto 0;
     }
-    margin-top: 2rem;
+    margin-top: 1rem;
+  }
+
+  &:hover {
+    background-color: #171d2d;
   }
 }
 
 .header {
   display: flex;
+  align-items: center;
 
   &__title {
-    font-size: 1.2rem;
+    font-size: 0.9rem;
     justify-content: left;
     flex-grow: 1;
   }
 
   &__support {
     display: flex;
-    justify-content: right;
+    gap: 1.25rem;
   }
 
   &__feature-tag {
+    color: $gray4;
     display: flex;
-    margin-left: 1rem;
-    background-color: rgba(200, 200, 255, 0.4);
-    padding: 0.5em;
-    border-radius: 8px;
+    padding: 0.2rem 0;
     align-items: center;
     transition: $transition;
 
     svg {
       height: 16px;
       width: 16px;
-      fill: $almost-black;
+      fill: $gray4;
+      transition: $transition;
     }
 
     &:hover {
-      background-color: $gray5;
-      color: $almost-black;
+      color: lighten($gray4, 30);
+
+      svg {
+        fill: lighten($gray4, 30);
+      }
     }
   }
 
   &__icon-text {
     display: inline-block;
-    font-size: 0.8em;
-    color: $almost-black;
-    margin-left: 0.5em;
-    margin-top: auto;
-    margin-bottom: -3px;
+    margin-left: 0.25em;
+    font-size: 0.9rem;
   }
 
   &__accordion-icons {
     position: relative;
-    width: 18px;
-    height: 18px;
+    width: 14px;
+    height: 14px;
     margin-left: 1rem;
     align-self: center;
 
@@ -336,6 +342,7 @@ $brightblue: rgba(255, 255, 255, 0.1);
 
 .support-list {
   margin: 1rem 0;
+  list-style-position: inside;
   ul {
     margin-left: 1rem;
     margin-top: 0;

--- a/packages/components/src/components/install-guide/ProjectPickerRow.vue
+++ b/packages/components/src/components/install-guide/ProjectPickerRow.vue
@@ -62,7 +62,10 @@
       </template>
       <template v-else>
         <template v-if="!languageSupported">
-          <p>AppMap currently supports the following languages:</p>
+          <p>
+            This project does not meet all the requirements to create AppMaps. AppMap currently
+            supports the following languages:
+          </p>
           <ul class="support-list">
             <li><strong>Ruby</strong></li>
             <li><strong>Python</strong></li>
@@ -78,7 +81,6 @@
             information.
           </p>
         </template>
-        <p>This project does not meet all the requirements to create AppMaps.</p>
       </template>
     </div>
   </v-accordion>

--- a/packages/components/src/components/install-guide/ProjectPickerTable.vue
+++ b/packages/components/src/components/install-guide/ProjectPickerTable.vue
@@ -64,9 +64,10 @@ export default {
 
 <style lang="scss" scoped>
 .project-picker-table {
-  width: 100%;
-  border-radius: 8px;
-  border-spacing: 0;
+  border-top: 1px solid lighten($gray2, 15);
   color: $white;
+  display: flex;
+  flex-direction: column;
+  margin: 0.5rem -1.75rem 0 -1.75rem;
 }
 </style>

--- a/packages/components/src/components/install-guide/install-instructions/Ruby.vue
+++ b/packages/components/src/components/install-guide/install-instructions/Ruby.vue
@@ -1,12 +1,12 @@
 <template>
   <section>
-    <p>Add the following line to the top of your Gemfile.</p>
+    <p>
+      Add the following line of code to the top of your Gemfile to ensure the gem is loaded first
+      and has a chance to observe other gems as they're loaded.
+    </p>
     <v-code-snippet
       clipboard-text="# This must be the first gem listed\ngem 'appmap', group: %i[test development]"
     />
-    <p class="note">
-      This ensures the gem is loaded first and has a chance to observe other gems as they're loaded.
-    </p>
   </section>
 </template>
 

--- a/packages/components/src/pages/install-guide/ProjectPicker.vue
+++ b/packages/components/src/pages/install-guide/ProjectPicker.vue
@@ -1,6 +1,6 @@
 <template>
   <QuickstartLayout>
-    <section>
+    <section class="project-picker">
       <header>
         <h1 data-cy="title">Add AppMap to your project</h1>
       </header>
@@ -24,12 +24,12 @@
             ref="projectTable"
           />
         </article>
-        <article v-if="projects.length > 1">
-          <h2 class="install subhead">Projects</h2>
+        <article class="project-list" v-if="projects.length > 1">
           <p data-cy="multiple-projects-text">
             You have multiple projects in this workspace. We’ve outlined the projects that are ready
             to start making AppMaps. <br />Select a project to continue.
           </p>
+          <h3 class="">Projects</h3>
           <div class="table-wrap">
             <v-project-picker-table
               :projects="projects"
@@ -109,9 +109,19 @@ h2 {
   margin-bottom: 0.5rem;
 }
 
+.project-picker {
+  h3 {
+    text-transform: uppercase;
+    color: $gray4;
+  }
+  .project-list {
+    p {
+      margin-bottom: 1.75rem;
+    }
+  }
+}
+
 .table-wrap {
-  border: 1px solid $gray-secondary;
-  border-radius: $border-radius;
   &::-webkit-scrollbar-thumb {
     background: $gray-secondary;
   }


### PR DESCRIPTION
Update the project picker so that the `Supported features` don't look like buttons. List styles should match lists used on other Instruction pages