### PR TITLE
User can expand sequence diagram packages to classes

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@appland/diagrams": "workspace:^1.6.2",
     "@appland/models": "workspace:^2.6.0",
-    "@appland/sequence-diagram": "workspace:^1.5.0",
+    "@appland/sequence-diagram": "workspace:^1.5.2",
     "buffer": "^6.0.3",
     "diff": "^5.1.0",
     "dom-to-svg": "^0.12.2",

--- a/packages/components/src/assets/collapse-icon.svg
+++ b/packages/components/src/assets/collapse-icon.svg
@@ -1,0 +1,4 @@
+<svg width="13" height="13" viewBox="0 0 13 13" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="10" y="6" width="1" height="7" transform="rotate(90 10 6)" fill="#E3E5E8" fill-opacity="0.33"/>
+<rect x="0.5" y="0.5" width="12" height="12" stroke="#E3E5E8" stroke-opacity="0.33"/>
+</svg>

--- a/packages/components/src/assets/expand-icon.svg
+++ b/packages/components/src/assets/expand-icon.svg
@@ -1,0 +1,4 @@
+<svg width="13" height="13" viewBox="0 0 13 13" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M7 3H6V6H3V7H6V10H7V7H10V6H7V3Z" fill="#E3E5E8" fill-opacity="0.33"/>
+<rect x="0.5" y="0.5" width="12" height="12" stroke="#E3E5E8" stroke-opacity="0.33"/>
+</svg>

