### PR TITLE
feat: Show a warning when watch scanning fails

### DIFF
--- a/packages/scanner/src/cli/scan/watchScan.ts
+++ b/packages/scanner/src/cli/scan/watchScan.ts
@@ -54,6 +54,7 @@ export class Watcher {
 
   constructor(private options: WatchScanOptions) {
     WatchScanTelemetry.watch(this.scanEventEmitter);
+    this.queue.error((error, task) => console.warn(`Problem processing ${task}:\n`, error));
   }
 
   async watch(): Promise<void> {


### PR DESCRIPTION
A tiny addition: I noticed when a scan fails for some file in watch scanning mode, the user is not notified. With this change, a warning is shown.