### PR TITLE
fix: Prevent data from being dropped during serialization

### DIFF
--- a/packages/cli/src/fingerprint/fingerprinter.ts
+++ b/packages/cli/src/fingerprint/fingerprinter.ts
@@ -16,6 +16,10 @@ const renameFile = promisify(gracefulFs.rename);
 /**
  * CHANGELOG
  *
+ * # 1.1.4
+ *
+ * Add missing status_code to normalized AppMaps.
+ *
  * # 1.1.3
  *
  * * Removed ctime file. Use mtime to determine when the AppMap was last updated.
@@ -36,7 +40,7 @@ const renameFile = promisify(gracefulFs.rename);
  * * Fix handling of parent assignment in normalization.
  * * sql can contain the analysis (action, tables, columns), and/or the normalized query string.
  */
-const VERSION = '1.1.3';
+const VERSION = '1.1.4';
 
 const MAX_APPMAP_SIZE = 50 * 1000 * 1000;
 

--- a/packages/cli/tests/unit/fingerprint/canonicalize.spec.js
+++ b/packages/cli/tests/unit/fingerprint/canonicalize.spec.js
@@ -27,11 +27,11 @@ describe('Canonicalize', () => {
       if (doUpdateFixtures()) {
         updateFixtureFile();
       }
-      expect(
+      expect(normalForm).toEqual(
         JSON.parse(
           readFileSync(`tests/unit/fixtures/ruby/canonicalize/revoke_api_key.${algorithmName}.json`)
         )
-      ).toEqual(normalForm);
+      );
     });
   });
 });