--- a/packages/components/src/components/sequence/Actor.vue
+++ b/packages/components/src/components/sequence/Actor.vue
@@ -122,7 +122,7 @@ export default {
     },
     numClasses() {
       const match = this.actor.id.match(/:(?<id>.*)/);
-      if (match && match.groups) {
+      if (match && match.groups && this.appMap) {
         const codeObj = this.appMap.classMap.codeObjectFromId(match.groups.id);
         if (codeObj) return codeObj.classes.length;
       }

--- a/packages/components/src/components/sequence/Actor.vue
+++ b/packages/components/src/components/sequence/Actor.vue
@@ -35,6 +35,8 @@
               <span v-if="expandable">({{ numClasses }})</span>
             </span>
           </div>
+          <div v-if="expandable" class="label-container stack stack1"></div>
+          <div v-if="expandable" class="label-container stack stack2"></div>
         </div>
       </div>
     </div>
@@ -176,7 +178,7 @@ export default {
 </script>
 
 <style scoped lang="scss">
-$min-width: 160px; // See: CallLabel .label wax-width
+$min-width: 175px; // See: CallLabel .label wax-width
 $min-height: 3rem;
 
 .offset {
@@ -308,6 +310,21 @@ $min-height: 3rem;
   }
   .database {
     color: $royal;
+  }
+}
+
+.label-container.stack {
+  //border: 2px solid $black;
+  border-radius: 0rem;
+  &.stack1 {
+    z-index: 4;
+    margin: 8px 0 0 6px;
+    border: 1px solid darken($gray4, 15);
+  }
+  &.stack2 {
+    z-index: 3;
+    margin: 14px 0 0 12px;
+    border: 1px solid darken($gray4, 30);
   }
 }
 

--- a/packages/components/src/components/sequence/Actor.vue
+++ b/packages/components/src/components/sequence/Actor.vue
@@ -30,7 +30,7 @@
                 </v-popper>
               </div>
             </template>
-            <span class="label">
+            <span :class="['label', type]">
               {{ actor.name }}
               <span v-if="expandable">({{ numClasses }})</span>
             </span>
@@ -104,6 +104,10 @@ export default {
         'label-container--selected': this.actor === this.selectedActor,
         interactive: this.interactive,
       };
+    },
+    type() {
+      if (this.actor.id && this.actor.id.includes(':')) return this.actor.id.split(':')[0];
+      return '';
     },
     expandable() {
       return this.isPackage && this.numClasses && this.numClasses > 1;
@@ -195,6 +199,7 @@ $min-height: 3rem;
   text-overflow: ellipsis;
   overflow: visible;
   box-shadow: 0px 0px 20px 0px rgba(0, 0, 0, 0.55);
+  z-index: 5;
 
   min-width: 145px;
   min-height: 60px;
@@ -208,14 +213,40 @@ $min-height: 3rem;
   background-color: $black;
   color: $white;
   font-size: 9pt;
+  border: 1px solid $gray4; //lighten($gray4, 15);
+  border-radius: 0;
   display: grid;
   grid-template-rows: 20px auto;
   grid-template-columns: 100%;
   justify-content: center;
   align-items: center;
+  transition: $transition;
 
   &--selected {
-    background-color: #444e69;
+    background-color: $actor-highlight;
+    .label {
+      text-shadow: #181b24 0 0 12px;
+      &.http {
+        color: #bd64e1;
+      }
+
+      &.external-service {
+        color: $yellow;
+      }
+      &.package {
+        color: $teal;
+      }
+      &.class {
+        color: lighten($blue, 13);
+      }
+      &.database {
+        color: lighten($royal, 13);
+      }
+    }
+  }
+
+  .label {
+    padding-bottom: 1rem;
   }
 
   .hover-text-popper {
@@ -261,14 +292,27 @@ $min-height: 3rem;
     justify-content: space-between;
     padding: 0 0.5rem;
   }
+
+  .http {
+    color: #8e45aa;
+  }
+
+  .external-service {
+    color: $yellow;
+  }
+  .package {
+    color: $teal;
+  }
+  .class {
+    color: $blue;
+  }
+  .database {
+    color: $royal;
+  }
 }
 
 .interactive.label-container:hover {
   cursor: pointer;
-  background-color: #444e69;
-  .hide-container {
-    background-color: #444e69;
-  }
 }
 
 .lane {

--- a/packages/components/src/components/sequence/LoopAction.vue
+++ b/packages/components/src/components/sequence/LoopAction.vue
@@ -76,16 +76,15 @@ export default {
 <style scoped lang="scss">
 .loop {
   margin: 15px -20px 10px -20px;
-  border: 2px solid #444e69;
+  border: 2px solid $actor-highlight; //#444e69;
   position: relative;
   display: inline-block;
   font-weight: bold;
   pointer-events: none;
-  border-radius: 0.4rem;
-
+  border-radius: 0;
   .label-container {
     white-space: nowrap;
-    background-color: #444e69;
+    background-color: $actor-highlight; // #444e69;
     div {
       display: inline-block;
     }
@@ -93,9 +92,9 @@ export default {
     .label {
       padding: 5px;
       height: 28px;
-      background-color: #444e69;
+      background-color: $actor-highlight; // #444e69;
       color: $white;
-      border-bottom: 2px solid #444e69;
+      border-bottom: 2px solid $actor-highlight; // #444e69;
       position: relative;
 
       .rhs-effect {

--- a/packages/components/src/pages/VsCodeExtension.vue
+++ b/packages/components/src/pages/VsCodeExtension.vue
@@ -458,6 +458,8 @@ import {
   SELECT_LABEL,
   POP_SELECTION_STACK,
   CLEAR_SELECTION_STACK,
+  SET_EXPANDED_PACKAGES,
+  CLEAR_EXPANDED_PACKAGES,
 } from '../store/vsCode';
 
 export default {
@@ -783,6 +785,14 @@ export default {
       return this.$store.state.currentView;
     },
 
+    expandedPackages() {
+      return this.$store.state.expandedPackages;
+    },
+
+    baseActors() {
+      return this.$store.state.baseActors;
+    },
+
     isViewingComponent() {
       return this.currentView === VIEW_COMPONENT;
     },
@@ -910,6 +920,8 @@ export default {
       const state = {};
 
       state.currentView = this.currentView;
+      if (this.expandedPackages.length > 0)
+        state.expandedPackages = this.expandedPackages.map((expandedPackage) => expandedPackage.id);
 
       if (this.selectedObject && this.selectedObject.fqid) {
         state.selectedObject = this.selectedObject.fqid;
@@ -1025,9 +1037,16 @@ export default {
           } while (false);
         }
 
-        const { filters } = state;
+        const { filters, expandedPackages } = state;
         if (filters) {
           this.filters = deserializeFilter(filters);
+        }
+
+        if (expandedPackages) {
+          const codeObjects = expandedPackages.map((expandedPackageId) =>
+            this.filteredAppMap.classMap.codeObjectFromId(expandedPackageId)
+          );
+          this.$store.commit(SET_EXPANDED_PACKAGES, codeObjects);
         }
 
         this.$nextTick(() => {
@@ -1062,6 +1081,7 @@ export default {
     },
 
     resetDiagram() {
+      this.$store.commit(CLEAR_EXPANDED_PACKAGES);
       this.clearSelection();
       this.resetFilters();
       this.$root.$emit('resetDiagram');
@@ -1867,9 +1887,6 @@ code {
     padding: 0;
     span {
       display: none;
-    }
-    svg {
-      fill: $gray4;
     }
   }
 }

--- a/packages/components/src/scss/_variables.scss
+++ b/packages/components/src/scss/_variables.scss
@@ -100,6 +100,8 @@ $sequence-diff-insert-bg-color: rgba(32, 200, 63, 0.23);
 $sequence-diff-delete-bg-color: rgba(246, 47, 47, 0.25);
 $sequence-diff-change-bg-color: rgba(71, 122, 184, 0.25);
 
+$actor-highlight: #262b3a;
+
 // End sequence diagram
 
 //VS Code

--- a/packages/components/src/store/vsCode.js
+++ b/packages/components/src/store/vsCode.js
@@ -16,6 +16,8 @@ export const VIEW_SEQUENCE = 'viewSequence';
 export const VIEW_FLOW = 'viewFlow';
 export const ADD_EXPANDED_PACKAGE = 'addExpandedPackage';
 export const REMOVE_EXPANDED_PACKAGE = 'removeExpandedPackage';
+export const SET_EXPANDED_PACKAGES = 'setExpandedPackage';
+export const CLEAR_EXPANDED_PACKAGES = 'clearExpandedPackage';
 export const DEFAULT_VIEW = VIEW_COMPONENT;
 
 export function buildStore() {
@@ -110,6 +112,14 @@ export function buildStore() {
         state.expandedPackages = state.expandedPackages.filter(
           (expandedPackage) => expandedPackage.fqid !== subClass.packageObject.fqid
         );
+      },
+
+      [SET_EXPANDED_PACKAGES](state, expandedPackages) {
+        state.expandedPackages = expandedPackages;
+      },
+
+      [CLEAR_EXPANDED_PACKAGES](state) {
+        state.expandedPackages = [];
       },
     },
   });

--- a/packages/components/src/store/vsCode.js
+++ b/packages/components/src/store/vsCode.js
@@ -14,6 +14,8 @@ export const SET_FOCUSED_EVENT = 'setFocusedEvent';
 export const VIEW_COMPONENT = 'viewComponent';
 export const VIEW_SEQUENCE = 'viewSequence';
 export const VIEW_FLOW = 'viewFlow';
+export const ADD_EXPANDED_PACKAGE = 'addExpandedPackage';
+export const REMOVE_EXPANDED_PACKAGE = 'removeExpandedPackage';
 export const DEFAULT_VIEW = VIEW_COMPONENT;
 
 export function buildStore() {
@@ -24,6 +26,7 @@ export function buildStore() {
       currentView: DEFAULT_VIEW,
       selectedLabel: null,
       focusedEvent: null,
+      expandedPackages: [],
     },
 
     getters: {
@@ -43,6 +46,9 @@ export function buildStore() {
       },
       focusedEvent(state) {
         return state.focusedEvent;
+      },
+      expandedPackages(state) {
+        return state.expandedPackages;
       },
     },
 
@@ -94,6 +100,16 @@ export function buildStore() {
       // This action does not imply that the sidebar display should be changed.
       [SET_FOCUSED_EVENT](state, event) {
         state.focusedEvent = event;
+      },
+
+      [ADD_EXPANDED_PACKAGE](state, packageToAdd) {
+        state.expandedPackages.push(packageToAdd);
+      },
+
+      [REMOVE_EXPANDED_PACKAGE](state, subClass) {
+        state.expandedPackages = state.expandedPackages.filter(
+          (expandedPackage) => expandedPackage.fqid !== subClass.packageObject.fqid
+        );
       },
     },
   });

--- a/packages/components/tests/e2e/specs/appmap/sequenceDiagram.spec.js
+++ b/packages/components/tests/e2e/specs/appmap/sequenceDiagram.spec.js
@@ -18,6 +18,33 @@ context('AppMap sequence diagram', () => {
       cy.get('.tabs__controls .popper__button').click();
       cy.get('.filters .filters__hide-item').should('have.length', 1);
     });
+
+    it('expands packages to classes', () => {
+      cy.get('.sequence-diagram').children('.lane').should('have.length', 9);
+      cy.get('.sequence-actor[data-actor-id="package:openssl"] .expand-actor').click();
+
+      const children = cy.get('.sequence-diagram').children('.lane');
+      children.should('have.length', 10);
+      const expected = [
+        'HTTP server requests',
+        'app/controllers',
+        'Instance',
+        'Cipher',
+        'active_support',
+        'json',
+        'app/helpers',
+        'lib',
+        '127.0.0.1:9515',
+        'Database',
+      ];
+
+      children.each(($el, index) => {
+        cy.wrap($el).should('contain.text', expected[index]);
+      });
+
+      cy.get('.sequence-actor[data-actor-id="class:openssl/Digest::Instance"]').should('exist');
+      cy.get('.sequence-actor[data-actor-id="class:openssl/OpenSSL::Cipher"]').should('exist');
+    });
   });
 
   context('with no data provided', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -214,7 +214,7 @@ __metadata:
   dependencies:
     "@appland/diagrams": "workspace:^1.6.2"
     "@appland/models": "workspace:^2.6.0"
-    "@appland/sequence-diagram": "workspace:^1.5.0"
+    "@appland/sequence-diagram": "workspace:^1.5.2"
     "@babel/core": ^7.13.1
     "@babel/node": ^7.13.0
     "@babel/preset-env": ^7.9.5
@@ -427,7 +427,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@appland/sequence-diagram@workspace:^1, @appland/sequence-diagram@workspace:^1.5.0, @appland/sequence-diagram@workspace:packages/sequence-diagram":
+"@appland/sequence-diagram@workspace:^1, @appland/sequence-diagram@workspace:^1.5.2, @appland/sequence-diagram@workspace:packages/sequence-diagram":
   version: 0.0.0-use.local
   resolution: "@appland/sequence-diagram@workspace:packages/sequence-diagram"
   dependencies:


### PR DESCRIPTION
Fixes #1166

For some reason the Travis build isn't attached anymore, but you can find it [here](https://app.travis-ci.com/github/getappmap/appmap-js/builds/262948442).

[Here](https://www.chromatic.com/component?appId=5fe18baf66f2280021e634d0&csfId=pages-vs-code--extension-with-default-sequence-view&buildNumber=2186&k=645bdb3bb4699530485605ba-1200-interactive-true&h=10&b=-5) is the interactive chromatic build where you can try out this feature.

- [x] Adds an expand button in the top left of the lifeline box for packages. When clicked, the classes within the package will become lifeline boxes that have a collapse button:

![image](https://github.com/getappmap/appmap-js/assets/45714532/f7637700-f500-4bce-b4b3-900e84e40e24)


- [x] The collapse button will collapse all of the classes back into the package.
- [x] Classes will expand out and will render adjacent to each other to the right of the package that they were expanded from.
- [x] The actor labels are now the appropriate colors.
- [x] The state provided by `getState` now includes the expanded packages.