### PR TITLE
Flamegraph in house rebuild

### DIFF
--- a/packages/components/rollup.config.js
+++ b/packages/components/rollup.config.js
@@ -14,6 +14,7 @@ const argv = minimist(process.argv.slice(2));
 const baseConfig = {
   input: 'src/index.js',
   external: Object.keys(pkg.dependencies),
+  inlineDynamicImports: true,
   plugins: {
     preVue: [
       alias({

--- a/packages/components/rollup.config.js
+++ b/packages/components/rollup.config.js
@@ -80,16 +80,6 @@ if (!argv.format || argv.format === 'es') {
       vue(baseConfig.plugins.vue),
       image({ exclude: ['**/*.svg'] }),
       commonjs(),
-
-      // The Trace component is expected to be loaded dynamically as an asynchronous component.
-      // However, because it's no longer a single module (it's bundled into a much larger module),
-      // we must retain the `__esModule` flag in order for Vue to properly perform dynamic loading.
-      //
-      // See the following source:
-      // https://github.com/vuejs/vue/blob/b51430f598b354ed60851bb62885539bd25de3d8/src/core/vdom/helpers/resolve-async-component.js#L18-L28
-      // This may go away after updating to Vue 3?
-      replace({ 'var Trace': 'var Trace = { __esModule: true, //' }),
-
       terser(),
     ],
   };

--- a/packages/components/src/components/DetailsPanel.vue
+++ b/packages/components/src/components/DetailsPanel.vue
@@ -66,6 +66,7 @@
         :object="selectedObject"
         :is-root-object="isRootObject"
         :filters-root-objects="filtersRootObjects"
+        :flamegraphEnabled="flamegraphEnabled"
         :appMap="appMap"
       />
       <v-details-panel-labels
@@ -147,6 +148,10 @@ export default {
       default: false,
     },
     isGiantAppMap: {
+      type: Boolean,
+      default: false,
+    },
+    flamegraphEnabled: {
       type: Boolean,
       default: false,
     },

--- a/packages/components/src/components/DetailsPanelEvent.vue
+++ b/packages/components/src/components/DetailsPanelEvent.vue
@@ -13,6 +13,12 @@
         <v-details-button v-if="shouldDisplayViewInTrace" @click.native="viewEventInTrace">
           Show in Trace
         </v-details-button>
+        <v-details-button
+          v-if="shouldDisplayViewInFlamegraph"
+          @click.native="viewEventInFlamegraph"
+        >
+          Show in Flamegraph
+        </v-details-button>
       </template>
     </v-details-panel-header>
 
@@ -108,7 +114,7 @@ import VDetailsButton from '@/components/DetailsButton.vue';
 import VDetailsPanelHeader from '@/components/DetailsPanelHeader.vue';
 import VDetailsPanelList from '@/components/DetailsPanelList.vue';
 import VSqlCode from '@/components/SqlCode.vue';
-import { SET_VIEW, VIEW_FLOW, VIEW_SEQUENCE } from '@/store/vsCode';
+import { SET_VIEW, VIEW_FLAMEGRAPH, VIEW_FLOW, VIEW_SEQUENCE } from '@/store/vsCode';
 import toListItem from '@/lib/finding';
 
 export default {
@@ -123,6 +129,10 @@ export default {
     object: {
       type: Object,
       required: true,
+    },
+    flamegraphEnabled: {
+      type: Boolean,
+      default: false,
     },
   },
   computed: {
@@ -198,6 +208,10 @@ export default {
       return this.$store.state.currentView !== VIEW_FLOW;
     },
 
+    shouldDisplayViewInFlamegraph() {
+      return this.flamegraphEnabled && this.$store.state.currentView !== VIEW_FLAMEGRAPH;
+    },
+
     caller() {
       return this.object.parent ? [this.object.parent] : null;
     },
@@ -213,6 +227,9 @@ export default {
     },
     viewEventInTrace() {
       this.$store.commit(SET_VIEW, VIEW_FLOW);
+    },
+    viewEventInFlamegraph() {
+      this.$store.commit(SET_VIEW, VIEW_FLAMEGRAPH);
     },
   },
 };

--- a/packages/components/src/components/Slider.vue
+++ b/packages/components/src/components/Slider.vue
@@ -1,0 +1,136 @@
+<!--
+  This is re-implementation of:
+  https://github.com/getappmap/appmap-js/blob/main/packages/diagrams/src/helpers/container/zoom.js
+  The problem with reusing the original implementation is that it is tangled with functionalities
+  like drag and drop panel, which we don't need here. Also it is not a vue component, so it is less
+  consistent with the packages/components codebase. In the future this component could be reused to
+  implement the zoom slider of the dependency diagram and trace diagram.
+-->
+
+<template>
+  <div class="slider">
+    <button class="button" @click="increase">&plus;</button>
+    <div ref="handle" class="handle" @click="set">
+      <div class="bar"></div>
+      <div class="grab" @mousedown="startDragging" :style="grabStyle"></div>
+    </div>
+    <button class="button" @click="decrease">&minus;</button>
+  </div>
+</template>
+
+<script>
+const clamp = (val, { min, max }) => Math.min(Math.max(val, min), max);
+export default {
+  name: 'v-slider',
+  emits: ['slide'],
+  props: {
+    value: {
+      type: Number,
+      required: true,
+    },
+    step: {
+      type: Number,
+      default: 0.1,
+    },
+  },
+  data() {
+    return {
+      dragging: false,
+    };
+  },
+  computed: {
+    grabStyle() {
+      return {
+        bottom: `${100 * this.value}%`,
+      };
+    },
+  },
+  methods: {
+    set(event) {
+      const rect = this.$refs.handle.getBoundingClientRect();
+      this.$emit(
+        'slide',
+        1 - (clamp(event.clientY, { min: rect.top, max: rect.bottom }) - rect.top) / rect.height
+      );
+    },
+    increase() {
+      this.$emit('slide', Math.min(1, this.value + this.step));
+    },
+    decrease() {
+      this.$emit('slide', Math.max(0, this.value - this.step));
+    },
+    startDragging() {
+      this.dragging = true;
+    },
+    drag(event) {
+      if (this.dragging) {
+        this.set(event);
+      }
+    },
+    stopDragging() {
+      this.dragging = false;
+    },
+  },
+  mounted() {
+    document.addEventListener('mousemove', this.drag);
+    document.addEventListener('mouseup', this.stopDragging);
+  },
+  beforeUnmount() {
+    document.removeEventListener('mousemove', this.drag);
+    document.removeEventListener('mouseup', this.stopDragging);
+  },
+};
+</script>
+
+<style scoped lang="css">
+.slider {
+  position: absolute;
+  top: 50%;
+  right: 0px;
+  transform: translate(-50%, -50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+.button {
+  border: none;
+  border-radius: 0.5rem;
+  padding: 0.25rem 0.5rem;
+  appearance: none;
+  background: #242c41;
+  color: #808b98;
+  font-weight: bold;
+  cursor: pointer;
+  opacity: 0.8;
+}
+
+.handle {
+  margin: 3px 6px;
+  position: relative;
+  width: 20px;
+  height: 90px;
+  cursor: pointer;
+}
+
+.bar {
+  position: absolute;
+  top: -3px;
+  left: 50%;
+  bottom: -3px;
+  margin-left: -3px;
+  width: 6px;
+  background: #242c41;
+  opacity: 0.8;
+}
+
+.grab {
+  transform: translateY(3px);
+  position: absolute;
+  border-radius: 3px;
+  left: 0;
+  width: 100%;
+  height: 6px;
+  background: #808b98;
+  cursor: grab;
+}
+</style>

--- a/packages/components/src/components/flamegraph/FlamegraphBranch.vue
+++ b/packages/components/src/components/flamegraph/FlamegraphBranch.vue
@@ -1,0 +1,132 @@
+<template>
+  <div class="flamegraph-branch">
+    <v-flamegraph-node
+      v-for="{ key, event, budget, focus } in children"
+      :key="key"
+      :event="event"
+      :budget="budget"
+      :focus="focus"
+      @selectEvent="propagateSelectEvent"
+    />
+    <v-flamegraph-rest :budget="rest" />
+  </div>
+</template>
+
+<script>
+import VFlamegraphRest from './FlamegraphRest.vue';
+import { isEventDurationValid, getEventDuration, add } from '../../lib/flamegraph';
+const getBudget = ({ budget }) => budget;
+const empty = new Set();
+export default {
+  name: 'v-flamegraph-branch',
+  emits: ['selectEvent'],
+  components: {
+    VFlamegraphNode: async () => (await import('./FlamegraphNode.vue')).default,
+    VFlamegraphRest,
+  },
+  props: {
+    events: {
+      type: Array,
+      required: true,
+    },
+    budget: {
+      type: Number,
+      required: true,
+    },
+    focus: {
+      type: Object,
+      required: false,
+      default: null,
+    },
+  },
+  computed: {
+    validDurationEventArray() {
+      return this.events.filter(isEventDurationValid);
+    },
+    totalDuration() {
+      return this.validDurationEventArray.map(getEventDuration).reduce(add, 0);
+    },
+    ancestors() {
+      if (this.focus) {
+        const ancestors = new Set(this.focus.ancestors());
+        ancestors.add(this.focus);
+        return ancestors;
+      } else {
+        return empty;
+      }
+    },
+    validBudget() {
+      const eventCount = this.events.length;
+      const validEventCount = this.validDurationEventArray.length;
+      const validBudget = Math.floor(this.budget * (validEventCount / eventCount));
+      return validBudget;
+    },
+    singleInvalidBudget() {
+      const eventCount = this.events.length;
+      const validEventCount = this.validDurationEventArray.length;
+      const invalidEventCount = eventCount - validEventCount;
+      const invalidBudget = Math.floor(this.budget * (invalidEventCount / eventCount));
+      const singleInvalidBudget = Math.floor(invalidBudget / invalidEventCount);
+      return singleInvalidBudget;
+    },
+    children() {
+      if (this.focus) {
+        return this.events.map((event) => {
+          const focused = this.ancestors.has(event);
+          return {
+            key: event.id,
+            event,
+            budget: focused ? this.budget : 0,
+            focus: focused ? this.focus : null,
+          };
+        });
+      } else {
+        return this.events.map((event) => {
+          if (isEventDurationValid(event)) {
+            return {
+              key: event.id,
+              event,
+              budget: Math.floor(this.validBudget * (getEventDuration(event) / this.totalDuration)),
+              focus: null,
+            };
+          } else {
+            return {
+              key: event.id,
+              event,
+              budget: this.singleInvalidBudget,
+              focus: null,
+            };
+          }
+        });
+      }
+    },
+    rest() {
+      const rest = this.budget - this.children.map(getBudget).reduce(add, 0);
+      if (rest < 0) {
+        console.warn('children budget overflow, this should never happen', rest);
+        console.dir({
+          budget: this.budget,
+          children: this.children,
+        });
+        return 0;
+      } else {
+        return rest;
+      }
+    },
+  },
+  methods: {
+    propagateSelectEvent(event) {
+      this.$emit('selectEvent', event);
+    },
+  },
+};
+</script>
+
+<style scoped lang="scss">
+.flamegraph-branch {
+  display: flex;
+  flex-direction: row;
+  align-items: flex-end;
+  flex-wrap: nowrap;
+}
+</style>

--- a/packages/components/src/components/flamegraph/FlamegraphItem.vue
+++ b/packages/components/src/components/flamegraph/FlamegraphItem.vue
@@ -1,0 +1,82 @@
+<template>
+  <v-popper :placement="'bottom'" :text="popperContent" class="flamegraph-popper">
+    <div ref="inner" class="flamegraph-common flamegraph-item" :style="style" @click="selectEvent">
+      {{ content }}
+    </div>
+  </v-popper>
+</template>
+
+<script>
+import {
+  PADDING,
+  BORDER,
+  CONTENT_THRESHOLD,
+  FONT_SIZE,
+  HEIGHT,
+  styleDimension,
+} from '../../lib/flamegraph';
+import { Event } from '@appland/models';
+import VPopper from '@/components/Popper.vue';
+const options = { padding: PADDING, border: BORDER };
+export default {
+  name: 'v-flamegraph-item',
+  emits: ['selectEvent'],
+  components: {
+    VPopper,
+  },
+  props: {
+    event: {
+      type: Object,
+      required: true,
+      validator: (value) => value instanceof Event,
+    },
+    budget: {
+      type: Number,
+      required: true,
+    },
+    focused: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  computed: {
+    // hasOverflow() {
+    //   // Not sure why this.$refs is empty here...
+    //   return this.$refs.inner.scrollWidth > this.$refs.inner.clientWidth;
+    // },
+    style() {
+      return {
+        ...styleDimension({ width: this.budget, height: HEIGHT }, options),
+        'border-color': this.focused ? '#ff07aa' : '#6FDDD6',
+        // 'border-color': this.focused ? '#ff07aa' : '#010306',
+        'font-size': `${FONT_SIZE}px`,
+      };
+    },
+    popperContent() {
+      return this.event.toString();
+      // return this.hasOverflow ? this.event.toString() : '';
+    },
+    content() {
+      return this.budget < CONTENT_THRESHOLD ? '' : this.event.toString();
+    },
+  },
+  methods: {
+    selectEvent() {
+      this.$emit('selectEvent', this.event);
+    },
+  },
+};
+</script>
+
+<style scoped lang="scss">
+@import '@/scss/flamegraph.scss';
+.flamegraph-item {
+  background: #4362b1;
+  color: #eaeaea;
+  cursor: pointer;
+  transition: all 1s linear;
+  &:hover {
+    color: #fc8cd5;
+  }
+}
+</style>

--- a/packages/components/src/components/flamegraph/FlamegraphNode.vue
+++ b/packages/components/src/components/flamegraph/FlamegraphNode.vue
@@ -1,0 +1,88 @@
+<template>
+  <div class="flamegraph-node">
+    <v-flamegraph-branch
+      v-if="areChildrenVisible"
+      :events="children"
+      :budget="childrenBudget"
+      :focus="childrenFocus"
+      @selectEvent="propagateSelectEvent"
+    />
+    <v-flamegraph-item
+      :event="event"
+      :budget="budget"
+      :focused="focused"
+      @selectEvent="propagateSelectEvent"
+    />
+  </div>
+</template>
+
+<script>
+import { Event } from '@appland/models';
+import VFlamegraphBranch from './FlamegraphBranch.vue';
+import VFlamegraphItem from './FlamegraphItem.vue';
+import { add, getEventDuration } from '../../lib/flamegraph';
+export default {
+  name: 'v-flamegraph-node',
+  emits: ['selectEvent'],
+  components: {
+    VFlamegraphBranch,
+    VFlamegraphItem,
+  },
+  props: {
+    event: {
+      type: Object,
+      required: true,
+      validator: (value) => value instanceof Event,
+    },
+    budget: {
+      type: Number,
+      required: true,
+    },
+    focus: {
+      type: Object,
+      required: false,
+      default: null,
+    },
+  },
+  methods: {
+    propagateSelectEvent(event) {
+      this.$emit('selectEvent', event);
+    },
+  },
+  computed: {
+    children() {
+      return this.event.children;
+    },
+    areChildrenVisible() {
+      return this.event.children.length > 0;
+    },
+    focused() {
+      return this.event === this.focus;
+    },
+    childrenFocus() {
+      return this.event === this.focus ? null : this.focus;
+    },
+    childrenBudget() {
+      const duration = getEventDuration(this.event);
+      if (duration === 0 || (this.focus && this.focus !== this.event)) {
+        return this.budget;
+      } else {
+        return Math.min(
+          this.budget,
+          Math.floor(
+            (this.budget * this.event.children.map(getEventDuration).reduce(add, 0)) / duration
+          )
+        );
+      }
+    },
+  },
+};
+</script>
+
+<style scoped lang="scss">
+.flamegraph-node {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+}
+</style>

--- a/packages/components/src/components/flamegraph/FlamegraphRest.vue
+++ b/packages/components/src/components/flamegraph/FlamegraphRest.vue
@@ -1,0 +1,34 @@
+<template>
+  <div class="flamegraph-common flamegraph-rest" :style="style"></div>
+</template>
+
+<script>
+import { BORDER, PADDING, HEIGHT, styleDimension, FONT_SIZE } from '../../lib/flamegraph';
+const options = { padding: PADDING, border: BORDER };
+export default {
+  name: 'v-flamegraph-rest',
+  props: {
+    budget: {
+      type: Number,
+      required: true,
+    },
+  },
+  computed: {
+    style() {
+      return {
+        ...styleDimension({ width: this.budget, height: HEIGHT }, options),
+        'font-size': `${FONT_SIZE}px`,
+      };
+    },
+  },
+};
+</script>
+
+<style scoped lang="scss">
+@import '@/scss/flamegraph.scss';
+.flamegraph-rest {
+  background: #ebdf90;
+  border-color: #beaf4e;
+  transition: all 1s ease;
+}
+</style>

--- a/packages/components/src/components/flamegraph/FlamegraphRoot.vue
+++ b/packages/components/src/components/flamegraph/FlamegraphRoot.vue
@@ -1,0 +1,54 @@
+<template>
+  <div class="flamegraph-common flamegraph-root" :style="style" @click="clearSelectEvent">
+    {{ sanitizedTitle }}
+  </div>
+</template>
+
+<script>
+import { BORDER, PADDING, HEIGHT, FONT_SIZE, styleDimension } from '../../lib/flamegraph';
+const options = { padding: PADDING, border: BORDER };
+export default {
+  name: 'v-flamegraph-root',
+  emits: ['clearSelectEvent'],
+  props: {
+    budget: {
+      type: Number,
+      required: true,
+    },
+    title: {
+      type: String,
+      default: 'root',
+    },
+  },
+  methods: {
+    clearSelectEvent() {
+      this.$emit('clearSelectEvent');
+    },
+  },
+  computed: {
+    sanitizedTitle() {
+      return typeof this.title === 'string' ? this.title : 'root';
+    },
+    style() {
+      return {
+        ...styleDimension({ width: this.budget, height: HEIGHT }, options),
+        'font-size': `${FONT_SIZE}px`,
+      };
+    },
+  },
+};
+</script>
+
+<style scoped lang="scss">
+@import '@/scss/flamegraph.scss';
+.flamegraph-root {
+  background: #9c2fba;
+  color: #eaeaea;
+  border-color: #681f7c;
+  cursor: pointer;
+  transition: all 1s ease;
+  &:hover {
+    color: #ffffff;
+  }
+}
+</style>

--- a/packages/components/src/components/trace/TraceEventBlock.vue
+++ b/packages/components/src/components/trace/TraceEventBlock.vue
@@ -54,7 +54,7 @@ import VTraceSummary from './TraceSummary.vue';
 export default {
   name: 'v-trace-event-block',
   components: {
-    'v-trace': () => import('./Trace.vue'),
+    VTrace: async () => (await import('./Trace.vue')).default,
     VTraceNode,
     VTraceSummary,
   },

--- a/packages/components/src/components/trace/TraceNode.vue
+++ b/packages/components/src/components/trace/TraceNode.vue
@@ -22,7 +22,6 @@
 
 <script>
 import { Event } from '@appland/models';
-import { CLEAR_SELECTION_STACK, SELECT_CODE_OBJECT } from '@/store/vsCode';
 import NodeConnection from '@/assets/node_connection.svg';
 import VTraceNodeBodyDefault from './TraceNodeBodyDefault.vue';
 import VTraceNodeBodyHttp from './TraceNodeBodyHttp.vue';
@@ -116,15 +115,6 @@ export default {
         'connection-icon--right': true,
         'connection-icon--connected': this.event.children.length > 0,
       };
-    },
-  },
-
-  methods: {
-    selectNode() {
-      if (this.$store) {
-        this.$store.commit(CLEAR_SELECTION_STACK);
-        this.$store.commit(SELECT_CODE_OBJECT, this.event);
-      }
     },
   },
 };

--- a/packages/components/src/pages/VsCodeExtension.vue
+++ b/packages/components/src/pages/VsCodeExtension.vue
@@ -123,6 +123,10 @@
           <v-diagram-flamegraph
             ref="viewFlamegraph_diagram"
             :events="filteredAppMap.rootEvents()"
+            :selected-events="selectedEvent"
+            :title="filteredAppMap.name"
+            @selectEvent="onClickTraceEvent"
+            @clearSelectEvent="clearSelection"
           />
         </v-tab>
 

--- a/packages/components/src/pages/VsCodeExtension.vue
+++ b/packages/components/src/pages/VsCodeExtension.vue
@@ -17,6 +17,7 @@
         :findings="findings"
         :wasAutoPruned="wasAutoPruned"
         :isGiantAppMap="isGiantAppMap"
+        :flamegraphEnabled="flamegraphEnabled"
         @onChangeFilter="
           (value) => {
             this.eventFilterText = value;

--- a/packages/components/src/scss/flamegraph.scss
+++ b/packages/components/src/scss/flamegraph.scss
@@ -1,0 +1,24 @@
+// It is ugly that the font url is relative to where the css is imported and not where to this
+// file is located. Anyway this font is declared in multiple places we should centralize it.
+@font-face {
+  font-family: 'IBM Plex Mono';
+  src: local('IBM Plex Mono'),
+    url(../../assets/fonts/IBM_Plex_Mono/IBMPlexMono-Regular.ttf) format('truetype');
+}
+
+.flamegraph-common {
+  display: block;
+  text-align: left;
+  font-family: 'IBM Plex Mono', monospace;
+  border-style: solid;
+  margin: 0px;
+  box-sizing: border-box;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.flamegraph-popper {
+  font-size: 0.8rem;
+  font-family: 'IBM Plex Mono', monospace;
+}

--- a/packages/components/src/stories/DiagramFlamegraph.stories.js
+++ b/packages/components/src/stories/DiagramFlamegraph.stories.js
@@ -5,6 +5,7 @@ import './scss/fullscreen.scss';
 
 const store = buildStore();
 store.commit(SET_APPMAP_DATA, scenario);
+const events = store.state.appMap.rootEvents();
 
 export default {
   title: 'AppLand/Diagrams/Flamegraph',
@@ -15,15 +16,30 @@ export default {
       diffThreshold: 1,
     },
   },
-  argTypes: {},
   args: {
-    events: store.state.appMap.rootEvents(),
+    events,
+    title: 'default title',
   },
+  argTypes: {},
 };
 
 export const flamegraph = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
   components: { VDiagramFlamegraph },
-  template: '<v-diagram-flamegraph v-bind="$props" />',
-  store,
+  template: `
+    <v-diagram-flamegraph
+      v-bind="$props"
+      :selected-events="selectedEventArray"
+      @selectEvent="(e) => { selectedEvent = e; }"
+      @clearSelectEvent="() => { selectedEvent = null; }"
+    />
+  `,
+  data() {
+    return { selectedEvent: null };
+  },
+  computed: {
+    selectedEventArray() {
+      return this.selectedEvent ? [this.selectedEvent] : [];
+    },
+  },
 });

--- a/packages/components/src/stories/Slider.stories.js
+++ b/packages/components/src/stories/Slider.stories.js
@@ -1,0 +1,22 @@
+import VSlider from '@/components/Slider.vue';
+
+export default {
+  title: 'AppLand/UI/Slider',
+  component: VSlider,
+  argTypes: {},
+};
+
+const Template = (args, { argTypes }) => ({
+  components: { VSlider },
+  data() {
+    return { state: 0.5 };
+  },
+  template: `
+    <v-slider
+      :value="state"
+      @slide="(v) => { state = v; }"
+    />
+  `,
+});
+
+export const slider = Template.bind({});

--- a/packages/components/tests/e2e/specs/diagramFlamegraph.spec.js
+++ b/packages/components/tests/e2e/specs/diagramFlamegraph.spec.js
@@ -6,10 +6,10 @@ context('Flamegraph', () => {
   });
 
   it('renders root', () => {
-    cy.get('.d3-flame-graph').contains('root');
+    cy.get('.flamegraph-root').contains('default title');
   });
 
   it('renders GET /admin/orders', () => {
-    cy.get('.d3-flame-graph').contains('GET /admin/orders');
+    cy.get('.flamegraph-item').contains('GET /admin/orders');
   });
 });

--- a/packages/components/tests/e2e/specs/slider.spec.js
+++ b/packages/components/tests/e2e/specs/slider.spec.js
@@ -1,0 +1,37 @@
+const plusRegex = /^\u002B$/;
+const minusRegex = /^\u2212$/;
+
+context('slider', () => {
+  beforeEach(() => {
+    cy.visit('http://localhost:6006/iframe.html?id=appland-ui-slider--slider&viewMode=story');
+    cy.viewport(100, 200);
+  });
+
+  it('contains the minus and plus button', () => {
+    const buttons = cy.get('.button');
+    cy.get('.button').contains(plusRegex);
+    cy.get('.button').contains(minusRegex);
+  });
+
+  it('moves grab handle up when clicking on plus', () => {
+    cy.get('.grab').then(([grab]) => {
+      const { y: y0 } = grab.getBoundingClientRect();
+      cy.get('.button').contains(plusRegex).click();
+      cy.get('.grab').then(([grab]) => {
+        const { y: y1 } = grab.getBoundingClientRect();
+        expect(y1).to.be.below(y0);
+      });
+    });
+  });
+
+  it('moves grab handle down when clicking on minus', () => {
+    cy.get('.grab').then(([grab]) => {
+      const { y: y0 } = grab.getBoundingClientRect();
+      cy.get('.button').contains(minusRegex).click();
+      cy.get('.grab').then(([grab]) => {
+        const { y: y1 } = grab.getBoundingClientRect();
+        expect(y1).to.be.above(y0);
+      });
+    });
+  });
+});

--- a/packages/components/tests/unit/flamegraph.spec.js
+++ b/packages/components/tests/unit/flamegraph.spec.js
@@ -1,33 +1,65 @@
-import { digestEventArray } from '@/lib/flamegraph.js';
-import scenario from '@/stories/data/scenario.json';
-import { buildAppMap } from '@appland/models';
+import { isEventDurationValid, getEventDuration, styleDimension } from '@/lib/flamegraph.js';
 
-const accumulateValue = (sum, { value }) => sum + value;
+describe('isEventDurationValid', () => {
+  it('returns true for event with positive duration', () => {
+    expect(isEventDurationValid({ elapsedTime: 123 })).toBe(true);
+  });
+  it('returns true for event with 0 duration', () => {
+    expect(isEventDurationValid({ elapsedTime: 0 })).toBe(true);
+  });
+  it('returns false for event with negative duration', () => {
+    expect(isEventDurationValid({ elapsedTime: -123 })).toBe(false);
+  });
+  it('returns false for event with NaN duration', () => {
+    expect(isEventDurationValid({ elapsedTime: NaN })).toBe(false);
+  });
+  it('returns false for event with duration of wrong type', () => {
+    expect(isEventDurationValid({ elapsedTime: '123' })).toBe(false);
+  });
+});
 
-const validateNode = (node) => {
-  // children
-  expect(node).toHaveProperty('children');
-  expect(node.children).toBeInstanceOf(Array);
-  node.children.forEach(validateNode);
-  // name //
-  expect(node).toHaveProperty('name');
-  expect(typeof node.name).toBe('string');
-  // value //
-  expect(node).toHaveProperty('value');
-  expect(typeof node.value).toBe('number');
-  expect(Number.isInteger(node.value)).toBe(true);
-  expect(node.value).toBeGreaterThanOrEqual(node.children.reduce(accumulateValue, 0));
-  expect(node.value);
-};
+describe('getEventDuration', () => {
+  it('returns 0 for event with invalid duration', () => {
+    expect(getEventDuration({ elapsedTime: -123 })).toBe(0);
+    expect(getEventDuration({ elapsedTime: NaN })).toBe(0);
+    expect(getEventDuration({ elapsedTime: '123' })).toBe(0);
+  });
+  it('returns the duration for event with valid duration', () => {
+    expect(getEventDuration({ elapsedTime: 123 })).toBe(123);
+  });
+});
 
-describe('digestEventArray', () => {
-  it('produce valid flamegraph tree', () => {
-    const { events } = buildAppMap(scenario).normalize().build();
-    const node = digestEventArray(events);
-    validateNode(node);
-    expect(node.name).toBe('root');
-    expect(node.children.length).toBeGreaterThan(2);
-    expect(node.children[0].name).toBe('GET /admin');
-    expect(node.children[1].name).toBe('Spree::Admin::RootController#index');
+describe('styleDimension', () => {
+  it('throws an error if height is too small', () => {
+    expect(() => styleDimension({ width: 10, height: 20 }, { border: 0, padding: 15 })).toThrow();
+    expect(() => styleDimension({ width: 10, height: 20 }, { border: 15, padding: 0 })).toThrow();
+  });
+  it('honor border and padding when possible', () => {
+    expect(styleDimension({ width: 10, height: 20 }, { border: 2, padding: 3 })).toEqual({
+      width: '10px',
+      height: '20px',
+      'padding-left': '3px',
+      'padding-right': '3px',
+      'padding-bottom': '3px',
+      'padding-top': '3px',
+      'border-left-width': '2px',
+      'border-right-width': '2px',
+      'border-top-width': '2px',
+      'border-bottom-width': '2px',
+    });
+  });
+  it('shrink border and padding when restricted', () => {
+    expect(styleDimension({ width: 1, height: 20 }, { border: 2, padding: 3 })).toEqual({
+      width: '1px',
+      height: '20px',
+      'padding-left': '0px',
+      'padding-right': '0px',
+      'padding-bottom': '3px',
+      'padding-top': '3px',
+      'border-left-width': '1px',
+      'border-right-width': '0px',
+      'border-top-width': '2px',
+      'border-bottom-width': '2px',
+    });
   });
 });

--- a/packages/scanner/package.json
+++ b/packages/scanner/package.json
@@ -72,7 +72,7 @@
     "chalk": "^4.1.2",
     "chokidar": "^3.5.1",
     "cli-progress": "^3.11.0",
-    "conf": "^10.0.2",
+    "conf": "^10.1.2",
     "crypto-js": "^4.0.0",
     "glob": "7.2.3",
     "inquirer": "^8.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -392,7 +392,7 @@ __metadata:
     chalk: ^4.1.2
     chokidar: ^3.5.1
     cli-progress: ^3.11.0
-    conf: ^10.0.2
+    conf: ^10.1.2
     crypto-js: ^4.0.0
     eslint: ^7.32.0
     eslint-config-prettier: ^8.3.0
@@ -11748,7 +11748,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"conf@npm:<11, conf@npm:^10.0.2":
+"conf@npm:<11, conf@npm:^10.1.2":
   version: 10.2.0
   resolution: "conf@npm:10.2.0"
   dependencies:


### PR DESCRIPTION
This PR is meant to put the flamegraph in the hand of the team so it can be iterated upon. Consequently, the flamegraph is hidden behind a configuration flag to not expose the lambda user.

Known area of improvements:

- Performance: The entire event tree is displayed at once. On my setup this is not an issue even on large Appmap. If performance becomes an issue, we can implement a minimal width required to instantiate components. That will cause to only instantiate components on the part of the flamegraph that is zoomed in. While this may seem like a no-brainer, it will make the flamegraph harder to animate because transitions are easier to add on kept-alive components.
- Animation: animations can be improved. First we should not use `transition: all` for performance reasons. Second the rendering of flamegraph from 0px to 1px can cause the animation to be bumpy.
- Styling: this can certainly be tweaked to be made more beautiful.

I think it will be valuable to first focus on bigger design decisions before spending time on the points above.