### PR TITLE
Improved highlighting for selected sequence diagram elements

### DIFF
--- a/packages/components/src/components/sequence/CallAction.vue
+++ b/packages/components/src/components/sequence/CallAction.vue
@@ -293,7 +293,7 @@ export default {
 }
 
 .call.selected > .call-line-segment {
-  background-color: #6c8ba54f;
+  background-color: #6fddbc94; //#6c8ba54f;
   &.arrow-base {
     border-radius: 0.5rem 0 0 0;
   }

--- a/packages/components/src/components/sequence/CallAction.vue
+++ b/packages/components/src/components/sequence/CallAction.vue
@@ -307,7 +307,7 @@ export default {
 
 @keyframes node-focused {
   from {
-    background-color: #6c8ba54f;
+    background-color: #6fddbc94;
   }
   to {
     background-color: black;

--- a/packages/components/src/components/sequence/CallLabel.vue
+++ b/packages/components/src/components/sequence/CallLabel.vue
@@ -176,6 +176,17 @@ $bg-fade: rgba(0, 0, 0, 0.8);
   }
 }
 
+.call.selected > .call-line-segment {
+  .label {
+    .name {
+      color: $white;
+    }
+    .elapsed {
+      color: #e3e5e8a6;
+    }
+  }
+}
+
 .name:hover,
 .collapse-expand:hover {
   cursor: pointer;


### PR DESCRIPTION
The existing color for selected elements in the sequence diagram was subtle, but made it hard to find the element if scrolling around the map. Updated to have a brighter color for easier navigation. 

Closes #1040 

## Before
![Screenshot 2023-02-21 at 5 39 31 PM](https://user-images.githubusercontent.com/123787/220475722-5fd90094-13b9-4a17-baa4-719616241893.png)

## After
![Screenshot 2023-02-21 at 5 39 08 PM](https://user-images.githubusercontent.com/123787/220475709-a763d009-59a0-4204-b10b-21d7d4e19ab0.png)
