### PR TITLE
Fix CLI bugs for handling large maps

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -74,7 +74,7 @@
     "@appland/client": "workspace:^1",
     "@appland/components": "workspace:^2",
     "@appland/diagrams": "workspace:^1",
-    "@appland/models": "workspace:^2.4.2",
+    "@appland/models": "workspace:^2.4.3",
     "@appland/openapi": "workspace:^1.4.3",
     "@appland/sequence-diagram": "workspace:^1",
     "@sidvind/better-ajv-errors": "^0.9.1",

--- a/packages/cli/src/cmds/stats/directory/statsForMap.ts
+++ b/packages/cli/src/cmds/stats/directory/statsForMap.ts
@@ -43,7 +43,10 @@ async function parseClassMap(mapPath: string): Promise<ClassMap> {
     fs.createReadStream(mapPath).pipe(
       JSONStream.parse('events.*')
         .on('header', (obj: any) => {
-          classMap = new ClassMap(obj.classMap);
+          if (obj.classMap) classMap = new ClassMap(obj.classMap);
+        })
+        .on('footer', (obj: any) => {
+          if (obj.classMap) classMap = new ClassMap(obj.classMap);
         })
         .on('close', () => {
           resolve(classMap);

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -28,7 +28,7 @@
   ],
   "dependencies": {
     "@appland/diagrams": "workspace:^1.6.2",
-    "@appland/models": "workspace:^2.4.2",
+    "@appland/models": "workspace:^2.4.3",
     "@appland/sequence-diagram": "workspace:^1.5.0",
     "buffer": "^6.0.3",
     "diff": "^5.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -90,7 +90,7 @@ __metadata:
     "@appland/client": "workspace:^1"
     "@appland/components": "workspace:^2"
     "@appland/diagrams": "workspace:^1"
-    "@appland/models": "workspace:^2.4.2"
+    "@appland/models": "workspace:^2.4.3"
     "@appland/openapi": "workspace:^1.4.3"
     "@appland/sequence-diagram": "workspace:^1"
     "@craftamap/esbuild-plugin-html": ^0.4.0
@@ -213,7 +213,7 @@ __metadata:
   resolution: "@appland/components@workspace:packages/components"
   dependencies:
     "@appland/diagrams": "workspace:^1.6.2"
-    "@appland/models": "workspace:^2.4.2"
+    "@appland/models": "workspace:^2.4.3"
     "@appland/sequence-diagram": "workspace:^1.5.0"
     "@babel/core": ^7.13.1
     "@babel/node": ^7.13.0
@@ -320,7 +320,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@appland/models@workspace:*, @appland/models@workspace:^2.2.0, @appland/models@workspace:^2.4.2, @appland/models@workspace:packages/models":
+"@appland/models@workspace:*, @appland/models@workspace:^2.2.0, @appland/models@workspace:^2.4.3, @appland/models@workspace:packages/models":
   version: 0.0.0-use.local
   resolution: "@appland/models@workspace:packages/models"
   dependencies:


### PR DESCRIPTION
Fixes #1151 

Before this change, the stats command required that the `classMap` field preceded the `events` field. For example, this would work:

```
{
  "classMap": ...,
  "events": ...
}
```

However, this would result in an error:

```
{
  "events": ...,
  "classMap": ...
}
```

This change also pulls in the latest version of `@appland/models` to fix [this issue](https://github.com/getappmap/appmap-js/pull/1149) in the next release of `@appland/appmap`.