### PR TITLE
hide-actor is visible with really long actor names

### DIFF
--- a/packages/components/src/components/sequence/Actor.vue
+++ b/packages/components/src/components/sequence/Actor.vue
@@ -146,7 +146,6 @@ $min-height: 3rem;
   display: flex;
   justify-content: center;
   align-items: center;
-  transition: $transition;
 
   &--selected {
     background-color: #444e69;
@@ -158,7 +157,6 @@ $min-height: 3rem;
     right: 0px;
     top: 0px;
     z-index: 99999;
-    transition: all 0.6s ease;
     padding: 5px;
     border-radius: 4px;
 
@@ -171,7 +169,6 @@ $min-height: 3rem;
     svg {
       fill: $white;
       opacity: 33%;
-      transition: $transition;
       &:hover {
         opacity: 93%;
       }


### PR DESCRIPTION
When there is a long name in the `Actor` the hide button is obscured. Closes #1068 

## Before
![Screenshot 2023-03-01 at 10 04 02 AM](https://user-images.githubusercontent.com/123787/222179576-3b151103-86d2-468a-8a53-8492895b06e5.png)

## After 
![Screenshot 2023-03-01 at 10 03 07 AM](https://user-images.githubusercontent.com/123787/222179561-bdf47312-417a-4449-b9e9-3a2e1465fa25.png)
