### PR TITLE
fix alignment for text hover for export & share buttons

### DIFF
--- a/packages/components/src/pages/VsCodeExtension.vue
+++ b/packages/components/src/pages/VsCodeExtension.vue
@@ -117,29 +117,23 @@
             v-if="appMapUploadable"
             class="hover-text-popper"
             text="Create a link to this AppMap"
-            placement="bottom"
-            text-align="right"
+            placement="left"
+            text-align="left"
           >
-            <button class="control-button appmap-upload" @click="uploadAppmap" title="">
+            <button class="control-button" @click="uploadAppmap" title="">
               <UploadIcon class="control-button__icon" />
-              <span>Share</span>
             </button>
           </v-popper>
           <v-popper
             v-if="showDownload"
             class="hover-text-popper"
             text="Export in SVG format"
-            placement="bottom"
-            text-align="right"
+            placement="left"
+            text-align="left"
           >
             <v-download-sequence-diagram ref="export">
-              <button
-                class="control-button appmap-upload"
-                @click="$refs.export.download()"
-                title=""
-              >
+              <button class="control-button" @click="$refs.export.download()" title="">
                 <ExportIcon class="control-button__icon" />
-                <span>Export</span>
               </button>
             </v-download-sequence-diagram>
           </v-popper>


### PR DESCRIPTION
Make the controls for AppMap diagrams styled consistently. The purple styling was initially meant to draw attention to the Share button, but should remain consistent with other control styles.

## Before
![Screenshot 2023-03-06 at 10 11 03 AM](https://user-images.githubusercontent.com/123787/223474624-08eb3991-0836-4dc8-88fb-9afd00a3112e.png)

## After 
![Screenshot 2023-03-07 at 10 47 57 AM](https://user-images.githubusercontent.com/123787/223474614-b38972ad-a6aa-4dd2-bb89-38d03c1f0b69.png)
