### PR TITLE
Updates to handle large appmaps

### DIFF
--- a/packages/cli/src/cmds/prune/prune.ts
+++ b/packages/cli/src/cmds/prune/prune.ts
@@ -48,18 +48,26 @@ function parseSize(size: string) {
 export default {
   command: 'prune <file> <size>',
 
-  describe: 'Prune an appmap file down to the given size',
+  describe: 'Make an appmap file smaller by removing events',
 
   builder: (argv: Yargs.Argv) => {
     argv.option('output-dir', {
-      describe: 'Specifies the output directory. Pruned files will be written here.',
+      describe: 'Specifies the output directory',
       type: 'string',
       default: '.',
       alias: 'o',
     });
+
+    argv.option('format', {
+      describe: 'How to format the output',
+      choices: ['json', 'text'],
+      default: 'text',
+    });
+
     argv.positional('file', {
       describe: 'AppMap to prune',
     });
+
     argv.positional('size', {
       describe: 'Prune input file to this size',
     });
@@ -71,6 +79,15 @@ export default {
 
     const outputPath = `${argv.outputDir}/${basename(argv.file)}`;
     fs.writeFileSync(outputPath, JSON.stringify(appMap));
-    console.log('done');
+
+    let message = 'done';
+    if (argv.format === 'json' && !argv.fqids)
+      message = JSON.stringify(
+        { exclusions: Array.from(appMap.data.exclusions.values()) },
+        null,
+        2
+      );
+
+    console.log(message);
   },
 };

--- a/packages/cli/src/cmds/prune/prune.ts
+++ b/packages/cli/src/cmds/prune/prune.ts
@@ -3,7 +3,7 @@ import JSONStream from 'JSONStream';
 import { basename } from 'path';
 import Yargs from 'yargs';
 import { handleWorkingDirectory } from '../../lib/handleWorkingDirectory';
-import { AppMap, pruneAppMap, removeEventsByFqid } from './pruneAppMap';
+import { AppMap, pruneAppMap, pruneWithFilter } from './pruneAppMap';
 
 async function fromFile(filePath): Promise<AppMap> {
   let data: AppMap = { events: [] };
@@ -82,9 +82,9 @@ export default {
       alias: 'd',
     });
 
-    argv.option('fqids', {
-      describe: 'Remove events from the map by fqid',
-      type: 'array',
+    argv.option('filter', {
+      describe: 'Filter to use to prune the map',
+      type: 'string',
     });
   },
 
@@ -93,8 +93,8 @@ export default {
     const map = await fromFile(argv.file);
     let appMap: AppMap;
 
-    if (argv.fqids) {
-      appMap = removeEventsByFqid(map, argv.fqids);
+    if (argv.filter) {
+      appMap = pruneWithFilter(map, argv.filter);
     } else if (argv.size) {
       appMap = pruneAppMap(map, parseSize(argv.size));
     } else {

--- a/packages/cli/src/cmds/prune/prune.ts
+++ b/packages/cli/src/cmds/prune/prune.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import JSONStream from 'JSONStream';
 import { basename } from 'path';
 import Yargs from 'yargs';
+import { handleWorkingDirectory } from '../../lib/handleWorkingDirectory';
 import { AppMap, pruneAppMap } from './pruneAppMap';
 
 async function fromFile(filePath): Promise<AppMap> {
@@ -71,9 +72,16 @@ export default {
     argv.positional('size', {
       describe: 'Prune input file to this size',
     });
+
+    argv.option('directory', {
+      describe: 'Working directory for the command',
+      type: 'string',
+      alias: 'd',
+    });
   },
 
   handler: async (argv: any): Promise<void> => {
+    handleWorkingDirectory(argv.directory);
     const size = parseSize(argv.size);
     const appMap = pruneAppMap(await fromFile(argv.file), size);
 

--- a/packages/cli/src/cmds/prune/pruneAppMap.ts
+++ b/packages/cli/src/cmds/prune/pruneAppMap.ts
@@ -1,4 +1,4 @@
-import { AppMapFilter, buildAppMap } from '@appland/models';
+import { AppMapFilter, buildAppMap, deserializeAppmapState } from '@appland/models';
 
 // Simplified AppMap interface, just for pruning
 export interface AppMap {
@@ -10,10 +10,15 @@ export const pruneAppMap = (appMap: AppMap, size: number): any => {
   return buildAppMap().source(appMap).prune(size).normalize().build();
 };
 
-export const removeEventsByFqid = (appMap: AppMap, fqids: Array<any>): any => {
+export const pruneWithFilter = (appMap: AppMap, serializedFilter: string): any => {
   const fullMap = buildAppMap().source(appMap).normalize().build();
+
+  const filterOrState = deserializeAppmapState(serializedFilter);
+  const filters = 'filters' in filterOrState ? filterOrState.filters : filterOrState;
+
   const appmapFilter = new AppMapFilter();
-  appmapFilter.declutter.hideName.on = true;
-  appmapFilter.declutter.hideName.names = fqids;
+  appmapFilter.declutter.limitRootEvents.on = false;
+  appmapFilter.declutter.hideMediaRequests.on = false;
+  appmapFilter.apply(filters);
   return appmapFilter.filter(fullMap, []);
 };

--- a/packages/cli/src/cmds/prune/pruneAppMap.ts
+++ b/packages/cli/src/cmds/prune/pruneAppMap.ts
@@ -20,5 +20,8 @@ export const pruneWithFilter = (appMap: AppMap, serializedFilter: string): any =
   appmapFilter.declutter.limitRootEvents.on = false;
   appmapFilter.declutter.hideMediaRequests.on = false;
   appmapFilter.apply(filters);
-  return appmapFilter.filter(fullMap, []);
+
+  const prunedMap = appmapFilter.filter(fullMap, []) as any;
+  prunedMap.data = { ...prunedMap.data, exclusions: filters };
+  return prunedMap;
 };

--- a/packages/cli/src/cmds/prune/pruneAppMap.ts
+++ b/packages/cli/src/cmds/prune/pruneAppMap.ts
@@ -1,4 +1,4 @@
-import { buildAppMap } from '@appland/models';
+import { AppMapFilter, buildAppMap } from '@appland/models';
 
 // Simplified AppMap interface, just for pruning
 export interface AppMap {
@@ -8,4 +8,12 @@ export interface AppMap {
 
 export const pruneAppMap = (appMap: AppMap, size: number): any => {
   return buildAppMap().source(appMap).prune(size).normalize().build();
+};
+
+export const removeEventsByFqid = (appMap: AppMap, fqids: Array<any>): any => {
+  const fullMap = buildAppMap().source(appMap).normalize().build();
+  const appmapFilter = new AppMapFilter();
+  appmapFilter.declutter.hideName.on = true;
+  appmapFilter.declutter.hideName.names = fqids;
+  return appmapFilter.filter(fullMap, []);
 };

--- a/packages/cli/src/lib/handleWorkingDirectory.ts
+++ b/packages/cli/src/lib/handleWorkingDirectory.ts
@@ -1,5 +1,3 @@
-const { promises: fsp } = require('fs');
-
 export function handleWorkingDirectory(directory?: string) {
   if (directory) process.chdir(directory);
 }

--- a/packages/cli/tests/unit/prune.spec.ts
+++ b/packages/cli/tests/unit/prune.spec.ts
@@ -24,7 +24,7 @@ describe('prune subcommand', () => {
   it('works', async () => {
     const parser = yargs.command(cmd);
 
-    sinon.stub(PruneAppMap, 'pruneAppMap').returns({ events: [] });
+    sinon.stub(PruneAppMap, 'pruneAppMap').returns({ events: [], data: { exclusions: [] } });
 
     const appMapFile = path.join(projectDir, 'revoke_api_key.appmap.json');
     const cmdLine = `prune -o ${projectDir} ${appMapFile} 2MB`;
@@ -41,7 +41,7 @@ describe('prune subcommand', () => {
     // Check that we wrote the output file correctly. Validity of pruning is
     // tested in @appland/models.
     const actual = fs.readFileSync(appMapFile);
-    expect(actual.toString()).toEqual('{"events":[]}');
+    expect(actual.toString()).toEqual('{"events":[],"data":{"exclusions":[]}}');
   });
 
   it('correctly reduces the size of an appmap from a base64url-encoded filter', async () => {
@@ -72,6 +72,6 @@ describe('prune subcommand', () => {
     const outPath = path.join(projectDir, 'Microposts_interface_micropost_interface.appmap.json');
     const fileStats = fs.lstatSync(outPath);
     expect(fileStats.isFile);
-    expect(fileStats.size).toEqual(740567);
+    expect(fileStats.size).toEqual(740734);
   });
 });

--- a/packages/models/src/appMapFilter.js
+++ b/packages/models/src/appMapFilter.js
@@ -323,6 +323,32 @@ export default class AppMapFilter {
     return events;
   }
 
+  apply(filterState) {
+    if ('rootObjects' in filterState) {
+      this.declutter.rootObjects = filterState.rootObjects;
+    }
+    if ('limitRootEvents' in filterState) {
+      this.declutter.limitRootEvents.on = filterState.limitRootEvents;
+    }
+    if ('hideMediaRequests' in filterState) {
+      this.declutter.hideMediaRequests.on = filterState.hideMediaRequests;
+    }
+    if ('hideUnlabeled' in filterState) {
+      this.declutter.hideUnlabeled.on = filterState.hideUnlabeled;
+    }
+    if ('hideExternalPaths' in filterState) {
+      this.declutter.hideExternalPaths.on = filterState.hideExternalPaths;
+    }
+    if ('hideElapsedTimeUnder' in filterState && filterState.hideElapsedTimeUnder !== false) {
+      this.declutter.hideElapsedTimeUnder.on = true;
+      this.declutter.hideElapsedTimeUnder.time = filterState.hideElapsedTimeUnder;
+    }
+    if ('hideName' in filterState && filterState.hideName !== false) {
+      this.declutter.hideName.on = true;
+      this.declutter.hideName.names = filterState.hideName;
+    }
+  }
+
   static eventAlreadyHasFinding(event, finding) {
     return (
       event.findings &&

--- a/packages/models/src/util.js
+++ b/packages/models/src/util.js
@@ -1,6 +1,7 @@
 // eslint-disable-next-line import/extensions
 import sha256 from 'crypto-js/sha256.js';
 import analyze from './sql/analyze';
+import { Buffer } from 'buffer';
 
 export const hasProp = (obj, prop) => Object.prototype.hasOwnProperty.call(obj, prop);
 
@@ -445,4 +446,28 @@ export function transformToJSON(dataKeys, obj) {
     }
     return memo;
   }, {});
+}
+
+export function base64UrlDecode(encodedText) {
+  const buffer = Buffer.from(encodedText, 'base64');
+  return buffer.toString('utf-8');
+}
+
+export function base64UrlEncode(text) {
+  const buffer = Buffer.from(text, 'utf-8');
+  return buffer.toString('base64').replace(/=/g, '').replace(/_/g, '/').replace(/-/g, '+');
+}
+
+export function deserializeAppmapState(stringInput) {
+  let json;
+  const isStringifiedJson = stringInput.trimStart().startsWith('{');
+  if (isStringifiedJson) {
+    // The old style of deserialization expected a raw stringified JSON object.
+    // To avoid introducing a breaking change, we'll support both for now.
+    json = stringInput;
+  } else {
+    json = base64UrlDecode(stringInput);
+  }
+
+  return JSON.parse(json);
 }

--- a/packages/models/types/index.d.ts
+++ b/packages/models/types/index.d.ts
@@ -368,12 +368,21 @@ declare module '@appland/models' {
     }
   }
 
+  type FilterState = {
+    limitRootEvents?: boolean;
+    hideMediaRequests?: boolean;
+    hideUnlabeled?: boolean;
+    hideElapsedTimeUnder?: number;
+    hideName?: Array<string>;
+  };
+
   export class AppMapFilter {
     public rootObjects: CodeObject[];
     public declutter: Filter.Declutter;
 
     // TODO: Define Finding type
     filter(appMap: AppMap, findings: any[]): AppMap;
+    apply(filterState: FilterState): void;
   }
 
   export type SQLAnalysis = {
@@ -404,4 +413,7 @@ declare module '@appland/models' {
   export function normalizeSQL(sql: string, databaseType: string): string;
 
   export function buildAppMap(data?: string | Record<string, unknown>): AppMapBuilder;
+  // TODO: define type for appmap state
+  export function deserializeAppmapState(stringInput: string): any;
+  export function base64UrlEncode(text: string): string;
 }

--- a/packages/models/types/index.d.ts
+++ b/packages/models/types/index.d.ts
@@ -416,4 +416,5 @@ declare module '@appland/models' {
   // TODO: define type for appmap state
   export function deserializeAppmapState(stringInput: string): any;
   export function base64UrlEncode(text: string): string;
+  export function base64UrlDecode(text: string): string;
 }


### PR DESCRIPTION
Fixes #1104 

Alter the `prune` CLI command:

- [x] When using the `--size` option, prune the most expensive functions based on the entire appmap rather than the most expensive functions per "chunk"
- [x] Option to return json of what functions were excluded with `--format json`
- [x] Allow users to specify what to prune using the `--filter` option followed by a base64url-encoded string representing the filter state
- [x] The size argument was changed from positional to an option (`--size`, `-s`). This is necessary because it doesn't make sense to include a size when using the `--filter` option.
- [x] Added the `AppMapFilter#apply` function to apply a filter state object to an instance of `AppMapFilter`. This allows this code to be re-used by Vue components and the CLI.

**Example:**

command: 
```
node built/cli.js prune tests/unit/fixtures/stats/appmap/Microposts_interface_micropost_interface.appmap.json --format json -s 500kb
```

output:
```
{
  "exclusions": [
    "function:logger/Logger::LogDevice#write",
    "function:actionpack/ActionDispatch::Request::Session#[]",
    "function:activerecord/ActiveRecord::Relation#records",
    "function:actionview/ActionView::Resolver#find_all",
    "function:app/helpers/UsersHelper#gravatar_for"
  ]
}
```

**Example (with `--filter`):**

The filter for the command below is:
```
{
  hideName: [
    function:logger/Logger::LogDevice#write
    function:activerecord/ActiveRecord::Relation#records
    function:actionpack/ActionDispatch::Request::Session#[]
  ]
}
```

command:
```
node built/cli.js prune --filter eyJoaWRlTmFtZSI6WyJmdW5jdGlvbjpsb2dnZXIvTG9nZ2VyOjpMb2dEZXZpY2Ujd3JpdGUiLCJmdW5jdGlvbjphY3RpdmVyZWNvcmQvQWN0aXZlUmVjb3JkOjpSZWxhdGlvbiNyZWNvcmRzIiwiZnVuY3Rpb246YWN0aW9ucGFjay9BY3Rpb25EaXNwYXRjaDo6UmVxdWVzdDo6U2Vzc2lvbiNbXSJdfQ tests/unit/fixtures/stats/appmap/Microposts_interface_micropost_interface.appmap.json
```

output:
```
done
```