### PR TITLE
Consistent `fqid`s for queries and (external) routes

### DIFF
--- a/packages/cli/tests/unit/search/findCodeObjects.spec.ts
+++ b/packages/cli/tests/unit/search/findCodeObjects.spec.ts
@@ -49,7 +49,7 @@ describe('FindCodeObjects', () => {
             codeObject: {
               type: 'external-route',
               name: 'POST https://api.stripe.com/v1/customers',
-              fqid: 'external-route:api.stripe.com->POST https://api.stripe.com/v1/customers',
+              fqid: 'external-route:POST https://api.stripe.com/v1/customers',
             },
           },
         ],

--- a/packages/components/tests/e2e/specs/appmap/componentDiagram.spec.js
+++ b/packages/components/tests/e2e/specs/appmap/componentDiagram.spec.js
@@ -156,10 +156,7 @@ context('AppMap component diagram', () => {
 
       // Go back to the component diagram
       cy.get('.tabs .tab-btn').first().click();
-      cy.get(`.node[data-id="HTTP server requests->GET /admin/orders"]`).should(
-        'have.class',
-        'highlight'
-      );
+      cy.get(`.node[data-id="GET /admin/orders"]`).should('have.class', 'highlight');
 
       // Go back to Trace view and select event with exceptions
       cy.get('.tabs .tab-btn').contains('Trace View').click();

--- a/packages/components/tests/e2e/specs/appmap/viewFilter.spec.js
+++ b/packages/components/tests/e2e/specs/appmap/viewFilter.spec.js
@@ -50,11 +50,7 @@ context('AppMap view filter', () => {
       cy.get('.trace .trace-node').should('have.length', 4);
       cy.get('.tabs__controls .popper__button').click();
       cy.get('.filters__checkbox').first().click();
-      cy.get('.filters__form-input')
-        .first()
-        .type('route:HTTP server requests->GET /admin/orders')
-        .parent()
-        .submit();
+      cy.get('.filters__form-input').first().type('route:GET /admin/orders').parent().submit();
       cy.get('.trace .trace-node').should('have.length', 2);
       cy.get('.filters .filters__root .filters__root-icon').click();
 

--- a/packages/models/src/codeObjectId.js
+++ b/packages/models/src/codeObjectId.js
@@ -1,8 +1,19 @@
 import { CodeObjectType } from './codeObjectType';
 
+function isExcludedParentType(type) {
+  return [CodeObjectType.HTTP, CodeObjectType.DATABASE, CodeObjectType.EXTERNAL_SERVICE].includes(
+    type
+  );
+}
+
 export default function codeObjectId(codeObject, tokens = []) {
-  if (codeObject.parent) {
-    codeObjectId(codeObject.parent, tokens);
+  const { parent } = codeObject;
+
+  // If it's a route, query, or external service we don't need to include the parent name
+  //  because it's always the same ('HTTP server requests' for route and 'Database' for queries).
+  // This mirrors the VS Code implementation.
+  if (parent && !isExcludedParentType(parent.type)) {
+    codeObjectId(parent, tokens);
 
     let separator;
     switch (codeObject.parent.type) {

--- a/packages/models/tests/unit/codeObjectId.spec.js
+++ b/packages/models/tests/unit/codeObjectId.spec.js
@@ -82,6 +82,53 @@ describe('codeObjectId', () => {
         ).join('')
       ).toEqual('foo/Foo.gloat');
     });
+    it('database', () => {
+      expect(
+        codeObjectId(buildCodeObject([{ type: 'database', name: 'Database' }])).join('')
+      ).toEqual('Database');
+    });
+    it('query', () => {
+      expect(
+        codeObjectId(
+          buildCodeObject([
+            { type: 'database', name: 'Database' },
+            { type: 'query', name: 'SELECT * FROM fake' },
+          ])
+        ).join('')
+      ).toEqual('SELECT * FROM fake');
+    });
+    it('http', () => {
+      expect(
+        codeObjectId(buildCodeObject([{ type: 'http', name: 'HTTP server requests' }])).join('')
+      ).toEqual('HTTP server requests');
+    });
+    it('route', () => {
+      expect(
+        codeObjectId(
+          buildCodeObject([
+            { type: 'http', name: 'HTTP server requests' },
+            { type: 'route', name: 'GET /' },
+          ])
+        ).join('')
+      ).toEqual('GET /');
+    });
+    it('external service', () => {
+      expect(
+        codeObjectId(buildCodeObject([{ type: 'external-service', name: '127.0.0.1:9515' }])).join(
+          ''
+        )
+      ).toEqual('127.0.0.1:9515');
+    });
+    it('external route', () => {
+      expect(
+        codeObjectId(
+          buildCodeObject([
+            { type: 'external-service', name: '127.0.0.1:9515' },
+            { type: 'external-route', name: 'POST http://127.0.0.1:9515/session/1234567890' },
+          ])
+        ).join('')
+      ).toEqual('POST http://127.0.0.1:9515/session/1234567890');
+    });
     it('other type', () => {
       expect(
         codeObjectId(


### PR DESCRIPTION
Fixes #1269 

We do not need to include the parent name for queries and routes because the relationship between a query/route and its parent is always the same and can be inferred from the type.

For more information, see discussion [here](https://github.com/getappmap/appmap-js/pull/1265).