### PR TITLE
fix inconsistent border-radius for selected diagram elements

### DIFF
--- a/packages/components/src/components/sequence/Actor.vue
+++ b/packages/components/src/components/sequence/Actor.vue
@@ -187,7 +187,7 @@ $min-height: 3rem;
 
 .on-top {
   position: absolute;
-  z-index: 1;
+  z-index: 99999;
   height: 100%;
 }
 

--- a/packages/components/src/components/sequence/CallAction.vue
+++ b/packages/components/src/components/sequence/CallAction.vue
@@ -319,13 +319,16 @@ export default {
 .call.selected > .self-call {
   background-color: #6fddbc94; //#6c8ba54f;
   &.arrow-base {
-    border-radius: 0.5rem 0 0 0;
+    border-radius: 0;
+    margin-top: 0.5rem;
   }
   &.arrow-head {
-    border-radius: 0 0.5rem 0 0;
+    border-radius: 0;
+    margin-top: 0.5rem;
   }
   &.single-span {
-    border-radius: 0.5rem 0.5rem 0 0;
+    border-radius: 0;
+    margin-top: 0.5rem;
   }
 }
 
@@ -454,6 +457,7 @@ export default {
 
   .connecting-span {
     border-radius: 0;
+    margin-top: 0.5rem;
   }
 
   .arrow {

--- a/packages/components/src/components/sequence/CallAction.vue
+++ b/packages/components/src/components/sequence/CallAction.vue
@@ -317,18 +317,19 @@ export default {
 
 .call.selected > .call-line-segment,
 .call.selected > .self-call {
-  background-color: #6fddbc94; //#6c8ba54f;
+  background-color: #6fddbc94;
+  border-top: 4px solid $black;
   &.arrow-base {
     border-radius: 0;
-    margin-top: 0.5rem;
+    border-top: 4px solid $black;
   }
   &.arrow-head {
     border-radius: 0;
-    margin-top: 0.5rem;
+    border-top: 4px solid $black;
   }
   &.single-span {
     border-radius: 0;
-    margin-top: 0.5rem;
+    border-top: 4px solid $black;
   }
 }
 
@@ -337,7 +338,7 @@ export default {
     background-color: #6fddbc94;
   }
   to {
-    background-color: black;
+    background-color: $black;
   }
 }
 
@@ -443,6 +444,7 @@ export default {
     right: 0px;
     position: absolute;
     bottom: -7px;
+    z-index: 9999;
   }
 }
 
@@ -457,7 +459,7 @@ export default {
 
   .connecting-span {
     border-radius: 0;
-    margin-top: 0.5rem;
+    border-top: 4px solid $black;
   }
 
   .arrow {
@@ -472,6 +474,11 @@ export default {
     left: calc(((var(--callee-lifecycle-depth)) * $sequence-activation-gutter-width));
   }
 
+  .connecting-span {
+    border-radius: 0;
+    border-top: 4px solid $black;
+  }
+
   .arrow-head {
     left: calc((var(--callee-lifecycle-depth) * $sequence-activation-gutter-width));
   }
@@ -481,6 +488,7 @@ export default {
     transform: rotate(180deg);
     position: absolute;
     bottom: -7px;
+    z-index: 9999;
   }
 }
 

--- a/packages/components/src/components/sequence/ReturnAction.vue
+++ b/packages/components/src/components/sequence/ReturnAction.vue
@@ -253,6 +253,7 @@ export default {
     transform: rotate(180deg);
     position: absolute;
     bottom: -7px;
+    z-index: 9999;
   }
 }
 


### PR DESCRIPTION
When sequence diagram arrows go from right to left, the border-radius is inconsistent and looks broken. Update so the selection looks clean from L -> R, as well as from R -> L

Fixes #1062 

## Before
<img width="581" alt="Screenshot 2023-02-23 at 11 16 43 AM" src="https://user-images.githubusercontent.com/123787/221216000-f49c1449-7c51-4d1a-9507-998631baa9f7.png">

## After 
![Screenshot 2023-02-24 at 10 14 50 AM](https://user-images.githubusercontent.com/123787/221216010-aa69cc14-4ff8-4bbf-b885-cd60d863e5fe.png)
