### PR TITLE
feat: Manual instructions instruct the user to create appmap.yml

### DIFF
--- a/packages/components/src/components/install-guide/install-instructions/JavaScript.vue
+++ b/packages/components/src/components/install-guide/install-instructions/JavaScript.vue
@@ -10,26 +10,30 @@
     <section>
       <h3>Add the <code class="inline">appmap</code> package to your project</h3>
 
-      <div>
-        <v-code-snippet clipboard-text="npm install --save-dev appmap-agent-js" />
-      </div>
-      <div>
-        <div>OR</div>
-        <v-code-snippet clipboard-text="yarn add --dev appmap-agent-js" />
-      </div>
+      <p>
+        <span class="subheading">Install with NPM</span>
+        <v-code-snippet
+          clipboard-text="npm install --save-dev @appland/appmap-agent-js"
+          class="mt-0"
+        />
+      </p>
+      <p>
+        <span class="subheading">Install with Yarn</span>
+        <v-code-snippet clipboard-text="yarn add --dev @appland/appmap-agent-js" class="mt-0" />
+      </p>
     </section>
 
     <section>
-      <h3>Create <code class="inline">appmap.yml</code></h3>
-      <br />
-      <div>
-        Follow the
+      <h3>Configure AppMap</h3>
+      <p>
+        Lastly, create an <i>appmap.yml</i> configuration file by following the
         <a
           href="https://appmap.io/docs/reference/appmap-agent-js.html#configuration"
           target="_blank"
-          >appmap-agent-js Configuration guide</a
-        >.
-      </div>
+        >
+          AppMap Agent for JavaScript configuration guide.
+        </a>
+      </p>
     </section>
   </div>
 </template>
@@ -47,5 +51,15 @@ export default {
   display: flex;
   justify-content: center;
   margin: 1em;
+}
+
+.mt-0 {
+  margin-top: 0;
+}
+
+.subheading {
+  font-size: 90%;
+  font-weight: 400;
+  color: $gray4;
 }
 </style>

--- a/packages/components/src/components/install-guide/install-instructions/Python.vue
+++ b/packages/components/src/components/install-guide/install-instructions/Python.vue
@@ -28,8 +28,12 @@
     </section>
 
     <section>
-      A default configuration file, <code class="inline">appmap.yml</code>, will be created the
-      first time you run your application with AppMap enabled.
+      <h3>Configure AppMap</h3>
+      <p>
+        Finalize the installation by running the command below. An <i>appmap.yml</i> configuration
+        file will automatically be created in the current working directory.
+      </p>
+      <v-code-snippet clipboard-text="python -c 'import appmap'" :kind="ctaButtonType" />
     </section>
   </div>
 </template>

--- a/packages/components/src/components/install-guide/install-instructions/Ruby.vue
+++ b/packages/components/src/components/install-guide/install-instructions/Ruby.vue
@@ -8,12 +8,20 @@
       <p>Add the following line of code to the <strong>top of your Gemfile</strong>.</p>
       <v-code-snippet
         clipboard-text="# This should be the first gem listed, so that appmap is loaded first\ngem 'appmap', group: %i[test development]"
+        :kind="ctaButtonType"
       />
-      <p>Update your bundle.</p>
-      <v-code-snippet clipboard-text="bundle install" />
 
-      A default configuration file, <code class="inline">appmap.yml</code>, will be created the
-      first time you run your application with AppMap enabled.
+      <p>Update your bundle.</p>
+      <v-code-snippet clipboard-text="bundle install" :kind="ctaButtonType" />
+    </section>
+
+    <section>
+      <h3>Configure AppMap</h3>
+      <p>
+        Finally, run the configuration bootstrapper to automatically create an
+        <i>appmap.yml</i> file for this project.
+      </p>
+      <v-code-snippet clipboard-text="bundle exec appmap-agent-config" :kind="ctaButtonType" />
     </section>
   </div>
 </template>
@@ -24,5 +32,6 @@ import VCodeSnippet from '@/components/CodeSnippet.vue';
 export default {
   name: 'Ruby',
   components: { VCodeSnippet },
+  props: { ctaButtonType: { type: String, default: 'primary' } },
 };
 </script>

--- a/packages/components/src/stories/install-guide/ProjectPicker.stories.js
+++ b/packages/components/src/stories/install-guide/ProjectPicker.stories.js
@@ -29,7 +29,7 @@ const Template = (args, { argTypes }) => ({
   data: () => ({
     projects: args.projects.map((project) => ({
       ...project,
-      debugConfigurationStatus: args.debugConfigurationStatus,
+      debugConfigurationStatus: project.debugConfigurationStatus || args.debugConfigurationStatus,
       javaAgentStatus: args.javaAgentStatus,
     })),
   }),
@@ -270,8 +270,10 @@ JavaVSCode.args = {
         name: 'Spring',
         score: 2,
       },
+      debugConfigurationStatus: 1,
     },
   ],
+  javaAgentStatus: 2,
   editor: 'vscode',
 };
 


### PR DESCRIPTION
This pull request updates manual instructions for Python, Ruby and JavaScript, informing the user to create an `appmap.yml` in a language specific manner.

Java is addressed via an upcoming change in `vscode-appland`.

![image](https://github.com/getappmap/appmap-js/assets/8737782/d01ed17e-de98-461a-af00-ee140f733ad5)
![image](https://github.com/getappmap/appmap-js/assets/8737782/f24824bf-7447-4965-9e57-19998e6dd315)
![image](https://github.com/getappmap/appmap-js/assets/8737782/2234d1bf-a42f-45eb-8a64-7ab0c29de765)
