### PR TITLE
feat: Add exceptions to the index

### DIFF
--- a/packages/cli/src/fingerprint/algorithms.js
+++ b/packages/cli/src/fingerprint/algorithms.js
@@ -4,7 +4,10 @@ function notNull(event) {
 }
 
 function makeUnique(events) {
-  const eventsJSON = events.flat().map((e) => JSON.stringify(e));
+  const eventsJSON = events
+    .filter((item) => item !== undefined)
+    .flat()
+    .map((e) => JSON.stringify(e));
   return [...new Set(eventsJSON)].sort().map((json) => JSON.parse(json));
 }
 

--- a/packages/cli/src/fingerprint/canonicalize.js
+++ b/packages/cli/src/fingerprint/canonicalize.js
@@ -5,6 +5,7 @@ const algorithms = {
   httpClientRequests: require('./canonicalize/httpClientRequests'),
   httpServerRequests: require('./canonicalize/httpServerRequests'),
   labels: require('./canonicalize/labels'),
+  exceptions: require('./canonicalize/exceptions'),
   packages: require('./canonicalize/packages'),
   packageDependencies: require('./canonicalize/packageDependencies'),
   sqlNormalized: require('./canonicalize/sqlNormalized'),

--- a/packages/cli/src/fingerprint/canonicalize/exceptions.ts
+++ b/packages/cli/src/fingerprint/canonicalize/exceptions.ts
@@ -1,0 +1,45 @@
+/* eslint-disable class-methods-use-this */
+import { AppMap, Event, ExceptionObject } from '@appland/models';
+import Unique from './unique';
+
+type CanonicalException = {
+  class: string;
+  message: string;
+  location?: string;
+  stack: string[];
+};
+
+function formatException(event: Event, exception: ExceptionObject): CanonicalException {
+  const result: CanonicalException = {
+    class: exception.class,
+    message: exception.message,
+    stack: [],
+  };
+
+  let { path, lineno } = exception;
+  if (path) {
+    result.location = [path, lineno].filter(Boolean).join(':');
+    result.stack.push(result.location);
+  }
+
+  let ancestor: Event | undefined = event;
+  while (ancestor) {
+    if (ancestor.codeObject.location) {
+      result.stack.push(ancestor.codeObject.location);
+    }
+    ancestor = ancestor.parent;
+  }
+
+  return result;
+}
+
+class Canonicalize extends Unique {
+  functionCall(event: Event) {
+    const { exceptions } = event;
+    if (!exceptions || exceptions.length === 0) return;
+
+    return exceptions.map((exception) => formatException(event, exception)).filter(Boolean);
+  }
+}
+
+module.exports = (appmap: AppMap) => new Canonicalize(appmap).execute();

--- a/packages/cli/src/fingerprint/fingerprinter.ts
+++ b/packages/cli/src/fingerprint/fingerprinter.ts
@@ -16,6 +16,10 @@ const renameFile = promisify(gracefulFs.rename);
 /**
  * CHANGELOG
  *
+ * * # 1.3.0
+ *
+ * * Include exceptions in the index.
+ *
  * # 1.2.0
  *
  * * Drop fingerprint fields, as these are no longer used by downstream tools.

--- a/packages/cli/tests/unit/fingerprint/exceptions.spec.js
+++ b/packages/cli/tests/unit/fingerprint/exceptions.spec.js
@@ -1,0 +1,227 @@
+const { buildAppMap } = require('@appland/models');
+const Exceptions = require('../../../src/fingerprint/canonicalize/exceptions');
+
+describe('Exceptions', () => {
+  test('not present', () => {
+    const result = Exceptions(
+      buildAppMap({
+        events: [
+          {
+            id: 1,
+            event: 'call',
+          },
+          {
+            id: 2,
+            event: 'return',
+            parent_id: 1,
+          },
+        ],
+      }).build()
+    );
+    expect(result).toEqual([]);
+  });
+  test('single exception', () => {
+    const result = Exceptions(
+      buildAppMap({
+        events: [
+          {
+            id: 1,
+            event: 'call',
+          },
+          {
+            id: 2,
+            event: 'return',
+            parent_id: 1,
+            exceptions: [
+              {
+                path: '/home/travis/.rvm/gems/ruby-2.6.5/bundler/gems/appmap-ruby-d2ba81e811c2/lib/appmap/hook/method.rb',
+                class: 'JSON::ParserError',
+                lineno: 67,
+                message:
+                  "767: unexpected token at 'PjWXCtB4Y9DH4KajHNB1lkxlOuG7PuhxktaiFETErowH0kNO+VCJ292e854O+LeS/pLOEjzI7nj2EDSATCOdr103jdWt5JY3CFh8eHAyNNwQQiD1XQY2SvfaG+ld9T7t0KjOQx1zkayjlZP9+X/LsUuy1g77cQA83qDtCAL18dRu29OEjnCf1St3UU+X/gRmun7Og7ffd+tkIGNi4lmKA==--MhYqMRJLLhRkZLU3z1N1LA=='",
+                object_id: 47346496836920,
+              },
+            ],
+          },
+        ],
+      }).build()
+    );
+    expect(result).toEqual([
+      {
+        location:
+          '/home/travis/.rvm/gems/ruby-2.6.5/bundler/gems/appmap-ruby-d2ba81e811c2/lib/appmap/hook/method.rb:67',
+        class: 'JSON::ParserError',
+        message:
+          "767: unexpected token at 'PjWXCtB4Y9DH4KajHNB1lkxlOuG7PuhxktaiFETErowH0kNO+VCJ292e854O+LeS/pLOEjzI7nj2EDSATCOdr103jdWt5JY3CFh8eHAyNNwQQiD1XQY2SvfaG+ld9T7t0KjOQx1zkayjlZP9+X/LsUuy1g77cQA83qDtCAL18dRu29OEjnCf1St3UU+X/gRmun7Og7ffd+tkIGNi4lmKA==--MhYqMRJLLhRkZLU3z1N1LA=='",
+        stack: [
+          '/home/travis/.rvm/gems/ruby-2.6.5/bundler/gems/appmap-ruby-d2ba81e811c2/lib/appmap/hook/method.rb:67',
+        ],
+      },
+    ]);
+  });
+  test('collect ancestors into stack', () => {
+    const appmap = buildAppMap({
+      classMap: [
+        {
+          type: 'package',
+          name: 'app',
+          children: [
+            {
+              type: 'package',
+              name: 'controllers',
+              children: [
+                {
+                  type: 'class',
+                  name: 'HomeController',
+                  children: [
+                    {
+                      type: 'function',
+                      name: 'index',
+                      static: false,
+                      location: 'app/controllers/home_controller.rb:5',
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              type: 'package',
+              name: 'models',
+              children: [
+                {
+                  type: 'class',
+                  name: 'User',
+                  children: [
+                    {
+                      type: 'function',
+                      name: 'find',
+                      static: true,
+                      location: 'app/models/user.rb:10',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      events: [
+        {
+          id: 1,
+          thread_id: 1,
+          event: 'call',
+          path: 'app/controllers/home_controller.rb',
+          defined_class: 'HomeController',
+          method_id: 'index',
+          static: false,
+          lineno: 5,
+        },
+        {
+          id: 2,
+          thread_id: 1,
+          event: 'call',
+          path: 'app/models/user.rb',
+          defined_class: 'User',
+          method_id: 'find',
+          static: true,
+          lineno: 10,
+        },
+        {
+          id: 3,
+          thread_id: 1,
+          event: 'return',
+          parent_id: 2,
+          exceptions: [
+            {
+              path: '/home/travis/.rvm/gems/ruby-2.6.5/bundler/gems/appmap-ruby-d2ba81e811c2/lib/appmap/hook/method.rb',
+              class: 'JSON::ParserError',
+              lineno: 67,
+              message:
+                "767: unexpected token at 'PjWXCtB4Y9DH4KajHNB1lkxlOuG7PuhxktaiFETErowH0kNO+VCJ292e854O+LeS/pLOEjzI7nj2EDSATCOdr103jdWt5JY3CFh8eHAyNNwQQiD1XQY2SvfaG+ld9T7t0KjOQx1zkayjlZP9+X/LsUuy1g77cQA83qDtCAL18dRu29OEjnCf1St3UU+X/gRmun7Og7ffd+tkIGNi4lmKA==--MhYqMRJLLhRkZLU3z1N1LA=='",
+              object_id: 47346496836920,
+            },
+          ],
+        },
+        {
+          id: 4,
+          thread_id: 1,
+          parent_id: 1,
+          event: 'return',
+        },
+      ],
+    }).build();
+    const result = Exceptions(appmap);
+    expect(result).toEqual([
+      {
+        location:
+          '/home/travis/.rvm/gems/ruby-2.6.5/bundler/gems/appmap-ruby-d2ba81e811c2/lib/appmap/hook/method.rb:67',
+        class: 'JSON::ParserError',
+        message:
+          "767: unexpected token at 'PjWXCtB4Y9DH4KajHNB1lkxlOuG7PuhxktaiFETErowH0kNO+VCJ292e854O+LeS/pLOEjzI7nj2EDSATCOdr103jdWt5JY3CFh8eHAyNNwQQiD1XQY2SvfaG+ld9T7t0KjOQx1zkayjlZP9+X/LsUuy1g77cQA83qDtCAL18dRu29OEjnCf1St3UU+X/gRmun7Og7ffd+tkIGNi4lmKA==--MhYqMRJLLhRkZLU3z1N1LA=='",
+        stack: [
+          '/home/travis/.rvm/gems/ruby-2.6.5/bundler/gems/appmap-ruby-d2ba81e811c2/lib/appmap/hook/method.rb:67',
+          'app/models/user.rb:10',
+          'app/controllers/home_controller.rb:5',
+        ],
+      },
+    ]);
+  });
+  test('uniquify exception', () => {
+    const result = Exceptions(
+      buildAppMap({
+        events: [
+          {
+            id: 1,
+            event: 'call',
+          },
+          {
+            id: 2,
+            event: 'return',
+            parent_id: 1,
+            exceptions: [
+              {
+                path: '/home/travis/.rvm/gems/ruby-2.6.5/bundler/gems/appmap-ruby-d2ba81e811c2/lib/appmap/hook/method.rb',
+                class: 'JSON::ParserError',
+                lineno: 67,
+                message:
+                  "767: unexpected token at 'PjWXCtB4Y9DH4KajHNB1lkxlOuG7PuhxktaiFETErowH0kNO+VCJ292e854O+LeS/pLOEjzI7nj2EDSATCOdr103jdWt5JY3CFh8eHAyNNwQQiD1XQY2SvfaG+ld9T7t0KjOQx1zkayjlZP9+X/LsUuy1g77cQA83qDtCAL18dRu29OEjnCf1St3UU+X/gRmun7Og7ffd+tkIGNi4lmKA==--MhYqMRJLLhRkZLU3z1N1LA=='",
+                object_id: 47346496836920,
+              },
+            ],
+          },
+          {
+            id: 3,
+            event: 'call',
+          },
+          {
+            id: 4,
+            event: 'return',
+            parent_id: 3,
+            exceptions: [
+              {
+                path: '/home/travis/.rvm/gems/ruby-2.6.5/bundler/gems/appmap-ruby-d2ba81e811c2/lib/appmap/hook/method.rb',
+                class: 'JSON::ParserError',
+                lineno: 67,
+                message:
+                  "767: unexpected token at 'PjWXCtB4Y9DH4KajHNB1lkxlOuG7PuhxktaiFETErowH0kNO+VCJ292e854O+LeS/pLOEjzI7nj2EDSATCOdr103jdWt5JY3CFh8eHAyNNwQQiD1XQY2SvfaG+ld9T7t0KjOQx1zkayjlZP9+X/LsUuy1g77cQA83qDtCAL18dRu29OEjnCf1St3UU+X/gRmun7Og7ffd+tkIGNi4lmKA==--MhYqMRJLLhRkZLU3z1N1LA=='",
+                object_id: 47346496836921, // Different object_id
+              },
+            ],
+          },
+        ],
+      }).build()
+    );
+    expect(result).toEqual([
+      {
+        location:
+          '/home/travis/.rvm/gems/ruby-2.6.5/bundler/gems/appmap-ruby-d2ba81e811c2/lib/appmap/hook/method.rb:67',
+        class: 'JSON::ParserError',
+        message:
+          "767: unexpected token at 'PjWXCtB4Y9DH4KajHNB1lkxlOuG7PuhxktaiFETErowH0kNO+VCJ292e854O+LeS/pLOEjzI7nj2EDSATCOdr103jdWt5JY3CFh8eHAyNNwQQiD1XQY2SvfaG+ld9T7t0KjOQx1zkayjlZP9+X/LsUuy1g77cQA83qDtCAL18dRu29OEjnCf1St3UU+X/gRmun7Og7ffd+tkIGNi4lmKA==--MhYqMRJLLhRkZLU3z1N1LA=='",
+        stack: [
+          '/home/travis/.rvm/gems/ruby-2.6.5/bundler/gems/appmap-ruby-d2ba81e811c2/lib/appmap/hook/method.rb:67',
+        ],
+      },
+    ]);
+  });
+});

--- a/packages/models/src/classMap.js
+++ b/packages/models/src/classMap.js
@@ -136,9 +136,7 @@ export default class ClassMap {
         e.codeObject = codeObject;
         codeObject.events.push(e);
 
-        const ancestors = codeObject.ancestors();
-        validCodeObjects.add(codeObject);
-        ancestors.forEach((obj) => validCodeObjects.add(obj));
+        codeObject.visitAncestors((obj) => validCodeObjects.add(obj));
       });
 
     this.codeObjects = this.codeObjects.filter((obj) => validCodeObjects.has(obj));


### PR DESCRIPTION
Add exceptions to the AppMap index. This allows exceptions to be efficiently compared across versions, and displayed in the Code Objects view.