### PR TITLE
formatting for install instructions

### DIFF
--- a/packages/components/src/components/install-guide/ProjectPickerRow.vue
+++ b/packages/components/src/components/install-guide/ProjectPickerRow.vue
@@ -40,10 +40,10 @@
           Two things are required to make AppMaps of your Java project:
 
           <ol>
-            <li>The <tt>appmap.jar</tt> must be available on your machine.</li>
+            <li>The <code class="inline">appmap.jar</code> must be available on your machine.</li>
             <li>
               Application code and test cases use the JVM flag
-              <tt>-Djavaagent=appmap.jar</tt>.
+              <code class="inline">-Djavaagent=appmap.jar</code>.
             </li>
           </ol>
 
@@ -52,9 +52,12 @@
           enabled.
         </template>
         <template v-if="isRuby">
-          To make AppMaps of your Ruby project, you need to add the <tt>appmap</tt> gem to your
-          "test" and "development" bundles. We provide an open source installer to do this, or you
-          can install manually. Advantages of using the installer include:
+          <h3>Run the AppMap Installer</h3>
+          <br />
+          To make AppMaps of your Ruby project, you need to add the
+          <code class="inline">appmap</code> gem to your "test" and "development" bundles. We
+          provide an open source installer to do this, or you can install manually. Advantages of
+          using the installer include:
           <ol>
             <li>Verifies that your Ruby version is supported by AppMap.</li>
             <li>Verifies that your Rails version (if present) is supported by AppMap.</li>
@@ -63,22 +66,30 @@
           </ol>
         </template>
         <template v-if="isPython">
-          To make AppMaps of your Python project, you need to install the <tt>appmap</tt> package
-          and configure your project to use it. We provide an open source installer, or you can
-          install manually. Advantages of using the installer include:
+          <h3>Run the AppMap Installer</h3>
+          <br />
+          To make AppMaps of your Python project, you need to install the
+          <code class="inline">appmap</code> package and configure your project to use it. We
+          provide an open source installer, or you can install manually. Advantages of using the
+          installer include:
           <ol>
             <li>Verifies that your Python version is supported by AppMap.</li>
             <li>
               Verifies that your Django and Flask versions (if present) are supported by AppMap.
             </li>
-            <li>Detects and supports <tt>pip</tt>, <tt>pipenv</tt>, and <tt>poetry</tt>.</li>
+            <li>
+              Detects and supports <code class="inline">pip</code>,
+              <code class="inline">pipenv</code>, and <code class="inline">poetry</code>.
+            </li>
             <li>Creates the configuration file <i>appmap.yml</i>.</li>
             <li>Has built-in support if you encounter any problems.</li>
           </ol>
         </template>
         <template v-if="isJS">
+          <h3>Run the AppMap Installer</h3>
+          <br />
           To make AppMaps of your JavaScript project, you need to install the
-          <tt>appmap-agent-js</tt>
+          <code class="inline">appmap-agent-js</code>
           package from NPM and configure your project to use it. We provide an open source
           installer, or you can install manually. Advantages of using the installer include:
           <ol>
@@ -98,8 +109,8 @@
       <template v-if="supported">
         <template v-if="isJetBrains && isJava">
           <p class="mb20">
-            ✓ <tt>appmap.jar</tt> has been downloaded and saved to your machine by the AppMap
-            plugin.
+            ✓ <code class="inline">appmap.jar</code> has been downloaded and saved to your machine
+            by the AppMap plugin.
           </p>
           <p class="mb20">
             ✓ Run configurations called <component :is="runConfigIcon" class="run-config-icon" /><b
@@ -127,9 +138,10 @@
 
             <div class="separator">OR</div>
 
-            <div style="margin: 0px auto 1em auto; width: 18ex">
-              <h3>Install manually</h3>
+            <div>
+              <h3>Install AppMap manually</h3>
             </div>
+            <br />
 
             <p>
               <component :is="manualInstructions" data-cy="manual-install" /></p

--- a/packages/components/src/components/install-guide/ProjectPickerRow.vue
+++ b/packages/components/src/components/install-guide/ProjectPickerRow.vue
@@ -52,8 +52,7 @@
           enabled.
         </template>
         <template v-if="isRuby">
-          <h3>Run the AppMap Installer</h3>
-          <br />
+          <h3 class="install-heading">Run the AppMap Installer</h3>
           To make AppMaps of your Ruby project, you need to add the
           <code class="inline">appmap</code> gem to your "test" and "development" bundles. We
           provide an open source installer to do this, or you can install manually. Advantages of
@@ -66,8 +65,7 @@
           </ol>
         </template>
         <template v-if="isPython">
-          <h3>Run the AppMap Installer</h3>
-          <br />
+          <h3 class="install-heading">Run the AppMap Installer</h3>
           To make AppMaps of your Python project, you need to install the
           <code class="inline">appmap</code> package and configure your project to use it. We
           provide an open source installer, or you can install manually. Advantages of using the
