### PR TITLE
Users can filter external code

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -28,7 +28,7 @@
   ],
   "dependencies": {
     "@appland/diagrams": "workspace:^1.6.2",
-    "@appland/models": "workspace:^2.6.0",
+    "@appland/models": "workspace:^2.6.1",
     "@appland/sequence-diagram": "workspace:^1.5.2",
     "buffer": "^6.0.3",
     "diff": "^5.1.0",

--- a/packages/components/src/components/FilterMenu.vue
+++ b/packages/components/src/components/FilterMenu.vue
@@ -43,6 +43,13 @@
           </label>
           <div class="filters__block-row-content">Hide media HTTP requests</div>
         </div>
+        <div class="filters__block-row" v-if="hideExternalSupported">
+          <label class="filters__checkbox">
+            <input type="checkbox" v-model="hideExternal" />
+            <CheckIcon class="filters__checkbox-icon" />
+          </label>
+          <div class="filters__block-row-content">Hide external code</div>
+        </div>
         <div class="filters__block-row">
           <label class="filters__checkbox">
             <input type="checkbox" v-model="hideUnlabeled" />
@@ -158,6 +165,15 @@ export default {
       },
     },
 
+    hideExternal: {
+      get() {
+        return this.$store.state.filters.declutter.hideExternalPaths.on;
+      },
+      set(value) {
+        this.$store.commit(SET_DECLUTTER_ON, { declutterProperty: 'hideExternalPaths', value });
+      },
+    },
+
     hideElapsedTimeUnder: {
       get() {
         return this.$store.state.filters.declutter.hideElapsedTimeUnder.on;
@@ -199,6 +215,15 @@ export default {
       return this.filteredAppMap.classMap.codeObjects
         .map((co) => co.fqid)
         .filter((fqid) => !this.filters.declutter.hideName.names.includes(fqid));
+    },
+
+    hideExternalSupported() {
+      const { appMap } = this.$store.state;
+      return (
+        appMap.metadata &&
+        appMap.metadata.language &&
+        ['ruby', 'javascript'].includes(appMap.metadata.language.name)
+      );
     },
   },
 

--- a/packages/components/tests/e2e/specs/appmap/viewFilter.spec.js
+++ b/packages/components/tests/e2e/specs/appmap/viewFilter.spec.js
@@ -136,7 +136,7 @@ context('AppMap view filter', () => {
       cy.get('.details-search__block--class .details-search__block-item').should('have.length', 11);
 
       cy.get('.tabs__controls .popper__button').click();
-      cy.get('.filters__checkbox').eq(2).click();
+      cy.get('.filters__checkbox').eq(3).click();
 
       cy.get('.details-search__block--package .details-search__block-item').should(
         'have.length',
@@ -153,7 +153,7 @@ context('AppMap view filter', () => {
       cy.get('.tabs__controls .popper__button').click();
 
       cy.get('.filters__elapsed input').type('00');
-      cy.get('.filters__checkbox').eq(3).click();
+      cy.get('.filters__checkbox').eq(4).click();
 
       cy.get('.trace .trace-node').should('have.length', 3);
     });
@@ -188,6 +188,44 @@ context('AppMap view filter', () => {
 
       cy.get('.trace-node[data-event-id="1"].highlight').should('exist');
     });
+
+    it('filters external code', () => {
+      cy.get('.tabs .tab-btn').eq(1).click();
+      cy.get('.sequence-actor').should('have.length', 9);
+
+      const expectedInitial = [
+        'HTTP server requests',
+        'app/controllers',
+        'openssl',
+        'active_support',
+        'json',
+        'app/helpers',
+        'lib',
+        '127.0.0.1:9515',
+        'Database',
+      ];
+
+      cy.get('.sequence-actor').each(($el, index) => {
+        cy.wrap($el).should('contain.text', expectedInitial[index]);
+      });
+
+      cy.get('.popper__button').click();
+      cy.get('.filters__checkbox').eq(2).click();
+      cy.get('.sequence-actor').should('have.length', 6);
+
+      const expectedFiltered = [
+        'HTTP server requests',
+        'app/controllers',
+        'app/helpers',
+        'lib',
+        '127.0.0.1:9515',
+        'Database',
+      ];
+
+      cy.get('.sequence-actor').each(($el, index) => {
+        cy.wrap($el).should('contain.text', expectedFiltered[index]);
+      });
+    });
   });
 
   context('without HTTP events', () => {
@@ -200,6 +238,22 @@ context('AppMap view filter', () => {
     it('"Limit root events to HTTP" filter is disabled', () => {
       cy.get('.popper__button').click();
       cy.get('.filters__checkbox input[type="checkbox"]').first().should('not.be.checked');
+    });
+  });
+
+  context('in a Java map', () => {
+    beforeEach(() => {
+      cy.visit(
+        'http://localhost:6006/iframe.html?args=&id=pages-vs-code--extension-java&viewMode=story'
+      );
+    });
+
+    it('does not show the hide external code checkbox', () => {
+      cy.get('.popper__button').click();
+      cy.get('.filters__block-row-content').should('have.length', 5);
+      cy.get('.filters__block-row-content').each(($el) =>
+        cy.wrap($el).should('not.contain.text', 'Hide external code')
+      );
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -213,7 +213,7 @@ __metadata:
   resolution: "@appland/components@workspace:packages/components"
   dependencies:
     "@appland/diagrams": "workspace:^1.6.2"
-    "@appland/models": "workspace:^2.6.0"
+    "@appland/models": "workspace:^2.6.1"
     "@appland/sequence-diagram": "workspace:^1.5.2"
     "@babel/core": ^7.13.1
     "@babel/node": ^7.13.0
@@ -320,7 +320,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@appland/models@workspace:*, @appland/models@workspace:^2.2.0, @appland/models@workspace:^2.6.0, @appland/models@workspace:packages/models":
+"@appland/models@workspace:*, @appland/models@workspace:^2.2.0, @appland/models@workspace:^2.6.0, @appland/models@workspace:^2.6.1, @appland/models@workspace:packages/models":
   version: 0.0.0-use.local
   resolution: "@appland/models@workspace:packages/models"
   dependencies:


### PR DESCRIPTION
Fixes #1175 

Adds the ability for users to filter external code:

![image](https://github.com/getappmap/appmap-js/assets/45714532/85330f72-b2e8-4290-97b8-5ec21cc0bf35)

This option only appears in Ruby and JavaScript maps because we're only filtering out external code in `vendor` and `node_modules` at the moment.