### PR TITLE
feat: Apply filter string to sequence diagram

### DIFF
--- a/packages/cli/src/cmds/prune/pruneAppMap.ts
+++ b/packages/cli/src/cmds/prune/pruneAppMap.ts
@@ -1,4 +1,5 @@
-import { AppMapFilter, buildAppMap, deserializeAppmapState } from '@appland/models';
+import { buildAppMap } from '@appland/models';
+import deserializeFilter from '../../lib/deserializeFilter';
 
 // Simplified AppMap interface, just for pruning
 export interface AppMap {
@@ -6,7 +7,7 @@ export interface AppMap {
   [key: string]: any;
 }
 
-type PruneFilter = {
+export type PruneFilter = {
   hideUnlabeled?: boolean;
   hideMediaRequests?: boolean;
   hideExternalPaths?: boolean;
@@ -61,15 +62,11 @@ export const pruneAppMap = (appMap: AppMap, size: number): any => {
 export const pruneWithFilter = (appMap: AppMap, serializedFilter: string): any => {
   // TODO: update type for AppMap
   const fullMap = buildAppMap().source(appMap).normalize().build() as any;
+
   const filterBefore = fullMap.data.pruneFilter || {};
-
-  const filterOrState = deserializeAppmapState(serializedFilter);
-  const filter = 'filters' in filterOrState ? filterOrState.filters : filterOrState;
-
-  const appmapFilter = new AppMapFilter();
-  appmapFilter.declutter.limitRootEvents.on = false;
-  appmapFilter.declutter.hideMediaRequests.on = false;
-  appmapFilter.apply(filter);
+  // Note: Preserving the default of these two options to false, even though I am not sure why
+  // that is done in the original implementation.
+  const { filter, appmapFilter } = deserializeFilter(serializedFilter, false, false);
 
   // TODO: update type for AppMap
   const prunedMap = appmapFilter.filter(fullMap, []) as any;

--- a/packages/cli/src/lib/deserializeFilter.ts
+++ b/packages/cli/src/lib/deserializeFilter.ts
@@ -1,0 +1,22 @@
+import { AppMapFilter, deserializeAppmapState } from '@appland/models';
+import { PruneFilter } from '../cmds/prune/pruneAppMap';
+
+export default function deserializeFilter(
+  serializedFilter: string,
+  limitRootEvents?: boolean,
+  hideMediaRequests?: boolean
+): {
+  filter: PruneFilter;
+  appmapFilter: AppMapFilter;
+} {
+  const filterOrState = deserializeAppmapState(serializedFilter);
+  const filter = 'filters' in filterOrState ? filterOrState.filters : filterOrState;
+
+  const appmapFilter = new AppMapFilter();
+  if (limitRootEvents !== undefined) appmapFilter.declutter.limitRootEvents.on = limitRootEvents;
+  if (hideMediaRequests !== undefined)
+    appmapFilter.declutter.hideMediaRequests.on = hideMediaRequests;
+  appmapFilter.apply(filter);
+
+  return { filter, appmapFilter };
+}

--- a/packages/cli/src/lib/filterAppMap.ts
+++ b/packages/cli/src/lib/filterAppMap.ts
@@ -1,0 +1,7 @@
+import { AppMap } from '@appland/models';
+import deserializeFilter from './deserializeFilter';
+
+export default function filterAppMap(appMap: AppMap, serializedFilter: string): AppMap {
+  const { appmapFilter } = deserializeFilter(serializedFilter);
+  return appmapFilter.filter(appMap, []);
+}


### PR DESCRIPTION
When generating a sequence diagram from an AppMap, accept a serialized filter string.