### PR TITLE
Do not test on node 14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,11 +27,6 @@ jobs:
 
     - node_js: 16
 
-    - node_js: 14
-      # appmapping doesn't work on node 14
-      # https://github.com/getappmap/appmap-agent-js/issues/229
-      script: yarn test:no-appmap
-
     - os: windows
       node_js: 18
       env:

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   "scripts": {
     "lint": "yarn workspaces foreach --exclude root -v run lint",
     "test": "yarn workspaces foreach --exclude '{root}' -v run test",
-    "test:no-appmap": "yarn workspaces foreach --exclude '{root}' -v run test:no-appmap",
     "build": "yarn workspaces foreach -t --exclude root -v run build",
     "build-native": "yarn workspaces foreach -t --exclude root -v run build-native",
     "codesign": "yarn workspaces foreach -t --exclude root -v run codesign",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,7 +15,6 @@
     "lint:fix": "eslint 'src/**/*.js' 'tests/**/*.js' --fix",
     "pre-commit": "lint-staged",
     "test": "appmap-agent-js && jest -t @appmap-fixme",
-    "test:no-appmap": "jest --filter=./tests/testFilter.js",
     "jest": "jest --filter=./tests/testFilter.js",
     "build": "tsc && yarn build:html",
     "watch": "tsc --watch",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -9,8 +9,7 @@
   "scripts": {
     "build": "tsc",
     "lint": "eslint",
-    "test": "appmap-agent-js",
-    "test:no-appmap": "jest"
+    "test": "appmap-agent-js"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -11,7 +11,6 @@
     "test:unit": "vue-cli-service test:unit",
     "test:e2e": "cypress run",
     "test": "npm run test:unit && node .storybook/run.js",
-    "test:no-appmap": "yarn test",
     "lint": "eslint --ext .js --ext .vue src",
     "pre-commit": "lint-staged",
     "storybook": "start-storybook -p 6006",

--- a/packages/diagrams/package.json
+++ b/packages/diagrams/package.json
@@ -14,7 +14,6 @@
     "lint:fix": "eslint 'src/**/*.js' 'tests/**/*.js' --fix",
     "pre-commit": "lint-staged",
     "test": "cross-env NODE_OPTIONS=--experimental-vm-modules jest",
-    "test:no-appmap": "yarn test",
     "watch": "rollup -c -w"
   },
   "lint-staged": {

--- a/packages/models/package.json
+++ b/packages/models/package.json
@@ -14,7 +14,6 @@
     "lint:fix": "eslint 'src/**/*.[jt]s' 'tests/**/*.[jt]s' --fix",
     "pre-commit": "lint-staged",
     "test": "appmap-agent-js",
-    "test:no-appmap": "jest",
     "watch": "tsup --watch"
   },
   "lint-staged": {

--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -10,7 +10,6 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "test": "appmap-agent-js",
-    "test:no-appmap": "jest",
     "build": "tsc -p tsconfig.build.json",
     "watch": "tsc -p tsconfig.build.json --watch",
     "lint": "eslint src"

--- a/packages/scanner/package.json
+++ b/packages/scanner/package.json
@@ -20,7 +20,6 @@
     "lint": "eslint src --ext .ts",
     "ci": "yarn lint && yarn build && yarn schema-up-to-date && yarn doc-up-to-date && yarn test",
     "test": "appmap-agent-js && jest -t @appmap-fixme --filter=./test/testFilter.js",
-    "test:no-appmap": "yarn jest",
     "jest": "jest --filter=./test/testFilter.js",
     "semantic-release": "semantic-release",
     "watch": "node bin/preBuild.js && tsc -p tsconfig.build.json --watch"

--- a/packages/sequence-diagram/package.json
+++ b/packages/sequence-diagram/package.json
@@ -14,7 +14,6 @@
     "lint": "eslint src --ext .ts",
     "ci": "yarn lint && yarn build && yarn test",
     "test": "jest",
-    "test:no-appmap": "yarn test",
     "semantic-release": "semantic-release"
   },
   "author": "AppLand, Inc.",

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -5,7 +5,6 @@
   "license": "MIT",
   "scripts": {
     "test": "appmap-agent-js",
-    "test:no-appmap": "jest",
     "lint": "eslint telemetry.ts",
     "pre-commit": "lint-staged"
   },

--- a/packages/validate/package.json
+++ b/packages/validate/package.json
@@ -4,7 +4,6 @@
   "scripts": {
     "start": "node bin/index.js",
     "test": "npx c8 --reporter=text-summary --check-coverage --branches=100 --functions=100 --lines=100 --statements=100 --include lib/index.js node test/smoke.js",
-    "test:no-appmap": "yarn test",
     "build": "node src/build.js",
     "test-html": "npx c8 --reporter=html node test/smoke.js && open coverage/index.html",
     "format": "npx prettier --write 'bin/*.js' 'lib/*.js' 'test/*.js' 'src/*.js' 'schema/*.js'",


### PR DESCRIPTION
Fixes #1255 

We can stop supporting Node 14 and so we can stop testing with it in CI to save time and resources.