### PR TITLE
Upgrade @appland/models to 2.6.3

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -76,7 +76,7 @@
     "@appland/client": "workspace:^1",
     "@appland/components": "workspace:^2",
     "@appland/diagrams": "workspace:^1.7.0",
-    "@appland/models": "workspace:^2.6.2",
+    "@appland/models": "workspace:^2.6.3",
     "@appland/openapi": "workspace:^1.4.3",
     "@appland/sequence-diagram": "workspace:^1",
     "@sidvind/better-ajv-errors": "^0.9.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -28,7 +28,7 @@
   ],
   "dependencies": {
     "@appland/diagrams": "workspace:^1.7.0",
-    "@appland/models": "workspace:^2.6.2",
+    "@appland/models": "workspace:^2.6.3",
     "@appland/sequence-diagram": "workspace:^1.6.1",
     "buffer": "^6.0.3",
     "d3": "^7.8.4",

--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -27,7 +27,7 @@
     "typescript": "^4.9.5"
   },
   "dependencies": {
-    "@appland/models": "workspace:^2.6.2",
+    "@appland/models": "workspace:^2.6.3",
     "js-yaml": "^4.1.0"
   },
   "publishConfig": {

--- a/packages/scanner/package.json
+++ b/packages/scanner/package.json
@@ -63,7 +63,7 @@
   },
   "dependencies": {
     "@appland/client": "^1.5.0",
-    "@appland/models": "workspace:^2.6.2",
+    "@appland/models": "workspace:^2.6.3",
     "@appland/openapi": "workspace:packages/openapi",
     "@appland/sql-parser": "^1.5.0",
     "@types/cli-progress": "^3.9.2",

--- a/packages/sequence-diagram/package.json
+++ b/packages/sequence-diagram/package.json
@@ -19,7 +19,7 @@
   "author": "AppLand, Inc.",
   "license": "Commons Clause + MIT",
   "dependencies": {
-    "@appland/models": "workspace:^2.6.2",
+    "@appland/models": "workspace:^2.6.3",
     "@appland/openapi": "workspace:^1.4.3",
     "@datastructures-js/priority-queue": "^6.1.3",
     "crypto-js": "^4.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -126,7 +126,7 @@ __metadata:
     "@appland/client": "workspace:^1"
     "@appland/components": "workspace:^2"
     "@appland/diagrams": "workspace:^1.7.0"
-    "@appland/models": "workspace:^2.6.2"
+    "@appland/models": "workspace:^2.6.3"
     "@appland/openapi": "workspace:^1.4.3"
     "@appland/sequence-diagram": "workspace:^1"
     "@craftamap/esbuild-plugin-html": ^0.4.0
@@ -250,7 +250,7 @@ __metadata:
   resolution: "@appland/components@workspace:packages/components"
   dependencies:
     "@appland/diagrams": "workspace:^1.7.0"
-    "@appland/models": "workspace:^2.6.2"
+    "@appland/models": "workspace:^2.6.3"
     "@appland/sequence-diagram": "workspace:^1.6.1"
     "@babel/core": ^7.22.5
     "@babel/node": ^7.22.5
@@ -360,7 +360,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@appland/models@workspace:*, @appland/models@workspace:^2.2.0, @appland/models@workspace:^2.6.2, @appland/models@workspace:packages/models":
+"@appland/models@workspace:*, @appland/models@workspace:^2.2.0, @appland/models@workspace:^2.6.3, @appland/models@workspace:packages/models":
   version: 0.0.0-use.local
   resolution: "@appland/models@workspace:packages/models"
   dependencies:
@@ -387,7 +387,7 @@ __metadata:
   resolution: "@appland/openapi@workspace:packages/openapi"
   dependencies:
     "@appland/appmap-agent-js": ^13.9.0
-    "@appland/models": "workspace:^2.6.2"
+    "@appland/models": "workspace:^2.6.3"
     "@types/jest": ^29.4.1
     "@types/js-yaml": ^4.0.5
     "@typescript-eslint/eslint-plugin": ^5.7.0
@@ -407,7 +407,7 @@ __metadata:
   dependencies:
     "@appland/appmap-agent-js": ^13.9.0
     "@appland/client": ^1.5.0
-    "@appland/models": "workspace:^2.6.2"
+    "@appland/models": "workspace:^2.6.3"
     "@appland/openapi": "workspace:packages/openapi"
     "@appland/sql-parser": ^1.5.0
     "@semantic-release/changelog": ^6.0.1
@@ -475,7 +475,7 @@ __metadata:
   resolution: "@appland/sequence-diagram@workspace:packages/sequence-diagram"
   dependencies:
     "@appland/appmap-agent-js": ^13.9.0
-    "@appland/models": "workspace:^2.6.2"
+    "@appland/models": "workspace:^2.6.3"
     "@appland/openapi": "workspace:^1.4.3"
     "@datastructures-js/priority-queue": ^6.1.3
     "@types/diff": ^5.0.2


### PR DESCRIPTION
Upgrades `@appland/models` to 2.6.3 to include the changes made in [this PR](https://github.com/getappmap/appmap-js/pull/1271) to make `fqid`s consistent with VS Code.