### PR TITLE
Revert "test: fix broken sequence diagram test"

### DIFF
--- a/packages/components/cypress.config.ts
+++ b/packages/components/cypress.config.ts
@@ -1,7 +1,6 @@
 import { defineConfig } from 'cypress';
 
 export default defineConfig({
-  scrollBehavior: 'center',
   video: false,
   fixturesFolder: 'tests/e2e/fixtures',
   screenshotsFolder: 'tests/e2e/screenshots',

--- a/packages/components/tests/e2e/specs/appmap/sequenceDiagram.spec.js
+++ b/packages/components/tests/e2e/specs/appmap/sequenceDiagram.spec.js
@@ -39,7 +39,12 @@ context('AppMap sequence diagram', () => {
       cy.get('button').contains('Show in Sequence').click();
       cy.get('.call.selected > :first').should('be.visible');
     });
-    it('pans to the correct location when selecting "View in Sequence"', () => {
+    // TODO: Passes locally, but fails in CI.
+    // ➤ YN0000: [@appland/components]:      AssertionError: Timed out retrying after 4000ms: expected '<div.call-line-segment.single-span>' to be 'visible'
+    // ➤ YN0000: [@appland/components]:
+    // ➤ YN0000: [@appland/components]: This element `<div.call-line-segment.single-span>` is not visible because its content is being clipped by one of its parent elements, which has a CSS property of overflow: `hidden`, `scroll` or `auto`
+    // ➤ YN0000: [@appland/components]:       at Context.eval (http://localhost:6006/__cypress/tests?p=tests/e2e/specs/appmap/sequenceDiagram.spec.js:128:41)
+    xit('pans to the correct location when selecting "View in Sequence"', () => {
       cy.get('.node.class[data-id="active_support/ActiveSupport::SecurityUtils"]').click();
 
       cy.get('.v-details-panel-list')


### PR DESCRIPTION
Fixes #1099 

This reverts commit abc9ba1136f3e42551024bd465d23450d217148e.

This test just failed in CI again, so it seems that it wasn't fixed after all.