### PR TITLE
User can bookmark filter settings

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -74,7 +74,7 @@
     "@appland/client": "workspace:^1",
     "@appland/components": "workspace:^2",
     "@appland/diagrams": "workspace:^1",
-    "@appland/models": "workspace:^2.6.0",
+    "@appland/models": "workspace:^2.6.2",
     "@appland/openapi": "workspace:^1.4.3",
     "@appland/sequence-diagram": "workspace:^1",
     "@sidvind/better-ajv-errors": "^0.9.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -28,7 +28,7 @@
   ],
   "dependencies": {
     "@appland/diagrams": "workspace:^1.6.2",
-    "@appland/models": "workspace:^2.6.1",
+    "@appland/models": "workspace:^2.6.2",
     "@appland/sequence-diagram": "workspace:^1.5.2",
     "buffer": "^6.0.3",
     "d3": "^7.8.4",

--- a/packages/components/src/components/FilterMenu.vue
+++ b/packages/components/src/components/FilterMenu.vue
@@ -120,7 +120,7 @@
         <div class="filters__block-row">
           <div class="filters__block-row-content">
             Filter:
-            <select class="filters__select" v-model="selectedFilter">
+            <select class="filters__select" v-model="selectedSavedFilter">
               <option
                 v-for="savedFilter in savedFilters"
                 :value="savedFilter"
@@ -172,7 +172,7 @@ import {
   REMOVE_ROOT_OBJECT,
   ADD_HIDDEN_NAME,
   REMOVE_HIDDEN_NAME,
-  SET_SELECTED_FILTER,
+  SET_SELECTED_SAVED_FILTER,
   DEFAULT_FILTER_NAME,
 } from '@/store/vsCode';
 import { serializeFilter, base64UrlEncode } from '@appland/models';
@@ -211,12 +211,12 @@ export default {
       return this.$store.state.savedFilters;
     },
 
-    selectedFilter: {
+    selectedSavedFilter: {
       get() {
-        return this.$store.state.selectedFilter;
+        return this.$store.state.selectedSavedFilter;
       },
       set(value) {
-        this.$store.commit(SET_SELECTED_FILTER, value);
+        this.$store.commit(SET_SELECTED_SAVED_FILTER, value);
       },
     },
 
@@ -309,13 +309,14 @@ export default {
     },
 
     defaultButtonClass() {
-      const suffix = this.selectedFilter && this.selectedFilter.default ? '-disabled' : '';
+      const suffix =
+        this.selectedSavedFilter && this.selectedSavedFilter.default ? '-disabled' : '';
       return 'filters__button' + suffix;
     },
 
     deleteButtonClass() {
       const suffix =
-        this.selectedFilter && this.selectedFilter.filterName === DEFAULT_FILTER_NAME
+        this.selectedSavedFilter && this.selectedSavedFilter.filterName === DEFAULT_FILTER_NAME
           ? '-disabled'
           : '';
       return 'filters__button' + suffix;
@@ -348,33 +349,37 @@ export default {
 
     saveFilter() {
       const filterName = this.newFilterName.trim();
-      if (this.newFilterName.trim() === '') return;
+      if (this.newFilterName.trim() === '' || this.newFilterName === DEFAULT_FILTER_NAME) {
+        this.newFilterName = '';
+        return;
+      }
 
       const serializedFilter = serializeFilter(this.filters);
       const state = base64UrlEncode(JSON.stringify({ filters: serializedFilter }));
       const filterToSave = { filterName, state, default: false };
 
-      this.$store.commit(SET_SELECTED_FILTER, filterToSave);
+      this.$store.commit(SET_SELECTED_SAVED_FILTER, filterToSave);
       this.$root.$emit('saveFilter', filterToSave);
 
       this.newFilterName = '';
     },
 
     applyFilter() {
-      this.$emit('setState', this.selectedFilter.state);
+      this.$emit('setState', this.selectedSavedFilter.state);
     },
 
     deleteFilter() {
-      if (this.selectedFilter.filterName === DEFAULT_FILTER_NAME) return;
-      this.$root.$emit('deleteFilter', this.selectedFilter);
+      if (this.selectedSavedFilter.filterName === DEFAULT_FILTER_NAME) return;
+      this.$root.$emit('deleteFilter', this.selectedSavedFilter);
     },
 
     setAsDefault() {
-      this.$root.$emit('defaultFilter', this.selectedFilter);
+      this.$root.$emit('defaultFilter', this.selectedSavedFilter);
     },
 
     copyFilterState() {
-      const state = this.$store.state.selectedFilter && this.$store.state.selectedFilter.state;
+      const state =
+        this.$store.state.selectedSavedFilter && this.$store.state.selectedSavedFilter.state;
       if (!state) return;
       navigator.clipboard.writeText(state);
 

--- a/packages/components/src/components/PopperMenu.vue
+++ b/packages/components/src/components/PopperMenu.vue
@@ -101,7 +101,7 @@ export default {
     width: max-content;
     height: max-content;
     max-width: 70vw;
-    max-height: 70vh;
+    max-height: 85vh;
     margin-top: 1.5rem;
     padding: 1rem;
     font-family: $appland-text-font-family;

--- a/packages/components/src/pages/VsCodeExtension.vue
+++ b/packages/components/src/pages/VsCodeExtension.vue
@@ -757,7 +757,7 @@ export default {
       const hasClassMap =
         Array.isArray(appMap.classMap.codeObjects) && appMap.classMap.codeObjects.length;
 
-      return !this.eventFilterText && (!hasEvents || !hasClassMap);
+      return !this.filtersChanged && !this.eventFilterText && (!hasEvents || !hasClassMap);
     },
 
     isGiantAppMap() {
@@ -767,11 +767,18 @@ export default {
     filtersChanged() {
       return (
         this.filters.rootObjects.length > 0 ||
-        Object.values(this.filters.declutter).some(
-          (f) =>
-            (typeof f.on === 'boolean' && f.on !== f.default) ||
-            (typeof on === 'function' && f.on() !== f.default)
-        )
+        Object.keys(this.filters.declutter).some((declutterPropertyName) => {
+          // This might get set to a non-default value if the map does not have an HTTP root
+          if (declutterPropertyName === 'limitRootEvents') return false;
+
+          const declutterProperty = this.filters.declutter[declutterPropertyName];
+          const on = declutterProperty.on;
+
+          return (
+            (typeof on === 'boolean' && on !== declutterProperty.default) ||
+            (typeof on === 'function' && on() !== declutterProperty.default)
+          );
+        })
       );
     },
 

--- a/packages/components/src/pages/VsCodeExtension.vue
+++ b/packages/components/src/pages/VsCodeExtension.vue
@@ -196,7 +196,11 @@
               </v-popper>
             </template>
             <template v-slot:body>
-              <v-filter-menu :filteredAppMap="filteredAppMap"></v-filter-menu>
+              <v-filter-menu
+                :filteredAppMap="filteredAppMap"
+                :initialSavedFilters="savedFilters"
+                @setState="(stateString) => setState(stateString)"
+              ></v-filter-menu>
             </template>
           </v-popper-menu>
           <v-popper class="hover-text-popper" text="Reload map" placement="left" text-align="left">
@@ -368,10 +372,11 @@ import {
   CLEAR_EXPANDED_PACKAGES,
   SET_FILTER,
   SET_DECLUTTER_ON,
-  SET_DECLUTTER_DEFAULT,
   RESET_FILTERS,
   ADD_ROOT_OBJECT,
   REMOVE_ROOT_OBJECT,
+  SET_SAVED_FILTERS,
+  SET_SELECTED_FILTER,
 } from '../store/vsCode';
 
 export default {
@@ -443,6 +448,10 @@ export default {
     flamegraphEnabled: {
       type: Boolean,
       default: false,
+    },
+    savedFilters: {
+      type: Array,
+      default: () => [],
     },
   },
 
@@ -748,7 +757,7 @@ export default {
       const hasClassMap =
         Array.isArray(appMap.classMap.codeObjects) && appMap.classMap.codeObjects.length;
 
-      return !this.filtersChanged && !this.eventFilterText && (!hasEvents || !hasClassMap);
+      return !this.eventFilterText && (!hasEvents || !hasClassMap);
     },
 
     isGiantAppMap() {
@@ -779,19 +788,20 @@ export default {
   methods: {
     loadData(data) {
       this.$store.commit(SET_APPMAP_DATA, data);
+      this.initializeSavedFilters();
 
       const rootEvents = this.$store.state.appMap.rootEvents();
       const hasHttpRoot = rootEvents.some((e) => e.httpServerRequest);
+      const isUsingAppMapDefault = this.$store.state.savedFilters.some(
+        (savedFilter) => savedFilter.filterName === 'AppMap default' && savedFilter.default
+      );
 
-      this.$store.commit(SET_DECLUTTER_ON, {
-        declutterProperty: 'limitRootEvents',
-        value: hasHttpRoot,
-      });
-
-      this.$store.commit(SET_DECLUTTER_DEFAULT, {
-        declutterProperty: 'limitRootEvents',
-        value: hasHttpRoot,
-      });
+      if (isUsingAppMapDefault && !hasHttpRoot) {
+        this.$store.commit(SET_DECLUTTER_ON, {
+          declutterProperty: 'limitRootEvents',
+          value: hasHttpRoot,
+        });
+      }
 
       this.isLoading = false;
     },
@@ -973,6 +983,14 @@ export default {
         const { filters, expandedPackages } = state;
         if (filters) this.$store.commit(SET_FILTER, deserializeFilter(filters));
 
+        const base64EncodedFilters = base64UrlEncode(JSON.stringify({ filters }));
+        const selectedFilter =
+          this.$store.state.savedFilters &&
+          this.$store.state.savedFilters.find(
+            (savedFilter) => savedFilter.state === base64EncodedFilters
+          );
+        if (selectedFilter) this.$store.commit(SET_SELECTED_FILTER, selectedFilter);
+
         if (expandedPackages) {
           const codeObjects = expandedPackages.map((expandedPackageId) =>
             this.filteredAppMap.classMap.codeObjectFromId(expandedPackageId)
@@ -1146,6 +1164,21 @@ export default {
       if (this.eventFilterMatch) {
         this.$store.commit(SELECT_CODE_OBJECT, this.eventFilterMatch);
       }
+    },
+
+    initializeSavedFilters() {
+      const savedFilters = this.savedFilters;
+      this.$store.commit(SET_SAVED_FILTERS, savedFilters);
+
+      const defaultFilter = savedFilters.find((savedFilter) => savedFilter.default);
+      if (defaultFilter) {
+        this.$store.commit(SET_SELECTED_FILTER, defaultFilter);
+        this.setState(defaultFilter.state);
+      }
+    },
+
+    updateFilters(updatedFilters) {
+      this.$store.commit(SET_SAVED_FILTERS, updatedFilters);
     },
   },
 

--- a/packages/components/src/pages/VsCodeExtension.vue
+++ b/packages/components/src/pages/VsCodeExtension.vue
@@ -376,7 +376,7 @@ import {
   ADD_ROOT_OBJECT,
   REMOVE_ROOT_OBJECT,
   SET_SAVED_FILTERS,
-  SET_SELECTED_FILTER,
+  SET_SELECTED_SAVED_FILTER,
 } from '../store/vsCode';
 
 export default {
@@ -989,7 +989,7 @@ export default {
           this.$store.state.savedFilters.find(
             (savedFilter) => savedFilter.state === base64EncodedFilters
           );
-        if (selectedFilter) this.$store.commit(SET_SELECTED_FILTER, selectedFilter);
+        if (selectedFilter) this.$store.commit(SET_SELECTED_SAVED_FILTER, selectedFilter);
 
         if (expandedPackages) {
           const codeObjects = expandedPackages.map((expandedPackageId) =>
@@ -1172,7 +1172,7 @@ export default {
 
       const defaultFilter = savedFilters.find((savedFilter) => savedFilter.default);
       if (defaultFilter) {
-        this.$store.commit(SET_SELECTED_FILTER, defaultFilter);
+        this.$store.commit(SET_SELECTED_SAVED_FILTER, defaultFilter);
         this.setState(defaultFilter.state);
       }
     },

--- a/packages/components/src/store/vsCode.js
+++ b/packages/components/src/store/vsCode.js
@@ -35,7 +35,7 @@ export const REMOVE_ROOT_OBJECT = 'removeRootObject';
 export const ADD_HIDDEN_NAME = 'addHiddenName';
 export const REMOVE_HIDDEN_NAME = 'removeHiddenName';
 export const SET_SAVED_FILTERS = 'setSavedFilters';
-export const SET_SELECTED_FILTER = 'setSelectedFilter';
+export const SET_SELECTED_SAVED_FILTER = 'setselectedSavedFilter';
 export const DEFAULT_VIEW = VIEW_COMPONENT;
 export const DEFAULT_FILTER_NAME = 'AppMap default';
 
@@ -63,7 +63,7 @@ export function buildStore() {
       expandedPackages: [],
       filters: new AppMapFilter(),
       savedFilters: [],
-      selectedFilter: null,
+      selectedSavedFilter: null,
       defaultFilter: null,
     },
 
@@ -170,7 +170,7 @@ export function buildStore() {
           const parsedState = JSON.parse(filterStateString);
 
           newDefault = deserializeFilter(parsedState.filters);
-          state.selectedFilter = defaultFilter;
+          state.selectedSavedFilter = defaultFilter;
         } else {
           newDefault = new AppMapFilter();
         }
@@ -206,17 +206,17 @@ export function buildStore() {
         state.savedFilters = savedFilters;
         state.savedFilters.sort(savedFiltersSorter);
 
-        const selectedFilter = state.selectedFilter;
-        if (selectedFilter) {
-          const newSelectedFilter = state.savedFilters.find(
-            (savedFilter) => savedFilter.filterName === selectedFilter.filterName
+        const selectedSavedFilter = state.selectedSavedFilter;
+        if (selectedSavedFilter) {
+          const newselectedSavedFilter = state.savedFilters.find(
+            (savedFilter) => savedFilter.filterName === selectedSavedFilter.filterName
           );
-          if (newSelectedFilter) state.selectedFilter = newSelectedFilter;
+          if (newselectedSavedFilter) state.selectedSavedFilter = newselectedSavedFilter;
         }
       },
 
-      [SET_SELECTED_FILTER](state, selectedFilter) {
-        state.selectedFilter = selectedFilter;
+      [SET_SELECTED_SAVED_FILTER](state, selectedSavedFilter) {
+        state.selectedSavedFilter = selectedSavedFilter;
       },
     },
   });

--- a/packages/components/src/stories/ViewFilterMenu.stories.js
+++ b/packages/components/src/stories/ViewFilterMenu.stories.js
@@ -1,0 +1,31 @@
+import VFilterMenu from '@/components/FilterMenu.vue';
+import {
+  buildStore,
+  SET_APPMAP_DATA,
+  SET_SAVED_FILTERS,
+  SET_SELECTED_FILTER,
+} from '@/store/vsCode';
+import scenario from './data/scenario.json';
+import savedFilters from './data/saved_filters.js';
+
+const store = buildStore();
+store.commit(SET_APPMAP_DATA, scenario);
+store.commit(SET_SAVED_FILTERS, savedFilters);
+store.commit(SET_SELECTED_FILTER, savedFilters[0]);
+const filteredAppMap = store.state.appMap;
+
+export default {
+  title: 'Pages/VS Code',
+  component: VFilterMenu,
+};
+
+const Template = (args, { argTypes }) => ({
+  props: Object.keys(argTypes),
+  components: { VFilterMenu },
+  template:
+    '<v-filter-menu v-bind="$props" :style="{ color: \'white\', backgroundColor: \'#242c41\' }" />',
+  store,
+});
+
+export const filterMenu = Template.bind({});
+filterMenu.args = { filteredAppMap };

--- a/packages/components/src/stories/ViewFilterMenu.stories.js
+++ b/packages/components/src/stories/ViewFilterMenu.stories.js
@@ -3,7 +3,7 @@ import {
   buildStore,
   SET_APPMAP_DATA,
   SET_SAVED_FILTERS,
-  SET_SELECTED_FILTER,
+  SET_SELECTED_SAVED_FILTER,
 } from '@/store/vsCode';
 import scenario from './data/scenario.json';
 import savedFilters from './data/saved_filters.js';
@@ -11,7 +11,7 @@ import savedFilters from './data/saved_filters.js';
 const store = buildStore();
 store.commit(SET_APPMAP_DATA, scenario);
 store.commit(SET_SAVED_FILTERS, savedFilters);
-store.commit(SET_SELECTED_FILTER, savedFilters[0]);
+store.commit(SET_SELECTED_SAVED_FILTER, savedFilters[0]);
 const filteredAppMap = store.state.appMap;
 
 export default {

--- a/packages/components/src/stories/VsCodeExtension.stories.js
+++ b/packages/components/src/stories/VsCodeExtension.stories.js
@@ -1,5 +1,5 @@
 import VVsCodeExtension from '@/pages/VsCodeExtension.vue';
-import { VIEW_SEQUENCE } from '@/store/vsCode';
+import { VIEW_SEQUENCE, DEFAULT_FILTER_NAME } from '@/store/vsCode';
 import defaultScenario from './data/scenario.json';
 import pruned from './data/scenario_pruned.json';
 import giant from './data/giant_map.json';
@@ -45,6 +45,13 @@ export default {
   args: {
     appMapUploadable: true,
     flamegraphEnabled: true,
+    savedFilters: [
+      {
+        filterName: DEFAULT_FILTER_NAME,
+        state: 'eyJmaWx0ZXJzIjp7fX0',
+        default: true,
+      },
+    ],
   },
 };
 

--- a/packages/components/src/stories/VsCodeExtension.stories.js
+++ b/packages/components/src/stories/VsCodeExtension.stories.js
@@ -76,6 +76,29 @@ extensionWithDefaultSequenceView.args = {
   defaultView: VIEW_SEQUENCE,
 };
 
+export const extensionWithSavedFilters = Template.bind({});
+extensionWithSavedFilters.args = {
+  defaultView: VIEW_SEQUENCE,
+  savedFilters: [
+    {
+      filterName: DEFAULT_FILTER_NAME,
+      state: 'eyJmaWx0ZXJzIjp7fX0',
+      default: true,
+    },
+    {
+      filterName: 'another test',
+      state: 'eyJmaWx0ZXJzIjp7ImxpbWl0Um9vdEV2ZW50cyI6ZmFsc2UsImhpZGVVbmxhYmVsZWQiOnRydWV9fQ',
+      default: false,
+    },
+    {
+      filterName: 'filter',
+      state:
+        'eyJmaWx0ZXJzIjp7ImxpbWl0Um9vdEV2ZW50cyI6ZmFsc2UsImhpZGVNZWRpYVJlcXVlc3RzIjpmYWxzZSwiaGlkZUVsYXBzZWRUaW1lVW5kZXIiOjF9fQ',
+      default: false,
+    },
+  ],
+};
+
 export const extensionWithNotification = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
   components: { VVsCodeExtension },

--- a/packages/components/src/stories/VsCodeExtension.stories.js
+++ b/packages/components/src/stories/VsCodeExtension.stories.js
@@ -1,5 +1,5 @@
 import VVsCodeExtension from '@/pages/VsCodeExtension.vue';
-import { VIEW_SEQUENCE, DEFAULT_FILTER_NAME } from '@/store/vsCode';
+import { VIEW_SEQUENCE } from '@/store/vsCode';
 import defaultScenario from './data/scenario.json';
 import pruned from './data/scenario_pruned.json';
 import giant from './data/giant_map.json';
@@ -11,6 +11,7 @@ import mapWithFindings from './data/appmap_with_finding.json';
 import mapWithTwoFindings from './data/appmap_with_two_findings.json';
 import patchNotes from './data/patch_notes_html';
 import bindResolvePath from './support/resolvePath';
+import savedFilters from './data/saved_filters.js';
 import './scss/fullscreen.scss';
 
 const scenarioData = {
@@ -45,13 +46,7 @@ export default {
   args: {
     appMapUploadable: true,
     flamegraphEnabled: true,
-    savedFilters: [
-      {
-        filterName: DEFAULT_FILTER_NAME,
-        state: 'eyJmaWx0ZXJzIjp7fX0',
-        default: true,
-      },
-    ],
+    savedFilters: [savedFilters[0]],
   },
 };
 
@@ -79,24 +74,7 @@ extensionWithDefaultSequenceView.args = {
 export const extensionWithSavedFilters = Template.bind({});
 extensionWithSavedFilters.args = {
   defaultView: VIEW_SEQUENCE,
-  savedFilters: [
-    {
-      filterName: DEFAULT_FILTER_NAME,
-      state: 'eyJmaWx0ZXJzIjp7fX0',
-      default: true,
-    },
-    {
-      filterName: 'another test',
-      state: 'eyJmaWx0ZXJzIjp7ImxpbWl0Um9vdEV2ZW50cyI6ZmFsc2UsImhpZGVVbmxhYmVsZWQiOnRydWV9fQ',
-      default: false,
-    },
-    {
-      filterName: 'filter',
-      state:
-        'eyJmaWx0ZXJzIjp7ImxpbWl0Um9vdEV2ZW50cyI6ZmFsc2UsImhpZGVNZWRpYVJlcXVlc3RzIjpmYWxzZSwiaGlkZUVsYXBzZWRUaW1lVW5kZXIiOjF9fQ',
-      default: false,
-    },
-  ],
+  savedFilters,
 };
 
 export const extensionWithNotification = (args, { argTypes }) => ({

--- a/packages/components/src/stories/data/saved_filters.js
+++ b/packages/components/src/stories/data/saved_filters.js
@@ -1,0 +1,20 @@
+import { DEFAULT_FILTER_NAME } from '@/store/vsCode';
+
+export default [
+  {
+    filterName: DEFAULT_FILTER_NAME,
+    state: 'eyJmaWx0ZXJzIjp7fX0',
+    default: true,
+  },
+  {
+    filterName: 'another test',
+    state: 'eyJmaWx0ZXJzIjp7ImxpbWl0Um9vdEV2ZW50cyI6ZmFsc2UsImhpZGVVbmxhYmVsZWQiOnRydWV9fQ',
+    default: false,
+  },
+  {
+    filterName: 'filter',
+    state:
+      'eyJmaWx0ZXJzIjp7ImxpbWl0Um9vdEV2ZW50cyI6ZmFsc2UsImhpZGVNZWRpYVJlcXVlc3RzIjpmYWxzZSwiaGlkZUVsYXBzZWRUaW1lVW5kZXIiOjF9fQ',
+    default: false,
+  },
+];

--- a/packages/components/tests/e2e/specs/appmap/viewFilter.spec.js
+++ b/packages/components/tests/e2e/specs/appmap/viewFilter.spec.js
@@ -41,7 +41,7 @@ context('AppMap view filter', () => {
       cy.get('.filters__form-input').first().type('{enter}');
       cy.get('.filters__form-suggestions').should('be.visible');
       cy.get('.nodes .node').should('have.length', 9);
-      cy.get('.filters__form-suggestions-item').eq(1).click();
+      cy.get('.filters__form-suggestions-item').first().click();
       cy.get('.nodes .node').should('have.length', 3);
       cy.get('.filters .filters__root .filters__root-icon').click();
       cy.get('.nodes .node').should('have.length', 9);
@@ -49,7 +49,7 @@ context('AppMap view filter', () => {
       cy.get('.tabs .tab-btn').contains('Trace View').click();
       cy.get('.trace .trace-node').should('have.length', 4);
       cy.get('.tabs__controls .popper__button').click();
-      cy.get('.filters__checkbox').eq(0).click();
+      cy.get('.filters__checkbox').first().click();
       cy.get('.filters__form-input')
         .first()
         .type('route:HTTP server requests->GET /admin/orders')
@@ -250,7 +250,7 @@ context('AppMap view filter', () => {
 
     it('does not show the hide external code checkbox', () => {
       cy.get('.popper__button').click();
-      cy.get('.filters__block-row-content').should('have.length', 5);
+      cy.get('.filters__block-row-content').should('have.length', 8);
       cy.get('.filters__block-row-content').each(($el) =>
         cy.wrap($el).should('not.contain.text', 'Hide external code')
       );

--- a/packages/components/tests/e2e/specs/appmap/viewFilter.spec.js
+++ b/packages/components/tests/e2e/specs/appmap/viewFilter.spec.js
@@ -228,6 +228,54 @@ context('AppMap view filter', () => {
     });
   });
 
+  context('with savedFilters', () => {
+    beforeEach(() => {
+      cy.visit(
+        'http://localhost:6006/iframe.html?args=&id=pages-vs-code--extension-with-saved-filters&viewMode=story'
+      );
+    });
+
+    it('disables the delete and default buttons for AppMap default filter', () => {
+      cy.get('.tabs .tab-btn').contains('Trace View').click();
+      cy.get('.trace .trace-node').should('have.length', 4);
+      cy.get('.tabs__controls .popper__button').click();
+
+      cy.get('.filters__select').find(':selected').should('contain.text', 'AppMap default');
+      cy.get('.filters__button').eq(1).should('contain.text', 'Apply');
+      cy.get('.filters__button').eq(2).should('contain.text', 'Copy');
+      cy.get('.filters__button-disabled').first().should('contain.text', 'Delete');
+      cy.get('.filters__button-disabled').eq(1).should('contain.text', 'Set as default');
+    });
+
+    it('enables all buttons for a non-default filter', () => {
+      cy.get('.tabs .tab-btn').contains('Trace View').click();
+      cy.get('.trace .trace-node').should('have.length', 4);
+      cy.get('.tabs__controls .popper__button').click();
+
+      cy.get('.filters__select').select('filter');
+      cy.get('.filters__select').find(':selected').should('contain.text', 'filter');
+      cy.get('.filters__button').eq(1).should('contain.text', 'Apply');
+      cy.get('.filters__button').eq(2).should('contain.text', 'Delete');
+      cy.get('.filters__button').eq(3).should('contain.text', 'Set as default');
+      cy.get('.filters__button').eq(4).should('contain.text', 'Copy');
+      cy.get('.filters__button-disabled').should('not.exist');
+    });
+
+    it('correctly applies a saved filter', () => {
+      cy.get('.tabs .tab-btn').first().click();
+      cy.get('.nodes .node').should('have.length', 9);
+
+      cy.get('.tabs__controls .popper__button').click();
+      cy.get('.filters__select').select('filter');
+      cy.get('[data-cy="apply-filter-button"]').click();
+      cy.get('.nodes .node').should('have.length', 5);
+
+      cy.get('.filters__select').select('another test');
+      cy.get('[data-cy="apply-filter-button"]').click();
+      cy.get('.nodes .node').should('have.length', 6);
+    });
+  });
+
   context('without HTTP events', () => {
     beforeEach(() => {
       cy.visit(

--- a/packages/components/tests/unit/filterMenu.spec.js
+++ b/packages/components/tests/unit/filterMenu.spec.js
@@ -1,0 +1,98 @@
+import { mount, createWrapper } from '@vue/test-utils';
+import FilterMenu from '@/components/FilterMenu.vue';
+import { store, SET_SAVED_FILTERS, SET_SELECTED_FILTER, DEFAULT_FILTER_NAME } from '@/store/vsCode';
+import data from './fixtures/user_page_scenario.appmap.json';
+import { buildAppMap, AppMapFilter } from '@appland/models';
+
+const defaultFilter = {
+  filterName: DEFAULT_FILTER_NAME,
+  state: 'eyJmaWx0ZXJzIjp7fX0',
+  default: true,
+};
+
+const savedFilters = [
+  defaultFilter,
+  {
+    filterName: 'another test',
+    state: 'eyJmaWx0ZXJzIjp7ImxpbWl0Um9vdEV2ZW50cyI6ZmFsc2UsImhpZGVVbmxhYmVsZWQiOnRydWV9fQ',
+    default: false,
+  },
+  {
+    filterName: 'filter',
+    state:
+      'eyJmaWx0ZXJzIjp7ImxpbWl0Um9vdEV2ZW50cyI6ZmFsc2UsImhpZGVNZWRpYVJlcXVlc3RzIjpmYWxzZSwiaGlkZUVsYXBzZWRUaW1lVW5kZXIiOjF9fQ',
+    default: false,
+  },
+];
+
+const filterToSave = {
+  filterName: 'test',
+  state: 'eyJmaWx0ZXJzIjp7ImhpZGVVbmxhYmVsZWQiOnRydWV9fQ',
+};
+
+store.commit(SET_SAVED_FILTERS, savedFilters);
+
+describe('FilterMenu.vue', () => {
+  let clipboardText;
+  Object.assign(navigator, {
+    clipboard: {
+      async writeText(val) {
+        clipboardText = val;
+        return Promise.resolve();
+      },
+      async readText() {
+        return Promise.resolve(clipboardText);
+      },
+    },
+  });
+
+  let wrapper; // Wrapper<Vue>
+  let rootWrapper; // Wrapper<Vue>
+
+  beforeEach(() => {
+    const filter = new AppMapFilter();
+    const appMap = buildAppMap().source(data).normalize().build();
+    const propsData = { filteredAppMap: filter.filter(appMap) };
+    const mocks = { navigator };
+    store.commit(SET_SELECTED_FILTER, defaultFilter);
+    wrapper = mount(FilterMenu, { propsData, store, mocks });
+    rootWrapper = createWrapper(wrapper.vm.$root);
+  });
+
+  it('emits the correct event when deleting', () => {
+    expect(rootWrapper.emitted()['deleteFilter']).toBeUndefined();
+    expect(wrapper.find('option:checked').text()).toBe('AppMap default');
+    wrapper.find('select.filters__select').findAll('option').at(1).setSelected();
+    expect(wrapper.find('option:checked').text()).toBe('another test');
+    wrapper.find('[data-cy="delete-filter-button"]').trigger('click');
+    expect(rootWrapper.emitted()['deleteFilter']).toBeArrayOfSize(1);
+    expect(rootWrapper.emitted()['deleteFilter']).toMatchObject([[savedFilters[1]]]);
+  });
+
+  it('emits the correct event when setting as default', () => {
+    expect(rootWrapper.emitted()['defaultFilter']).toBeUndefined();
+    expect(wrapper.find('option:checked').text()).toBe('AppMap default');
+    wrapper.find('select.filters__select').findAll('option').at(1).setSelected();
+    expect(wrapper.find('option:checked').text()).toBe('another test');
+    wrapper.find('[data-cy="default-filter-button"]').trigger('click');
+    expect(rootWrapper.emitted()['defaultFilter']).toBeArrayOfSize(1);
+    expect(rootWrapper.emitted()['defaultFilter']).toMatchObject([[savedFilters[1]]]);
+  });
+
+  it('copies the state to the clipboard', async () => {
+    expect(wrapper.find('option:checked').text()).toBe('AppMap default');
+    wrapper.find('[data-cy="copy-filter-button"]').trigger('click');
+    const actualClipboardText = await navigator.clipboard.readText();
+    expect(actualClipboardText).toBe(defaultFilter.state);
+  });
+
+  it('emits the correct event when saving', () => {
+    expect(rootWrapper.emitted()['saveFilter']).toBeUndefined();
+    wrapper.findAll('label.filters__checkbox').at(2).trigger('click');
+    wrapper.find('input.filters__input').setValue('test');
+    expect(wrapper.find('input.filters__input').element.value).toBe('test');
+    wrapper.find('[data-cy="save-filter-button"]').trigger('click');
+    expect(rootWrapper.emitted()['saveFilter']).toBeArrayOfSize(1);
+    expect(rootWrapper.emitted()['saveFilter']).toMatchObject([[filterToSave]]);
+  });
+});

--- a/packages/components/tests/unit/filterMenu.spec.js
+++ b/packages/components/tests/unit/filterMenu.spec.js
@@ -1,6 +1,11 @@
 import { mount, createWrapper } from '@vue/test-utils';
 import FilterMenu from '@/components/FilterMenu.vue';
-import { store, SET_SAVED_FILTERS, SET_SELECTED_FILTER, DEFAULT_FILTER_NAME } from '@/store/vsCode';
+import {
+  store,
+  SET_SAVED_FILTERS,
+  SET_SELECTED_SAVED_FILTER,
+  DEFAULT_FILTER_NAME,
+} from '@/store/vsCode';
 import data from './fixtures/user_page_scenario.appmap.json';
 import { buildAppMap, AppMapFilter } from '@appland/models';
 
@@ -54,7 +59,7 @@ describe('FilterMenu.vue', () => {
     const appMap = buildAppMap().source(data).normalize().build();
     const propsData = { filteredAppMap: filter.filter(appMap) };
     const mocks = { navigator };
-    store.commit(SET_SELECTED_FILTER, defaultFilter);
+    store.commit(SET_SELECTED_SAVED_FILTER, defaultFilter);
     wrapper = mount(FilterMenu, { propsData, store, mocks });
     rootWrapper = createWrapper(wrapper.vm.$root);
   });

--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -26,7 +26,7 @@
     "typescript": "^4.9.5"
   },
   "dependencies": {
-    "@appland/models": "workspace:^2.2.0",
+    "@appland/models": "workspace:^2.6.2",
     "js-yaml": "^4.1.0"
   },
   "publishConfig": {

--- a/packages/scanner/package.json
+++ b/packages/scanner/package.json
@@ -61,7 +61,7 @@
   },
   "dependencies": {
     "@appland/client": "^1.5.0",
-    "@appland/models": "workspace:^2.6.0",
+    "@appland/models": "workspace:^2.6.2",
     "@appland/openapi": "workspace:packages/openapi",
     "@appland/sql-parser": "^1.5.0",
     "@types/cli-progress": "^3.9.2",

--- a/packages/sequence-diagram/package.json
+++ b/packages/sequence-diagram/package.json
@@ -18,7 +18,7 @@
   "author": "AppLand, Inc.",
   "license": "Commons Clause + MIT",
   "dependencies": {
-    "@appland/models": "workspace:^2.2.0",
+    "@appland/models": "workspace:^2.6.2",
     "@appland/openapi": "workspace:^1.4.3",
     "@datastructures-js/priority-queue": "^6.1.3",
     "crypto-js": "^4.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -90,7 +90,7 @@ __metadata:
     "@appland/client": "workspace:^1"
     "@appland/components": "workspace:^2"
     "@appland/diagrams": "workspace:^1"
-    "@appland/models": "workspace:^2.6.0"
+    "@appland/models": "workspace:^2.6.2"
     "@appland/openapi": "workspace:^1.4.3"
     "@appland/sequence-diagram": "workspace:^1"
     "@craftamap/esbuild-plugin-html": ^0.4.0
@@ -213,7 +213,7 @@ __metadata:
   resolution: "@appland/components@workspace:packages/components"
   dependencies:
     "@appland/diagrams": "workspace:^1.6.2"
-    "@appland/models": "workspace:^2.6.1"
+    "@appland/models": "workspace:^2.6.2"
     "@appland/sequence-diagram": "workspace:^1.5.2"
     "@babel/core": ^7.13.1
     "@babel/node": ^7.13.0
@@ -322,7 +322,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@appland/models@workspace:*, @appland/models@workspace:^2.2.0, @appland/models@workspace:^2.6.0, @appland/models@workspace:^2.6.1, @appland/models@workspace:packages/models":
+"@appland/models@workspace:*, @appland/models@workspace:^2.2.0, @appland/models@workspace:^2.6.2, @appland/models@workspace:packages/models":
   version: 0.0.0-use.local
   resolution: "@appland/models@workspace:packages/models"
   dependencies:
@@ -347,7 +347,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@appland/openapi@workspace:packages/openapi"
   dependencies:
-    "@appland/models": "workspace:^2.2.0"
+    "@appland/models": "workspace:^2.6.2"
     "@types/jest": ^29.4.1
     "@types/js-yaml": ^4.0.5
     "@typescript-eslint/eslint-plugin": ^5.7.0
@@ -366,7 +366,7 @@ __metadata:
   resolution: "@appland/scanner@workspace:packages/scanner"
   dependencies:
     "@appland/client": ^1.5.0
-    "@appland/models": "workspace:^2.6.0"
+    "@appland/models": "workspace:^2.6.2"
     "@appland/openapi": "workspace:packages/openapi"
     "@appland/sql-parser": ^1.5.0
     "@semantic-release/changelog": ^6.0.1
@@ -433,7 +433,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@appland/sequence-diagram@workspace:packages/sequence-diagram"
   dependencies:
-    "@appland/models": "workspace:^2.2.0"
+    "@appland/models": "workspace:^2.6.2"
     "@appland/openapi": "workspace:^1.4.3"
     "@datastructures-js/priority-queue": ^6.1.3
     "@types/diff": ^5.0.2


### PR DESCRIPTION
Fixes #1187 

This feature allows users to save filter settings. Users can save the filter settings with a name and then select from previously saved filter settings from a dropdown menu in the filters menu:

![image](https://github.com/getappmap/appmap-js/assets/45714532/1d297941-acc1-4c9b-97b7-b14068e81698)

Because the saved filters need to propagate across AppMaps in the workspace, the VS Code extension handles some of the logic for this feature (and the JetBrains plugin will have to do the same in the future). Therefore, much of the functionality is not present in Storybook.

Features:

- [x] Initially, only the `AppMap default` filter will be in the dropdown menu.
- [x] After selecting a filter from the menu, clicking the `Apply` button will apply the saved settings to the current AppMap.
- [x] Any of the saved filters can be set to be the default filter, this will make it default for the current workspace in VS Code.
- [x] Any of the saved filters can be deleted except for the `AppMap default` filter.
- [x] There is a `Copy` button that will copy the filter state as a base-64-URL-encoded string to the clipboard.
- [x] The `Root` state is not saved, only the `Filter` state.

There was some discussion about including an option to save a new filter as the default filter. I did a quick mock-up of that and I didn't like how it came out, so if we want to add this feature, we'll need to come up with a better design.

![image](https://github.com/getappmap/appmap-js/assets/45714532/6bfdfcc2-750b-4d09-864e-c464d256d5f0)

