### PR TITLE
tooltip for map controls

### DIFF
--- a/packages/components/src/assets/stats-icon.svg
+++ b/packages/components/src/assets/stats-icon.svg
@@ -1,6 +1,6 @@
 <svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
-<rect y="6.54546" width="2.18182" height="5.45455" fill="#808B98"/>
-<rect x="3.27246" y="3.27272" width="2.18182" height="8.72727" fill="#808B98"/>
-<rect x="6.5459" width="2.18182" height="12" fill="#808B98"/>
-<rect x="9.81836" y="1.09091" width="2.18182" height="10.9091" fill="#808B98"/>
+<rect y="6.54546" width="2.18182" height="5.45455" fill="none"/>
+<rect x="3.27246" y="3.27272" width="2.18182" height="8.72727" fill="none"/>
+<rect x="6.5459" width="2.18182" height="12" fill="none"/>
+<rect x="9.81836" y="1.09091" width="2.18182" height="10.9091" fill="none"/>
 </svg>

--- a/packages/components/src/pages/VsCodeExtension.vue
+++ b/packages/components/src/pages/VsCodeExtension.vue
@@ -167,11 +167,18 @@
           </v-popper>
           <v-popper-menu v-if="!isGiantAppMap" :isHighlight="filtersChanged">
             <template v-slot:icon>
-              <FilterIcon
-                class="control-button__icon"
-                data-cy="filter-button"
-                @click="openFilterModal"
-              />
+              <v-popper
+                class="hover-text-popper"
+                text="Filter your view"
+                placement="left"
+                text-align="left"
+              >
+                <FilterIcon
+                  class="control-button__icon"
+                  data-cy="filter-button"
+                  @click="openFilterModal"
+                />
+              </v-popper>
             </template>
             <template v-slot:body>
               <div class="filters">
@@ -284,15 +291,17 @@
               </div>
             </template>
           </v-popper-menu>
-          <button
-            v-if="!isGiantAppMap"
-            data-cy="reload-button"
-            class="control-button diagram-reload"
-            @click="resetDiagram"
-            title="Clear"
-          >
-            <ReloadIcon class="control-button__icon" />
-          </button>
+          <v-popper class="hover-text-popper" text="Reload map" placement="left" text-align="left">
+            <button
+              v-if="!isGiantAppMap"
+              data-cy="reload-button"
+              class="control-button diagram-reload"
+              @click="resetDiagram"
+              title="Clear"
+            >
+              <ReloadIcon class="control-button__icon" />
+            </button>
+          </v-popper>
         </template>
       </v-tabs>
 


### PR DESCRIPTION
Add UI tooltips for all map controls. (Filter & Reload were missing tool tips). Closes #1124 
![hover states](https://user-images.githubusercontent.com/123787/230999057-14b38d91-6015-4673-a7ea-a78dbd9aa986.gif)
