### PR TITLE
fix self-call and lane-seperator colors

### DIFF
--- a/packages/components/src/assets/sequence-self-call-no-return.svg
+++ b/packages/components/src/assets/sequence-self-call-no-return.svg
@@ -1,3 +1,3 @@
-<svg width="30" height="22" viewBox="0 0 30 22" stroke="#6fddbc" stroke-width="2" xmlns="http://www.w3.org/2000/svg">
+<svg width="30" height="22" viewBox="0 0 30 22" stroke-width="2" xmlns="http://www.w3.org/2000/svg">
   <path d="M 28 11 T 2 2 V 20 Z" />
 </svg>

--- a/packages/components/src/assets/sequence-self-call-with-return.svg
+++ b/packages/components/src/assets/sequence-self-call-with-return.svg
@@ -1,3 +1,3 @@
-<svg width="30" height="22" viewBox="0 0 30 22" stroke="#6fddbc" stroke-width="2" xmlns="http://www.w3.org/2000/svg">
+<svg width="30" height="22" viewBox="0 0 30 22" stroke-width="2" xmlns="http://www.w3.org/2000/svg">
   <path d="M 29 1 H 1 V 21 H 22" />
 </svg>

--- a/packages/components/src/components/sequence/Actor.vue
+++ b/packages/components/src/components/sequence/Actor.vue
@@ -370,7 +370,7 @@ $min-height: 3rem;
 }
 
 .sequence-actor-lane-separator {
-  border-left: 1px dashed #242c41;
+  border-left: 1px dashed darken($gray4, 20);
   position: relative;
   height: 100%;
   width: 1px;

--- a/packages/components/src/scss/_variables.scss
+++ b/packages/components/src/scss/_variables.scss
@@ -89,7 +89,7 @@ $sequence-activation-gutter-width: 4px;
 
 // Lines that indicate call or return from one actor to another.
 $sequence-call-line-width: 3px;
-$sequence-call-line-color: $gray4; //#959faa; //#242c41; //$gray4; #808b98; #6fddbc; #7f8a97;
+$sequence-call-line-color: $gray4;
 
 // Border around a group element, e.g. a loop.
 $sequence-group-border-width: 2px;


### PR DESCRIPTION
- Lane-separator contrast is too low, should be brighter
- self-call arrows should match gray ($gray4) of other sequence diagram arrows
## Before
![Screenshot 2023-06-09 at 10 16 29 AM](https://github.com/getappmap/appmap-js/assets/123787/0a8c4a09-9933-472d-8690-d012f9615297)


## After 
![Screenshot 2023-06-09 at 10 15 58 AM](https://github.com/getappmap/appmap-js/assets/123787/f487bbf8-123e-444a-8821-46e4047ef3e7)
