### PR TITLE
success-message styling for recording appmaps

### DIFF
--- a/packages/components/src/components/Pending.vue
+++ b/packages/components/src/components/Pending.vue
@@ -51,7 +51,7 @@ export default {
     margin: auto 0;
     margin-right: 0.5em;
     width: 24px;
-    fill: #69ad34;
+    fill: $white;
   }
 
   &--animate svg {

--- a/packages/components/src/components/install-guide/ProjectPickerRow.vue
+++ b/packages/components/src/components/install-guide/ProjectPickerRow.vue
@@ -36,12 +36,14 @@
 
     <div class="project-picker-row__body">
       <template v-if="supported && isJetBrains && isJava">
-        <p class="mb20 success-message">
-          <strong>You're good to go!</strong> By using the AppMap plugin for IntelliJ, you don't
-          need to install any additional dependencies to your project.
+        <p class="mb20 status-message">
+          <strong>Success!</strong> By using the AppMap plugin for IntelliJ, you don't need to
+          install any additional dependencies to your project.
         </p>
-        <p>Continue on to the next step.</p>
-        <v-navigation-buttons :first="true" :last="!supported" />
+        <div class="page-control-wrap">
+          <p>Continue on to the next step.</p>
+          <v-navigation-buttons :first="true" :last="!supported" />
+        </div>
       </template>
       <template v-else-if="supported">
         You're almost done! Install AppMap as a development dependency in your project. Click the
@@ -223,6 +225,12 @@ export default {
 <style lang="scss" scoped>
 $brightblue: rgba(255, 255, 255, 0.1);
 
+.page-control-wrap {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+}
 .project-picker-row {
   border-bottom: 1px solid lighten($gray2, 15);
   padding: 0;
@@ -235,6 +243,12 @@ $brightblue: rgba(255, 255, 255, 0.1);
   &__body {
     padding: 1rem 0;
     border-top: 1px solid lighten($gray2, 15);
+
+    .status-message {
+      border-radius: 0.5rem;
+      background-color: #69ad34;
+      padding: 0.5rem;
+    }
   }
   &__nav {
     display: flex;

--- a/packages/components/src/components/install-guide/ProjectPickerRow.vue
+++ b/packages/components/src/components/install-guide/ProjectPickerRow.vue
@@ -36,9 +36,9 @@
 
     <div class="project-picker-row__body">
       <template v-if="supported && isJetBrains && isJava">
-        <p class="mb20">
-          You're good to go! By using the AppMap plugin for IntelliJ, you don't need to install any
-          additional dependencies to your project.
+        <p class="mb20 success-message">
+          <strong>You're good to go!</strong> By using the AppMap plugin for IntelliJ, you don't
+          need to install any additional dependencies to your project.
         </p>
         <p>Continue on to the next step.</p>
         <v-navigation-buttons :first="true" :last="!supported" />

--- a/packages/components/src/components/quickstart/QuickstartLayout.vue
+++ b/packages/components/src/components/quickstart/QuickstartLayout.vue
@@ -173,7 +173,7 @@ h1 {
 }
 
 article {
-  margin-bottom: 2.5em;
+  margin-bottom: 1.5em;
 }
 
 .center {

--- a/packages/components/src/components/quickstart/QuickstartLayout.vue
+++ b/packages/components/src/components/quickstart/QuickstartLayout.vue
@@ -137,7 +137,6 @@ body {
   margin-bottom: 12px;
   background: $gray2;
   filter: $shadow-tile;
-  //max-width: 900px;
   border-radius: 8px;
   margin: 1em auto;
   padding: 2em;

--- a/packages/components/src/pages/install-guide/InvestigateFindings.vue
+++ b/packages/components/src/pages/install-guide/InvestigateFindings.vue
@@ -54,9 +54,9 @@
             </p>
           </article>
           <article v-else>
-            <p>
-              You're good to go! AppMap has scanned your application and found no flaws. We'll
-              continue scanning for flaws automatically.
+            <p class="success-message">
+              <strong>You're good to go!</strong> AppMap has scanned your application and found no
+              flaws. We'll continue scanning for flaws automatically.
             </p>
           </article>
         </div>

--- a/packages/components/src/pages/install-guide/InvestigateFindings.vue
+++ b/packages/components/src/pages/install-guide/InvestigateFindings.vue
@@ -55,8 +55,8 @@
           </article>
           <article v-else>
             <p class="success-message">
-              <strong>You're good to go!</strong> AppMap has scanned your application and found no
-              flaws. We'll continue scanning for flaws automatically.
+              <strong>Success!</strong> AppMap has scanned your application and found no flaws.
+              We'll continue scanning for flaws automatically.
             </p>
           </article>
         </div>

--- a/packages/components/src/pages/install-guide/RecordAppMaps.vue
+++ b/packages/components/src/pages/install-guide/RecordAppMaps.vue
@@ -79,7 +79,7 @@
           </template>
 
           <v-pending
-            class="mb20"
+            class="mb20 status-message"
             :is-pending="!complete"
             :message="pendingMessage"
             v-if="showPendingState"
@@ -266,6 +266,12 @@ export default {
 </script>
 
 <style>
+.status-message {
+  border-radius: 0.5rem;
+  background-color: #69ad34;
+  padding: 0.5rem 0;
+}
+
 .bold {
   font-weight: bold;
 }


### PR DESCRIPTION
Closes #976 

Update styling of success messages so they are more prominent

## Project Picker
![Screenshot 2023-01-23 at 3 34 32 PM](https://user-images.githubusercontent.com/123787/214144404-4c255caa-29e8-43c4-82fe-426364bb3129.png)


## Recording AppMaps
![record-appmaps-automated-recording](https://user-images.githubusercontent.com/123787/214144376-e00ef40e-3ae1-430c-ad99-0be5b5a1f775.png)
![record-appmaps-intellij](https://user-images.githubusercontent.com/123787/214144377-a0aa651e-eb64-4e7d-be0e-74f4c61a6ac9.png)
![record-appmaps-js](https://user-images.githubusercontent.com/123787/214144379-405392b1-3aa9-4824-8e3f-f2b60e5319bf.png)
![record-appmaps-no-test-framework](https://user-images.githubusercontent.com/123787/214144381-4f43b523-f37d-4b04-815a-92ec453a6cae.png)
![record-appmaps-no-web-framework](https://user-images.githubusercontent.com/123787/214144383-7a813e46-2f89-461c-8797-e7c2ec1f6ec4.png)
![record-appmaps-no-web-or-test-framework](https://user-images.githubusercontent.com/123787/214144384-89419c6a-4430-459a-b80a-ed2e7213e0cb.png)
![record-appmaps-unsupported-lang](https://user-images.githubusercontent.com/123787/214144386-94fc8d59-841f-4df1-a53c-fa2eebaac85d.png)

