### PR TITLE
Create default AppMap filter if none exists

### DIFF
--- a/packages/components/src/pages/VsCodeExtension.vue
+++ b/packages/components/src/pages/VsCodeExtension.vue
@@ -202,7 +202,6 @@
             <template v-slot:body>
               <v-filter-menu
                 :filteredAppMap="filteredAppMap"
-                :initialSavedFilters="savedFilters"
                 @setState="(stateString) => setState(stateString)"
               ></v-filter-menu>
             </template>
@@ -333,6 +332,7 @@ import {
   deserializeFilter,
   filterStringToFilterState,
   base64UrlEncode,
+  AppMapFilter,
 } from '@appland/models';
 import CopyIcon from '@/assets/copy-icon.svg';
 import CloseIcon from '@/assets/close.svg';
@@ -1187,6 +1187,22 @@ export default {
 
     initializeSavedFilters() {
       const savedFilters = this.savedFilters;
+
+      if (this.savedFilters.length === 0) {
+        const defaultFilter = new AppMapFilter();
+        const serialized = serializeFilter(defaultFilter);
+        const base64encoded = base64UrlEncode(JSON.stringify({ filters: serialized }));
+
+        const filterObject = {
+          filterName: 'AppMap default',
+          state: base64encoded,
+          default: true,
+        };
+
+        this.$root.$emit('saveFilter', filterObject);
+        savedFilters.push(filterObject);
+      }
+
       this.$store.commit(SET_SAVED_FILTERS, savedFilters);
 
       const defaultFilter = savedFilters.find((savedFilter) => savedFilter.default);

--- a/packages/components/tests/unit/VsCodeExtension.spec.js
+++ b/packages/components/tests/unit/VsCodeExtension.spec.js
@@ -4,6 +4,7 @@ import { VIEW_FLOW } from '@/store/vsCode';
 import data from './fixtures/user_page_scenario.appmap.json';
 import Vue from 'vue';
 import { RESET_FILTERS } from '../../src/store/vsCode';
+import { AppMapFilter, serializeFilter, base64UrlEncode } from '@appland/models';
 
 describe('VsCodeExtension.vue', () => {
   let wrapper; // Wrapper<Vue>
@@ -162,5 +163,21 @@ describe('VsCodeExtension.vue', () => {
 
     wrapper.vm.onChangeTab(wrapper.vm.$refs[VIEW_FLOW]);
     expect(rootWrapper.emitted().changeTab[1]).toContain(VIEW_FLOW);
+  });
+
+  it('creates a default filter', () => {
+    const defaultFilter = new AppMapFilter();
+    const serialized = serializeFilter(defaultFilter);
+    const base64encoded = base64UrlEncode(JSON.stringify({ filters: serialized }));
+
+    const expectedFilterObject = {
+      filterName: 'AppMap default',
+      state: base64encoded,
+      default: true,
+    };
+
+    const actual = rootWrapper.emitted().saveFilter;
+    expect(actual).toBeArrayOfSize(1);
+    expect(actual[0][0]).toEqual(expectedFilterObject);
   });
 });


### PR DESCRIPTION
Fixes #1247 

Previously, the VS Code extension was creating the default AppMap filter, but to make the filter feature compatible with JetBrains we want to move this code into the Vue frontend.