### PR TITLE
feat: Env var telemetry

### DIFF
--- a/packages/cli/tests/unit/openapi.spec.ts
+++ b/packages/cli/tests/unit/openapi.spec.ts
@@ -10,7 +10,7 @@ describe('OpenAPI', () => {
 
   it('handles valid and malformed HTTP server requests', async () => {
     const cmd = new openapi.OpenAPICommand(fixtureDirectory);
-    const result = await cmd.execute();
+    const [result, numAppMaps] = await cmd.execute();
     assert.deepStrictEqual(result, {
       paths: {
         '/*unmatched_route': {
@@ -27,17 +27,18 @@ describe('OpenAPI', () => {
       securitySchemes: {},
     });
     assert.deepStrictEqual(cmd.errors, []);
+    assert.deepStrictEqual(numAppMaps, 1);
   });
 
   it('accepts a relative --appmap-dir path', async () => {
     const cmd = new openapi.OpenAPICommand(fixtureDirectory);
-    const result = await cmd.execute();
+    const [result] = await cmd.execute();
     assert(Object.keys(result.paths).length);
   });
 
   it('accepts an absolute --appmap-dir path', async () => {
     const cmd = new openapi.OpenAPICommand(path.resolve(fixtureDirectory));
-    const result = await cmd.execute();
+    const [result] = await cmd.execute();
     assert(Object.keys(result.paths).length);
   });
 });

--- a/packages/scanner/src/report/scanResults.ts
+++ b/packages/scanner/src/report/scanResults.ts
@@ -114,5 +114,6 @@ export function sendScanResultsTelemetry(telemetry: ScanTelemetry): void {
       numAppMaps: telemetry.numAppMaps,
       numFindings: telemetry.numFindings,
     },
-  });
+  }),
+    { includeEnvironmentVariables: true };
 }

--- a/packages/telemetry/telemetry.spec.ts
+++ b/packages/telemetry/telemetry.spec.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import sinon, { SinonSpy } from 'sinon';
 import Conf from 'conf';
 import * as os from 'os';
@@ -109,11 +111,14 @@ describe('telemetry', () => {
       expect(properties['common.os']).not.toHaveLength(0);
       expect(properties['common.platformversion']).not.toHaveLength(0);
       expect(properties['common.arch']).not.toHaveLength(0);
+      expect(properties).not.toHaveProperty('common.environmentVariables');
+
       expect(properties['appland.telemetry.version']).toBe(version);
       expect(properties['appmap.cli.machineId']).toBe(Telemetry.machineId);
       expect(properties['appmap.cli.sessionId']).toBe(Telemetry.session.id);
       expect(typeof properties['appland.telemetry.args']).toBe('string');
       expect(properties['appland.telemetry.prop']).toBe('value');
+
       expect(measurements['appland.telemetry.metric']).toBe(1);
     });
 
@@ -135,6 +140,24 @@ describe('telemetry', () => {
 
       expect(properties).not.toHaveProperty('appmap.cli.prop');
       expect(properties).not.toHaveProperty('appmap.cli.metric');
+    });
+
+    it('sends env var names upon request', () => {
+      Telemetry.sendEvent(
+        {
+          name: 'test',
+        },
+        { includeEnvironment: true }
+      );
+
+      const [[{ properties }]] = trackEvent.args;
+
+      if (!properties) {
+        throw new Error('properties not found');
+      }
+      const envVars: string = properties['common.environmentVariables'];
+      expect(envVars.split(',')).toBeInstanceOf(Array);
+      expect(envVars).toMatch(/\bNODE_ENV\b/);
     });
   });
 });


### PR DESCRIPTION
Add an option to send environment variable names in telemetry.
Include environment variable names in scan completion events.
 
Send a telemetry message when openapi CLI command is invoked.
Include environment variable names.
