### PR TITLE
update wording for analysis CTA in web view

### DIFF
--- a/packages/components/src/pages/install-guide/InvestigateFindings.vue
+++ b/packages/components/src/pages/install-guide/InvestigateFindings.vue
@@ -10,6 +10,11 @@
           maintainability. Our runtime code analysis can find the problems that static code
           analyzers miss — and that cause serious production issues.
         </article>
+        <article v-if="!(analysisEnabled && scanned)" class="subheading">
+          To unlock this feature you will authenticate to the AppMap server with your GitHub or
+          GitLab account. AppMap does not upload your AppMaps. AppMap does not read the contents of
+          your AppMaps. AppMap does not have read or write access to your repo.
+        </article>
         <div v-if="analysisEnabled">
           <article v-if="!scanned">
             <p>


### PR DESCRIPTION
A minor change to the Analysis CTA to put users minds at ease about us having access to their data.

New:
![image](https://user-images.githubusercontent.com/1229326/217328490-1301f238-3933-49f7-bb4b-5ce0771f364d.png)

Old:
![image](https://user-images.githubusercontent.com/1229326/217328782-26cafb12-f140-47af-9b33-32d344ea24af.png)
