### PR TITLE
Improved arrowhead alignment

### DIFF
--- a/packages/components/src/assets/sequence-action-arrow.svg
+++ b/packages/components/src/assets/sequence-action-arrow.svg
@@ -1,3 +1,3 @@
 <svg width="12" height="12" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg">
-  <path d="M 12 6 l -12 6 l 0 -12 Z" />
+<path d="M12 5V7L2 12H0V0H2L12 5Z" />
 </svg>


### PR DESCRIPTION
The arrowheads in the sequence diagrams look broken because the tip of the arrow is thinner than the line of the arrow. Update the arrowhead SVG to have squared-off edges (2px to match line width), so it doesn't look broken.
Fixes #1054 

## Before
![Screenshot 2023-02-23 at 10 06 52 AM](https://user-images.githubusercontent.com/123787/220946779-85ff7abf-9b69-4b78-adbc-c5c37e7b0142.png)


## After
![Screenshot 2023-02-23 at 10 05 06 AM](https://user-images.githubusercontent.com/123787/220946824-22cf488a-11df-4b0c-b98b-3763bac73731.png)

  