### PR TITLE
feat: 'depends' performance

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -109,7 +109,7 @@ yargs(process.argv.slice(2))
           }
         }, 5);
         appMapNames.forEach((name) => q.push(name));
-        await q.drain();
+        if (!q.idle()) await q.drain();
       } else {
         appMapNames.forEach((name) => values.push(name));
       }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -107,7 +107,7 @@ yargs(process.argv.slice(2))
           } else {
             console.warn(`No ${field} in ${appMapBaseName}`);
           }
-        }, 5);
+        }, 2);
         appMapNames.forEach((name) => q.push(name));
         if (!q.idle()) await q.drain();
       } else {

--- a/packages/cli/src/cmds/openapi.ts
+++ b/packages/cli/src/cmds/openapi.ts
@@ -44,7 +44,7 @@ class OpenAPICommand {
       number
     ]
   > {
-    const q = queue(this.collectAppMap.bind(this), 5);
+    const q = queue(this.collectAppMap.bind(this), 2);
     q.pause();
 
     // Make sure the directory exists -- if it doesn't, the glob below just returns nothing.

--- a/packages/cli/src/cmds/sequenceDiagramDiff.ts
+++ b/packages/cli/src/cmds/sequenceDiagramDiff.ts
@@ -135,7 +135,7 @@ export const handler = async (argv: any) => {
             data.diagrams.set(relativePath, diagram);
           }, 2);
           matches.forEach((fileName) => loader.push(fileName));
-          await loader.drain();
+          if (!loader.idle()) await loader.drain();
         });
       })
     );

--- a/packages/cli/src/fingerprint/fingerprintQueue.ts
+++ b/packages/cli/src/fingerprint/fingerprintQueue.ts
@@ -40,6 +40,8 @@ export default class FingerprintQueue {
           console.warn(`Skipped: ${error.path}\nThe file does not exist.`);
         } else reject(error);
       });
+      // The queue will run continuously from here on out, which is what we want.
+      // Items will be added to the queue as they are discovered.
       this.queue.resume();
     });
   }

--- a/packages/cli/src/sequenceDiagram/buildDiagrams.ts
+++ b/packages/cli/src/sequenceDiagram/buildDiagrams.ts
@@ -19,7 +19,7 @@ export default async function buildDiagrams(
       appmapFile,
       diagram: buildDiagram([appmapFile, 'appmap.json'].join('.'), appmap, specification),
     });
-  }, 5);
+  }, 2);
   for (const appmap of appmaps) diagramQueue.push(appmap);
   diagramQueue.error((err) => console.warn(err));
   if (!diagramQueue.idle()) await diagramQueue.drain();

--- a/packages/cli/src/sequenceDiagram/buildDiagrams.ts
+++ b/packages/cli/src/sequenceDiagram/buildDiagrams.ts
@@ -22,7 +22,7 @@ export default async function buildDiagrams(
   }, 5);
   for (const appmap of appmaps) diagramQueue.push(appmap);
   diagramQueue.error((err) => console.warn(err));
-  await diagramQueue.drain();
+  if (!diagramQueue.idle()) await diagramQueue.drain();
 
   return diagrams;
 }

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -102,8 +102,6 @@ export async function processFiles(
   if (q.length()) await q.drain();
 }
 
