### PR TITLE
fix: `CodeObject#location` may be `undefined`

### DIFF
--- a/packages/models/src/codeObject.js
+++ b/packages/models/src/codeObject.js
@@ -216,8 +216,8 @@ export default class CodeObject {
   classLocations(paths = new Set()) {
     this.children.forEach((child) => child.classLocations(paths));
 
-    if (this.type === CodeObjectType.FUNCTION) {
-      const tokens = this.data.location.split(':', 2);
+    if (this.type === CodeObjectType.FUNCTION && this.location) {
+      const tokens = this.location.split(':', 2);
       paths.add(tokens[0]);
     }
     return paths;

--- a/packages/models/tests/unit/appMap.spec.js
+++ b/packages/models/tests/unit/appMap.spec.js
@@ -116,6 +116,47 @@ describe('AppMap', () => {
       const result = JSON.parse(JSON.stringify(httpAppMap));
       expect(result.events).toEqual([httpServerRequest, httpServerResponse]);
     });
+
+    it('successfully serializes and deserializes an AppMap containing empty locations in code objects', () => {
+      const baselineCodeObjects = [
+        {
+          type: 'class',
+          name: '<templates>/Navbar',
+          children: [
+            {
+              type: 'function',
+              name: 'render',
+              static: false,
+              location: '',
+            },
+          ],
+        },
+      ];
+      const expectedCodeObjects = JSON.stringify([
+        {
+          type: 'class',
+          name: '<templates>/Navbar',
+          children: [
+            {
+              type: 'function',
+              name: 'render',
+              static: false,
+            },
+          ],
+        },
+      ]);
+
+      const baselineAppMap = buildAppMap({
+        events: [],
+        metadata: {},
+        classMap: baselineCodeObjects,
+      })
+        .normalize()
+        .build();
+      const reserializedAppMap = buildAppMap(JSON.stringify(baselineAppMap)).normalize().build();
+
+      expect(JSON.stringify(reserializedAppMap.classMap)).toEqual(expectedCodeObjects);
+    });
   });
 
   test('getEvent', () => {

--- a/packages/models/types/index.d.ts
+++ b/packages/models/types/index.d.ts
@@ -98,7 +98,7 @@ declare module '@appland/models' {
     readonly name: string;
     readonly type: CodeObjectType;
     readonly static: boolean;
-    readonly location: string;
+    readonly location: string | undefined;
     readonly locations: string[];
     readonly packageOf: string;
     readonly classOf: string;

--- a/packages/scanner/src/ruleChecker.ts
+++ b/packages/scanner/src/ruleChecker.ts
@@ -135,7 +135,7 @@ export default class RuleChecker {
       const stack: string[] = [
         findingEvent.codeObject.location,
         ...findingEvent.ancestors().map((ancestor) => ancestor.codeObject.location),
-      ].filter(Boolean);
+      ].filter(Boolean) as string[];
 
       const hashV1 = new HashV1(
         checkInstance.ruleId,


### PR DESCRIPTION
If a CodeObject's location is empty, it'll be omitted upon serialization. This means that if an AppMap was serialized, saved out and loaded again, access to `data.location` would result in an undefined value. Instead of returning `undefined`, return an empty string.

This unblocks https://github.com/getappmap/vscode-appland/pull/606. A test case uses a Python AppMap which contains an empty location, resulting in failures after it's indexed.