### PR TITLE
Propagate user identifier(s) via environment variables

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -136,4 +136,4 @@
   "optionalDependencies": {
     "puppeteer": "^19.7.5"
   }
-}
+} 

--- a/packages/scanner/package.json
+++ b/packages/scanner/package.json
@@ -110,4 +110,4 @@
     ],
     "outputPath": "dist"
   }
-}
+} 

--- a/packages/telemetry/telemetry.spec.ts
+++ b/packages/telemetry/telemetry.spec.ts
@@ -2,17 +2,26 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import sinon, { SinonSpy } from 'sinon';
 import Conf from 'conf';
-import Telemetry, { Git, GitState } from './telemetry';
+import Telemetry, {
+  EnvironmentSession,
+  Git,
+  GitState,
+  TelemetrySession,
+  getMachineId,
+  getSession,
+} from './telemetry';
 import { name as appName, version } from './package.json';
 import child_process, { ChildProcess } from 'node:child_process';
 import { nextTick } from 'node:process';
 import { Contracts } from 'applicationinsights';
 import assert from 'node:assert';
+import { SinonStub } from 'sinon';
 
 const invalidExpiration = () => Date.now() - 1000 * 60 * 60;
 
 describe('telemetry', () => {
   const sandbox = sinon.createSandbox();
+  let confMemory: Record<string, unknown> = {};
   let trackEvent: sinon.SinonStub<[Contracts.EventTelemetry]>;
   beforeEach(() => {
     // Don't accidentally send data
@@ -22,68 +31,140 @@ describe('telemetry', () => {
     });
 
     // Don't persist data locally
-    sandbox.stub(Conf.prototype, 'set');
+    // We have to cast to the correct type because the stub is not typed correctly
+    // according to the implementation. It's using the first overload.
+    const setStub = sandbox.stub(Conf.prototype, 'set');
+    const setStubOverload = setStub as unknown as SinonStub<[string, unknown], void>;
+    setStubOverload.callsFake((key: string, value: unknown): void => {
+      confMemory[key] = value;
+    });
+
+    sandbox.stub(Conf.prototype, 'get').callsFake((key: string): unknown => {
+      return confMemory[key];
+    });
   });
 
   afterEach(() => {
     sandbox.restore();
+    confMemory = {};
   });
 
-  describe('Session', () => {
+  describe('TelemetrySession', () => {
     it('writes persistent session data', () => {
-      // Ignore any existing sessions.
-      const conf = sandbox.stub(Conf.prototype, 'get');
-      conf.withArgs(sinon.match('sessionId')).returns(undefined);
+      const session = new TelemetrySession();
 
-      const setStub = Conf.prototype['set'] as SinonSpy;
-      const { session } = Telemetry;
-
-      expect(setStub.getCall(-2).args[1]).toBe(session.id);
-      expect(setStub.getCall(-1).args[1]).toBe(session.expiration);
+      // The session id will be generated on first access, so we need to access it
+      // before we can check it against what is persisted.
+      const { id } = session;
+      expect(confMemory.sessionId).toBe(id);
+      expect(confMemory.sessionExpiration).toBe(session['expiration']);
     });
 
     it('reads persistent session data', () => {
-      const expiration = Date.now() + 1000;
-      const conf = sandbox.stub(Conf.prototype, 'get');
-      conf.withArgs(sinon.match('sessionId')).returns('sessionId');
-      conf.withArgs(sinon.match('sessionExpiration')).returns(expiration);
+      const sessionId = 'sessionId';
+      const sessionExpiration = Date.now() + 1000;
+      confMemory = { sessionId, sessionExpiration };
 
-      // Force a new session
-      Telemetry.session.expiration = invalidExpiration();
-
-      const { session } = Telemetry;
-      expect(session.id).toBe('sessionId');
-      expect(session.expiration).toBe(expiration);
+      const session = new TelemetrySession();
+      expect(session['sessionId']).toBe(sessionId);
+      expect(session['expiration']).toBe(sessionExpiration);
     });
 
     it('issues a new session once an existing session has expired', () => {
-      const conf = sandbox.stub(Conf.prototype, 'get');
-      conf.withArgs(sinon.match('sessionId')).returns(undefined);
-      const firstSession = Telemetry.session;
-      const firstSessionId = firstSession.id;
+      const session = new TelemetrySession();
+      const firstSessionId = session.id;
 
-      expect(firstSession.valid).toBe(true);
-      sandbox.stub(firstSession, 'expiration').value(invalidExpiration());
-      expect(firstSession.valid).toBe(false);
+      session['expiration'] = invalidExpiration();
 
-      const secondSession = Telemetry.session;
-      expect(firstSession).not.toBe(secondSession);
-      expect(secondSession.id).not.toBe(firstSessionId);
-      expect(secondSession.valid).toBe(true);
-      expect(secondSession.expiration).toBeGreaterThan(Date.now());
+      expect(session.id).not.toBe(firstSessionId);
+      expect(session['expiration']).toBeGreaterThan(Date.now());
     });
 
     it('updates the expiration when the session is touched', async () => {
-      const { session } = Telemetry;
-      const sessionExpiration = session.expiration;
+      const session = new TelemetrySession();
+      const sessionId = session.id;
+      const sessionExpiration = session['expiration'];
 
-      // Guarantee the session expiration should change once the telemetry is sent
+      // Guarantee the session expiration should change once the session is updated
       await new Promise((r) => setTimeout(r, 16));
 
       session.touch();
 
-      expect(sessionExpiration).not.toBe(Telemetry.session.expiration); // session should have been updated
-      expect(session).toBe(Telemetry.session); // session should be the same
+      // The session expiration should have been updated
+      expect(sessionExpiration).not.toBe(session['expiration']);
+      expect(sessionExpiration).toBeLessThan(session['expiration'] || 0);
+
+      // The session identifier should remain the same
+      expect(session.id).toBe(sessionId);
+    });
+
+    it('touching an expired session does nothing', () => {
+      const session = new TelemetrySession();
+      const expired = invalidExpiration();
+      const sessionId = session.id;
+
+      session['expiration'] = expired;
+      session.touch();
+
+      // The session remains expired as it's not possible to update a dead session
+      expect(session['expiration']).toBe(expired);
+
+      // The session identifer is updated upon request
+      expect(session.id).not.toBe(sessionId);
+    });
+  });
+
+  describe('getMachineId', () => {
+    it('reflects APPMAP_USER_ID if set', () => {
+      const userId = 'test';
+      sandbox.stub(process, 'env').value({ APPMAP_USER_ID: userId });
+      expect(getMachineId()).toBe(userId);
+    });
+
+    it('returns a value if APPMAP_USER_ID is not set', () => {
+      sandbox.stub(process, 'env').value({ APPMAP_USER_ID: undefined });
+      expect(getMachineId()).toBeTruthy();
+    });
+  });
+
+  describe('EnvironmentSession', () => {
+    it('reflects the value of APPMAP_SESSION_ID', () => {
+      const sessionId = 'test';
+      sandbox.stub(process, 'env').value({ APPMAP_SESSION_ID: sessionId });
+      const session = new EnvironmentSession();
+      expect(session.id).toBe(sessionId);
+    });
+
+    it('raises an error if APPMAP_SESSION_ID is not set', () => {
+      sandbox.stub(process, 'env').value({ APPMAP_SESSION_ID: undefined });
+      expect(() => new EnvironmentSession()).toThrowError();
+    });
+
+    it('is not persisted', () => {
+      sandbox.stub(process, 'env').value({ APPMAP_SESSION_ID: 'test' });
+      const session = new EnvironmentSession();
+      expect(session.id).toBeDefined();
+      expect(confMemory.sessionId).toBeUndefined();
+    });
+  });
+
+  describe('getSession', () => {
+    it('returns an environment session when APPMAP_SESSION_ID is present', () => {
+      sandbox.stub(process, 'env').value({ APPMAP_SESSION_ID: 'test' });
+      const session = getSession();
+      expect(session).toBeInstanceOf(EnvironmentSession);
+    });
+
+    it('returns a telemetry session when APPMAP_SESSION_ID is not present', () => {
+      sandbox.stub(process, 'env').value({ APPMAP_SESSION_ID: undefined });
+      const session = getSession();
+      expect(session).toBeInstanceOf(TelemetrySession);
+    });
+
+    it('returns a telemetry session when APPMAP_SESSION_ID is empty', () => {
+      sandbox.stub(process, 'env').value({ APPMAP_SESSION_ID: '' });
+      const session = getSession();
+      expect(session).toBeInstanceOf(TelemetrySession);
     });
   });
 


### PR DESCRIPTION
This allows code editors to pass along their own identifiers, guaranteeing one single timeline of anonymous identity.