-
-
 /**
  * Finds all occurrances of `fileName` within a base directory. Each match must be a file, not a directory.
  * This is optimized compared to `processFiles` because it does not use `glob`, which is pretty slow for this use case.
@@ -124,11 +122,13 @@ export async function processNamedFiles(
     }
   };
 
+  let matchCount = 0;
   const processDir = async (dir: string) => {
     // If the directory contains the target fileName, add it to the process queue and return.
     const targetFileName = join(dir, fileName);
     const target = await stats(targetFileName);
     if (target && target.isFile()) {
+      matchCount += 1;
       q.push(targetFileName);
       return;
     }
@@ -143,7 +143,7 @@ export async function processNamedFiles(
   };
   await processDir(baseDir);
 
-  if (q.length()) await q.drain();
+  if (matchCount) await q.drain();
 }
 
 /**

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -100,7 +100,7 @@ export async function processFiles(
 
   const q = queue(fn, 2);
   files.forEach((file) => q.push(file));
-  await q.drain();
+  if (!q.idle()) await q.drain();
 }
 
 /**
@@ -123,13 +123,11 @@ export async function processNamedFiles(
     }
   };
 
-  let matchCount = 0;
   const processDir = async (dir: string) => {
     // If the directory contains the target fileName, add it to the process queue and return.
     const targetFileName = join(dir, fileName);
     const target = await stats(targetFileName);
     if (target && target.isFile()) {
-      matchCount += 1;
       q.push(targetFileName);
       return;
     }
@@ -144,7 +142,7 @@ export async function processNamedFiles(
   };
   await processDir(baseDir);
 
-  if (matchCount) await q.drain();
+  if (!q.idle()) await q.drain();
 }
 
 /**

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -92,14 +92,15 @@ export async function processFiles(
   fn: AsyncWorker<string>,
   fileCountFn = (count: number) => {}
 ): Promise<void> {
-  const q = queue(fn, 5);
   const files = await promisify(glob)(pattern);
   if (fileCountFn) {
     fileCountFn(files.length);
   }
   if (files.length === 0) return;
+
+  const q = queue(fn, 2);
   files.forEach((file) => q.push(file));
-  if (q.length()) await q.drain();
+  await q.drain();
 }
 
 /**

--- a/packages/cli/tests/unit/depends.spec.ts
+++ b/packages/cli/tests/unit/depends.spec.ts
@@ -20,7 +20,7 @@ describe('Depends', () => {
   beforeAll(async () => verbose(process.env.DEBUG === 'true'));
   beforeEach(async () => {
     appMapDir = tmp.dirSync().name;
-    expected = join(appMapDir, 'user_page_scenario').replace(/\\/g, '/');
+    expected = join(appMapDir, 'user_page_scenario');
     userModelFilePath = join(appMapDir, 'app/models/user.rb');
 
     fs.copySync(fixtureDir, appMapDir);

--- a/packages/cli/tests/unit/queue.spec.ts
+++ b/packages/cli/tests/unit/queue.spec.ts
@@ -1,0 +1,14 @@
+import assert from 'assert';
+import { queue } from 'async';
+
+describe('async', () => {
+  it('hangs if you drain an idle queue', async () => {
+    const q = queue(async () => {}, 1);
+    expect(q.idle()).toBe(true);
+    let drained = false;
+    q.drain().then(() => (drained = true));
+    return new Promise<void>((resolve, reject) => {
+      setTimeout(() => (drained ? reject(`drain should not have resolved yet`) : resolve()), 50);
+    });
+  });
+});

--- a/packages/scanner/src/cli/upload.ts
+++ b/packages/scanner/src/cli/upload.ts
@@ -111,7 +111,7 @@ export default async function create(
   });
   if (verbose()) console.log(`Uploading ${relevantFilePaths.length} AppMaps`);
   q.push(relevantFilePaths);
-  await q.drain();
+  if (!q.idle()) await q.drain();
 
   const mostFrequent = (counts: Record<string, number>): string | undefined => {
     if (Object.keys(counts).length === 0) return;


### PR DESCRIPTION
* Optimize target file enumeration
* Cache file modified times
* Remove the most verbose logging
* Remove source locations that are blank

Before optimization:
```
node ./built/cli.js depends -d ~/source/land-of-apps/forem > forem.log  11.41s user 6.40s system 169% cpu 10.537 total
```

After optimization:
```
node ./built/cli.js depends -d ~/source/land-of-apps/forem > forem.log  3.86s user 1.59s system 127% cpu 4.296 total
```