### PR TITLE
fix: Fix basePath to not return '' when there's ( and )

### DIFF
--- a/packages/cli/src/cmds/openapi.ts
+++ b/packages/cli/src/cmds/openapi.ts
@@ -76,7 +76,7 @@ class OpenAPICommand {
       });
     } catch (e) {
       // Re-throwing this error crashes the whole process.
-      // So if these is a malformed AppMap, indicate it here but don't blow everything up.
+      // So if there is a malformed AppMap, indicate it here but don't blow everything up.
       // Do not write to stdout!
       let errorString: string;
       try {

--- a/packages/openapi/src/model.ts
+++ b/packages/openapi/src/model.ts
@@ -27,7 +27,6 @@ export default class Model {
 
   static basePath(path: string): string {
     const pathTokens = path
-      .split('(')[0]
       .split('/')
       .map((entry) => {
         if (entry.match(/^:(.*)/)) {

--- a/packages/openapi/test/model.spec.ts
+++ b/packages/openapi/test/model.spec.ts
@@ -82,3 +82,23 @@ describe('openapi.method', () => {
     });
   });
 });
+
+// similar to https://github.com/getappmap/appmap-ruby/blob/master/spec/util_spec.rb#L21
+describe('basePath', () => {
+  it('simple path', async () => {
+    const path = Model.basePath('/api/users');
+    expect(path).toEqual('/api/users');
+  });
+  it('malformed parameter specs', async () => {
+    const path = Model.basePath('/org/o:rg_id');
+    expect(path).toEqual('/org/o:rg_id');
+  });
+  it('already swaggerized path', async () => {
+    const path = Model.basePath('/org/{org_id}');
+    expect(path).toEqual('/org/{org_id}');
+  });
+  it('ignores ( and ) to not create blank path', async () => {
+    const path = Model.basePath('(/locale/{locale})/api/users/{id}');
+    expect(path).toEqual('(/locale/{locale})/api/users/{id}');
+  });
+});


### PR DESCRIPTION
Before this change, `basePath` produced paths that were blank like
```
requestPath (/locale/{locale})/api/users/{id} produced 
requestPath (/locale/{locale})/api/readinglist produced 
```

After this change, `basePath` produces paths like
```
requestPath (/locale/{locale})/api/users/{id} produced (/locale/{locale})/api/users/{id}
requestPath (/locale/{locale})/api/readinglist produced (/locale/{locale})/api/readinglist
```
With this change the [`openapi.yml`](https://github.com/forem/forem/compare/main...symwell:forem:sw/use_appmap_to_create_openapi_doc?expand=1#diff-5016bdc926b6c0f649f363739d09159a1db664aae19a08fa6b38b03406f040dc) file for Forem was generated with many paths instead of a path named `''`. `openapi.yml` contains all 42 API calls that were found in the AppMap files.

I didn't understand why `basePath` was attempting to `.split('(')`.  Maybe this logic was obsolete; maybe it tried to remove format specifiers, like convert `'/org/:org_id(.:format)'` into `'/org/{org_id}` , which are removed by [`appmap-ruby`](https://github.com/getappmap/appmap-ruby/blob/master/lib/appmap/util.rb#L149) instead.