--- a/packages/cli/tests/unit/fixtures/ruby/canonicalize/revoke_api_key.update.json
+++ b/packages/cli/tests/unit/fixtures/ruby/canonicalize/revoke_api_key.update.json
@@ -2,6 +2,7 @@
   {
     "kind": "http_server_request",
     "route": "DELETE /api/api_keys",
+    "status_code": 200,
     "children": [
       {
         "kind": "function",
@@ -42,6 +43,7 @@
   {
     "kind": "http_server_request",
     "route": "DELETE /api/api_keys",
+    "status_code": 401,
     "children": [
       {
         "kind": "function",

--- a/packages/models/src/appMapBuilder/index.js
+++ b/packages/models/src/appMapBuilder/index.js
@@ -104,19 +104,6 @@ class AppMapBuilder extends EventSource {
         event.returnEvent.parent_id = event.id;
       }
 
-      // Normalize status/status_code properties
-      const { httpServerResponse, httpClientResponse } = event;
-      if (event.isReturn()) {
-        if (httpServerResponse && httpServerResponse.status_code) {
-          httpServerResponse.status = httpServerResponse.status_code;
-          delete httpServerResponse.status_code;
-        }
-        if (httpClientResponse && httpClientResponse.status_code) {
-          httpClientResponse.status = httpClientResponse.status_code;
-          delete httpClientResponse.status_code;
-        }
-      }
-
       // Normalize path info
       const { httpServerRequest } = event;
       if (httpServerRequest && httpServerRequest.normalized_path_info) {

--- a/packages/models/src/event.js
+++ b/packages/models/src/event.js
@@ -3,6 +3,19 @@ import analyzeSQL, { abstractSqlAstJSON } from './sql/analyze';
 import normalizeSQL from './sql/normalize';
 import HashBuilder from './hashBuilder';
 
+function alias(obj, prop, alias) {
+  if (!obj || typeof obj[prop] === 'undefined' || typeof obj[alias] !== 'undefined') {
+    return;
+  }
+
+  Object.defineProperty(obj, alias, {
+    get() {
+      return this[prop];
+    },
+    enumerable: false,
+  });
+}
+
 // This class supercedes `CallTree` and `CallNode`. Events are stored in a flat
 // array and can also be traversed like a tree via `parent` and `children`.
 export default class Event {
@@ -58,6 +71,14 @@ export default class Event {
     addHiddenProperty(this, 'hash');
     addHiddenProperty(this, 'identityHash');
     addHiddenProperty(this, 'depth');
+
+    // Backward compatibility
+    // `status_code` used to be normalized to `status` during normalization. They can now be used
+    // interchangeably.
+    alias(data.http_server_response, 'status_code', 'status');
+    alias(data.http_server_response, 'status', 'status_code');
+    alias(data.http_client_response, 'status_code', 'status');
+    alias(data.http_client_response, 'status', 'status_code');
 
     // Data must be written last, after our properties are configured.
     Object.assign(this, data);

--- a/packages/models/src/util.js
+++ b/packages/models/src/util.js
@@ -413,19 +413,32 @@ export function getRootEvents(eventArray) {
   return eventArray.filter((e) => e.isCall() && !e.parent);
 }
 
-export function transformToJSON(dataKeys, obj) {
-  const emptyLength = (value) => 'length' in value && value.length === 0;
-  const emptySize = (value) => 'size' in value && value.size === 0;
-  const empty = (value) =>
-    value === undefined ||
-    value === null ||
-    (typeof value === 'object' && [emptyLength, emptySize].find((fn) => fn(value)));
+function isEmpty(value) {
+  if (value === undefined || value === null) {
+    return true;
+  }
 
+  if (Array.isArray(value) || typeof value === 'string') {
+    return value.length === 0;
+  }
+
+  if (value instanceof Set || value instanceof Map) {
+    return value.size === 0;
+  }
+
+  if (typeof value === 'object') {
+    return Object.values(value).every(isEmpty);
+  }
+
+  return false;
+}
+
+export function transformToJSON(dataKeys, obj) {
   return dataKeys.reduce((memo, key) => {
     const value = obj[key];
-    if (empty(value)) {
+    if (isEmpty(value)) {
       // nop
-    } else if (value.constructor === Set) {
+    } else if (value instanceof Set) {
       memo[key] = [...value];
     } else {
       memo[key] = value;

--- a/packages/models/tests/unit/appMap.spec.js
+++ b/packages/models/tests/unit/appMap.spec.js
@@ -20,8 +20,102 @@ describe('AppMap', () => {
     expect(appMap.rootEvent.count()).toEqual(409);
   });
 
-  test('serialization', () => {
-    expect(() => JSON.stringify(appMap)).not.toThrow();
+  describe('serialization', () => {
+    it('can be stringified', () => {
+      expect(() => JSON.stringify(appMap)).not.toThrow();
+    });
+
+    it('outputs the expected JSON for http_server_response', () => {
+      const httpServerRequest = {
+        id: 1,
+        event: 'call',
+        thread_id: 1,
+        http_server_request: {
+          request_method: 'POST',
+          path_info: '/user/profile',
+          normalized_path_info: '/user/profile',
+          headers: {
+            Version: 'HTTP/1.0',
+            Host: 'localhost',
+            'X-Access-Token': '8feb7269-aa44-4ab9-9023-e4543400f744',
+            'Content-Type': 'application/json',
+            'Content-Length': '177',
+          },
+        },
+        message: [
+          {
+            name: 'data',
+            class: 'ActiveSupport::HashWithIndifferentAccess',
+            value: '{profile=>{display_name=>John Doe, bio=>About me, status=>string}}',
+            object_id: 30880,
+            properties: [
+              {
+                name: 'profile',
+                class: 'ActiveSupport::HashWithIndifferentAccess',
+                properties: [
+                  { name: 'display_name', class: 'String' },
+                  { name: 'bio', class: 'String' },
+                  { name: 'status', class: 'String' },
+                ],
+              },
+            ],
+          },
+          {
+            name: 'format',
+            class: 'Symbol',
+            value: ':json',
+            object_id: 10,
+          },
+          {
+            name: 'controller',
+            class: 'String',
+            value: 'user',
+            object_id: 20,
+          },
+          {
+            name: 'action',
+            class: 'String',
+            value: 'profile',
+            object_id: 30,
+          },
+        ],
+      };
+      const httpServerResponse = {
+        id: 2,
+        event: 'return',
+        thread_id: 1,
+        parent_id: 1,
+        elapsed: 0.01,
+        elapsed_instrumentation: 0.0005,
+        return_value: {
+          class: 'Hash',
+          value: '{}',
+          object_id: 1,
+          size: 0,
+        },
+        http_server_response: {
+          status_code: 200,
+          headers: {
+            'X-Frame-Options': 'SAMEORIGIN',
+            'X-XSS-Protection': '1; mode=block',
+            'X-Content-Type-Options': 'nosniff',
+            'X-Permitted-Cross-Domain-Policies': 'none',
+            'Referrer-Policy': 'strict-origin-when-cross-origin',
+            'Content-Type': 'application/json; charset=utf-8',
+          },
+        },
+      };
+      const httpAppMap = buildAppMap({
+        events: [httpServerRequest, httpServerResponse],
+        classMap: [],
+        metadata: { name: 'test' },
+      })
+        .normalize()
+        .build();
+
+      const result = JSON.parse(JSON.stringify(httpAppMap));
+      expect(result.events).toEqual([httpServerRequest, httpServerResponse]);
+    });
   });
 
   test('getEvent', () => {

--- a/packages/models/tests/unit/event.spec.js
+++ b/packages/models/tests/unit/event.spec.js
@@ -152,6 +152,10 @@ describe('Event', () => {
         (e) => e.http_server_request && e.http_server_request.path_info === '/admin'
       );
 
+      it('provides access to the response status', () => {
+        expect(event.httpServerResponse.status).toEqual(302);
+        expect(event.httpServerResponse.status_code).toEqual(302);
+      });
       it('route', () => {
         expect(event.route).toEqual('GET /admin');
       });

--- a/packages/models/tests/unit/fixtures/many_requests_scenario.json
+++ b/packages/models/tests/unit/fixtures/many_requests_scenario.json
@@ -2662,7 +2662,7 @@
           "parent_id": 9,
           "thread_id": 47346401950060,
           "http_server_response": {
-              "status": 200,
+              "status_code": 200,
               "mime_type": "text/html; charset=utf-8"
           }
       },
@@ -5266,7 +5266,7 @@
           "parent_id": 149,
           "thread_id": 47346401950060,
           "http_server_response": {
-              "status": 200,
+              "status_code": 200,
               "mime_type": "text/html; charset=utf-8"
           }
       },
@@ -8598,7 +8598,7 @@
           "parent_id": 289,
           "thread_id": 47346401950060,
           "http_server_response": {
-              "status": 200,
+              "status_code": 200,
               "mime_type": "text/html; charset=utf-8"
           }
       },


### PR DESCRIPTION
This fixes two cases. First, event properties would not always be serialized when the value was an object. Only in cases where the object contained an Array or a Set would it have been serialized. Second, `http_server_response.status_code` was being re-written to `http_server_response.status`. This likely wasn't resulting in any bugs, but would change the contents of an AppMap after serialization occurred. `status` and `status_code` can now be safely interchanged for backwards compatibility reasons in case anything downstream depends on one or the other.