### PR TITLE
Unsupported projects show helpful information

### DIFF
--- a/packages/components/src/components/install-guide/ProjectPickerRow.vue
+++ b/packages/components/src/components/install-guide/ProjectPickerRow.vue
@@ -421,16 +421,16 @@ export default {
       return this.editor === 'vscode';
     },
     isPython() {
-      return this.language.name.toLowerCase() === 'python';
+      return this.language?.name.toLowerCase() === 'python';
     },
     isRuby() {
-      return this.language.name.toLowerCase() === 'ruby';
+      return this.language?.name.toLowerCase() === 'ruby';
     },
     isJava() {
-      return this.language.name.toLowerCase() === 'java';
+      return this.language?.name.toLowerCase() === 'java';
     },
     isJS() {
-      return this.language.name.toLowerCase() === 'javascript';
+      return this.language?.name.toLowerCase() === 'javascript';
     },
     runConfigIcon() {
       return this.theme === 'dark' ? VRunConfigDark : VRunConfigLight;

--- a/packages/components/src/stories/install-guide/ProjectPicker.stories.js
+++ b/packages/components/src/stories/install-guide/ProjectPicker.stories.js
@@ -106,6 +106,26 @@ BadProject.args = {
   ],
 };
 
+export const UnsupportedProjectWithNoLanguage = Template.bind({});
+UnsupportedProjectWithNoLanguage.args = {
+  projects: [
+    {
+      name: 'pgvector',
+      path: '/home/ahtrotta/projects/test-apps/pgvector',
+      agentInstalled: false,
+      appMapsRecorded: false,
+      investigatedFindings: false,
+      appMapOpened: false,
+      generatedOpenApi: false,
+      appMaps: [],
+      numHttpRequests: 0,
+      numAppMaps: 0,
+      hasNode: false,
+      languages: [],
+    },
+  ],
+};
+
 export const OkProject = Template.bind({});
 OkProject.args = {
   projects: [

--- a/packages/components/tests/e2e/specs/projectPickerBadProject.spec.js
+++ b/packages/components/tests/e2e/specs/projectPickerBadProject.spec.js
@@ -1,31 +1,73 @@
-context('Project Picker (Bad Project)', () => {
-  beforeEach(() => {
-    cy.visit(
-      'http://localhost:6006/iframe.html?id=pages-vs-code-install-guide-pages-project-picker--bad-project&args=&viewMode=story'
-    );
+context('Project Picker', () => {
+  describe('with a bad project', () => {
+    beforeEach(() => {
+      cy.visit(
+        'http://localhost:6006/iframe.html?id=pages-vs-code-install-guide-pages-project-picker--bad-project&args=&viewMode=story'
+      );
+    });
+
+    it('displays a title', () => {
+      cy.get('[data-cy="title"]').should('contain.text', 'Add AppMap to your project');
+    });
+
+    it('does not show empty state content', () => {
+      cy.get('[data-cy="empty-state-content').should('not.exist');
+    });
+
+    it('selects project and does not show next button', () => {
+      cy.get('[data-cy="next-button"]').should('not.exist');
+    });
+
+    it('selects project and does not show back button', () => {
+      cy.get('[data-cy="back-button"]').should('not.exist');
+    });
+
+    it('selects project and does not show code snippet', () => {
+      cy.get('[data-cy="code-snippet"]').should('not.exist');
+    });
+
+    it('selects project and does not show agent installed message', () => {
+      cy.get('[data-cy="agent-installed-message"]').should('not.exist');
+    });
+
+    it('shows that the project is unsupported', () => {
+      cy.get('.header__support').should('contain.text', 'Unsupported');
+    });
   });
 
-  it('displays a title', () => {
-    cy.get('[data-cy="title"]').should('contain.text', 'Add AppMap to your project');
-  });
+  describe('with an unsupported project with no language property, web framework, or test framework', () => {
+    beforeEach(() => {
+      cy.visit(
+        'http://localhost:6006/iframe.html?args=&id=pages-vs-code-install-guide-pages-project-picker--unsupported-project-with-no-language&viewMode=story'
+      );
+    });
 
-  it('does not show empty state content', () => {
-    cy.get('[data-cy="empty-state-content').should('not.exist');
-  });
+    it('displays a title', () => {
+      cy.get('[data-cy="title"]').should('contain.text', 'Add AppMap to your project');
+    });
 
-  it('selects project and does not show next button', () => {
-    cy.get('[data-cy="next-button"]').should('not.exist');
-  });
+    it('does not show empty state content', () => {
+      cy.get('[data-cy="empty-state-content').should('not.exist');
+    });
 
-  it('selects project and does not show back button', () => {
-    cy.get('[data-cy="back-button"]').should('not.exist');
-  });
+    it('selects project and does not show next button', () => {
+      cy.get('[data-cy="next-button"]').should('not.exist');
+    });
 
-  it('selects project and does not show code snippet', () => {
-    cy.get('[data-cy="code-snippet"]').should('not.exist');
-  });
+    it('selects project and does not show back button', () => {
+      cy.get('[data-cy="back-button"]').should('not.exist');
+    });
 
-  it('selects project and does not show agent installed message', () => {
-    cy.get('[data-cy="agent-installed-message"]').should('not.exist');
+    it('selects project and does not show code snippet', () => {
+      cy.get('[data-cy="code-snippet"]').should('not.exist');
+    });
+
+    it('selects project and does not show agent installed message', () => {
+      cy.get('[data-cy="agent-installed-message"]').should('not.exist');
+    });
+
+    it('shows that the project is unsupported', () => {
+      cy.get('.header__support').should('contain.text', 'Unsupported');
+    });
   });
 });


### PR DESCRIPTION
Fixes #1266 

Unsupported projects didn't have a `language` property, and several methods in the `v-project-picker-row` component were assuming that `language` existed, which was causing an error, making the project picker row fail to render. This PR fixes that by using optional chaining.

Before:

![Image](https://user-images.githubusercontent.com/1229326/252788734-e7ac34c1-db9e-464d-b877-f760d401a987.png)

After:

![Image](https://user-images.githubusercontent.com/1229326/252788547-1e6f65ee-f849-4c61-853d-c970f16a06dd.png)