### PR TITLE
Serialize and deserialize work correctly for hide external

### DIFF
--- a/packages/models/src/serialize.js
+++ b/packages/models/src/serialize.js
@@ -49,8 +49,7 @@ export function serializeFilter(filter) {
     limitRootEvents: declutter.limitRootEvents.on,
     hideMediaRequests: declutter.hideMediaRequests.on,
     hideUnlabeled: declutter.hideUnlabeled.on,
-    hideExternal: declutter.hideExternalPaths.on,
-    dependencyFolders: declutter.hideExternalPaths.on
+    hideExternalPaths: declutter.hideExternalPaths.on
       ? declutter.hideExternalPaths.dependencyFolders
       : false,
     hideElapsedTimeUnder: declutter.hideElapsedTimeUnder.on
@@ -107,7 +106,8 @@ export function deserializeFilter(filterState) {
   }
   ['hideExternal', 'hideExternalPaths'].forEach((key) => {
     if (key in filterState) {
-      filter.declutter.hideExternalPaths.on = filterState[key];
+      filter.declutter.hideExternalPaths.on = true;
+      filter.declutter.hideExternalPaths.dependencyFolders = filterState[key];
     }
   });
   if ('dependencyFolders' in filterState && filterState.dependencyFolders !== false) {

--- a/packages/models/tests/unit/serialize.spec.js
+++ b/packages/models/tests/unit/serialize.spec.js
@@ -1,0 +1,81 @@
+import { serializeFilter, deserializeFilter, AppMapFilter } from '@appland/models';
+
+const TEST_STATE = {
+  hideElapsedTimeUnder: 1,
+  hideMediaRequests: false,
+  hideName: ['package:activesupport'],
+  hideUnlabeled: true,
+  limitRootEvents: false,
+  hideExternalPaths: ['vendor', 'node_modules'],
+};
+
+function stateObjectToBase64(stateObject) {
+  return Buffer.from(JSON.stringify(stateObject), 'utf-8').toString('base64url');
+}
+
+describe('serializeFilter', () => {
+  it('handles default values', () => {
+    const filter = new AppMapFilter();
+    const serialized = serializeFilter(filter);
+    expect(serialized).toStrictEqual({});
+  });
+
+  it('handles non-default values', () => {
+    const filter = new AppMapFilter();
+
+    filter.declutter.limitRootEvents.on = false;
+    filter.declutter.hideMediaRequests.on = false;
+    filter.declutter.hideUnlabeled.on = true;
+    filter.declutter.hideElapsedTimeUnder.on = true;
+    filter.declutter.hideElapsedTimeUnder.time = 1;
+    filter.declutter.hideName.on = true;
+    filter.declutter.hideName.names = ['package:activesupport'];
+    filter.declutter.hideExternalPaths.on = true;
+
+    const serialized = serializeFilter(filter);
+    expect(serialized).toStrictEqual(TEST_STATE);
+  });
+});
+
+describe('deserializeFilter', () => {
+  it('handles default values', () => {
+    const deserialized = deserializeFilter({});
+    const expectedFilter = new AppMapFilter();
+    expect(deserialized).toStrictEqual(expectedFilter);
+  });
+
+  it('handles non-default values', () => {
+    const deserialized = deserializeFilter(TEST_STATE);
+
+    const expectedFilter = new AppMapFilter();
+
+    expectedFilter.declutter.limitRootEvents.on = false;
+    expectedFilter.declutter.hideMediaRequests.on = false;
+    expectedFilter.declutter.hideUnlabeled.on = true;
+    expectedFilter.declutter.hideElapsedTimeUnder.on = true;
+    expectedFilter.declutter.hideElapsedTimeUnder.time = 1;
+    expectedFilter.declutter.hideName.on = true;
+    expectedFilter.declutter.hideName.names = ['package:activesupport'];
+    expectedFilter.declutter.hideExternalPaths.on = true;
+
+    expect(deserialized).toStrictEqual(expectedFilter);
+  });
+
+  it('handles base64-encoded strings', () => {
+    const base64Encoded = stateObjectToBase64(TEST_STATE);
+    const deserialized = deserializeFilter(base64Encoded);
+
+    const expectedFilter = new AppMapFilter();
+
+    expectedFilter.declutter.limitRootEvents.on = false;
+    expectedFilter.declutter.hideMediaRequests.on = false;
+    expectedFilter.declutter.hideUnlabeled.on = true;
+    expectedFilter.declutter.hideElapsedTimeUnder.on = true;
+    expectedFilter.declutter.hideElapsedTimeUnder.time = 1;
+    expectedFilter.declutter.hideName.on = true;
+    expectedFilter.declutter.hideName.names = ['package:activesupport'];
+    expectedFilter.declutter.hideExternalPaths.on = true;
+
+    expect(deserialized).toStrictEqual(expectedFilter);
+  });
+});


### PR DESCRIPTION
Fixes #1185 

This needs to be merged and a new version of `models` needs to be released before the [`Hide external code` filter option PR](https://github.com/getappmap/appmap-js/pull/1178) can be merged and released.

This PR fixes the `serialize` and `deserialize` functions in `models` that was not working with the `hideExternalPaths` declutter field.