### PR TITLE
define font-family

### DIFF
--- a/packages/components/src/components/SignIn.vue
+++ b/packages/components/src/components/SignIn.vue
@@ -61,6 +61,7 @@ export default {
 .signin-sidebar {
   background-color: $black;
   color: $white;
+  font-family: $appland-text-font-family;
   width: auto;
   height: 100%;
   padding: 1.5rem;


### PR DESCRIPTION
Explicitly define font-family. Fonts in JetBrains were rendered incorrectly. Closes #1160 

JetBrains:
![image](https://user-images.githubusercontent.com/123787/234350104-4039ca8d-e25f-4207-87b9-e21872c9a251.png)

Font-family defined (local Storybook):
![Screenshot 2023-04-25 at 1 02 40 PM](https://user-images.githubusercontent.com/123787/234350263-e3ccf8e6-42f0-4d74-9e9f-34964e98b4b6.png)
