### PR TITLE
OpenAPI: Describe and merge non-object array types

### DIFF
--- a/packages/models/types/index.d.ts
+++ b/packages/models/types/index.d.ts
@@ -19,14 +19,23 @@ declare module '@appland/models' {
   export interface ValueBase extends ObjectBase {
     readonly value: string;
     readonly size?: number;
-    readonly properties?: ParameterProperty[];
+    readonly properties?: NamedParameterProperty[];
+    readonly items?: ParameterProperty[];
   }
 
   export interface ParameterProperty {
-    readonly name: string;
+    readonly name?: string;
     readonly class: string;
-    readonly properties?: ParameterProperty[];
+    readonly properties?: NamedParameterProperty[];
+    readonly items?: ParameterProperty[];
   }
+
+  // Utility types for ParameterProperty
+  export type NamedParameterProperty = ParameterProperty & { readonly name: string };
+  export type ArrayParameterProperty = ParameterProperty & { readonly items: ParameterProperty[] };
+  export type ObjectParameterProperty = ParameterProperty & {
+    readonly properties: NamedParameterProperty[];
+  };
 
   export interface ParameterObject extends ValueBase {
     readonly name?: string;

--- a/packages/openapi/src/appmap/index.ts
+++ b/packages/openapi/src/appmap/index.ts
@@ -1,0 +1,21 @@
+import { OpenAPIV3 } from 'openapi-types';
+import { NamedParameterProperty, ParameterProperty } from '@appland/models';
+import { default as PropertiesParserV1 } from './propertiesParserV1';
+import { default as PropertiesParserV2 } from './propertiesParserV2';
+
+export type SchemaExample = {
+  class: string;
+  properties?: NamedParameterProperty[];
+  items?: ParameterProperty[];
+};
+
+export interface PropertiesParser {
+  canParse(example: SchemaExample): boolean;
+  parse(example: SchemaExample): OpenAPIV3.SchemaObject | undefined;
+}
+
+const parsers: ReadonlyArray<PropertiesParser> = [PropertiesParserV2, PropertiesParserV1];
+export function parse(example: SchemaExample): OpenAPIV3.SchemaObject | undefined {
+  const parser = parsers.find((p) => p.canParse(example));
+  if (parser) return parser.parse(example);
+}

--- a/packages/openapi/src/appmap/propertiesParserV1.ts
+++ b/packages/openapi/src/appmap/propertiesParserV1.ts
@@ -1,0 +1,63 @@
+import { OpenAPIV3 } from 'openapi-types';
+import { SchemaExample } from '.';
+import { classNameToOpenAPIType } from '../util';
+
+export default class PropertiesParser {
+  static canParse(): boolean {
+    // We should be evaluating whether or not parsers can parse the example in reverse order.
+    // This is the original implementation, so there's no other options. We're the last stand!
+    return true;
+  }
+
+  static parse(example: SchemaExample): OpenAPIV3.SchemaObject | undefined {
+    const type = classNameToOpenAPIType(example.class);
+    if (type === undefined) return;
+
+    if (example.properties) {
+      const properties = example.properties.filter(Boolean).reduce((memo, msgProperty) => {
+        // This guard clause is new. It's not in the original implementation. It also shouldn't be
+        // necessary, as properties without a name should have been parsed by another parser.
+        if (!msgProperty.name) return memo;
+
+        const type = classNameToOpenAPIType(msgProperty.class);
+        if (type === 'array') {
+          let schema;
+          if (msgProperty.properties) {
+            // eslint-disable-next-line no-param-reassign
+            schema = this.parse(msgProperty);
+          }
+          if (schema) {
+            memo[msgProperty.name] = schema;
+          } else {
+            memo[msgProperty.name] = { type, items: {} } as OpenAPIV3.ArraySchemaObject;
+          }
+        } else if (type === 'object' && msgProperty.properties) {
+          // eslint-disable-next-line no-param-reassign
+          const schema = this.parse(msgProperty);
+          if (schema) {
+            memo[msgProperty.name] = schema;
+          } else {
+            memo[msgProperty.name] = { type };
+          }
+        } else if (type) {
+          // eslint-disable-next-line no-param-reassign
+          memo[msgProperty.name] = {
+            type,
+          };
+        }
+        return memo;
+      }, {} as Record<string, OpenAPIV3.NonArraySchemaObject | OpenAPIV3.ArraySchemaObject>);
+      if (type === 'array') {
+        return { type: 'array', items: { type: 'object', properties } };
+      } else {
+        return { type: 'object', properties };
+      }
+    } else {
+      if (type === 'array') {
+        return { type: 'array', items: { type: 'string' } };
+      }
+    }
+
+    return { type };
+  }
+}

--- a/packages/openapi/src/appmap/propertiesParserV2.ts
+++ b/packages/openapi/src/appmap/propertiesParserV2.ts
@@ -1,0 +1,109 @@
+import { NamedParameterProperty, ParameterProperty } from '@appland/models';
+import { OpenAPIV3 } from 'openapi-types';
+import { type } from 'os';
+import { SchemaExample } from '.';
+import { mergeItems, mergeType } from '../schemaInferrer';
+import { classNameToOpenAPIType } from '../util';
+
+const mergeReducer = (acc: OpenAPIV3.SchemaObject, obj: OpenAPIV3.SchemaObject) =>
+  mergeType(obj, acc) || acc || acc;
+
+function parseProperty(paramProperty: ParameterProperty): OpenAPIV3.SchemaObject | undefined {
+  const type = classNameToOpenAPIType(paramProperty.class);
+  if (type === undefined) return undefined;
+
+  if (paramProperty.items) {
+    return parseArrayProperties(paramProperty.items);
+  }
+
+  if (type === 'array') {
+    // If we made it here, we're an array with no additional information.
+    return { type: 'array', items: {} };
+  }
+
+  if (paramProperty.properties) {
+    return parseObjectProperties(paramProperty.properties);
+  }
+
+  // `type` should be an expected value, but TypeScript doesn't know that. Maybe there's
+  // a smarter cast we can do here, but it's beyond me at the moment.
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
+  return { type: type as any };
+}
+
+function parseArrayProperties(
+  paramProperties: ReadonlyArray<ParameterProperty>
+): OpenAPIV3.ArraySchemaObject {
+  const itemArray = paramProperties.map(parseProperty).filter(Boolean) as OpenAPIV3.SchemaObject[];
+
+  if (itemArray.length === 0) return { type: 'array', items: {} };
+  else if (itemArray.length === 1) return { type: 'array', items: itemArray[0] };
+
+  const primitiveTypes = new Set(
+    itemArray
+      .filter((item) => item.type && item.type !== 'object' && item.type !== 'array')
+      .map(
+        ({ type }) => type as OpenAPIV3.NonArraySchemaObjectType | OpenAPIV3.ArraySchemaObjectType
+      )
+  );
+  const primitives = Array.from(primitiveTypes).map((type) => ({
+    type,
+  })) as OpenAPIV3.SchemaObject[];
+  const mergedArrays = itemArray
+    .filter((item) => item.type === 'array')
+    .reduce(mergeReducer, { items: {} } as OpenAPIV3.ArraySchemaObject);
+  const mergedObject = itemArray
+    .filter((item) => item.type === 'object')
+    .reduce(mergeReducer, {} as OpenAPIV3.SchemaObject);
+  const allMergedItems = [...primitives, mergedArrays, mergedObject].filter(
+    (item) => item && item.type
+  );
+
+  if (allMergedItems.length === 0) {
+    return { type: 'array', items: {} };
+  }
+
+  if (allMergedItems.length === 1) {
+    return { type: 'array', items: allMergedItems[0] };
+  }
+
+  return { type: 'array', items: { anyOf: allMergedItems } };
+}
+
+function parseObjectProperties(
+  paramProperties: ReadonlyArray<NamedParameterProperty>
+): OpenAPIV3.SchemaObject {
+  const properties = paramProperties.filter(Boolean).reduce((memo, msgProperty) => {
+    const property = parseProperty(msgProperty);
+    if (property) memo[msgProperty.name] = property;
+    return memo;
+  }, {} as Record<string, OpenAPIV3.SchemaObject>);
+
+  return { type: 'object', properties };
+}
+
+export default class PropertiesParser {
+  static canParse(example: SchemaExample): boolean {
+    if (!example.properties) return true;
+
+    const properties = [...example.properties, example as ParameterProperty];
+    while (properties.length) {
+      const property = properties.pop();
+      if (!property) continue;
+
+      const type = classNameToOpenAPIType(property.class);
+      if (!type) continue;
+      if (type === 'array' && property.items === undefined) return false;
+      if (property.name === undefined) return true;
+      if (property.class === undefined) return false;
+      if (property.items !== undefined) return true;
+      property.properties?.forEach((p) => properties.push(p));
+    }
+
+    return false;
+  }
+
+  static parse(example: SchemaExample): OpenAPIV3.SchemaObject | undefined {
+    return parseProperty(example as ParameterProperty);
+  }
+}

--- a/packages/openapi/src/method.ts
+++ b/packages/openapi/src/method.ts
@@ -1,4 +1,4 @@
-import { ParameterObject } from '@appland/models';
+import { Event, ParameterObject } from '@appland/models';
 import { OpenAPIV3, OpenAPIV3_1 } from 'openapi-types';
 import Response from './response';
 import { headerValue, RPCRequest } from './rpcRequest';

--- a/packages/openapi/test/data/examples/appmap-v1.10.0.yml
+++ b/packages/openapi/test/data/examples/appmap-v1.10.0.yml
@@ -1,0 +1,15 @@
+---
+- class: Array
+  items:
+    - class: Hash
+      properties:
+        - name: mapset_id
+          class: NilClass
+        - name: scenario_uuid
+          class: String
+        - name: code_objects
+          class: Array
+        - name: metadata
+          class: Sequel::Postgres::JSONBHash
+        - name: labels
+          class: Sequel::Postgres::PGArray

--- a/packages/openapi/test/data/examples/appmap-v1.9.0.yml
+++ b/packages/openapi/test/data/examples/appmap-v1.9.0.yml
@@ -1,0 +1,13 @@
+---
+- class: Array
+  properties:
+    - name: mapset_id
+      class: NilClass
+    - name: scenario_uuid
+      class: String
+    - name: code_objects
+      class: Array
+    - name: metadata
+      class: Sequel::Postgres::JSONBHash
+    - name: labels
+      class: Sequel::Postgres::PGArray

--- a/packages/openapi/test/data/examples/deep-merge.yml
+++ b/packages/openapi/test/data/examples/deep-merge.yml
@@ -1,0 +1,149 @@
+- class: Hash
+  value: '{}'
+  properties:
+    - name: id
+      class: Integer
+    - name: created_at
+      class: String
+    - name: updated_at
+      class: String
+    - name: uuid
+      class: String
+    - name: data
+      class: Hash
+      properties:
+        - name: events
+          class: Array
+          items:
+            - class: Hash
+        - name: version
+          class: String
+        - name: classMap
+          class: Array
+          items:
+            - class: Hash
+        - name: metadata
+          class: Hash
+          properties:
+            - name: git
+              class: Hash
+            - name: name
+              class: String
+            - name: labels
+              class: Array
+              items:
+                - class: String
+            - name: feature
+              class: String
+            - name: language
+              class: Hash
+    - name: org_id
+      class: Integer
+    - name: mapset_id
+      class: Integer
+    - name: link_sharing
+      class: FalseClass
+    - name: name
+      class: String
+- class: Hash
+  value: '{}'
+  properties:
+    - name: events
+      class: Array
+      items:
+        - class: Hash
+          properties:
+            - name: id
+              class: Integer
+            - name: event
+              class: String
+            - name: message
+              class: Array
+              items:
+                - class: Hash
+            - name: http_server_request
+              class: Hash
+        - class: Hash
+          properties:
+            - name: id
+              class: Integer
+            - name: self
+              class: Hash
+            - name: event
+              class: String
+            - name: sql_query
+              class: Hash
+        - class: Hash
+          properties:
+            - name: id
+              class: Integer
+            - name: path
+              class: String
+            - name: self
+              class: Hash
+            - name: event
+              class: String
+            - name: lineno
+              class: Integer
+            - name: method_id
+              class: String
+            - name: defined_class
+              class: String
+        - class: Hash
+          properties:
+            - name: id
+              class: Integer
+            - name: path
+              class: String
+            - name: event
+              class: String
+            - name: lineno
+              class: Integer
+            - name: method_id
+              class: String
+            - name: parent_id
+              class: Integer
+            - name: defined_class
+              class: String
+    - name: version
+      class: String
+    - name: classMap
+      class: Array
+      items:
+        - class: Hash
+          properties:
+            - name: name
+              class: String
+            - name: type
+              class: String
+            - name: children
+              class: Array
+              items:
+                - class: Hash
+            - name: location
+              class: String
+    - name: metadata
+      class: Hash
+      properties:
+        - name: git
+          class: Hash
+          properties:
+            - name: branch
+              class: String
+            - name: commit
+              class: String
+            - name: repository
+              class: String
+        - name: name
+          class: String
+        - name: labels
+          class: Array
+          items:
+            - class: String
+        - name: feature
+          class: String
+        - name: language
+          class: Hash
+          properties:
+            - name: name
+              class: String

--- a/packages/openapi/test/data/examples/expected/deep-merge.yml
+++ b/packages/openapi/test/data/examples/expected/deep-merge.yml
@@ -1,0 +1,240 @@
+examples:
+  - type: object
+    properties:
+      created_at:
+        type: string
+      data:
+        type: object
+        properties:
+          classMap:
+            type: array
+            items:
+              type: object
+          events:
+            type: array
+            items:
+              type: object
+          metadata:
+            type: object
+            properties:
+              feature:
+                type: string
+              git:
+                type: object
+              labels:
+                type: array
+                items:
+                  type: string
+              language:
+                type: object
+              name:
+                type: string
+          version:
+            type: string
+      id:
+        type: integer
+      link_sharing:
+        type: boolean
+      mapset_id:
+        type: integer
+      name:
+        type: string
+      org_id:
+        type: integer
+      updated_at:
+        type: string
+      uuid:
+        type: string
+
+  - type: object
+    properties:
+      classMap:
+        type: array
+        items:
+          type: object
+          properties:
+            children:
+              type: array
+              items:
+                type: object
+            location:
+              type: string
+            name:
+              type: string
+            type:
+              type: string
+      events:
+        type: array
+        items:
+          type: object
+          properties:
+            defined_class:
+              type: string
+            event:
+              type: string
+            http_server_request:
+              type: object
+            id:
+              type: integer
+            lineno:
+              type: integer
+            message:
+              type: array
+              items:
+                type: object
+            method_id:
+              type: string
+            parent_id:
+              type: integer
+            path:
+              type: string
+            self:
+              type: object
+            sql_query:
+              type: object
+      metadata:
+        type: object
+        properties:
+          feature:
+            type: string
+          git:
+            type: object
+            properties:
+              branch:
+                type: string
+              commit:
+                type: string
+              repository:
+                type: string
+          labels:
+            type: array
+            items:
+              type: string
+          language:
+            type: object
+            properties:
+              name:
+                type: string
+          name:
+            type: string
+      version:
+        type: string
+
+mergeResult:
+  type: object
+  properties:
+    classMap:
+      type: array
+      items:
+        type: object
+        properties:
+          children:
+            type: array
+            items:
+              type: object
+          location:
+            type: string
+          name:
+            type: string
+          type:
+            type: string
+    created_at:
+      type: string
+    data:
+      type: object
+      properties:
+        classMap:
+          type: array
+          items:
+            type: object
+        events:
+          type: array
+          items:
+            type: object
+        metadata:
+          type: object
+          properties:
+            feature:
+              type: string
+            git:
+              type: object
+            labels:
+              type: array
+              items:
+                type: string
+            language:
+              type: object
+            name:
+              type: string
+        version:
+          type: string
+    events:
+      type: array
+      items:
+        type: object
+        properties:
+          defined_class:
+            type: string
+          event:
+            type: string
+          http_server_request:
+            type: object
+          id:
+            type: integer
+          lineno:
+            type: integer
+          message:
+            type: array
+            items:
+              type: object
+          method_id:
+            type: string
+          parent_id:
+            type: integer
+          path:
+            type: string
+          self:
+            type: object
+          sql_query:
+            type: object
+    id:
+      type: integer
+    link_sharing:
+      type: boolean
+    mapset_id:
+      type: integer
+    metadata:
+      type: object
+      properties:
+        feature:
+          type: string
+        git:
+          type: object
+          properties:
+            branch:
+              type: string
+            commit:
+              type: string
+            repository:
+              type: string
+        labels:
+          type: array
+          items:
+            type: string
+        language:
+          type: object
+          properties:
+            name:
+              type: string
+        name:
+          type: string
+    name:
+      type: string
+    org_id:
+      type: integer
+    updated_at:
+      type: string
+    uuid:
+      type: string
+    version:
+      type: string

--- a/packages/openapi/test/data/http_server_response_with_object_list.yaml
+++ b/packages/openapi/test/data/http_server_response_with_object_list.yaml
@@ -41,17 +41,19 @@
       code]'
     object_id: 119460
     size: 1
-    properties:
-    - name: mapset_id
-      class: NilClass
-    - name: scenario_uuid
-      class: String
-    - name: code_objects
-      class: Array
-    - name: metadata
-      class: Sequel::Postgres::JSONBHash
-    - name: labels
-      class: Sequel::Postgres::PGArray
+    items:
+      - class: Hash
+        properties:
+        - name: mapset_id
+          class: NilClass
+        - name: scenario_uuid
+          class: String
+        - name: code_objects
+          class: Array
+        - name: metadata
+          class: Sequel::Postgres::JSONBHash
+        - name: labels
+          class: Sequel::Postgres::PGArray
   http_server_response:
     status_code: 200
     headers:

--- a/packages/openapi/test/model.spec.ts
+++ b/packages/openapi/test/model.spec.ts
@@ -20,7 +20,7 @@ describe('openapi.method', () => {
       },
     });
   });
