### PR TITLE
Add explicit option to serialize

### DIFF
--- a/packages/models/src/serialize.js
+++ b/packages/models/src/serialize.js
@@ -106,8 +106,14 @@ export function deserializeFilter(filterState) {
   }
   ['hideExternal', 'hideExternalPaths'].forEach((key) => {
     if (key in filterState) {
-      filter.declutter.hideExternalPaths.on = true;
-      filter.declutter.hideExternalPaths.dependencyFolders = filterState[key];
+      const value = filterState[key];
+
+      if (value && Array.isArray(value)) {
+        filter.declutter.hideExternalPaths.on = true;
+        filter.declutter.hideExternalPaths.dependencyFolders = filterState[key];
+      } else {
+        filter.declutter.hideExternalPaths.on = filterState[key];
+      }
     }
   });
   if ('dependencyFolders' in filterState && filterState.dependencyFolders !== false) {

--- a/packages/models/tests/unit/serialize.spec.js
+++ b/packages/models/tests/unit/serialize.spec.js
@@ -9,6 +9,15 @@ const TEST_STATE = {
   hideExternalPaths: ['vendor', 'node_modules'],
 };
 
+const TEST_STATE_BOOL = {
+  hideElapsedTimeUnder: 1,
+  hideMediaRequests: false,
+  hideName: ['package:activesupport'],
+  hideUnlabeled: true,
+  limitRootEvents: false,
+  hideExternal: true,
+};
+
 function stateObjectToBase64(stateObject) {
   return Buffer.from(JSON.stringify(stateObject), 'utf-8').toString('base64url');
 }
@@ -31,6 +40,7 @@ describe('serializeFilter', () => {
     filter.declutter.hideName.on = true;
     filter.declutter.hideName.names = ['package:activesupport'];
     filter.declutter.hideExternalPaths.on = true;
+    filter.declutter.hideExternalPaths.dependencyFolders = ['vendor', 'node_modules'];
 
     const serialized = serializeFilter(filter);
     expect(serialized).toStrictEqual(TEST_STATE);
@@ -57,6 +67,7 @@ describe('deserializeFilter', () => {
     expectedFilter.declutter.hideName.on = true;
     expectedFilter.declutter.hideName.names = ['package:activesupport'];
     expectedFilter.declutter.hideExternalPaths.on = true;
+    expectedFilter.declutter.hideExternalPaths.dependencyFolders = ['vendor', 'node_modules'];
 
     expect(deserialized).toStrictEqual(expectedFilter);
   });
@@ -75,6 +86,26 @@ describe('deserializeFilter', () => {
     expectedFilter.declutter.hideName.on = true;
     expectedFilter.declutter.hideName.names = ['package:activesupport'];
     expectedFilter.declutter.hideExternalPaths.on = true;
+    expectedFilter.declutter.hideExternalPaths.dependencyFolders = ['vendor', 'node_modules'];
+
+    expect(deserialized).toStrictEqual(expectedFilter);
+  });
+
+  it('can deserialise when hideExternal is a boolean value', () => {
+    const base64Encoded = stateObjectToBase64(TEST_STATE_BOOL);
+    const deserialized = deserializeFilter(base64Encoded);
+
+    const expectedFilter = new AppMapFilter();
+
+    expectedFilter.declutter.limitRootEvents.on = false;
+    expectedFilter.declutter.hideMediaRequests.on = false;
+    expectedFilter.declutter.hideUnlabeled.on = true;
+    expectedFilter.declutter.hideElapsedTimeUnder.on = true;
+    expectedFilter.declutter.hideElapsedTimeUnder.time = 1;
+    expectedFilter.declutter.hideName.on = true;
+    expectedFilter.declutter.hideName.names = ['package:activesupport'];
+    expectedFilter.declutter.hideExternalPaths.on = true;
+    expectedFilter.declutter.hideExternalPaths.dependencyFolders = ['vendor', 'node_modules'];
 
     expect(deserialized).toStrictEqual(expectedFilter);
   });


### PR DESCRIPTION
Fixes #1194 

These changes are needed prior to merging [this PR](https://github.com/getappmap/appmap-js/pull/1186).

- [x] Add an `explicit` option to `serializeFilter` that will return the entire filter state, even if some of the declutter settings are the default settings. 
- [x] Correctly handle when an object is passed to `deserializeFilter` with the `hideExternal` field set to `true` or `false`.