### PR TITLE
fix: Include git contributor count in OpenAPI event

### DIFF
--- a/packages/cli/src/cmds/openapi.ts
+++ b/packages/cli/src/cmds/openapi.ts
@@ -20,7 +20,7 @@ import { inspect } from 'util';
 import { locateAppMapDir } from '../lib/locateAppMapDir';
 import { handleWorkingDirectory } from '../lib/handleWorkingDirectory';
 import { locateAppMapConfigFile } from '../lib/locateAppMapConfigFile';
-import Telemetry from '../telemetry';
+import Telemetry, { Git } from '../telemetry';
 
 type FilterFunction = (file: string) => Promise<{ enable: boolean; message?: string }>;
 
@@ -186,7 +186,7 @@ export default {
     const cmd = new OpenAPICommand(appmapDir);
     cmd.filter = fileSizeFilter(maxAppMapSizeInBytes);
     const [openapi, numAppMaps] = await cmd.execute();
-    sendTelemetry(openapi.paths, numAppMaps);
+    sendTelemetry(openapi.paths, numAppMaps, appmapDir);
 
     for (const error of cmd.errors) {
       console.warn(error);
@@ -246,12 +246,13 @@ ${yaml.dump(template)}
   },
 };
 
-function sendTelemetry(paths: OpenAPIV3.PathsObject, numAppMaps: number) {
+async function sendTelemetry(paths: OpenAPIV3.PathsObject, numAppMaps: number, appmapDir: string) {
   Telemetry.sendEvent(
     {
       name: 'appmap:openapi',
       metrics: {
         paths: Object.keys(paths).length,
+        contributors: (await Git.contributors(60, appmapDir)).length,
         numAppMaps,
       },
     },

--- a/packages/cli/src/cmds/openapi.ts
+++ b/packages/cli/src/cmds/openapi.ts
@@ -20,7 +20,7 @@ import { inspect } from 'util';
 import { locateAppMapDir } from '../lib/locateAppMapDir';
 import { handleWorkingDirectory } from '../lib/handleWorkingDirectory';
 import { locateAppMapConfigFile } from '../lib/locateAppMapConfigFile';
-import Telemetry, { Git } from '../telemetry';
+import Telemetry, { Git, GitState } from '../telemetry';
 
 type FilterFunction = (file: string) => Promise<{ enable: boolean; message?: string }>;
 
@@ -247,12 +247,17 @@ ${yaml.dump(template)}
 };
 
 async function sendTelemetry(paths: OpenAPIV3.PathsObject, numAppMaps: number, appmapDir: string) {
+  const gitState = GitState[await Git.state(appmapDir)];
+  const contributors = (await Git.contributors(60, appmapDir)).length;
   Telemetry.sendEvent(
     {
       name: 'appmap:openapi',
+      properties: {
+        git_state: gitState,
+      },
       metrics: {
         paths: Object.keys(paths).length,
-        contributors: (await Git.contributors(60, appmapDir)).length,
+        contributors,
         numAppMaps,
       },
     },

--- a/packages/cli/src/cmds/upload.ts
+++ b/packages/cli/src/cmds/upload.ts
@@ -96,7 +96,7 @@ export async function handler(argv: Arguments): Promise<void> {
   if (paths.length === 0) throw new Error(`No AppMaps found in directory '${appmapDir}'`);
 
   let total = paths.length;
-  const { baseURL } = loadConfiguration();
+  const { baseURL } = await loadConfiguration();
   UI.progress(`Uploading ${total} AppMaps for ${app} to ${baseURL}...`);
 
   const uuids: string[] = [];

--- a/packages/cli/src/fingerprint/fingerprintWatchCommand.ts
+++ b/packages/cli/src/fingerprint/fingerprintWatchCommand.ts
@@ -5,7 +5,7 @@ import path, { join, resolve } from 'path';
 import EventAggregator from '../lib/eventAggregator';
 import flattenMetadata from '../lib/flattenMetadata';
 import { intersectMaps } from '../lib/intersectMaps';
-import Telemetry from '../telemetry';
+import Telemetry, { Git } from '../telemetry';
 import { verbose } from '../utils';
 import { FingerprintEvent } from './fingerprinter';
 import FingerprintQueue from './fingerprintQueue';
@@ -17,6 +17,7 @@ export default class FingerprintWatchCommand {
   public watcher?: FSWatcher;
   private poller?: Globber;
   private _numProcessed = 0;
+  private pendingTelemetry?: Promise<void>;
   public unreadableFiles = new Set<string>();
   public symlinkLoopFiles = new Set<string>();
 
@@ -34,7 +35,10 @@ export default class FingerprintWatchCommand {
 
     new EventAggregator((events) => {
       const indexEvents = events.map(({ args: [event] }) => event) as FingerprintEvent[];
-      this.sendTelemetry(indexEvents.map(({ metadata }) => metadata));
+      this.pendingTelemetry = this.sendTelemetry(
+        indexEvents.map(({ metadata }) => metadata),
+        directory
+      );
       this.numProcessed += events.length;
     }).attach(this.fpQueue.handler, 'index');
   }
@@ -242,7 +246,7 @@ export default class FingerprintWatchCommand {
     this.fpQueue.push(file);
   }
 
-  private sendTelemetry(metadata: Metadata[]) {
+  private async sendTelemetry(metadata: Metadata[], appmapDir: string) {
     const properties = Object.fromEntries(
       intersectMaps(...metadata.map(flattenMetadata)).entries()
     );
@@ -251,7 +255,15 @@ export default class FingerprintWatchCommand {
       properties,
       metrics: {
         appmaps: metadata.length,
+        contributors: (await Git.contributors(60, appmapDir)).length,
       },
     });
+  }
+
+  async telemetrySent(): Promise<void> {
+    if (this.pendingTelemetry) {
+      await this.pendingTelemetry;
+      this.pendingTelemetry = undefined;
+    }
   }
 }

--- a/packages/scanner/jest.config.js
+++ b/packages/scanner/jest.config.js
@@ -3,4 +3,5 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   testTimeout: parseInt(process.env.TEST_TIMEOUT, 10) || 5000,
+  setupFilesAfterEnv: ['./test/setup.ts'],
 };

--- a/packages/scanner/jest.config.js
+++ b/packages/scanner/jest.config.js
@@ -3,5 +3,6 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   testTimeout: parseInt(process.env.TEST_TIMEOUT, 10) || 5000,
+  testRegex: '(/tests/.*|(\\.|/)(test|spec))\\.ts?$',
   setupFilesAfterEnv: ['./test/setup.ts'],
 };

--- a/packages/scanner/src/cli/scan/singleScan.ts
+++ b/packages/scanner/src/cli/scan/singleScan.ts
@@ -80,5 +80,6 @@ export default async function singleScan(options: SingleScanOptions): Promise<vo
     numAppMaps: scanResults.summary.numAppMaps,
     numFindings: scanResults.summary.numFindings,
     elapsedMs: elapsed,
+    appmapDir: options.appmapDir,
   });
 }

