### PR TITLE
More robust pruning

### DIFF
--- a/packages/models/src/appMapBuilder/index.js
+++ b/packages/models/src/appMapBuilder/index.js
@@ -215,15 +215,16 @@ class AppMapBuilder extends EventSource {
         const { callEvent } = e;
 
         // If there's no call event, there's no need to retain this event
-        if (!callEvent) {
-          return false;
-        }
+        if (!callEvent) return false;
 
-        if (callEvent.http_server_request || callEvent.http_client_request || callEvent.sql_query) {
+        if (callEvent.http_server_request || callEvent.http_client_request || callEvent.sql_query)
           return true;
-        }
 
         const codeObj = classMap.codeObjectFromEvent(callEvent);
+
+        // keep events where the code object cannot be found
+        if (!codeObj || !codeObj.fqid) return true;
+
         return !exclusions.has(codeObj.fqid);
       })
     );


### PR DESCRIPTION
Fixes #1150 

Prevent an error where call events that cannot be converted to a code object cause the prune command to fail. This change keeps any call event that cannot be found in the class map.

Before this change, pruning this file failed: https://github.com/getappmap/board/files/11126270/21-Mb-appmap.json.zip