-  it('http_server_request', async () => {
+  it('http_server_request', () => {
     const request = rpcRequestForEvent(httpServerRequests[0])!;
     expect(request.status).toEqual(201);
 
@@ -69,6 +69,7 @@ describe('openapi.method', () => {
                         },
                         appmaps: {
                           type: 'array',
+                          items: {},
                         },
                       },
                     },

--- a/packages/openapi/test/openapi.spec.ts
+++ b/packages/openapi/test/openapi.spec.ts
@@ -12,8 +12,9 @@ type ClassName = string;
 type SchemaObjectType = OpenAPIV3.ArraySchemaObjectType | OpenAPIV3.NonArraySchemaObjectType;
 
 const message = (c: ClassName) => ({ message: { class: c } });
-const expected = (t?: SchemaObjectType, i?: SchemaObjectType) => {
+const expected = (t?: SchemaObjectType, i?: SchemaObjectType | object) => {
   if (!t) return { expected: undefined };
+  if (i && typeof i === 'object') return { expected: { type: t, items: i } };
 
   const r: any = { expected: { type: t } };
   if (i) {
@@ -22,7 +23,7 @@ const expected = (t?: SchemaObjectType, i?: SchemaObjectType) => {
   return r;
 };
 
-const mapping = (c: ClassName, t?: SchemaObjectType, i?: SchemaObjectType) => ({
+const mapping = (c: ClassName, t?: SchemaObjectType, i?: SchemaObjectType | object) => ({
   ...message(c),
   ...expected(t, i),
 });
@@ -141,9 +142,7 @@ describe('openapi', () => {
                         type: 'string',
                       },
                       selected_items: {
-                        items: {
-                          type: 'string',
-                        },
+                        items: {},
                         type: 'array',
                       },
                       sort: {
@@ -173,7 +172,7 @@ describe('openapi', () => {
 describe('messageToOpenAPISchema', () => {
   describe('for Ruby types', () => {
     const rubyMappings = [
-      mapping('Array', 'array', 'string'),
+      mapping('Array', 'array', {}),
       mapping('NilClass', undefined),
       mapping('MyClass', 'object'),
       ...multi(['Hash', 'ActiveSupport::HashWithIndifferentAccess'], 'object'),
@@ -188,7 +187,7 @@ describe('messageToOpenAPISchema', () => {
       mapping('builtins.bool', 'boolean'),
       mapping('builtins.dict', 'object'),
       mapping('builtins.int', 'integer'),
-      mapping('builtins.list', 'array', 'string'),
+      mapping('builtins.list', 'array', {}),
       mapping('builtins.str', 'string'),
       mapping('builtins.NoneType', undefined),
       mapping('MyPythonClass', 'object'),

--- a/packages/openapi/test/propertiesParser.spec.ts
+++ b/packages/openapi/test/propertiesParser.spec.ts
@@ -1,0 +1,229 @@
+import { promises as fs } from 'fs';
+import * as path from 'path';
+import yaml from 'js-yaml';
+import { parse, SchemaExample } from '../src/appmap';
+import PropertiesParserV1 from '../src/appmap/propertiesParserV1';
+import PropertiesParserV2 from '../src/appmap/propertiesParserV2';
+import { OpenAPIV3 } from 'openapi-types';
+import { assert } from 'console';
+import { mergeType } from '../src/schemaInferrer';
+
+interface ExpectedExampleOutput {
+  examples: ReadonlyArray<OpenAPIV3.SchemaObject>;
+  mergeResult?: OpenAPIV3.SchemaObject;
+}
+
+const ExamplesDir = path.join(__dirname, 'data', 'examples');
+
+const getExamples = (fixtureName: string) =>
+  fs
+    .readFile(path.join(ExamplesDir, fixtureName), 'utf8')
+    .then(yaml.load)
+    .then((data) => data as ReadonlyArray<SchemaExample>);
+
+const getExpectedExampleOutput = (fixtureName: string) =>
+  fs
+    .readFile(path.join(ExamplesDir, 'expected', fixtureName), 'utf8')
+    .then(yaml.load)
+    .then((data) => data as ExpectedExampleOutput);
+
+describe('PropertiesParser', () => {
+  describe('version switching', () => {
+    it('parses AppMaps adhering to v1.9.0 spec', async () => {
+      const examples = await getExamples('appmap-v1.9.0.yml');
+      expect(PropertiesParserV2.canParse(examples[0])).toBe(false);
+      console.log(parse(examples[0]));
+      expect(parse(examples[0])).toStrictEqual({
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            scenario_uuid: { type: 'string' },
+            code_objects: { type: 'array', items: {} },
+            metadata: { type: 'object' },
+            labels: { type: 'array', items: {} },
+          },
+        },
+      });
+    });
+
+    it('parses AppMaps adhering to v1.10.0 spec', async () => {
+      const examples = await getExamples('appmap-v1.10.0.yml');
+      expect(PropertiesParserV2.canParse(examples[0])).toBe(true);
+      expect(parse(examples[0])).toStrictEqual({
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            scenario_uuid: { type: 'string' },
+            code_objects: { type: 'array', items: {} },
+            metadata: { type: 'object' },
+            labels: { type: 'array', items: {} },
+          },
+        },
+      });
+    });
+
+    describe('V1', () => {
+      it('adds an empty object to array types if they cannot be determined', () => {
+        expect(
+          PropertiesParserV1.parse({
+            class: 'Array',
+            properties: [{ name: 'labels', class: 'Array' }],
+          })
+        ).toStrictEqual({
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              labels: { type: 'array', items: {} },
+            },
+          },
+        });
+      });
+    });
+
+    describe('V2', () => {
+      it('merges array element types of the same type (array)', () => {
+        expect(
+          PropertiesParserV2.parse({
+            class: 'Array',
+            items: [{ class: 'Array' }, { class: 'Array' }],
+          })
+        ).toStrictEqual({
+          type: 'array',
+          items: {
+            type: 'array',
+            items: {},
+          },
+        });
+      });
+
+      it('merges array element types of the same type (primitive)', () => {
+        expect(
+          PropertiesParserV2.parse({
+            class: 'Array',
+            items: [{ class: 'Integer' }, { class: 'Integer' }],
+          })
+        ).toStrictEqual({
+          type: 'array',
+          items: {
+            type: 'integer',
+          },
+        });
+      });
+
+      it('merges array element types of the same type (object)', () => {
+        expect(
+          PropertiesParserV2.parse({
+            class: 'Array',
+            items: [
+              { class: 'Hash', properties: [{ name: 'id', class: 'Integer' }] },
+              { class: 'Hash', properties: [{ name: 'id', class: 'Integer' }] },
+            ],
+          })
+        ).toStrictEqual({
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              id: { type: 'integer' },
+            },
+          },
+        });
+      });
+
+      it('merges array element types of the same type (partial object)', () => {
+        expect(
+          PropertiesParserV2.parse({
+            class: 'Array',
+            items: [
+              {
+                class: 'Hash',
+                properties: [
+                  { name: 'id', class: 'Integer' },
+                  { name: 'name', class: 'String' },
+                ],
+              },
+              {
+                class: 'Hash',
+                properties: [
+                  { name: 'id', class: 'Integer' },
+                  { name: 'uuid', class: 'String' },
+                ],
+              },
+            ],
+          })
+        ).toStrictEqual({
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              id: { type: 'integer' },
+              name: { type: 'string' },
+              uuid: { type: 'string' },
+            },
+          },
+        });
+      });
+
+      it('merges nested arrays and objects', () => {
+        const arrayElement = {
+          class: 'Hash',
+          properties: [
+            {
+              name: 'nested_objects',
+              class: 'Array',
+              items: [{ class: 'Hash', properties: [{ name: 'id', class: 'Integer' }] }],
+            },
+          ],
+        };
+        expect(
+          PropertiesParserV2.parse({
+            class: 'Array',
+            items: [arrayElement, arrayElement, arrayElement],
+          })
+        ).toStrictEqual({
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              nested_objects: {
+                type: 'array',
+                items: { type: 'object', properties: { id: { type: 'integer' } } },
+              },
+            },
+          },
+        });
+      });
+
+      it('merges array element types of mixed types', () => {
+        expect(
+          PropertiesParserV2.parse({
+            class: 'Array',
+            items: [{ class: 'Float' }, { class: 'Integer' }],
+          })
+        ).toStrictEqual({
+          type: 'array',
+          items: {
+            anyOf: [{ type: 'number' }, { type: 'integer' }],
+          },
+        });
+      });
+
+      it('merges large objects', async () => {
+        const expected = await getExpectedExampleOutput('deep-merge.yml');
+        assert(expected.mergeResult !== undefined);
+
+        const examples = await getExamples('deep-merge.yml');
+        const results = examples.map((item) => PropertiesParserV2.parse(item));
+
+        expected.examples.forEach((expected, index) => {
+          expect(results[index]).toStrictEqual(expected);
+        });
+
+        expect(mergeType(results[0], results[1])).toStrictEqual(expected.mergeResult);
+      });
+    });
+  });
+});

--- a/packages/openapi/test/response.spec.ts
+++ b/packages/openapi/test/response.spec.ts
@@ -31,12 +31,14 @@ describe('openapi.response', () => {
                 },
                 code_objects: {
                   type: 'array',
+                  items: {},
                 },
                 metadata: {
                   type: 'object',
                 },
                 labels: {
                   type: 'array',
+                  items: {},
                 },
               },
             },

--- a/packages/openapi/tsconfig.json
+++ b/packages/openapi/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "dist",
-    "declaration": true
+    "declaration": true,
+    "inlineSourceMap": true
   },
   "include": ["src", "test"]
 }

--- a/packages/sequence-diagram/src/buildDiagram.ts
+++ b/packages/sequence-diagram/src/buildDiagram.ts
@@ -124,7 +124,8 @@ export default function buildDiagram(
       }
 
       const typeName =
-        classNameToOpenAPIType(returnEvent.returnValue.class) || returnEvent.returnValue.class;
+        classNameToOpenAPIType(returnEvent.returnValue.class, { strict: true }) ||
+        returnEvent.returnValue.class;
       returnValueType = {
         name: typeName,
         properties: propertyNames,

--- a/packages/sequence-diagram/tests/fixtures/app/tmp/appmap/show_user.sequence.uml
+++ b/packages/sequence-diagram/tests/fixtures/app/tmp/appmap/show_user.sequence.uml
@@ -10,7 +10,7 @@ participant posts as "posts"
     controllers->models: <u>find</u> <color:gray> 0.046 ms</color>
     activate models
       models->database: <u>query</u> <color:gray> 0.001 ms</color>
-    controllers<--models: object
+    controllers<--models: User
     deactivate models
     controllers->users: show <color:gray> 0.153 ms</color>
     activate users

--- a/packages/sequence-diagram/tests/fixtures/sequenceDiagrams/userFoundVsNotFound.sequence.uml
+++ b/packages/sequence-diagram/tests/fixtures/sequenceDiagrams/userFoundVsNotFound.sequence.uml
@@ -10,7 +10,7 @@ participant posts as "posts"
     controllers-[#CA9C3F]>models: <u>find</u> <color:gray> 0.046 ms</color>
     activate models
       models-[#green]>database: <u><color:lightgray><back:#172238>query</back></color></u> <color:gray> 0.001 ms</color>
-    controllers<[#CA9C3F]--models: <color:lightgray><back:#29201A>--exception!--</back></color> <color:lightgray><back:#172238>object</back></color>
+    controllers<[#CA9C3F]--models: <color:lightgray><back:#29201A>--exception!--</back></color> <color:lightgray><back:#172238>User</back></color>
     deactivate models
     controllers-[#green]>users: <color:lightgray><back:#172238>show</back></color> <color:gray> 0.153 ms</color>
     activate users


### PR DESCRIPTION
This PR adds support for AppMaps which include the following change to the specification: https://github.com/getappmap/appmap/pull/36

I've included some notes at the bottom. I'd also like to increase the test coverage a bit more before merging.

Here's an example before/after:
```yaml
/api/appmaps:
  get:
    responses:
      '200':
        content:
          application/json:
            schema:
              type: array
              items:
                type: object
                properties:
                  code_objects:
                    type: array
                    items: {}
                  labels:
                    type: array
                    items: {}
                  mapset_id:
                    type: integer
                  metadata:
                    type: object
                    properties:
                      feature:
                        type: string
                      git:
                        type: object
                      labels:
                        type: array
                        items: {}
                      language:
                        type: object
                      name:
                        type: string
                  scenario_uuid:
                    type: string
        description: OK
```

After:
```yaml
/api/appmaps:
  get:
    responses:
      '200':
        content:
          application/json:
            schema:
              type: array
              items:
                type: object
                properties:
                  code_objects:
                    type: array
                    items:
                      type: string
                  labels:
                    type: array
                    items:
                      type: string
                  mapset_id:
                    type: integer
                  metadata:
                    type: object
                    properties:
                      feature:
                        type: string
                      git:
                        type: object
                      labels:
                        type: array
                        items:
                          type: string
                      language:
                        type: object
                      name:
                        type: string
                  scenario_uuid:
                    type: string
        description: OK
```

The difference is actually pretty minimal. Prior to recording `class` information within an array, `items` would often be missing. I've added a fix so it'll at least default to `{}`, allowing it to pass a linter, and in cases where `class` information is available for elements of the array, it'll use that.