--- a/packages/scanner/src/cli/scan/watchScan.ts
+++ b/packages/scanner/src/cli/scan/watchScan.ts
@@ -53,7 +53,7 @@ export class Watcher {
   scanEventEmitter = new EventEmitter();
 
   constructor(private options: WatchScanOptions) {
-    WatchScanTelemetry.watch(this.scanEventEmitter);
+    WatchScanTelemetry.watch(this.scanEventEmitter, options.appmapDir);
     this.queue.error((error, task) => console.warn(`Problem processing ${task}:\n`, error));
   }
 

--- a/packages/scanner/src/cli/scan/watchScanTelemetry.ts
+++ b/packages/scanner/src/cli/scan/watchScanTelemetry.ts
@@ -10,7 +10,7 @@ export type ScanEvent = {
 export class WatchScanTelemetry {
   cancelFn: CancelFn | undefined;
 
-  constructor(scanEvents: EventEmitter) {
+  constructor(scanEvents: EventEmitter, private readonly appmapDir?: string) {
     this.cancelFn = new EventAggregator<ScanEvent>((events) => {
       const scanEvents = events.map((e) => e.arg);
       this.sendTelemetry(scanEvents);
@@ -23,8 +23,8 @@ export class WatchScanTelemetry {
     this.cancelFn = undefined;
   }
 
-  static watch(scanEvents: EventEmitter): CancelFn {
-    const telemetry = new WatchScanTelemetry(scanEvents);
+  static watch(scanEvents: EventEmitter, appmapDir?: string): CancelFn {
+    const telemetry = new WatchScanTelemetry(scanEvents, appmapDir);
     return () => telemetry.cancel();
   }
 
@@ -43,6 +43,7 @@ export class WatchScanTelemetry {
       numAppMaps: telemetryScanResults.summary.numAppMaps,
       numFindings: telemetryScanResults.summary.numFindings,
       elapsedMs: elapsed,
+      appmapDir: this.appmapDir,
     });
   }
 }

--- a/packages/scanner/src/report/scanResults.ts
+++ b/packages/scanner/src/report/scanResults.ts
@@ -3,7 +3,7 @@ import Check from '../check';
 import Configuration from '../configuration/types/configuration';
 import { Finding } from '../types';
 import { AppMapMetadata, ScanSummary } from './scanSummary';
-import Telemetry from '../telemetry';
+import Telemetry, { Git } from '../telemetry';
 
 class DistinctItems<T> {
   private members: Record<string, T> = {};
@@ -100,9 +100,10 @@ export type ScanTelemetry = {
   numAppMaps: number;
   numFindings: number;
   elapsedMs: number;
+  appmapDir?: string;
 };
 
-export function sendScanResultsTelemetry(telemetry: ScanTelemetry): void {
+export async function sendScanResultsTelemetry(telemetry: ScanTelemetry): Promise<void> {
   Telemetry.sendEvent({
     name: 'scan:completed',
     properties: {
@@ -113,6 +114,7 @@ export function sendScanResultsTelemetry(telemetry: ScanTelemetry): void {
       numRules: telemetry.ruleIds.length,
       numAppMaps: telemetry.numAppMaps,
       numFindings: telemetry.numFindings,
+      contributors: (await Git.contributors(60, telemetry.appmapDir)).length,
     },
   }),
     { includeEnvironmentVariables: true };

--- a/packages/scanner/test/cli/commands.spec.ts
+++ b/packages/scanner/test/cli/commands.spec.ts
@@ -8,8 +8,6 @@ import tmp from 'tmp-promise';
 import { copyFile, mkdir, writeFile } from 'node:fs/promises';
 import path, { basename } from 'node:path';
 
-jest.mock('../../src/telemetry');
-
 const defaultArguments: Arguments<CommandOptions> = {
   _: [],
   $0: 'scan',

--- a/packages/scanner/test/cli/scan.spec.ts
+++ b/packages/scanner/test/cli/scan.spec.ts
@@ -17,8 +17,6 @@ import assert from 'assert';
 import { FSWatcher } from 'chokidar';
 import { mkdir, chmod } from 'fs/promises';
 
-jest.mock('../../src/telemetry');
-
 process.env['APPMAP_TELEMETRY_DISABLED'] = 'true';
 delete process.env.APPLAND_API_KEY;
 delete process.env.APPLAND_URL;

--- a/packages/scanner/test/cli/watchScanTelemetry.spec.ts
+++ b/packages/scanner/test/cli/watchScanTelemetry.spec.ts
@@ -79,7 +79,13 @@ describe(watchScanTelemetry.WatchScanTelemetry, () => {
       'Expected sendScanResultsTelemetry to have been called once'
     );
     assert.deepEqual(sendScanResultsTelemetry.firstCall.args, [
-      { elapsedMs: 15, numAppMaps: 22, numFindings: 3, ruleIds: ['a', 'b', 'c'] },
+      {
+        elapsedMs: 15,
+        numAppMaps: 22,
+        numFindings: 3,
+        ruleIds: ['a', 'b', 'c'],
+        appmapDir: undefined,
+      },
     ]);
   });
 
@@ -114,10 +120,10 @@ describe(watchScanTelemetry.WatchScanTelemetry, () => {
       'Expected sendScanResultsTelemetry to have been called twice'
     );
     assert.deepEqual(sendScanResultsTelemetry.firstCall.args, [
-      { elapsedMs: 5, numAppMaps: 10, numFindings: 1, ruleIds: ['a', 'b'] },
+      { elapsedMs: 5, numAppMaps: 10, numFindings: 1, ruleIds: ['a', 'b'], appmapDir: undefined },
     ]);
     assert.deepEqual(sendScanResultsTelemetry.secondCall.args, [
-      { elapsedMs: 10, numAppMaps: 12, numFindings: 2, ruleIds: ['b', 'c'] },
+      { elapsedMs: 10, numAppMaps: 12, numFindings: 2, ruleIds: ['b', 'c'], appmapDir: undefined },
     ]);
   });
 });

--- a/packages/scanner/test/setup.ts
+++ b/packages/scanner/test/setup.ts
@@ -1,0 +1,4 @@
+import { stubTelemetry, unstubTelemetry } from './util';
+
+beforeEach(stubTelemetry);
+afterEach(unstubTelemetry);

--- a/packages/scanner/test/util.ts
+++ b/packages/scanner/test/util.ts
@@ -47,4 +47,23 @@ const scan = async (
   return { appMap: appMapData, findings };
 };
 
-export { fixtureAppMap, fixtureAppMapFileName, scan };
+const stubTelemetry = (): void => {
+  jest.mock('../src/telemetry', () => {
+    const originalModule = jest.requireActual('../src/telemetry');
+
+    //Mock the default export and named export 'foo'
+    return {
+      __esModule: true,
+      ...originalModule,
+      default: {
+        sendEvent: jest.fn(),
+      },
+    };
+  });
+};
+
+const unstubTelemetry = (): void => {
+  jest.unmock('../src/telemetry');
+};
+
+export { fixtureAppMap, fixtureAppMapFileName, scan, stubTelemetry, unstubTelemetry };

--- a/packages/telemetry/telemetry.spec.ts
+++ b/packages/telemetry/telemetry.spec.ts
@@ -163,9 +163,22 @@ describe('telemetry', () => {
   });
 
   describe('Git', () => {
+    const sinceDaysAgo = 365;
+
     it('returns a list of unique git contributors', async () => {
-      const contributors = await Git.contributors(365 * 10);
+      const contributors = await Git.contributors(sinceDaysAgo);
       expect(contributors.length).toBeGreaterThan(0);
+    });
+
+    it('properly caches the list of git contributors', async () => {
+      let firstResult: string[] | undefined;
+      for (let i = 0; i < 10; i++) {
+        if (!firstResult) {
+          firstResult = await Git.contributors(sinceDaysAgo);
+        }
+
+        expect(await Git.contributors(sinceDaysAgo)).toEqual(firstResult);
+      }
     });
   });
 });

--- a/packages/telemetry/telemetry.spec.ts
+++ b/packages/telemetry/telemetry.spec.ts
@@ -3,8 +3,9 @@
 import sinon, { SinonSpy } from 'sinon';
 import Conf from 'conf';
 import * as os from 'os';
-import Telemetry from './telemetry';
+import Telemetry, { Git } from './telemetry';
 import { name as appName, version } from './package.json';
+import * as childProcess from 'child_process';
 
 const invalidExpiration = () => Date.now() - 1000 * 60 * 60;
 
@@ -158,6 +159,13 @@ describe('telemetry', () => {
       const envVars: string = properties['common.environmentVariables'];
       expect(envVars.split(',')).toBeInstanceOf(Array);
       expect(envVars).toMatch(/\bNODE_ENV\b/);
+    });
+  });
+
+  describe('Git', () => {
+    it('returns a list of unique git contributors', async () => {
+      const contributors = await Git.contributors(365 * 10);
+      expect(contributors.length).toBeGreaterThan(0);
     });
   });
 });

--- a/packages/telemetry/telemetry.spec.ts
+++ b/packages/telemetry/telemetry.spec.ts
@@ -2,10 +2,8 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import sinon, { SinonSpy } from 'sinon';
 import Conf from 'conf';
-import * as os from 'os';
 import Telemetry, { Git } from './telemetry';
 import { name as appName, version } from './package.json';
-import * as childProcess from 'child_process';
 
 const invalidExpiration = () => Date.now() - 1000 * 60 * 60;
 


### PR DESCRIPTION
This will count the number of unique contributors within a repository. The API is safe to call in any context, returning `0` if an error occurs (e.g. `git` is missing, not a repository, etc.).