### PR TITLE
fix: Bump @appland/models to v1.23.2

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -69,7 +69,7 @@
   "dependencies": {
     "@appland/components": "workspace:^2",
     "@appland/diagrams": "workspace:^1",
-    "@appland/models": "workspace:^1",
+    "@appland/models": "workspace:^1.23.2",
     "@appland/openapi": "workspace:^1",
     "@appland/sequence-diagram": "workspace:^1",
     "@sidvind/better-ajv-errors": "^0.9.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -79,7 +79,7 @@ __metadata:
   dependencies:
     "@appland/components": "workspace:^2"
     "@appland/diagrams": "workspace:^1"
-    "@appland/models": "workspace:^1"
+    "@appland/models": "workspace:^1.23.2"
     "@appland/openapi": "workspace:^1"
     "@appland/sequence-diagram": "workspace:^1"
     "@craftamap/esbuild-plugin-html": ^0.4.0
@@ -290,7 +290,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@appland/models@workspace:*, @appland/models@workspace:^1, @appland/models@workspace:^1.18.1, @appland/models@workspace:^1.23.0, @appland/models@workspace:packages/models":
+"@appland/models@workspace:*, @appland/models@workspace:^1.18.1, @appland/models@workspace:^1.23.0, @appland/models@workspace:^1.23.2, @appland/models@workspace:packages/models":
   version: 0.0.0-use.local
   resolution: "@appland/models@workspace:packages/models"
   dependencies:


### PR DESCRIPTION
`^1` works as a JS dependency, but a binary must be built with the correct version constraints as well, so these may as well be more tightly constrained to their minimum version so we can create releases for version bumps. Otherwise there's no way for an upstream fix to propagate to a binary release.