### PR TITLE
Add include option to sequence diagram spec

### DIFF
--- a/packages/sequence-diagram/src/specification.ts
+++ b/packages/sequence-diagram/src/specification.ts
@@ -8,6 +8,8 @@ export interface SequenceDiagramOptions {
   // default: []
   exclude?: CodeObjectId[];
   // default: []
+  include?: CodeObjectId[];
+  // default: []
   expand?: CodeObjectId[];
 
   // default: {}
@@ -55,7 +57,7 @@ export default class Specification {
   static build(appmap: AppMap, options: SequenceDiagramOptions): Specification {
     const excludeSet = new Set<string>(options.exclude || []);
     const expandSet = new Set<string>(options.expand || []);
-    const includedCodeObjectIds = new Set<string>();
+    const includedCodeObjectIds = new Set<string>(options.include || []);
 
     const hasNonPackageChildren = (co: AppMapCodeObject): boolean => {
       if (co.type !== 'package') return true;

--- a/packages/sequence-diagram/tests/unit/sequenceDiagram.spec.ts
+++ b/packages/sequence-diagram/tests/unit/sequenceDiagram.spec.ts
@@ -132,4 +132,19 @@ describe('Sequence diagram', () => {
       });
     });
   });
+  describe('include', () => {
+    it('adds the correct classes', () => {
+      const include = ['class:lib/models/Post', 'class:lib/models/User'];
+      const diagram = loadDiagram(SHOW_USER_APPMAP, { loops: true, include });
+      const expectedActors = [
+        { id: 'package:lib/controllers', name: 'controllers', order: 1000 },
+        { id: 'class:lib/models/User', name: 'User', order: 2000 },
+        { id: 'package:lib/database', name: 'database', order: 3000 },
+        { id: 'package:lib/views/users', name: 'users', order: 4000 },
+        { id: 'class:lib/models/Post', name: 'Post', order: 5000 },
+        { id: 'package:lib/views/posts', name: 'posts', order: 6000 },
+      ];
+      assert.deepStrictEqual(diagram.actors, expectedActors);
+    });
+  });
 });


### PR DESCRIPTION
This is a precursor to [this PR](https://github.com/getappmap/appmap-js/pull/1168). The `include` option was needed because `require` filters out all events that are not children of the `require`d code objects.