### PR TITLE
Don't hang without git

### DIFF
--- a/packages/telemetry/telemetry.spec.ts
+++ b/packages/telemetry/telemetry.spec.ts
@@ -31,7 +31,7 @@ describe('telemetry', () => {
       const conf = sandbox.stub(Conf.prototype, 'get');
       conf.withArgs(sinon.match('sessionId')).returns(undefined);
 
-      const setStub = Conf.prototype.set as SinonSpy;
+      const setStub = Conf.prototype['set'] as SinonSpy;
       const { session } = Telemetry;
 
       expect(setStub.getCall(-2).args[1]).toBe(session.id);

--- a/packages/telemetry/telemetry.spec.ts
+++ b/packages/telemetry/telemetry.spec.ts
@@ -2,8 +2,10 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import sinon, { SinonSpy } from 'sinon';
 import Conf from 'conf';
-import Telemetry, { Git } from './telemetry';
+import Telemetry, { Git, GitState } from './telemetry';
 import { name as appName, version } from './package.json';
+import child_process, { ChildProcess } from 'node:child_process';
+import { nextTick } from 'node:process';
 
 const invalidExpiration = () => Date.now() - 1000 * 60 * 60;
 
@@ -177,6 +179,18 @@ describe('telemetry', () => {
 
         expect(await Git.contributors(sinceDaysAgo)).toEqual(firstResult);
       }
+    });
+
+    describe('state', () => {
+      it('returns NotInstalled on error', () => {
+        jest.spyOn(child_process, 'spawn').mockImplementation(() => {
+          const cp = new ChildProcess();
+          nextTick(() => cp.emit('error', new Error('test error')));
+          return cp;
+        });
+
+        return expect(Git.state()).resolves.toEqual(GitState.NotInstalled);
+      });
     });
   });
 });

--- a/packages/telemetry/telemetry.ts
+++ b/packages/telemetry/telemetry.ts
@@ -304,7 +304,7 @@ class GitProperties {
               return resolve(GitState.Ok);
           }
         });
-        commandProcess.on('error', () => GitState.NotInstalled);
+        commandProcess.on('error', () => resolve(GitState.NotInstalled));
       } catch {
         resolve(GitState.NotInstalled);
       }

--- a/packages/telemetry/telemetry.ts
+++ b/packages/telemetry/telemetry.ts
@@ -6,8 +6,7 @@ import { TelemetryClient, setup as AppInsights } from 'applicationinsights';
 import Conf from 'conf';
 import { exec as execCallback, spawn } from 'child_process';
 import { promisify } from 'util';
-import { PathLike, promises as fs, constants as fsConstants } from 'fs';
-import * as path from 'path';
+import { PathLike } from 'fs';
 
 const exec = promisify(execCallback);
 


### PR DESCRIPTION
Recent additions to telemetry cause processes to hang if git is not found. This fixes the problem.