### PR TITLE
Sequence diagram `expand` option includes child classes in `actors`

### DIFF
--- a/packages/sequence-diagram/src/specification.ts
+++ b/packages/sequence-diagram/src/specification.ts
@@ -64,14 +64,14 @@ export default class Specification {
     };
 
     const includeCodeObjects = (co: AppMapCodeObject): void => {
+      if (co.type === 'class' && co.packageObject && expandSet.has(co.packageObject.fqid)) {
+        includedCodeObjectIds.add(co.fqid);
+        co.children.forEach((child) => includeCodeObjects(child));
+      }
+
       if (!this.DefaultActorTypes.includes(co.type)) return;
       if (excludeSet.has(co.fqid)) return;
-
-      if (co.parent && expandSet.has(co.parent.fqid)) {
-        includedCodeObjectIds.add(co.fqid);
-      } else if (!expandSet.has(co.fqid) && hasNonPackageChildren(co)) {
-        includedCodeObjectIds.add(co.fqid);
-      }
+      if (!expandSet.has(co.fqid) && hasNonPackageChildren(co)) includedCodeObjectIds.add(co.fqid);
 
       co.children.forEach((child) => includeCodeObjects(child));
     };

--- a/packages/sequence-diagram/tests/unit/sequenceDiagram.spec.ts
+++ b/packages/sequence-diagram/tests/unit/sequenceDiagram.spec.ts
@@ -132,4 +132,22 @@ describe('Sequence diagram', () => {
       });
     });
   });
+
+  describe('expand option', () => {
+    it('adds subclasses', () => {
+      const expand = ['package:lib/models'];
+      const diagram = loadDiagram(SHOW_USER_APPMAP, { expand });
+
+      const expectedActors = [
+        { id: 'package:lib/controllers', name: 'controllers', order: 1000 },
+        { id: 'class:lib/models/User', name: 'User', order: 2000 },
+        { id: 'package:lib/database', name: 'database', order: 3000 },
+        { id: 'package:lib/views/users', name: 'users', order: 4000 },
+        { id: 'class:lib/models/Post', name: 'Post', order: 5000 },
+        { id: 'package:lib/views/posts', name: 'posts', order: 6000 },
+      ];
+
+      assert.deepStrictEqual(diagram.actors, expectedActors);
+    });
+  });
 });


### PR DESCRIPTION
Previously, the `expand` option would fail to include the child classes of the expanded package in the list of actors.