### PR TITLE
feat: Non-interactive AppMap installer

### DIFF
--- a/packages/cli/src/cmds/agentInstaller/agentInstaller.ts
+++ b/packages/cli/src/cmds/agentInstaller/agentInstaller.ts
@@ -2,6 +2,7 @@ import { resolve } from 'path';
 import { UserConfigError } from '../errors';
 import { run } from './commandRunner';
 import CommandStruct from './commandStruct';
+import InstallerUI from './installerUI';
 
 export default abstract class AgentInstaller {
   public abstract buildFile: string;
@@ -15,11 +16,11 @@ export default abstract class AgentInstaller {
 
   abstract get language(): string;
   abstract get appmap_dir(): string;
-  abstract installAgent(): Promise<void>;
+  abstract installAgent(ui: InstallerUI): Promise<void>;
 
-  abstract checkConfigCommand(): Promise<CommandStruct | undefined>;
-  async checkCurrentConfig(): Promise<void> {
-    const cmd = await this.checkConfigCommand();
+  abstract checkConfigCommand(ui: InstallerUI): Promise<CommandStruct | undefined>;
+  async checkCurrentConfig(ui: InstallerUI): Promise<void> {
+    const cmd = await this.checkConfigCommand(ui);
     if (!cmd) {
       return;
     }

--- a/packages/cli/src/cmds/agentInstaller/agentStatusProcedure.ts
+++ b/packages/cli/src/cmds/agentInstaller/agentStatusProcedure.ts
@@ -1,19 +1,20 @@
-import UI from '../userInteraction';
+import InstallerUI from './installerUI';
 import AgentProcedure from './agentProcedure';
 import { formatValidationError } from './ValidationResult';
 
 export default class AgentStatusProcedure extends AgentProcedure {
-  async run(): Promise<void> {
+  async run(ui: InstallerUI): Promise<void> {
     console.log('\nAgent environment:');
     const env = await this.getEnvironmentForDisplay();
     console.log(`${env.join('\n')}\n`);
 
     await this.verifyProject();
-    const result = await this.validateProject(true);
+    const result = await this.validateProject(ui, true);
 
-    UI.success('Success!');
+    ui.success('Success!');
 
-    if (result?.errors) for (const warning of result.errors.filter((e) => e.level === 'warning'))
-      UI.warn(formatValidationError(warning));
+    if (result?.errors)
+      for (const warning of result.errors.filter((e) => e.level === 'warning'))
+        ui.warn(formatValidationError(warning));
   }
 }

--- a/packages/cli/src/cmds/agentInstaller/installerUI.ts
+++ b/packages/cli/src/cmds/agentInstaller/installerUI.ts
@@ -1,0 +1,220 @@
+import UI from '../userInteraction';
+import chalk from 'chalk';
+import { Answers } from 'inquirer';
+
+export enum OverwriteOption {
+  USE_EXISTING = 'Use existing',
+  OVERWRITE = 'Overwrite',
+  ABORT = 'Abort',
+}
+
+export interface InstallerOptions {
+  overwriteAppMapConfig?: boolean;
+  installerName?: string;
+  buildFile?: string;
+}
+
+export default class InstallerUI {
+  constructor(public interactive: boolean, public options: InstallerOptions) {}
+
+  message(message: string) {
+    console.log(message);
+  }
+
+  status(status: string) {
+    UI.status = status;
+  }
+
+  success(message: string) {
+    UI.success(message);
+  }
+
+  warn(message: string) {
+    UI.warn(message);
+  }
+
+  error(message?: string) {
+    UI.error(message);
+  }
+
+  async confirm(message: string): Promise<boolean> {
+    if (!this.interactive) return true;
+
+    const { confirm } = await UI.prompt({
+      type: 'confirm',
+      name: 'confirm',
+      message: message,
+    });
+    return confirm;
+  }
+
+  async attemptUnsupportedProjectType(message: string): Promise<boolean> {
+    if (this.interactive) return true;
+
+    const { willContinue } = await UI.prompt([
+      {
+        type: 'confirm',
+        name: 'willContinue',
+        prefix: chalk.yellow('!'),
+        message,
+      },
+    ]);
+    return willContinue;
+  }
+
+  async chooseSubprojects(rootHasInstaller: boolean): Promise<boolean> {
+    if (!this.interactive) return false;
+
+    const { addSubprojects } = await UI.prompt({
+      type: 'confirm',
+      default: !rootHasInstaller,
+      name: 'addSubprojects',
+      message:
+        'This directory contains sub-projects. Would you like to choose sub-projects for installation?',
+    });
+    return addSubprojects;
+  }
+
+  async selectSubprojects(projects: string[]): Promise<string[]> {
+    if (!this.interactive) {
+      console.warn(
+        `The installer should not be prompting for sub-projects in non-interactive mode!`
+      );
+      return [];
+    }
+
+    const { selectedSubprojects } = await UI.prompt({
+      type: 'checkbox',
+      name: 'selectedSubprojects',
+      message: 'Select the projects to install AppMap to.',
+      choices: projects,
+    });
+    return selectedSubprojects;
+  }
+
+  async pythonBuildFile(defaultChoice: string, choices: string[]): Promise<string> {
+    if (this.options.buildFile) return this.options.buildFile;
+
+    if (!this.interactive)
+      throw new Error(
+        `Multiple build files are available in this project (${choices.join(
+          ', '
+        )}). Use the --build-file option to specify one of them.`
+      );
+
+    const { buildFile } = await UI.prompt([
+      {
+        type: 'list',
+        name: 'buildFile',
+        message: 'Please choose the requirements file used for development:',
+        choices,
+        default: defaultChoice,
+      },
+    ]);
+
+    return buildFile;
+  }
+
+  async selectProject(
+    message: string,
+    name: string,
+    availableInstallers: string[]
+  ): Promise<string> {
+    if (this.options.installerName) return this.options.installerName;
+
+    if (!this.interactive)
+      throw new Error(
+        `Project can be configured with multiple different installers (${availableInstallers.join(
+          ', '
+        )}). Use the --installer-name option to specify one of them.`
+      );
+
+    const result = await UI.prompt({
+      type: 'list',
+      name,
+      message: message,
+      choices: availableInstallers,
+    });
+    return result[name];
+  }
+
+  async addMavenCentral(): Promise<boolean> {
+    if (!this.interactive) return true;
+
+    const { addMavenCentral } = await UI.prompt({
+      type: 'list',
+      name: 'addMavenCentral',
+      message:
+        'The Maven Central repository is required by the AppMap plugin to fetch the AppMap agent JAR. Add it now?',
+      choices: ['Yes', 'No'],
+    });
+    return addMavenCentral === 'Yes';
+  }
+
+  async commitConfiguration(message: string): Promise<boolean> {
+    if (!this.interactive) {
+      console.warn(
+        `The installer should not be trying to commit configuration in non-interactive mode!`
+      );
+      return false;
+    }
+
+    const { commit } = await UI.prompt({
+      type: 'confirm',
+      name: 'commit',
+      message: message,
+    });
+    return commit;
+  }
+
+  async continueWithoutJavaPlugin(): Promise<boolean> {
+    if (!this.interactive) return true;
+
+    const { userWillContinue } = await UI.prompt({
+      type: 'list',
+      name: 'userWillContinue',
+      message: `The ${chalk.red(
+        "'java'"
+      )} plugin was not found. This configuration is unsupported and is likely to fail. Continue?`,
+      default: 'Abort',
+      choices: ['Abort', 'Continue'],
+    });
+
+    return userWillContinue === 'Continue';
+  }
+
+  async overwriteAppMapConfig(): Promise<OverwriteOption> {
+    if (this.options.overwriteAppMapConfig === true) return OverwriteOption.OVERWRITE;
+    if (this.options.overwriteAppMapConfig === false) return OverwriteOption.USE_EXISTING;
+
+    if (!this.interactive)
+      throw new Error(
+        `The project already contains an AppMap config file (e.g. appmap.yml). Use the --overwrite-appmap-config option to specify whether it should be overwritten.`
+      );
+
+    const { overwriteAppMapYml } = await UI.prompt({
+      type: 'list',
+      name: 'overwriteAppMapYml',
+      message:
+        'An appmap.yml configuration file already exists. How should the conflict be resolved?',
+
+      choices: [OverwriteOption.USE_EXISTING, OverwriteOption.OVERWRITE, OverwriteOption.ABORT],
+    });
+    return overwriteAppMapYml;
+  }
+
+  async shouldShowError(message: string): Promise<boolean> {
+    if (!this.interactive) return true;
+
+    const { showError } = await UI.prompt(
+      {
+        name: 'showError',
+        type: 'confirm',
+        message,
+        prefix: chalk.red('!'),
+      },
+      { supressSpinner: true }
+    );
+    return showError;
+  }
+}

--- a/packages/cli/src/cmds/agentInstaller/javaScriptAgentInstaller.ts
+++ b/packages/cli/src/cmds/agentInstaller/javaScriptAgentInstaller.ts
@@ -7,6 +7,7 @@ import chalk from 'chalk';
 import CommandStruct from './commandStruct';
 import { UserConfigError } from '../errors';
 import semver from 'semver';
+import InstallerUI from './installerUI';
 
 const AGENT_PACKAGE = '@appland/appmap-agent-js@latest';
 
@@ -63,11 +64,11 @@ export class NpmInstaller extends JavaScriptInstaller {
     return await exists(this.buildFilePath);
   }
 
-  async checkConfigCommand(): Promise<CommandStruct | undefined> {
+  async checkConfigCommand(_ui: InstallerUI): Promise<CommandStruct | undefined> {
     return new CommandStruct('npm', ['install', '--dry-run'], this.path);
   }
 
-  async installAgent(): Promise<void> {
+  async installAgent(_ui: InstallerUI): Promise<void> {
     const cmd = new CommandStruct(
       'npm',
       ['install', '--saveDev', process.env.APPMAP_AGENT_PACKAGE || AGENT_PACKAGE],
@@ -101,11 +102,11 @@ export class YarnInstaller extends JavaScriptInstaller {
     return await exists(this.buildFilePath);
   }
 
-  async checkConfigCommand(): Promise<CommandStruct | undefined> {
+  async checkConfigCommand(_ui: InstallerUI): Promise<CommandStruct | undefined> {
     return new CommandStruct('yarn', ['install', '--immutable'], this.path);
   }
 
-  async installAgent(): Promise<void> {
+  async installAgent(_ui: InstallerUI): Promise<void> {
     const cmd = new CommandStruct(
       'yarn',
       ['add', '--dev', process.env.APPMAP_AGENT_PACKAGE || AGENT_PACKAGE],

--- a/packages/cli/src/cmds/agentInstaller/mavenInstaller.ts
+++ b/packages/cli/src/cmds/agentInstaller/mavenInstaller.ts
@@ -8,6 +8,7 @@ import CommandStruct from './commandStruct';
 import { verbose, exists } from '../../utils';
 import JavaBuildToolInstaller from './javaBuildToolInstaller';
 import EncodedFile from '../../encodedFile';
+import InstallerUI from './installerUI';
 
 export default class MavenInstaller extends JavaBuildToolInstaller {
   static identifier = 'Maven';
@@ -66,11 +67,11 @@ export default class MavenInstaller extends JavaBuildToolInstaller {
   }
 
   // TODO: validate the user's project before adding AppMap
-  async checkConfigCommand(): Promise<CommandStruct | undefined> {
+  async checkConfigCommand(_ui: InstallerUI): Promise<CommandStruct | undefined> {
     return undefined;
   }
 
-  async installAgent(): Promise<void> {
+  async installAgent(_ui: InstallerUI): Promise<void> {
     const encodedFile: EncodedFile = new EncodedFile(this.buildFilePath);
     const buildFileSource = encodedFile.toString();
     const jsdom = new JSDOM();

--- a/packages/cli/src/cmds/agentInstaller/rubyAgentInstaller.ts
+++ b/packages/cli/src/cmds/agentInstaller/rubyAgentInstaller.ts
@@ -11,6 +11,7 @@ import { getOutput } from './commandUtil';
 import CommandStruct from './commandStruct';
 import EncodedFile from '../../encodedFile';
 import { BundlerConfigError } from '../errors';
+import InstallerUI from './installerUI';
 
 const REGEX_GEM_DECLARATION = /^(?:gem|group|require)\s/m;
 
@@ -48,7 +49,7 @@ export class BundleInstaller extends AgentInstaller {
     return await exists(this.buildFilePath);
   }
 
-  async checkConfigCommand(): Promise<CommandStruct | undefined> {
+  async checkConfigCommand(_ui: InstallerUI): Promise<CommandStruct | undefined> {
     return new CommandStruct('bundle', ['check', '--dry-run'], this.path);
   }
 
@@ -65,7 +66,7 @@ export class BundleInstaller extends AgentInstaller {
     }
   }
 
-  async installAgent(): Promise<void> {
+  async installAgent(_ui: InstallerUI): Promise<void> {
     await this.checkBundlerConfig();
     const encodedFile: EncodedFile = new EncodedFile(this.buildFilePath);
     let gemfile = encodedFile.toString();

--- a/packages/cli/src/cmds/agentInstaller/status.ts
+++ b/packages/cli/src/cmds/agentInstaller/status.ts
@@ -6,6 +6,7 @@ import AgentInstaller from './agentInstaller';
 import { INSTALLERS } from './installers';
 import AgentStatusProcedure from './agentStatusProcedure';
 import { getProjects } from './projectConfiguration';
+import InstallerUI from './installerUI';
 
 interface InstallCommandOptions {
   verbose?: any;
@@ -47,15 +48,16 @@ export default {
 
     verbose(isVerbose);
 
+    const ui = new InstallerUI(false, { overwriteAppMapConfig: false });
     try {
-      const [project] = await getProjects(installers, directory, false, projectType);
+      const [project] = await getProjects(ui, installers, directory, false, projectType);
 
       const statusProcedure = new AgentStatusProcedure(
         project.selectedInstaller as AgentInstaller,
         directory
       );
 
-      await statusProcedure.run();
+      await statusProcedure.run(ui);
     } catch (e) {
       const err = e as Error;
       UI.error(err.message);

--- a/packages/cli/tests/unit/agentInstall/agentInstallerProcedure.spec.ts
+++ b/packages/cli/tests/unit/agentInstall/agentInstallerProcedure.spec.ts
@@ -6,6 +6,7 @@ import { TestAgentInstaller } from './TestAgentProcedure';
 import UI from '../../../src/cmds/userInteraction';
 import sinon, { SinonStub } from 'sinon';
 import { withStubbedTelemetry } from '../../helper';
+import InstallerUI from '../../../src/cmds/agentInstaller/installerUI';
 
 jest.mock('../../../src/cmds/userInteraction');
 jest.mock('../../../src/cmds/agentInstaller/commandRunner');
@@ -14,6 +15,7 @@ const { prompt, success, warn } = jest.mocked(UI);
 const { run } = jest.mocked(CommandRunner);
 
 const procedure = new AgentInstallerProcedure(new TestAgentInstaller(), '/test/path');
+const interactiveUI = new InstallerUI(true, {});
 
 describe(AgentInstallerProcedure, () => {
   withStubbedTelemetry(sinon);
@@ -31,7 +33,7 @@ describe(AgentInstallerProcedure, () => {
     run.mockResolvedValue({ stdout: '{"configuration": {"contents": ""}}', stderr: '' });
     jest.spyOn(fs, 'writeFileSync').mockImplementation();
 
-    await procedure.run();
+    await procedure.run(interactiveUI);
 
     expect(success).toBeCalled();
 

--- a/packages/cli/tests/unit/agentInstall/agentProcedure.spec.ts
+++ b/packages/cli/tests/unit/agentInstall/agentProcedure.spec.ts
@@ -3,10 +3,12 @@ import { TestAgentProcedure } from './TestAgentProcedure';
 import UI from '../../../src/cmds/userInteraction';
 import sinon, { SinonStub } from 'sinon';
 import { withStubbedTelemetry } from '../../helper';
+import InstallerUI from '../../../src/cmds/agentInstaller/installerUI';
 
 jest.mock('../../../src/cmds/userInteraction');
 
 const procedure = new TestAgentProcedure();
+const interactiveUI = new InstallerUI(true, {});
 
 const { prompt } = jest.mocked(UI);
 
@@ -23,7 +25,7 @@ describe(AgentProcedure, () => {
         }
       }`,
       });
-      return expect(procedure.validateProject(false)).resolves.not.toThrow();
+      return expect(procedure.validateProject(interactiveUI, false)).resolves.not.toThrow();
     });
 
     it('does not fail if there are only warnings', () => {
@@ -36,7 +38,7 @@ describe(AgentProcedure, () => {
         }]
       }`,
       });
-      return expect(procedure.validateProject(false)).resolves.not.toThrow();
+      return expect(procedure.validateProject(interactiveUI, false)).resolves.not.toThrow();
     });
 
     it('fails if there are errors', () => {
@@ -49,7 +51,9 @@ describe(AgentProcedure, () => {
         }]
       }`,
       });
-      return expect(procedure.validateProject(false)).rejects.toThrowError(/test error/);
+      return expect(procedure.validateProject(interactiveUI, false)).rejects.toThrowError(
+        /test error/
+      );
     });
   });
 
@@ -79,14 +83,18 @@ describe(AgentProcedure, () => {
         const filesBefore = [];
         const filesAfter = [];
         jest.spyOn(procedure, 'gitStatus').mockResolvedValue(filesAfter);
-        return expect(procedure.commitConfiguration(filesBefore)).resolves.toBe(false);
+        return expect(procedure.commitConfiguration(interactiveUI, filesBefore)).resolves.toBe(
+          false
+        );
       });
 
       it('there is a diff and user selected to not commit', () => {
         const filesBefore = [];
         jest.spyOn(procedure, 'gitStatus').mockResolvedValue(filesAfter);
         prompt.mockResolvedValue({ commit: false });
-        return expect(procedure.commitConfiguration(filesBefore)).resolves.toBe(false);
+        return expect(procedure.commitConfiguration(interactiveUI, filesBefore)).resolves.toBe(
+          false
+        );
       });
     });
 
@@ -99,7 +107,9 @@ describe(AgentProcedure, () => {
           success: true,
           errorMessage: '',
         });
-        return expect(procedure.commitConfiguration(filesBefore)).resolves.toBe(true);
+        return expect(procedure.commitConfiguration(interactiveUI, filesBefore)).resolves.toBe(
+          true
+        );
       });
     });
   });

--- a/packages/cli/tests/unit/agentInstall/agentStatusProcedure.spec.ts
+++ b/packages/cli/tests/unit/agentInstall/agentStatusProcedure.spec.ts
@@ -1,4 +1,5 @@
 import AgentStatusProcedure from '../../../src/cmds/agentInstaller/agentStatusProcedure';
+import InstallerUI from '../../../src/cmds/agentInstaller/installerUI';
 
 import UI from '../../../src/cmds/userInteraction';
 import { TestAgentInstaller } from './TestAgentProcedure';
@@ -7,6 +8,7 @@ jest.mock('../../../src/cmds/userInteraction');
 const { success, warn } = jest.mocked(UI);
 
 const procedure = new AgentStatusProcedure(new TestAgentInstaller(), '/test/project/path');
+const nonInteractiveUI = new InstallerUI(false, { overwriteAppMapConfig: false });
 
 describe(AgentStatusProcedure, () => {
   it('prints any warnings from the validator', async () => {
@@ -20,7 +22,7 @@ describe(AgentStatusProcedure, () => {
       ],
     });
 
-    await procedure.run();
+    await procedure.run(nonInteractiveUI);
 
     expect(success).toBeCalled();
 

--- a/packages/cli/tests/unit/agentInstall/gradleInstaller.spec.ts
+++ b/packages/cli/tests/unit/agentInstall/gradleInstaller.spec.ts
@@ -4,9 +4,12 @@ import sinon from 'sinon';
 import inquirer from 'inquirer';
 import GradleInstaller from '../../../src/cmds/agentInstaller/gradleInstaller';
 import EncodedFile from '../../../src/encodedFile';
+import InstallerUI from '../../../src/cmds/agentInstaller/installerUI';
 
 const fixtureDir = path.join(__dirname, '..', 'fixtures', 'java', 'gradle');
 const dataDir = path.join(fixtureDir, 'data');
+
+const interactiveUI = new InstallerUI(true, {});
 
 describe('GradleInstaller', () => {
   afterEach(() => {
@@ -48,7 +51,7 @@ describe('GradleInstaller', () => {
 
           const efWrite = sinon.stub(EncodedFile.prototype, 'write');
 
-          await gradle.installAgent();
+          await gradle.installAgent(interactiveUI);
 
           let actual = efWrite.getCall(-1).args[0].toString();
           expect(actual).toMatchSnapshot();

--- a/packages/cli/tests/unit/agentInstall/installCommand.spec.ts
+++ b/packages/cli/tests/unit/agentInstall/installCommand.spec.ts
@@ -1289,7 +1289,7 @@ appmap_dir: tmp/appmap
   });
 
   describe('Multi-project install flow', () => {
-    let expectedStubs: SinonStub[];
+    let expectedStubs: SinonStub<any>[];
 
     beforeEach(() => {
       sinon.stub(commandRunner, 'run').resolves({

--- a/packages/cli/tests/unit/agentInstall/mavenInstaller.spec.ts
+++ b/packages/cli/tests/unit/agentInstall/mavenInstaller.spec.ts
@@ -5,9 +5,11 @@ import { promisify } from 'util';
 import sinon from 'sinon';
 import MavenInstaller from '../../../src/cmds/agentInstaller/mavenInstaller';
 import EncodedFile from '../../../src/encodedFile';
+import InstallerUI from '../../../src/cmds/agentInstaller/installerUI';
 
 const glob = promisify(globCallback);
 const fixtureDir = path.join(__dirname, '..', 'fixtures', 'java', 'maven');
+const interactiveUI = new InstallerUI(true, {});
 
 describe('MavenInstaller', () => {
   afterEach(() => {
@@ -35,11 +37,11 @@ describe('MavenInstaller', () => {
         const test = tests[i];
         sinon.stub(maven, 'buildFilePath').value(path.join(dataDir, `${test}.actual.xml`));
 
-        const expected = (
-          await fs.readFile(path.join(dataDir, `${test}${expectedExt}`))
-        ).toString().replace(/\s+/g, ' ');
+        const expected = (await fs.readFile(path.join(dataDir, `${test}${expectedExt}`)))
+          .toString()
+          .replace(/\s+/g, ' ');
 
-        await maven.installAgent();
+        await maven.installAgent(interactiveUI);
 
         const actual = efWrite.getCall(-1).args[0].replace(/\s+/g, ' ');
         expect(actual).toBe(expected);
@@ -58,7 +60,7 @@ describe('MavenInstaller', () => {
           encoding: undefined,
         });
 
-      expect(maven.installAgent()).rejects.toThrow(/No project section found/);
+      expect(maven.installAgent(interactiveUI)).rejects.toThrow(/No project section found/);
     });
   });
 });

--- a/packages/cli/tests/unit/agentInstall/python.spec.ts
+++ b/packages/cli/tests/unit/agentInstall/python.spec.ts
@@ -6,6 +6,7 @@ import { join } from 'path';
 import sinon from 'sinon';
 import tmp from 'tmp';
 import * as commandRunner from '../../../src/cmds/agentInstaller/commandRunner';
+import InstallerUI from '../../../src/cmds/agentInstaller/installerUI';
 import {
   PipenvInstaller,
   PipInstaller,
@@ -17,6 +18,7 @@ const Cwd = process.cwd();
 tmp.setGracefulCleanup();
 
 const fixtureDir = join(__dirname, '..', 'fixtures', 'python');
+const interactiveUI = new InstallerUI(true, {});
 
 function getProjectDirectory(projectType) {
   const projectFixtures = join(fixtureDir, projectType);
@@ -69,7 +71,7 @@ describe('Python Agent Installation', () => {
     it('adds appmap to requirements.txt when missing', async () => {
       sinon.stub(commandRunner, 'run').resolves({ stderr: '', stdout: '' });
 
-      await btInstaller.installAgent();
+      await btInstaller.installAgent(interactiveUI);
       const requirementsTxt = fs.readFileSync(join(projectDirectory, 'requirements.txt'), 'utf8');
       expect(requirementsTxt).toMatch(/^appmap>=/);
     });
@@ -80,7 +82,7 @@ describe('Python Agent Installation', () => {
       const requirementsPath = join(projectDirectory, 'requirements.txt');
       fs.writeFileSync(requirementsPath, ' appmap == 1.0.0');
 
-      await btInstaller.installAgent();
+      await btInstaller.installAgent(interactiveUI);
       const requirementsTxt = fs.readFileSync(join(projectDirectory, 'requirements.txt'), 'utf8');
       expect(requirementsTxt).toMatch(/^appmap>=/);
     });
@@ -91,7 +93,7 @@ describe('Python Agent Installation', () => {
       const requirementsPath = join(projectDirectory, 'requirements.txt');
       fs.writeFileSync(requirementsPath, ' not-appmap == 1.0.0');
 
-      await btInstaller.installAgent();
+      await btInstaller.installAgent(interactiveUI);
       const requirementsTxt = fs.readFileSync(join(projectDirectory, 'requirements.txt'), 'utf8');
       expect(requirementsTxt).toMatch(/^appmap>=/m);
       expect(requirementsTxt).toMatch(/^ not-appmap == 1.0.0/m);
@@ -113,7 +115,7 @@ describe('Python Agent Installation', () => {
         sinon.stub(glob, 'sync').returns(['test-requirements.txt']);
         const prompt = sinon.stub(UI, 'prompt');
 
-        expect(await installer.resolveBuildFile()).toBe('test-requirements.txt');
+        expect(await installer.resolveBuildFile(interactiveUI)).toBe('test-requirements.txt');
 
         expect(prompt).not.toBeCalled();
       });
@@ -121,7 +123,7 @@ describe('Python Agent Installation', () => {
       it('offers requirements files', async () => {
         const prompt = sinon.stub(UI, 'prompt').resolves({ buildFile: 'requirements.txt' });
 
-        expect(await installer.resolveBuildFile()).toBe('requirements.txt');
+        expect(await installer.resolveBuildFile(interactiveUI)).toBe('requirements.txt');
 
         const promptCalls = prompt.getCalls();
         expect(promptCalls.length).toStrictEqual(1);

--- a/packages/cli/tests/unit/agentInstall/ruby.spec.ts
+++ b/packages/cli/tests/unit/agentInstall/ruby.spec.ts
@@ -6,10 +6,12 @@ import { BundleInstaller } from '../../../src/cmds/agentInstaller/rubyAgentInsta
 import * as commandRunner from '../../../src/cmds/agentInstaller/commandRunner';
 import CommandStruct, { CommandReturn } from '../../../src/cmds/agentInstaller/commandStruct';
 import sinon from 'sinon';
+import InstallerUI from '../../../src/cmds/agentInstaller/installerUI';
 
 tmp.setGracefulCleanup();
 
 const fixtureDir = path.join(__dirname, '..', 'fixtures', 'ruby');
+const interactiveUI = new InstallerUI(true, {});
 
 function getProjectDirectory(projectFixtures: fs.PathLike) {
   const projectDir = tmp.dirSync({} as any).name;
@@ -69,7 +71,7 @@ describe('Ruby Agent Installation', () => {
         .onCall(callIdx++)
         .callsFake(bundleInstall);
 
-      await btInstaller.installAgent();
+      await btInstaller.installAgent(interactiveUI);
 
       const expected = fs.readFileSync(path.join(projectFixtures, 'Gemfile.expected'), 'utf-8');
       const actual = fs.readFileSync(path.join(btInstaller.path, 'Gemfile'), 'utf-8');


### PR DESCRIPTION
`--no-interactive` flag prevents the installer from prompting the user.

Other command options provide answers to different situations that the installer may encounter.

If the installer encounters a situation that the command-line options don't provide an answer for, it aborts.

This command is designed to be used to automatically configure standard/compliant projects for AppMap, e.g. using a GitHub Action.