### PR TITLE
feat: Sequence diagram model updates

### DIFF
--- a/packages/cli/src/fingerprint/index.js
+++ b/packages/cli/src/fingerprint/index.js
@@ -1,13 +1,8 @@
-const { verbose } = require('../utils');
 const { algorithms, canonicalize } = require('./canonicalize');
 const FingerprintDirectoryCommand = require('./fingerprintDirectoryCommand');
 const FingerprintWatchCommand = require('./fingerprintWatchCommand').default;
 
 async function fingerprintDirectory(dir, watch = false) {
-  if (verbose) {
-    verbose(true);
-  }
-
   let cmd;
   if (watch) {
     cmd = new FingerprintWatchCommand(dir);

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -15,8 +15,8 @@ export function endTime() {
 }
 
 let isVerbose = false;
-export function verbose(v: boolean | null = null) {
-  if (v !== null) {
+export function verbose(v?: boolean) {
+  if (v !== undefined) {
     isVerbose = v;
   }
   return isVerbose;

--- a/packages/models/src/event.js
+++ b/packages/models/src/event.js
@@ -93,15 +93,15 @@ export default class Event {
   }
 
   get returnValue() {
-    return this.returnEvent.return_value;
+    return this.returnEvent ? this.returnEvent.return_value : undefined;
   }
 
   get elapsedTime() {
-    return this.returnEvent.elapsed;
+    return this.returnEvent ? this.returnEvent.elapsed : undefined;
   }
 
   get elapsedInstrumentationTime() {
-    return this.returnEvent.elapsed_instrumentation;
+    return this.returnEvent ? this.returnEvent.elapsed_instrumentation : undefined;
   }
 
   get linkedEvent() {
@@ -138,7 +138,7 @@ export default class Event {
   }
 
   get exceptions() {
-    return this.returnEvent.$hidden.exceptions || [];
+    return this.returnEvent ? this.returnEvent.$hidden.exceptions || [] : [];
   }
 
   get message() {
@@ -150,7 +150,7 @@ export default class Event {
   }
 
   get httpServerResponse() {
-    return this.returnEvent.http_server_response;
+    return this.returnEvent ? this.returnEvent.http_server_response : undefined;
   }
 
   get httpClientRequest() {
@@ -158,7 +158,7 @@ export default class Event {
   }
 
   get httpClientResponse() {
-    return this.returnEvent.http_client_response;
+    return this.returnEvent ? this.returnEvent.http_client_response : undefined;
   }
 
   get definedClass() {
@@ -328,7 +328,7 @@ export default class Event {
   }
 
   get parentId() {
-    return this.returnEvent.parent_id;
+    return this.returnEvent ? this.returnEvent.parent_id : undefined;
   }
 
   get callEvent() {
@@ -523,7 +523,7 @@ export default class Event {
       properties = {
         event_type: 'function',
         id: this.codeObject.id,
-        raises_exception: this.returnEvent.exceptions && this.returnEvent.exceptions.length > 0,
+        raises_exception: this.exceptions.length > 0,
       };
     }
     return normalizeProperties(properties);

--- a/packages/models/tests/unit/event.spec.js
+++ b/packages/models/tests/unit/event.spec.js
@@ -130,6 +130,21 @@ describe('Event', () => {
           });
         });
       });
+
+      describe('without returnValue', () => {
+        const callOnlyEvent = new Event({ id: 1 });
+
+        it('has no returnValue', () => expect(callOnlyEvent.returnValue).toBeUndefined());
+        it('has no elapsedTime', () => expect(callOnlyEvent.elapsedTime).toBeUndefined());
+        it('has no elapsedInstrumentationTime', () =>
+          expect(callOnlyEvent.elapsedInstrumentationTime).toBeUndefined());
+        it('has no exceptions', () => expect(callOnlyEvent.exceptions).toEqual([]));
+        it('has no httpServerResponse', () =>
+          expect(callOnlyEvent.httpServerResponse).toBeUndefined());
+        it('has no httpClientResponse', () =>
+          expect(callOnlyEvent.httpClientResponse).toBeUndefined());
+        it('has no parentId', () => expect(callOnlyEvent.parentId).toBeUndefined());
+      });
     });
 
     describe('HTTP server request', () => {

--- a/packages/scanner/src/rules/lib/util.ts
+++ b/packages/scanner/src/rules/lib/util.ts
@@ -20,8 +20,8 @@ export async function collectAppMapFiles(
 }
 
 let isVerbose = false;
-function verbose(v: boolean | null = null): boolean {
-  if (v === true || v === false) {
+function verbose(v?: boolean): boolean {
+  if (v !== undefined) {
     isVerbose = v;
   }
   return isVerbose;

--- a/packages/sequence-diagram/package.json
+++ b/packages/sequence-diagram/package.json
@@ -9,6 +9,7 @@
   "types": "dist/types.d.ts",
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
+    "watch": "tsc -p tsconfig.build.json --watch",
     "lint": "eslint src --ext .ts",
     "ci": "yarn lint && yarn build && yarn test",
     "test": "jest",

--- a/packages/sequence-diagram/src/buildDiagram.ts
+++ b/packages/sequence-diagram/src/buildDiagram.ts
@@ -54,11 +54,12 @@ export default function buildDiagram(
   function buildRequest(caller?: Event | undefined, callee?: Event): Action | undefined {
     if (callee?.httpServerRequest && callee?.httpServerResponse) {
       assert(callee.route, 'callee.route');
+      const response = callee.httpServerResponse as any;
       return {
         nodeType: NodeType.ServerRPC,
         callee: findOrCreateActor(callee),
         route: callee.route,
-        status: callee.httpServerResponse?.status,
+        status: response.status || response.status_code,
         digest: callee.hash,
         subtreeDigest: 'undefined',
         children: [],
@@ -66,12 +67,13 @@ export default function buildDiagram(
       } as ServerRPC;
     } else if (callee?.httpClientRequest && callee?.httpClientResponse) {
       assert(callee.route, 'callee.route');
+      const response = callee.httpClientResponse as any;
       return {
         nodeType: NodeType.ClientRPC,
         caller: caller ? findOrCreateActor(caller) : undefined,
         callee: findOrCreateActor(callee),
         route: callee.route,
-        status: callee.httpClientResponse?.status,
+        status: response.status || response.status_code,
         digest: callee.hash,
         subtreeDigest: 'undefined',
         children: [],

--- a/packages/sequence-diagram/src/buildDiagram.ts
+++ b/packages/sequence-diagram/src/buildDiagram.ts
@@ -52,7 +52,7 @@ export default function buildDiagram(
   };
 
   function buildRequest(caller?: Event | undefined, callee?: Event): Action | undefined {
-    if (callee?.httpServerRequest) {
+    if (callee?.httpServerRequest && callee?.httpServerResponse) {
       assert(callee.route, 'callee.route');
       return {
         nodeType: NodeType.ServerRPC,
@@ -64,7 +64,7 @@ export default function buildDiagram(
         children: [],
         elapsed: callee.elapsedTime,
       } as ServerRPC;
-    } else if (callee?.httpClientRequest) {
+    } else if (callee?.httpClientRequest && callee?.httpClientResponse) {
       assert(callee.route, 'callee.route');
       return {
         nodeType: NodeType.ClientRPC,

--- a/packages/sequence-diagram/src/types.ts
+++ b/packages/sequence-diagram/src/types.ts
@@ -150,9 +150,9 @@ export const nodeResult = (action: Action | undefined): string | undefined => {
       if (action.returnValue.raisesException) return 'exception!';
       break;
     case NodeType.ServerRPC:
-      return action.status.toString();
+      return action.status ? action.status.toString() : '<unknown-status>';
     case NodeType.ClientRPC:
-      return action.status.toString();
+      return action.status ? action.status.toString() : '<unknown-status>';
   }
 };
 


### PR DESCRIPTION
Handle missing `returnEvent` a bit better.
Accept `status` or `status_code` because there still seem to be places where the wrong one occurs.