### PR TITLE
Fix broken sequence diagram test

### DIFF
--- a/packages/components/cypress.config.ts
+++ b/packages/components/cypress.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'cypress';
 
 export default defineConfig({
+  scrollBehavior: 'center',
   fixturesFolder: 'tests/e2e/fixtures',
   screenshotsFolder: 'tests/e2e/screenshots',
   videosFolder: 'tests/e2e/videos',

--- a/packages/components/cypress.config.ts
+++ b/packages/components/cypress.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'cypress';
+
+export default defineConfig({
+  fixturesFolder: 'tests/e2e/fixtures',
+  screenshotsFolder: 'tests/e2e/screenshots',
+  videosFolder: 'tests/e2e/videos',
+  e2e: {
+    specPattern: 'tests/e2e/specs/**/*.spec.{js,jsx,ts,tsx}',
+    supportFile: 'tests/e2e/support/index.js',
+  },
+});

--- a/packages/components/cypress.config.ts
+++ b/packages/components/cypress.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'cypress';
 
 export default defineConfig({
   scrollBehavior: 'center',
+  video: false,
   fixturesFolder: 'tests/e2e/fixtures',
   screenshotsFolder: 'tests/e2e/screenshots',
   videosFolder: 'tests/e2e/videos',

--- a/packages/components/cypress.json
+++ b/packages/components/cypress.json
@@ -1,3 +1,0 @@
-{
-  "pluginsFile": "tests/e2e/plugins/index.cjs"
-}

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -73,7 +73,7 @@
     "core-js": "^3.11.2",
     "cross-env": "^7.0.2",
     "css-loader": "5",
-    "cypress": "^9.4.1",
+    "cypress": "12.7.0",
     "eslint": "^6.7.2",
     "eslint-config-prettier": "^7.2.0",
     "eslint-plugin-import": "^2.20.2",

--- a/packages/components/tests/e2e/specs/appmap/componentDiagram.spec.js
+++ b/packages/components/tests/e2e/specs/appmap/componentDiagram.spec.js
@@ -18,12 +18,10 @@ context('AppMap component diagram', () => {
       cy.get(`.nodes .node[data-type="http"]`).should('not.have.class', 'highlight');
     });
 
-    xit('expands package when a child is selected from the sidebar', () => {
+    it('expands package when a child is selected from the sidebar', () => {
       cy.get('.node[data-id="app/helpers"]').click();
 
-      cy.get('.v-details-panel-list').within(() => {
-        cy.get('.list-item').first().click();
-      });
+      cy.get('.list-item').first().click();
 
       cy.get('.cluster[data-id="app/helpers"]').should('have.length', 1);
     });

--- a/packages/components/tests/e2e/specs/appmap/componentDiagram.spec.js
+++ b/packages/components/tests/e2e/specs/appmap/componentDiagram.spec.js
@@ -18,7 +18,7 @@ context('AppMap component diagram', () => {
       cy.get(`.nodes .node[data-type="http"]`).should('not.have.class', 'highlight');
     });
 
-    it('expands package when a child is selected from the sidebar', () => {
+    xit('expands package when a child is selected from the sidebar', () => {
       cy.get('.node[data-id="app/helpers"]').click();
 
       cy.get('.v-details-panel-list').within(() => {

--- a/packages/components/tests/e2e/specs/appmap/sequenceDiagram.spec.js
+++ b/packages/components/tests/e2e/specs/appmap/sequenceDiagram.spec.js
@@ -39,12 +39,7 @@ context('AppMap sequence diagram', () => {
       cy.get('button').contains('Show in Sequence').click();
       cy.get('.call.selected > :first').should('be.visible');
     });
-    // TODO: Passes locally, but fails in CI.
-    // ➤ YN0000: [@appland/components]:      AssertionError: Timed out retrying after 4000ms: expected '<div.call-line-segment.single-span>' to be 'visible'
-    // ➤ YN0000: [@appland/components]:
-    // ➤ YN0000: [@appland/components]: This element `<div.call-line-segment.single-span>` is not visible because its content is being clipped by one of its parent elements, which has a CSS property of overflow: `hidden`, `scroll` or `auto`
-    // ➤ YN0000: [@appland/components]:       at Context.eval (http://localhost:6006/__cypress/tests?p=tests/e2e/specs/appmap/sequenceDiagram.spec.js:128:41)
-    xit('pans to the correct location when selecting "View in Sequence"', () => {
+    it('pans to the correct location when selecting "View in Sequence"', () => {
       cy.get('.node.class[data-id="active_support/ActiveSupport::SecurityUtils"]').click();
 
       cy.get('.v-details-panel-list')

--- a/yarn.lock
+++ b/yarn.lock
@@ -235,7 +235,7 @@ __metadata:
     core-js: ^3.11.2
     cross-env: ^7.0.2
     css-loader: 5
-    cypress: ^9.4.1
+    cypress: 12.7.0
     diff: ^5.1.0
     dom-to-svg: ^0.12.2
     eslint: ^6.7.2
@@ -11997,9 +11997,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cypress@npm:^9.4.1":
-  version: 9.4.1
-  resolution: "cypress@npm:9.4.1"
+"cypress@npm:12.7.0":
+  version: 12.7.0
+  resolution: "cypress@npm:12.7.0"
   dependencies:
     "@cypress/request": ^2.88.10
     "@cypress/xvfb": ^1.2.4
@@ -12018,9 +12018,9 @@ __metadata:
     commander: ^5.1.0
     common-tags: ^1.8.0
     dayjs: ^1.10.4
-    debug: ^4.3.2
+    debug: ^4.3.4
     enquirer: ^2.3.6
-    eventemitter2: ^6.4.3
+    eventemitter2: 6.4.7
     execa: 4.1.0
     executable: ^4.1.1
     extract-zip: 2.0.1
@@ -12033,7 +12033,7 @@ __metadata:
     listr2: ^3.8.3
     lodash: ^4.17.21
     log-symbols: ^4.0.0
-    minimist: ^1.2.5
+    minimist: ^1.2.6
     ospath: ^1.2.2
     pretty-bytes: ^5.6.0
     proxy-from-env: 1.0.0
@@ -12045,7 +12045,7 @@ __metadata:
     yauzl: ^2.10.0
   bin:
     cypress: bin/cypress
-  checksum: d068704a1a13b6ab22db2cb6867683d0c2d383c41f4d8ded7529999ed1f2bc929f91edc0a69df56a272230c984458ee8198e007af611860dca6a4a1c918319e8
+  checksum: a9489f7f254dcee1b8a374d14d175c8f8681a3388e4c02181e0486f064f4de59bfc79dec1f401605332d3a5869bf2ba06b3a1653a5c287e447810d756d470078
   languageName: node
   linkType: hard
 
@@ -14252,10 +14252,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eventemitter2@npm:^6.4.3":
-  version: 6.4.5
-  resolution: "eventemitter2@npm:6.4.5"
-  checksum: 84504f9cf0cc30205cdd46783fe9df3733435e5097f13070b678023110b5ef07847651808ae280cd94c42cd5976880211c7a40321a8ff8fa56f7c5f9c5c11960
+"eventemitter2@npm:6.4.7":
+  version: 6.4.7
+  resolution: "eventemitter2@npm:6.4.7"
+  checksum: 1b36a77e139d6965ebf3a36c01fa00c089ae6b80faa1911e52888f40b3a7057b36a2cc45dcd1ad87cda3798fe7b97a0aabcbb8175a8b96092a23bb7d0f039e66
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes #1038 

- [x] Disable video recording during Cypress testing to dramatically increase testing speed (the test suite now takes ~15 min instead of ~35 min)
- [x] Fix a previously broken test by enforcing scrolling the active element to the center of the viewport before executing commands
- [x] Upgrade Cypress from `9.4.1` to `12.7.0`
