### PR TITLE
Bump sequence diagram version in components

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@appland/diagrams": "workspace:^1.7.0",
     "@appland/models": "workspace:^2.6.2",
-    "@appland/sequence-diagram": "workspace:^1.5.2",
+    "@appland/sequence-diagram": "workspace:^1.6.1",
     "buffer": "^6.0.3",
     "d3": "^7.8.4",
     "d3-flame-graph": "^4.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -251,7 +251,7 @@ __metadata:
   dependencies:
     "@appland/diagrams": "workspace:^1.7.0"
     "@appland/models": "workspace:^2.6.2"
-    "@appland/sequence-diagram": "workspace:^1.5.2"
+    "@appland/sequence-diagram": "workspace:^1.6.1"
     "@babel/core": ^7.22.5
     "@babel/node": ^7.22.5
     "@babel/preset-env": ^7.22.5
@@ -470,7 +470,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@appland/sequence-diagram@workspace:^1, @appland/sequence-diagram@workspace:^1.5.2, @appland/sequence-diagram@workspace:packages/sequence-diagram":
+"@appland/sequence-diagram@workspace:^1, @appland/sequence-diagram@workspace:^1.6.1, @appland/sequence-diagram@workspace:packages/sequence-diagram":
   version: 0.0.0-use.local
   resolution: "@appland/sequence-diagram@workspace:packages/sequence-diagram"
   dependencies:


### PR DESCRIPTION
Bump `@appland/sequence-diagram` to `1.6.1` in `@appland/components`.