### PR TITLE
feat: Consider loop iterations when diffing sequence diagrams

### DIFF
--- a/packages/components/src/components/sequence/LoopAction.vue
+++ b/packages/components/src/components/sequence/LoopAction.vue
@@ -10,6 +10,9 @@
       <div class="label">Loop</div>
       <div class="description">
         [
+        <div class="count-previous" v-if="actionSpec.action.formerCount !== undefined">
+          {{ actionSpec.action.formerCount }} times
+        </div>
         <div class="count">{{ actionSpec.action.count }} times</div>
         <div class="elapsed">{{ actionSpec.elapsedTimeMs }}ms</div>
         ]
@@ -52,7 +55,6 @@ export default {
 
       return result;
     },
-
     gridRows(): string {
       const gridEndFactor =
         this.actionSpec.action.children.reduce((accumulator, child) => {
@@ -112,6 +114,11 @@ export default {
 
       .elapsed {
         color: $sequence-elapsed-time-color;
+      }
+
+      .count-previous {
+        text-decoration: line-through;
+        color: #808b98;
       }
     }
   }

--- a/packages/components/src/stories/DiagramSequence.stories.js
+++ b/packages/components/src/stories/DiagramSequence.stories.js
@@ -1,5 +1,6 @@
 import VDiagramSequence from '@/components/DiagramSequence.vue';
 import appland_api_key_diff from '@/stories/data/sequence/appland_api_key_diff.sequence.json';
+import openai_api_diff from '@/stories/data/sequence/openai_api_diff.sequence.json';
 import create_api_key from '@/stories/data/sequence/create_api_key.sequence.json';
 import list_users from '@/stories/data/sequence/list_users.sequence.json';
 import list_users_prefetch from '@/stories/data/sequence/list_users_prefetch.sequence.json';
@@ -21,6 +22,12 @@ export const AppLandApiKeyDiff = Template.bind({});
 AppLandApiKeyDiff.args = {
   serializedDiagram: appland_api_key_diff,
 };
+
+export const OpenAiApiDiff = Template.bind({});
+OpenAiApiDiff.args = {
+  serializedDiagram: openai_api_diff,
+};
+
 export const Empty = Template.bind({});
 
 export const CreateApiKey = Template.bind({});

--- a/packages/components/src/stories/data/sequence/openai_api_diff.sequence.json
+++ b/packages/components/src/stories/data/sequence/openai_api_diff.sequence.json
@@ -1,0 +1,223 @@
+{
+  "actors": [
+    {
+      "id": "http:HTTP server requests",
+      "name": "HTTP server requests",
+      "order": 0
+    },
+    {
+      "id": "package:app/controllers",
+      "name": "controllers",
+      "order": 1000
+    },
+    {
+      "id": "package:app/models",
+      "name": "models",
+      "order": 2000
+    },
+    {
+      "id": "external-service:api.openai.com",
+      "name": "api.openai.com",
+      "order": 6000
+    },
+    {
+      "id": "database:Database",
+      "name": "Database",
+      "order": 7000
+    }
+  ],
+  "rootActions": [
+    {
+      "nodeType": 4,
+      "callee": "http:HTTP server requests",
+      "route": "GET /v1/code/completions",
+      "status": 200,
+      "digest": "ec900b9d1789e528e360fe2044ca7872aaa8c37aa32cc1efc19a5af5031b87a4",
+      "subtreeDigest": "unknown",
+      "children": [
+        {
+          "nodeType": 6,
+          "caller": "http:HTTP server requests",
+          "callee": "database:Database",
+          "query": "SAVEPOINT autopoint_1",
+          "digest": "e2acca958778708cd318075230576c80baf753d686a606ba55fb223a746335ee",
+          "subtreeDigest": "unknown",
+          "children": [],
+          "elapsed": 0.001344,
+          "eventIds": [
+            1034
+          ]
+        },
+        {
+          "nodeType": 3,
+          "caller": "http:HTTP server requests",
+          "callee": "package:app/controllers",
+          "name": "authenticate_session",
+          "static": false,
+          "digest": "c1555e7ba0c34ece558323b46161be2f3496b7ee89559246f10096d26163a1a8",
+          "subtreeDigest": "unknown",
+          "stableProperties": {
+            "event_type": "function",
+            "id": "app/controllers/ApplicationController#authenticate_session",
+            "raises_exception": false
+          },
+          "returnValue": {
+            "returnValueType": {
+              "name": "boolean"
+            },
+            "raisesException": false
+          },
+          "children": [
+            {
+              "nodeType": 3,
+              "caller": "package:app/controllers",
+              "callee": "package:app/models",
+              "name": "find_by_id",
+              "static": true,
+              "digest": "af70b626c42c2ab64eb3db771bec1704d3d8a36690cc1b04afe817e3e1b42627",
+              "subtreeDigest": "unknown",
+              "stableProperties": {
+                "event_type": "function",
+                "id": "app/models/User.find_by_id",
+                "raises_exception": false
+              },
+              "returnValue": {
+                "returnValueType": {
+                  "name": "User::Show"
+                },
+                "raisesException": false
+              },
+              "children": [
+                {
+                  "nodeType": 6,
+                  "caller": "package:app/models",
+                  "callee": "database:Database",
+                  "query": "SELECT * FROM \"users\" WHERE (\"id\" = 47) LIMIT 1",
+                  "digest": "0c35a882ce9d80661ab4e9db1ae4f3b03309c05a89ac023a9fc90d7472c8ff88",
+                  "subtreeDigest": "unknown",
+                  "children": [],
+                  "elapsed": 0.00115,
+                  "eventIds": [
+                    1051
+                  ]
+                }
+              ],
+              "elapsed": 0.0015119999879971147,
+              "eventIds": [
+                1048
+              ]
+            }
+          ],
+          "elapsed": 0.0018970000091940165,
+          "eventIds": [
+            1040
+          ]
+        },
+        {
+          "nodeType": 3,
+          "caller": "http:HTTP server requests",
+          "callee": "package:app/models",
+          "name": "generate_completions",
+          "static": true,
+          "digest": "d3415991153ee610183485885f9218b014158eb673c3a594821f87987a92dd18",
+          "subtreeDigest": "unknown",
+          "stableProperties": {
+            "event_type": "function",
+            "id": "app/models/ScannerJob.generate_completions",
+            "raises_exception": false
+          },
+          "returnValue": {
+            "returnValueType": {
+              "name": "CodeCompletion"
+            },
+            "raisesException": false
+          },
+          "children": [
+            {
+              "nodeType": 1,
+              "count": 36,
+              "digest": "loop:b0799aa7b357094b0da839a286c89f89e2a9c97eb4fa409906f9de7111af6d1b:36",
+              "subtreeDigest": "unknown",
+              "children": [
+                {
+                  "nodeType": 5,
+                  "caller": "package:app/models",
+                  "callee": "external-service:api.openai.com",
+                  "route": "POST https://api.openai.com/v1/completions",
+                  "status": 200,
+                  "digest": "13e5bff13c8429b6a579b2b6fc3f38ab05f51a8f14b9b10246c3c824e55bfeda",
+                  "subtreeDigest": "unknown",
+                  "children": [],
+                  "elapsed": 0.41432397812604904,
+                  "eventIds": [
+                    1097,
+                    1099,
+                    1111,
+                    1113,
+                    1115,
+                    1117,
+                    1119,
+                    1121,
+                    1123,
+                    1125,
+                    1127,
+                    1129,
+                    1131,
+                    1133,
+                    1135,
+                    1137,
+                    1139,
+                    1141,
+                    1143,
+                    1145,
+                    1147,
+                    1149,
+                    1151,
+                    1153,
+                    1155,
+                    1157,
+                    1159,
+                    1161,
+                    1163,
+                    1165,
+                    1167,
+                    1169,
+                    1171,
+                    1173,
+                    1175,
+                    1177
+                  ]
+                }
+              ],
+              "elapsed": 0.41432397812604904,
+              "eventIds": [],
+              "diffMode": 3,
+              "formerName": "loop",
+              "formerCount": 10
+            }
+          ],
+          "elapsed": 0.002129000029526651,
+          "eventIds": [
+            1094
+          ]
+        },
+        {
+          "nodeType": 6,
+          "caller": "http:HTTP server requests",
+          "callee": "database:Database",
+          "query": "RELEASE SAVEPOINT autopoint_1",
+          "digest": "682ac0a00b08652a98b568707671487755467437670b11481dd664a20840d2ed",
+          "subtreeDigest": "unknown",
+          "children": [],
+          "elapsed": 0.001451,
+          "eventIds": [
+            1360
+          ]
+        }
+      ],
+      "eventIds": [
+        967
+      ]
+    }
+  ]
+}

--- a/packages/sequence-diagram/src/buildDiffDiagram.ts
+++ b/packages/sequence-diagram/src/buildDiffDiagram.ts
@@ -43,6 +43,7 @@ export default function buildDiffDiagram(diff: Diff): Diagram {
         action.diffMode = DiffMode.Change;
         action.formerName = nodeName(lAction);
         action.formerResult = nodeResult(lAction);
+        if ('count' in lAction) action.formerCount = lAction.count;
         if (rAction.parent) {
           const parent = diffActionsByAction.get(rAction.parent);
           parent?.children.push(action);

--- a/packages/sequence-diagram/src/mergeWindow.ts
+++ b/packages/sequence-diagram/src/mergeWindow.ts
@@ -50,7 +50,7 @@ const buildLoop = (merge: Merge): Loop => {
   return {
     nodeType: NodeType.Loop,
     count: merge.length,
-    digest: 'loop',
+    digest: ['loop', merge.length].join(':'),
     subtreeDigest: ['loop', digest].join(':'),
     children: merge[0],
     elapsed: merge[0].reduce((sum, action) => sum + (action.elapsed || 0), 0),

--- a/packages/sequence-diagram/src/types.ts
+++ b/packages/sequence-diagram/src/types.ts
@@ -43,6 +43,7 @@ export type Node = {
   elapsed?: number;
   formerName?: string;
   formerResult?: string;
+  formerCount?: number;
   eventIds: number[];
 };
 

--- a/packages/sequence-diagram/tests/fixtures/diff/loop_baseline.sequence.json
+++ b/packages/sequence-diagram/tests/fixtures/diff/loop_baseline.sequence.json
@@ -1,0 +1,169 @@
+{
+  "actors": [
+    {
+      "id": "http:HTTP server requests",
+      "name": "HTTP server requests",
+      "order": 0
+    },
+    {
+      "id": "package:app/controllers",
+      "name": "controllers",
+      "order": 1000
+    },
+    {
+      "id": "package:app/models",
+      "name": "models",
+      "order": 2000
+    },
+    {
+      "id": "external-service:api.openai.com",
+      "name": "api.openai.com",
+      "order": 6000
+    },
+    {
+      "id": "database:Database",
+      "name": "Database",
+      "order": 7000
+    }
+  ],
+  "rootActions": [
+    {
+      "nodeType": 4,
+      "callee": "http:HTTP server requests",
+      "route": "GET /v1/code/completions",
+      "status": 200,
+      "digest": "ec900b9d1789e528e360fe2044ca7872aaa8c37aa32cc1efc19a5af5031b87a4",
+      "subtreeDigest": "e4a7654340830bbabc3400ff4499f919dfbd52b7687aec55f8cc7647647950f5",
+      "children": [
+        {
+          "nodeType": 6,
+          "caller": "http:HTTP server requests",
+          "callee": "database:Database",
+          "query": "SAVEPOINT autopoint_1",
+          "digest": "e2acca958778708cd318075230576c80baf753d686a606ba55fb223a746335ee",
+          "subtreeDigest": "f171f24683f0faf71758bd1430940774c78268d73adf164f7e222f04c1f14480",
+          "children": [],
+          "elapsed": 0.001344,
+          "eventIds": [1034]
+        },
+        {
+          "nodeType": 3,
+          "caller": "http:HTTP server requests",
+          "callee": "package:app/controllers",
+          "name": "authenticate_session",
+          "static": false,
+          "digest": "c1555e7ba0c34ece558323b46161be2f3496b7ee89559246f10096d26163a1a8",
+          "subtreeDigest": "1404d3c7c619b01f68505cddf2c286a5d11d800f9ce3d540ea3afe776bfed07e",
+          "stableProperties": {
+            "event_type": "function",
+            "id": "app/controllers/ApplicationController#authenticate_session",
+            "raises_exception": false
+          },
+          "returnValue": {
+            "returnValueType": {
+              "name": "boolean"
+            },
+            "raisesException": false
+          },
+          "children": [
+            {
+              "nodeType": 3,
+              "caller": "package:app/controllers",
+              "callee": "package:app/models",
+              "name": "find_by_id",
+              "static": true,
+              "digest": "af70b626c42c2ab64eb3db771bec1704d3d8a36690cc1b04afe817e3e1b42627",
+              "subtreeDigest": "ba7a94a4f7e7a96e806a20304cdb532d2a87caf0abd05a4485aa70760715d7c9",
+              "stableProperties": {
+                "event_type": "function",
+                "id": "app/models/User.find_by_id",
+                "raises_exception": false
+              },
+              "returnValue": {
+                "returnValueType": {
+                  "name": "User::Show"
+                },
+                "raisesException": false
+              },
+              "children": [
+                {
+                  "nodeType": 6,
+                  "caller": "package:app/models",
+                  "callee": "database:Database",
+                  "query": "SELECT * FROM \"users\" WHERE (\"id\" = 47) LIMIT 1",
+                  "digest": "0c35a882ce9d80661ab4e9db1ae4f3b03309c05a89ac023a9fc90d7472c8ff88",
+                  "subtreeDigest": "bc24f9b3398cb926c957cc1e94ea945720c54d0e322b1f76e04e4a939a766fa1",
+                  "children": [],
+                  "elapsed": 0.00115,
+                  "eventIds": [1051]
+                }
+              ],
+              "elapsed": 0.0015119999879971147,
+              "eventIds": [1048]
+            }
+          ],
+          "elapsed": 0.0018970000091940165,
+          "eventIds": [1040]
+        },
+        {
+          "nodeType": 3,
+          "caller": "http:HTTP server requests",
+          "callee": "package:app/models",
+          "name": "generate_completions",
+          "static": true,
+          "digest": "d3415991153ee610183485885f9218b014158eb673c3a594821f87987a92dd18",
+          "subtreeDigest": "ad37e2bbde3c95261dcfef011817b445dcfb77a1451ba39bf7613f87be014286",
+          "stableProperties": {
+            "event_type": "function",
+            "id": "app/models/ScannerJob.generate_completions",
+            "raises_exception": false
+          },
+          "returnValue": {
+            "returnValueType": {
+              "name": "CodeCompletion"
+            },
+            "raisesException": false
+          },
+          "children": [
+            {
+              "nodeType": 1,
+              "count": 10,
+              "digest": "loop:b0799aa7b357094b0da839a286c89f89e2a9c97eb4fa409906f9de7111af6d1b:10",
+              "subtreeDigest": "loop:b0799aa7b357094b0da839a286c89f89e2a9c97eb4fa409906f9de7111af6d1b",
+              "children": [
+                {
+                  "nodeType": 5,
+                  "caller": "package:app/models",
+                  "callee": "external-service:api.openai.com",
+                  "route": "POST https://api.openai.com/v1/completions",
+                  "status": 200,
+                  "digest": "13e5bff13c8429b6a579b2b6fc3f38ab05f51a8f14b9b10246c3c824e55bfeda",
+                  "subtreeDigest": "0a4f6d837a0a2ff611d9d431036200debe8a3cff13e4c966ef4f35faf80c20a8",
+                  "children": [],
+                  "elapsed": 0.11508999392390251,
+                  "eventIds": [1097, 1099, 1111, 1113, 1115, 1117, 1119, 1121, 1123, 1125]
+                }
+              ],
+              "elapsed": 0.11508999392390251,
+              "eventIds": []
+            }
+          ],
+          "elapsed": 0.002129000029526651,
+          "eventIds": [1094]
+        },
+        {
+          "nodeType": 6,
+          "caller": "http:HTTP server requests",
+          "callee": "database:Database",
+          "query": "RELEASE SAVEPOINT autopoint_1",
+          "digest": "682ac0a00b08652a98b568707671487755467437670b11481dd664a20840d2ed",
+          "subtreeDigest": "4d4255fe6d3ed5faa94d189cd35c1ba92e317287006dc20f9fa401477187e92d",
+          "children": [],
+          "elapsed": 0.001451,
+          "eventIds": [1360]
+        }
+      ],
+      "eventIds": [967]
+    }
+  ]
+}

--- a/packages/sequence-diagram/tests/fixtures/diff/loop_head.sequence.json
+++ b/packages/sequence-diagram/tests/fixtures/diff/loop_head.sequence.json
@@ -1,0 +1,173 @@
+{
+  "actors": [
+    {
+      "id": "http:HTTP server requests",
+      "name": "HTTP server requests",
+      "order": 0
+    },
+    {
+      "id": "package:app/controllers",
+      "name": "controllers",
+      "order": 1000
+    },
+    {
+      "id": "package:app/models",
+      "name": "models",
+      "order": 2000
+    },
+    {
+      "id": "external-service:api.openai.com",
+      "name": "api.openai.com",
+      "order": 6000
+    },
+    {
+      "id": "database:Database",
+      "name": "Database",
+      "order": 7000
+    }
+  ],
+  "rootActions": [
+    {
+      "nodeType": 4,
+      "callee": "http:HTTP server requests",
+      "route": "GET /v1/code/completions",
+      "status": 200,
+      "digest": "ec900b9d1789e528e360fe2044ca7872aaa8c37aa32cc1efc19a5af5031b87a4",
+      "subtreeDigest": "30aa84bcbde37b353a09322f00cfeba6c99db1f51c4c9e3e1e00b743219fc457",
+      "children": [
+        {
+          "nodeType": 6,
+          "caller": "http:HTTP server requests",
+          "callee": "database:Database",
+          "query": "SAVEPOINT autopoint_1",
+          "digest": "e2acca958778708cd318075230576c80baf753d686a606ba55fb223a746335ee",
+          "subtreeDigest": "f171f24683f0faf71758bd1430940774c78268d73adf164f7e222f04c1f14480",
+          "children": [],
+          "elapsed": 0.001344,
+          "eventIds": [1034]
+        },
+        {
+          "nodeType": 3,
+          "caller": "http:HTTP server requests",
+          "callee": "package:app/controllers",
+          "name": "authenticate_session",
+          "static": false,
+          "digest": "c1555e7ba0c34ece558323b46161be2f3496b7ee89559246f10096d26163a1a8",
+          "subtreeDigest": "1404d3c7c619b01f68505cddf2c286a5d11d800f9ce3d540ea3afe776bfed07e",
+          "stableProperties": {
+            "event_type": "function",
+            "id": "app/controllers/ApplicationController#authenticate_session",
+            "raises_exception": false
+          },
+          "returnValue": {
+            "returnValueType": {
+              "name": "boolean"
+            },
+            "raisesException": false
+          },
+          "children": [
+            {
+              "nodeType": 3,
+              "caller": "package:app/controllers",
+              "callee": "package:app/models",
+              "name": "find_by_id",
+              "static": true,
+              "digest": "af70b626c42c2ab64eb3db771bec1704d3d8a36690cc1b04afe817e3e1b42627",
+              "subtreeDigest": "ba7a94a4f7e7a96e806a20304cdb532d2a87caf0abd05a4485aa70760715d7c9",
+              "stableProperties": {
+                "event_type": "function",
+                "id": "app/models/User.find_by_id",
+                "raises_exception": false
+              },
+              "returnValue": {
+                "returnValueType": {
+                  "name": "User::Show"
+                },
+                "raisesException": false
+              },
+              "children": [
+                {
+                  "nodeType": 6,
+                  "caller": "package:app/models",
+                  "callee": "database:Database",
+                  "query": "SELECT * FROM \"users\" WHERE (\"id\" = 47) LIMIT 1",
+                  "digest": "0c35a882ce9d80661ab4e9db1ae4f3b03309c05a89ac023a9fc90d7472c8ff88",
+                  "subtreeDigest": "bc24f9b3398cb926c957cc1e94ea945720c54d0e322b1f76e04e4a939a766fa1",
+                  "children": [],
+                  "elapsed": 0.00115,
+                  "eventIds": [1051]
+                }
+              ],
+              "elapsed": 0.0015119999879971147,
+              "eventIds": [1048]
+            }
+          ],
+          "elapsed": 0.0018970000091940165,
+          "eventIds": [1040]
+        },
+        {
+          "nodeType": 3,
+          "caller": "http:HTTP server requests",
+          "callee": "package:app/models",
+          "name": "generate_completions",
+          "static": true,
+          "digest": "d3415991153ee610183485885f9218b014158eb673c3a594821f87987a92dd18",
+          "subtreeDigest": "6e4fdf19b01630abe1f5793b27c05e69a4d018b6e416677dabc4bf591290fb9a",
+          "stableProperties": {
+            "event_type": "function",
+            "id": "app/models/ScannerJob.generate_completions",
+            "raises_exception": false
+          },
+          "returnValue": {
+            "returnValueType": {
+              "name": "CodeCompletion"
+            },
+            "raisesException": false
+          },
+          "children": [
+            {
+              "nodeType": 1,
+              "count": 36,
+              "digest": "loop:b0799aa7b357094b0da839a286c89f89e2a9c97eb4fa409906f9de7111af6d1b:36",
+              "subtreeDigest": "loop:b0799aa7b357094b0da839a286c89f89e2a9c97eb4fa409906f9de7111af6d1b",
+              "children": [
+                {
+                  "nodeType": 5,
+                  "caller": "package:app/models",
+                  "callee": "external-service:api.openai.com",
+                  "route": "POST https://api.openai.com/v1/completions",
+                  "status": 200,
+                  "digest": "13e5bff13c8429b6a579b2b6fc3f38ab05f51a8f14b9b10246c3c824e55bfeda",
+                  "subtreeDigest": "0a4f6d837a0a2ff611d9d431036200debe8a3cff13e4c966ef4f35faf80c20a8",
+                  "children": [],
+                  "elapsed": 0.41432397812604904,
+                  "eventIds": [
+                    1097, 1099, 1111, 1113, 1115, 1117, 1119, 1121, 1123, 1125, 1127, 1129, 1131,
+                    1133, 1135, 1137, 1139, 1141, 1143, 1145, 1147, 1149, 1151, 1153, 1155, 1157,
+                    1159, 1161, 1163, 1165, 1167, 1169, 1171, 1173, 1175, 1177
+                  ]
+                }
+              ],
+              "elapsed": 0.41432397812604904,
+              "eventIds": []
+            }
+          ],
+          "elapsed": 0.002129000029526651,
+          "eventIds": [1094]
+        },
+        {
+          "nodeType": 6,
+          "caller": "http:HTTP server requests",
+          "callee": "database:Database",
+          "query": "RELEASE SAVEPOINT autopoint_1",
+          "digest": "682ac0a00b08652a98b568707671487755467437670b11481dd664a20840d2ed",
+          "subtreeDigest": "4d4255fe6d3ed5faa94d189cd35c1ba92e317287006dc20f9fa401477187e92d",
+          "children": [],
+          "elapsed": 0.001451,
+          "eventIds": [1360]
+        }
+      ],
+      "eventIds": [967]
+    }
+  ]
+}

--- a/packages/sequence-diagram/tests/unit/diff.spec.ts
+++ b/packages/sequence-diagram/tests/unit/diff.spec.ts
@@ -8,6 +8,9 @@ import {
   USER_NOT_FOUND_APPMAP,
   VERBOSE,
 } from '../util';
+import loopBaseline from '../fixtures/diff/loop_baseline.sequence.json';
+import loopHead from '../fixtures/diff/loop_head.sequence.json';
+import { Diagram } from '../../src/types';
 
 describe('Sequence diagram diff', () => {
   describe('user found vs not found', () => {
@@ -54,6 +57,29 @@ describe('Sequence diagram diff', () => {
           MoveType.InsertRight,
           MoveType.InsertRight,
 
+          MoveType.AdvanceBoth,
+          MoveType.AdvanceBoth,
+        ]
+      );
+    });
+  });
+  describe('Loop counts', () => {
+    it('identifies changes in number of iterations', () => {
+      const computedDiff = diff(
+        loopHead as unknown as Diagram,
+        loopBaseline as unknown as Diagram,
+        { verbose: VERBOSE }
+      );
+      assert.deepStrictEqual(
+        computedDiff.moves.map((state) => state.moveType),
+        [
+          MoveType.AdvanceBoth,
+          MoveType.AdvanceBoth,
+          MoveType.AdvanceBoth,
+          MoveType.AdvanceBoth,
+          MoveType.AdvanceBoth,
+          MoveType.AdvanceBoth,
+          MoveType.Change,
           MoveType.AdvanceBoth,
           MoveType.AdvanceBoth,
         ]


### PR DESCRIPTION
We'll now consider the number of loop iterations while diffing sequence diagrams. Consider a performance degradation due to an increase in costly iterations. Prior to this change, a sequence diagram diff would report no changes. With this change in place we can accurately describe the change that occurred.

![image](https://user-images.githubusercontent.com/8737782/231275938-51cdc6b3-a1a3-4a19-9e31-d46a6e658c27.png)

There's some additional work to be done to add diff gutters, however this is a more significant change as the way loops and diff channels are rendered are currently incompatible.
