### PR TITLE
Minor updates to the onboarding text

### DIFF
--- a/packages/components/src/components/install-guide/record-instructions/Python.vue
+++ b/packages/components/src/components/install-guide/record-instructions/Python.vue
@@ -2,8 +2,7 @@
   <section>
     <p>
       When you run your Python code with the <code class="inline"> appmap </code> package, AppMap
-      will be enabled for recording. The best way to run with AppMap is to add the
-      <code class="inline">appmap</code> package using Pip, Pipenv, or Poetry.
+      will be enabled for recording.
     </p>
     <br />
     <h2>Choose the best recording method for this project</h2>
@@ -41,10 +40,11 @@
           <i class="header-icon"><RequestsIcon /></i>Requests recording
         </h3>
         <p>
-          When your application uses {{ this.webFramework.name }}, and you run your application with
-          AppMap enabled, HTTP server requests recording is enabled. To record requests, first run
-          your application:
+          When your application uses Django or Flask, and you run your application with AppMap
+          enabled, HTTP server requests recording is enabled. To record requests, first run your
+          application:
         </p>
+        <br />
         <p>
           Start your Django server:
           <v-code-snippet clipboard-text="python manage.py runserver" />
@@ -53,10 +53,11 @@
           Start your Flask server:
           <v-code-snippet clipboard-text="flask run" />
         </p>
+        <br />
         <p>
-          Interact with your application, through its user interface and/or by making API requests
-          using a tool such as Postman. An AppMap will be created for each HTTP server request
-          that's served by your app.
+          Then, interact with your application through its user interface and/or by making API
+          requests using a tool such as Postman. An AppMap will be created for each HTTP server
+          request that's served by your app.
         </p>
         <p>
           For more information, visit

--- a/packages/components/src/components/quickstart/QuickstartLayout.vue
+++ b/packages/components/src/components/quickstart/QuickstartLayout.vue
@@ -177,6 +177,7 @@ article {
 
 .center {
   margin: auto;
+  text-align: center;
 }
 
 .fit {

--- a/packages/components/src/pages/install-guide/InvestigateFindings.vue
+++ b/packages/components/src/pages/install-guide/InvestigateFindings.vue
@@ -48,8 +48,8 @@
           </article>
           <article v-else>
             <p class="success-message">
-              <strong>Success!</strong> AppMap has scanned your application and found no flaws.
-              We'll continue scanning for flaws automatically.
+              AppMap has scanned your application and found no flaws. We'll continue scanning for
+              flaws automatically.
             </p>
           </article>
         </div>


### PR DESCRIPTION
- Removes a sentence from the Record AppMaps page for Python
![image](https://github.com/getappmap/appmap-js/assets/1229326/599e9f5a-c1f6-4391-92da-da978863d694)
- Removes the framework specific name from the instructions, because commands for both options are always present
- Updates text to include the work 'Then' to follow up on the 'First..' step and provide a sense of flow
Previous:
<img width="620" alt="image" src="https://github.com/getappmap/appmap-js/assets/1229326/525312c0-543a-42ca-8435-a0b16fdeb070">
Updated:
<img width="867" alt="image" src="https://github.com/getappmap/appmap-js/assets/1229326/3e91f7ec-cb78-4f9b-bebf-73642ce6be27">
-Centers the 'Generate OpenAPI' button to be consistent with other primary actions in the flow.
<img width="1031" alt="image" src="https://github.com/getappmap/appmap-js/assets/1229326/1302846b-dc44-4a35-81ed-ee2b8fe71e3f">
- Removes the word 'Success!' from the Runtime Analysis page because it doesn't make sense in the context of Runtime Analysis and is dissonant with the status messaging.

![image](https://github.com/getappmap/appmap-js/assets/1229326/4445fcb4-61d4-4a1d-8a2b-cc462e35e0a9)

