### PR TITLE
fix: select correct code object

### DIFF
--- a/packages/components/src/pages/VsCodeExtension.vue
+++ b/packages/components/src/pages/VsCodeExtension.vue
@@ -980,7 +980,9 @@ export default {
                 }
               }
             } else {
-              selectedObject = classMap.codeObjects.find((obj) => obj.fqid === fqid);
+              selectedObject = classMap.codeObjects.find(
+                (obj) => obj.fqid.includes(type) && obj.fqid.includes(object)
+              );
             }
 
             if (selectedObject) {


### PR DESCRIPTION
Fixes #1264 

An example: 
`fqid` sent from VS Code: `route:GET /`
`fqid` in Vue : `route:HTTP server requests->GET /`

Another example:
`fqid` from VS Code: `query:DELETE FROM "active_storage_attachments" WHERE "active_storage_attachments"."id" = ?`
`fqid` in Vue: `query:Database->DELETE FROM "active_storage_attachments" WHERE "active_storage_attachments"."id" = ?`

As you can see, the strings are not exact, so this PR changes the condition from an exact match to a conditional using `includes`.