### PR TITLE
Seq diagram bug fixes

### DIFF
--- a/packages/components/src/components/DetailsPanelExternalService.vue
+++ b/packages/components/src/components/DetailsPanelExternalService.vue
@@ -2,7 +2,7 @@
   <div>
     <v-details-panel-header object-type="External service" :object="object" :title="object.name" />
     <v-details-panel-filters :object="object" :is-root-object="isRootObject" />
-    <v-details-panel-list title="Events" :items="object.events" :event-quickview="true" />
+    <v-details-panel-list title="Events" :items="object.allEvents" :event-quickview="true" />
   </div>
 </template>
 
@@ -12,7 +12,7 @@ import VDetailsPanelFilters from '@/components/DetailsPanelFilters.vue';
 import VDetailsPanelList from '@/components/DetailsPanelList.vue';
 
 export default {
-  name: 'v-details-panel-route',
+  name: 'v-details-panel-external-service',
   components: {
     VDetailsPanelList,
     VDetailsPanelFilters,

--- a/packages/components/src/components/DetailsPanelHeader.vue
+++ b/packages/components/src/components/DetailsPanelHeader.vue
@@ -85,12 +85,18 @@ export default {
           result.push(codeObject.packageObject, codeObject.classObject, codeObject);
         }
 
-        if (codeObject.type === CodeObjectType.ROUTE || codeObject.type === CodeObjectType.QUERY) {
+        if (
+          codeObject.type === CodeObjectType.ROUTE ||
+          codeObject.type === CodeObjectType.QUERY ||
+          codeObject.type === CodeObjectType.EXTERNAL_ROUTE
+        ) {
           result.unshift(codeObject.parent);
         }
       }
 
-      return result.filter((obj) => obj && obj !== this.object);
+      return result.filter(
+        (obj) => obj && obj !== this.object && obj.type !== CodeObjectType.EXTERNAL_ROUTE
+      );
     },
   },
   methods: {

--- a/packages/components/src/pages/VsCodeExtension.vue
+++ b/packages/components/src/pages/VsCodeExtension.vue
@@ -817,11 +817,13 @@ export default {
     },
 
     setSelectedObject(fqid) {
-      const [match, type, object] = fqid.match(/^([a-z]+):(.+)/);
+      const matchResult = fqid.match(/^([a-z\-]+):(.+)/);
 
-      if (!match) {
+      if (!matchResult) {
         return;
       }
+
+      const [, type, object] = matchResult;
 
       if (type === 'label') {
         this.$store.commit(SELECT_LABEL, object);

--- a/packages/components/tests/e2e/specs/appmap/sidebar.spec.js
+++ b/packages/components/tests/e2e/specs/appmap/sidebar.spec.js
@@ -329,9 +329,7 @@ context('AppMap sidebar', () => {
       .should('not.match', /SELECT.*FROM/);
   });
 
-  // FIXME
-  // This test is broken.
-  xit('renders HTTP client requests correctly', () => {
+  it('renders HTTP client requests correctly', () => {
     cy.get('.details-search__block--external-service')
       .contains('External services')
       .get('.details-search__block-item')
@@ -383,7 +381,7 @@ context('AppMap sidebar', () => {
 
     cy.get('.trace-node.highlight').within(() => {
       cy.get('.trace-node__header--http-client').contains(
-        'External service call to 127.0.0.1:9515'
+        'External service call to POST http://127.0.0.1:9515'
       );
 
       cy.get('.columns__column--left').within(() => {


### PR DESCRIPTION
Fixes #1008 
Fixes #956 

- [x] Clicking on the HTTP client request in [the sequence diagram](http://localhost:6006/?path=/story/pages-vs-code--extension-with-default-sequence-view) , then clicking it again in the sidebar causes the entire sidebar display to become blank
- [x] Clicking the External Service 127.0.0.1:9515 and then clicking Hide  causes an error “Invalid attempt to destructure non-iterable instance.”