### PR TITLE
Text fix for Java instructions

### DIFF
--- a/packages/components/src/components/install-guide/ProjectPickerRow.vue
+++ b/packages/components/src/components/install-guide/ProjectPickerRow.vue
@@ -40,7 +40,10 @@
           Two things are required to make AppMaps of your Java project:
 
           <ol>
-            <li>The <code class="inline">appmap.jar</code> must be available on your machine.</li>
+            <li>
+              The <i>appmap.jar</i> must be available on your machine. This file will be installed
+              automatically for you.
+            </li>
             <li>
               Application code and test cases use the JVM flag
               <code class="inline">-Djavaagent=appmap.jar</code>.


### PR DESCRIPTION
Closes the two instructions related items in https://github.com/getappmap/appmap-js/issues/1231.

<img width="911" alt="image" src="https://github.com/getappmap/appmap-js/assets/1229326/1b82800e-3db8-4be4-9226-97d78be74de5">
