### PR TITLE
Telemetry to better understand sign in

### DIFF
--- a/packages/components/src/components/DetailsSearch.vue
+++ b/packages/components/src/components/DetailsSearch.vue
@@ -12,6 +12,7 @@
           placeholder="search code objects..."
           ref="searchInput"
           v-model="filter"
+          @focus="searchFocused"
         />
       </div>
     </form>
@@ -212,6 +213,10 @@ export default {
       }
 
       return false;
+    },
+
+    searchFocused() {
+      this.$root.$emit('sidebarSearchFocused');
     },
   },
 };

--- a/packages/components/src/components/DetailsSearch.vue
+++ b/packages/components/src/components/DetailsSearch.vue
@@ -191,6 +191,7 @@ export default {
 
   methods: {
     selectObject(type, object) {
+      this.$root.$emit('selectObjectInSidebar', type);
       if (type === 'labels') {
         this.$store.commit(SELECT_LABEL, object);
       } else {

--- a/packages/components/src/components/Tab.vue
+++ b/packages/components/src/components/Tab.vue
@@ -21,6 +21,7 @@ export default {
       type: String,
       required: true,
     },
+    reference: String,
   },
 
   data() {

--- a/packages/components/src/components/TabButton.vue
+++ b/packages/components/src/components/TabButton.vue
@@ -1,5 +1,5 @@
 <template>
-  <button :class="classes">
+  <button :class="classes" @click="clickTab">
     {{ label }}
   </button>
 </template>
@@ -23,6 +23,13 @@ export default {
       required: true,
     },
     isActive: Boolean,
+    reference: String,
+  },
+
+  methods: {
+    clickTab() {
+      this.$root.$emit('clickTab', this.reference);
+    },
   },
 };
 </script>

--- a/packages/components/src/components/Tabs.vue
+++ b/packages/components/src/components/Tabs.vue
@@ -6,6 +6,7 @@
         :key="tab.name"
         :label="tab.name"
         :is-active="activeTab === tab"
+        :reference="tab.reference"
         @click.native="activateTab(tab)"
       >
       </v-tab-button>

--- a/packages/components/src/pages/VsCodeExtension.vue
+++ b/packages/components/src/pages/VsCodeExtension.vue
@@ -107,7 +107,7 @@
           </v-popper>
           <v-popper-menu :isHighlight="filtersChanged">
             <template v-slot:icon>
-              <FilterIcon class="control-button__icon" />
+              <FilterIcon class="control-button__icon" @click="openFilterModal" />
             </template>
             <template v-slot:body>
               <div class="filters">
@@ -864,6 +864,10 @@ export default {
       }
 
       return base64UrlEncode(JSON.stringify(state));
+    },
+
+    openFilterModal() {
+      this.$root.$emit('clickFilterButton');
     },
 
     setSelectedObject(fqid) {

--- a/packages/components/src/pages/VsCodeExtension.vue
+++ b/packages/components/src/pages/VsCodeExtension.vue
@@ -1023,6 +1023,7 @@ export default {
     resetDiagram() {
       this.clearSelection();
       this.resetFilters();
+      this.$root.$emit('resetDiagram');
 
       this.renderKey += 1;
     },

--- a/packages/components/src/pages/VsCodeExtension.vue
+++ b/packages/components/src/pages/VsCodeExtension.vue
@@ -49,11 +49,16 @@
 
     <div class="main-column main-column--right">
       <v-tabs @activateTab="onChangeTab" ref="tabs">
-        <v-tab name="Dependency Map" :is-active="isViewingComponent" :ref="VIEW_COMPONENT">
+        <v-tab
+          name="Dependency Map"
+          :is-active="isViewingComponent"
+          :reference="VIEW_COMPONENT"
+          :ref="VIEW_COMPONENT"
+        >
           <v-diagram-component ref="componentDiagram" :class-map="filteredAppMap.classMap" />
         </v-tab>
 
-        <v-tab name="Trace View" :is-active="isViewingFlow" :ref="VIEW_FLOW">
+        <v-tab name="Trace View" :is-active="isViewingFlow" :reference="VIEW_FLOW" :ref="VIEW_FLOW">
           <div class="trace-view">
             <v-trace-filter
               ref="traceFilter"


### PR DESCRIPTION
Fixes #988 

This is the first of two PRs to help better understand user behavior. The follow-up PR is [here](https://github.com/getappmap/vscode-appland/pull/609).

This PR causes the frontend to emit events so we can collect telemetry about how users interact with an AppMap:

- When a user clicks on the Filter button
- When a user clicks on the Reset button
- When a user focuses on the search bar
- When a user clicks on a list item in the sidebar
- When a user switches view types by using the tabs

![spots](https://user-images.githubusercontent.com/45714532/215900510-aff2acb3-f143-4585-bb5d-286197461894.png)

**NOTES**

- There was already an event that was emitted when a user clicked on the Reset button [here](https://github.com/getappmap/appmap-js/blob/main/packages/components/src/pages/VsCodeExtension.vue#L1012), but it was also triggered when clearing the selection in the sidebar, so I made a new event that was only triggered when clicking on the reset button.
- There was already an event that was emitted when a user changed the AppMap view type between `Dependency Map` and `Trace View` [here](https://github.com/getappmap/appmap-js/blob/main/packages/components/src/pages/VsCodeExtension.vue#L809), but it was triggered no matter how the view was changed instead of just when the user clicked on one of the tabs. It was also triggered whenever an AppMap was opened, so I created a new event that was triggered only when the view was changed by clicking the tab.

