### PR TITLE
Robust appmap locating

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -74,7 +74,7 @@
     "@appland/client": "workspace:^1",
     "@appland/components": "workspace:^2",
     "@appland/diagrams": "workspace:^1",
-    "@appland/models": "workspace:^2.2.0",
+    "@appland/models": "workspace:^2.4.0",
     "@appland/openapi": "workspace:^1.4.3",
     "@appland/sequence-diagram": "workspace:^1",
     "@sidvind/better-ajv-errors": "^0.9.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -28,7 +28,7 @@
   ],
   "dependencies": {
     "@appland/diagrams": "workspace:^1.6.2",
-    "@appland/models": "workspace:^2.2.0",
+    "@appland/models": "workspace:^2.4.0",
     "@appland/sequence-diagram": "workspace:^1.5.0",
     "buffer": "^6.0.3",
     "diff": "^5.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -90,7 +90,7 @@ __metadata:
     "@appland/client": "workspace:^1"
     "@appland/components": "workspace:^2"
     "@appland/diagrams": "workspace:^1"
-    "@appland/models": "workspace:^2.2.0"
+    "@appland/models": "workspace:^2.4.0"
     "@appland/openapi": "workspace:^1.4.3"
     "@appland/sequence-diagram": "workspace:^1"
     "@craftamap/esbuild-plugin-html": ^0.4.0
@@ -213,7 +213,7 @@ __metadata:
   resolution: "@appland/components@workspace:packages/components"
   dependencies:
     "@appland/diagrams": "workspace:^1.6.2"
-    "@appland/models": "workspace:^2.2.0"
+    "@appland/models": "workspace:^2.4.0"
     "@appland/sequence-diagram": "workspace:^1.5.0"
     "@babel/core": ^7.13.1
     "@babel/node": ^7.13.0
@@ -320,7 +320,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@appland/models@workspace:*, @appland/models@workspace:^2.2.0, @appland/models@workspace:packages/models":
+"@appland/models@workspace:*, @appland/models@workspace:^2.2.0, @appland/models@workspace:^2.4.0, @appland/models@workspace:packages/models":
   version: 0.0.0-use.local
   resolution: "@appland/models@workspace:packages/models"
   dependencies:


### PR DESCRIPTION
Fixes #1120 

- [x] Fixes a bug where there are multiple matches of the same file and the command prompts the user to select between identical files:
![image](https://user-images.githubusercontent.com/45714532/226950546-070e291b-6d13-4677-8b23-4318e68bb998.png)

- [x] When a valid absolute path is specified for `--appmap-file`, the command no longer recursively searches for the file in the current directory or the `--appmap-dir`.
- [x] If no `--appmap-dir` is provided and no appmap directory can be found from the configuration file, default to using the current working directory.
- [x] Prevents recursive searching when an exact match can be found (this was a problem when running the command from VS Code, which automatically sets the current working directory to `~`, so the recursive search was taking a really long time and the command was hanging).