### PR TITLE
ci: Do a full build before chromatic release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,5 +44,6 @@ jobs:
         - curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --profile default -y
         - source "$HOME/.cargo/env"
       script: |
+        yarn build \
         yarn run semantic-release \
         && yarn run chromatic --auto-accept-changes


### PR DESCRIPTION
Building some packages requires dependencies to be built first. Chromatic only runs build on the packages that changes, which can lead to a build failure if the dependencies haven't been changed too.