### PR TITLE
test: Improved smoke test

### DIFF
--- a/ci/make-smoke-package-json.mjs
+++ b/ci/make-smoke-package-json.mjs
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+
+import fs from 'fs/promises';
+import { join } from 'path';
+import { pathToFileURL } from 'url';
+
+const pkgs = (await fs.readdir('.'))
+  .filter((f) => /@appland-.*\.tgz/.test(f))
+  .map((f) => f.replace(/\.tgz$/, ''));
+
+const pwd = process.cwd();
+
+function file(pkg) {
+  return pathToFileURL(join(pwd, `${pkg}.tgz`));
+}
+
+const resolutions = Object.fromEntries(pkgs.map((pkg) => [pkg.replace('-', '/'), file(pkg)]));
+
+await fs.writeFile(
+  'package.json',
+  JSON.stringify(
+    {
+      resolutions,
+      dependencies: { '@appland/appmap': file('@appland-appmap') },
+    },
+    undefined,
+    2
+  )
+);

--- a/smoketest.sh
+++ b/smoketest.sh
@@ -8,11 +8,10 @@ cp -r "packages/cli/tests/unit/fixtures/ruby" "${TESTDIR}"
 
 cd "${TESTDIR}"
 
-# make sure packages resolve to local versions
-ls @appland-*.tgz | sed -E -e '1i {"resolutions": {' -e 's/@appland-(.*).tgz/"@appland\/\1": ".\/&"/; $!a,' -e '$a}}' > package.json
+yarn set version 3.2.2  # 3.2.1 has broken pnp support
 
-yarn set version ^3.2.2  # 3.2.1 has broken pnp support
-yarn add ./@appland-appmap.tgz
+node "$PKGDIR/ci/make-smoke-package-json.mjs"
+YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn install
 
 yarn run appmap index --appmap-dir ruby
 yarn run appmap depends --appmap-dir ruby


### PR DESCRIPTION
For some reason our smoke test didn't catch new missing dependency of cli on the client. I've realized yarn doesn't always use the correct packages installing files when resolutions include relative path. Changing the smoke test to instead use absolute paths seems to resolve the issue and allow the test to catch it.

Fixes #1002