### PR TITLE
Sequence diagram horizontal scrollbar is visible

### DIFF
--- a/packages/components/src/components/Tab.vue
+++ b/packages/components/src/components/Tab.vue
@@ -50,5 +50,9 @@ export default {
 .tab-content.tab-content-scroll {
   overflow: auto;
   padding-bottom: 2rem;
+  height: 96.6%;
+  &::-webkit-scrollbar:horizontal {
+    height: 8px;
+  }
 }
 </style>

--- a/packages/components/src/components/Tab.vue
+++ b/packages/components/src/components/Tab.vue
@@ -50,7 +50,7 @@ export default {
 .tab-content.tab-content-scroll {
   overflow: auto;
   padding-bottom: 2rem;
-  height: 96.6%;
+  height: calc(100% - 44px);
   &::-webkit-scrollbar:horizontal {
     height: 8px;
   }

--- a/packages/components/src/components/Tabs.vue
+++ b/packages/components/src/components/Tabs.vue
@@ -68,7 +68,7 @@ export default {
 <style scoped lang="scss">
 .tabs {
   width: 100%;
-  height: 100%; //96.6%;
+  height: 100%;
 
   &__header {
     position: relative;

--- a/packages/components/src/components/Tabs.vue
+++ b/packages/components/src/components/Tabs.vue
@@ -68,7 +68,7 @@ export default {
 <style scoped lang="scss">
 .tabs {
   width: 100%;
-  height: 100%;
+  height: 100%; //96.6%;
 
   &__header {
     position: relative;

--- a/packages/components/src/components/sequence/Actor.vue
+++ b/packages/components/src/components/sequence/Actor.vue
@@ -111,6 +111,9 @@ $min-height: 3rem;
 }
 
 .label-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
   margin: 3px 0;
   text-align: center;
   padding: 3px;

--- a/packages/components/src/pages/VsCodeExtension.vue
+++ b/packages/components/src/pages/VsCodeExtension.vue
@@ -1516,6 +1516,9 @@ code {
       min-width: 400px;
       word-break: break-all;
       overflow: hidden;
+      &::-webkit-scrollbar:horizontal {
+        height: 100px;
+      }
 
       .control-button {
         border: none;


### PR DESCRIPTION
- Sequence diagram horizontal scrollbar is visible
- actor labels are centered in box

## Before
![sequence-diagram-no-scrollbar](https://user-images.githubusercontent.com/123787/217035117-bda4dab8-66b8-429d-b575-06fc8d811cad.gif)


## After
![sequence-diagram-scrollbar](https://user-images.githubusercontent.com/123787/217035108-60265876-2d3f-42b8-91a8-d0c1f8fb9ea7.gif)