@@ -86,8 +84,7 @@
           </ol>
         </template>
         <template v-if="isJS">
-          <h3>Run the AppMap Installer</h3>
-          <br />
+          <h3 class="install-heading">Run the AppMap Installer</h3>
           To make AppMaps of your JavaScript project, you need to install the
           <code class="inline">appmap-agent-js</code>
           package from NPM and configure your project to use it. We provide an open source
@@ -139,10 +136,8 @@
             <div class="separator">OR</div>
 
             <div>
-              <h3>Install AppMap manually</h3>
+              <h3 class="install-heading">Install AppMap manually</h3>
             </div>
-            <br />
-
             <p>
               <component :is="manualInstructions" data-cy="manual-install" /></p
           ></template>
@@ -341,6 +336,12 @@ $brightblue: rgba(255, 255, 255, 0.1);
   align-items: center;
   justify-content: space-between;
 }
+
+.install-heading {
+  margin-bottom: 1rem;
+  margin-top: 0.5rem;
+}
+
 .project-picker-row {
   border-bottom: 1px solid lighten($gray2, 15);
   padding: 0;

--- a/packages/components/src/components/install-guide/install-instructions/JavaScript.vue
+++ b/packages/components/src/components/install-guide/install-instructions/JavaScript.vue
@@ -1,25 +1,27 @@
 <template>
   <div>
     <section>
-      Manual installation is a good option if you want to install <tt>appmap-agent-js</tt> from
-      outside of the code editor. However, you'll have to create the <i>appmap.yml</i> file
-      yourself.
+      Manual installation is a good option if you want to install
+      <code class="inline">appmap-agent-js</code> from outside of the code editor. However, you'll
+      have to create the <i>appmap.yml</i> file yourself.
     </section>
+    <br />
 
     <section>
-      <h3>Add the <tt>appmap</tt> package to your project</h3>
+      <h3>Add the <code class="inline">appmap</code> package to your project</h3>
 
       <div>
         <v-code-snippet clipboard-text="npm install --save-dev appmap-agent-js" />
       </div>
       <div>
-        <div class="center-block">or</div>
+        <div>OR</div>
         <v-code-snippet clipboard-text="yarn add --dev appmap-agent-js" />
       </div>
     </section>
 
     <section>
-      <h3>Create <tt>appmap.yml</tt></h3>
+      <h3>Create <code class="inline">appmap.yml</code></h3>
+      <br />
       <div>
         Follow the
         <a

--- a/packages/components/src/components/install-guide/install-instructions/Python.vue
+++ b/packages/components/src/components/install-guide/install-instructions/Python.vue
@@ -7,11 +7,13 @@
         <li>
           Your project doesn't use <i>requirements.txt</i>, <i>Pipfile</i>, or <i>poetry.lock</i>.
         </li>
-        <li>You want to install <tt>appmap</tt> from outside of the code editor.</li>
+        <li>
+          You want to install <code class="inline">appmap</code> from outside of the code editor.
+        </li>
       </ol>
     </section>
     <section>
-      <h3>Add the <tt>appmap</tt> package to your project</h3>
+      <h3>Add the <code class="inline">appmap</code> package to your project</h3>
       <div>
         <v-code-snippet clipboard-text="pip install appmap" />
       </div>
@@ -26,8 +28,8 @@
     </section>
 
     <section>
-      A default configuration file, <tt>appmap.yml</tt>, will be created the first time you run your
-      application with AppMap enabled.
+      A default configuration file, <code class="inline">appmap.yml</code>, will be created the
+      first time you run your application with AppMap enabled.
     </section>
   </div>
 </template>

--- a/packages/components/src/components/install-guide/install-instructions/Ruby.vue
+++ b/packages/components/src/components/install-guide/install-instructions/Ruby.vue
@@ -1,8 +1,8 @@
 <template>
   <div>
     <section>
-      Manual installation is a good option if you want to install <tt>appmap</tt> from outside of
-      the code editor.
+      Manual installation is a good option if you want to install<code class="inline">appmap</code>
+      from outside of the code editor.
     </section>
     <section>
       <p>Add the following line of code to the <strong>top of your Gemfile</strong>.</p>
@@ -12,8 +12,8 @@
       <p>Update your bundle.</p>
       <v-code-snippet clipboard-text="bundle install" />
 
-      A default configuration file, <tt>appmap.yml</tt>, will be created the first time you run your
-      application with AppMap enabled.
+      A default configuration file, <code class="inline">appmap.yml</code>, will be created the
+      first time you run your application with AppMap enabled.
     </section>
   </div>
 </template>


### PR DESCRIPTION
Adds a header, spacing, and code formatting to the installer views...

Before
<img width="985" alt="image" src="https://github.com/getappmap/appmap-js/assets/1229326/83765e8b-6b13-40da-96ce-9f60c3b0fd40">

After
<img width="993" alt="image" src="https://github.com/getappmap/appmap-js/assets/1229326/4534626f-e462-409e-9330-4c7eea35f0b6">


