### PR TITLE
fix: add missing @appland/client dependency

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -68,6 +68,7 @@
     "vuex"
   ],
   "dependencies": {
+    "@appland/client": "workspace:^1",
     "@appland/components": "workspace:^2",
     "@appland/diagrams": "workspace:^1",
     "@appland/models": "workspace:^2.0.0",

--- a/packages/scanner/bin/schema.ts
+++ b/packages/scanner/bin/schema.ts
@@ -4,7 +4,7 @@ import { writeFileSync } from 'fs';
 import { createGenerator } from 'ts-json-schema-generator';
 
 function generate(schemaId: string, path: string) {
-  const generator = createGenerator({ path, schemaId });
+  const generator = createGenerator({ path, schemaId, skipTypeCheck: true });
   const schema = generator.createSchema();
 
   if (!schema.definitions) throw 'error generating schema';

--- a/yarn.lock
+++ b/yarn.lock
@@ -77,6 +77,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@appland/appmap@workspace:packages/cli"
   dependencies:
+    "@appland/client": "workspace:^1"
     "@appland/components": "workspace:^2"
     "@appland/diagrams": "workspace:^1"
     "@appland/models": "workspace:^2.0.0"
@@ -155,7 +156,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@appland/client@^1.5.0, @appland/client@workspace:packages/client":
+"@appland/client@^1.5.0, @appland/client@workspace:^1, @appland/client@workspace:packages/client":
   version: 0.0.0-use.local
   resolution: "@appland/client@workspace:packages/client"
   dependencies:


### PR DESCRIPTION
fixes https://github.com/getappmap/appmap-js/issues/998

I don't understand how this is only noticed now:

- `packages/cli/package.json` did not have a `@appland/client` dependency since at least edea424c8ad533118e23c6e983322ce44932b0c8 (3.50.0)
- `packages/cli/src/cmds/upload.ts` did have `import { AppMap, loadConfiguration, Mapset } from '@appland/client';` since its creation 7f83aa52890c86c604acb1233ca1b8b21dd74b69

Maybe it would be a good idea to invest in some e2e testing so that it does not happen in the future.

**EDIT `upload.ts` was only recently added, please disregard the above**