### PR TITLE
fix: Only "tests" AppMaps can be new or changed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ pnpm-debug.log*
 .pnp.*
 
 release
+
+# AppMaps
+packages/*/tmp/appmap
+

--- a/packages/cli/src/cmds/compare/Digests.ts
+++ b/packages/cli/src/cmds/compare/Digests.ts
@@ -1,10 +1,10 @@
 import { queue } from 'async';
-import { AppMapData } from './AppMapData';
+import { Paths } from './Paths';
 import { AppMapDigest, AppMapName } from './ChangeReport';
 import { RevisionName } from './RevisionName';
 import { SequenceDiagramDigest } from './SequenceDiagramDigest';
 
-export class AppMapIndex {
+export class Digests {
   // All digests for the base and head revisions.
   digests = {
     [RevisionName.Base]: new Set<AppMapDigest>(),
@@ -21,19 +21,15 @@ export class AppMapIndex {
     [RevisionName.Head]: new Map<AppMapName, AppMapDigest>(),
   };
 
-  constructor(public appmapData: AppMapData) {}
+  constructor(public paths: Paths) {}
 
   async build() {
-    const baseAppMaps = await this.appmapData.appmaps(RevisionName.Base);
-    const headAppMaps = await this.appmapData.appmaps(RevisionName.Head);
+    const baseAppMaps = await this.paths.appmaps(RevisionName.Base);
+    const headAppMaps = await this.paths.appmaps(RevisionName.Head);
     if (baseAppMaps.length === 0 && headAppMaps.length === 0) return;
 
     const q = queue(async ({ revisionName, appmap }) => {
-      const digest = await new SequenceDiagramDigest(
-        this.appmapData,
-        revisionName,
-        appmap
-      ).digest();
+      const digest = await new SequenceDiagramDigest(this.paths, revisionName, appmap).digest();
       this.digests[revisionName].add(digest);
 
       if (!this.appmapsByDigest[revisionName].has(digest))

--- a/packages/cli/src/cmds/compare/Paths.ts
+++ b/packages/cli/src/cmds/compare/Paths.ts
@@ -4,7 +4,7 @@ import { promisify } from 'util';
 import { AppMapName } from './ChangeReport';
 import { RevisionName } from './RevisionName';
 
-export class AppMapData {
+export class Paths {
   constructor(public workingDir: string) {}
 
   async appmaps(revisionName: RevisionName): Promise<AppMapName[]> {

--- a/packages/cli/src/cmds/compare/SequenceDiagramDigest.ts
+++ b/packages/cli/src/cmds/compare/SequenceDiagramDigest.ts
@@ -1,19 +1,15 @@
 import { createHash } from 'crypto';
 import { RevisionName } from './RevisionName';
-import { AppMapData } from './AppMapData';
+import { Paths } from './Paths';
 import { loadSequenceDiagram } from './loadSequenceDiagram';
 
 export class SequenceDiagramDigest {
-  constructor(
-    public appmapData: AppMapData,
-    public revisionName: RevisionName,
-    public appmap: string
-  ) {}
+  constructor(public paths: Paths, public revisionName: RevisionName, public appmap: string) {}
 
   async digest() {
     const digest = createHash('sha256');
     const diagram = await loadSequenceDiagram(
-      this.appmapData.sequenceDiagramPath(this.revisionName, this.appmap)
+      this.paths.sequenceDiagramPath(this.revisionName, this.appmap)
     );
     diagram.rootActions.forEach((action) => digest.update(action.subtreeDigest));
     return digest.digest('hex');

--- a/packages/cli/src/cmds/compare/compare.ts
+++ b/packages/cli/src/cmds/compare/compare.ts
@@ -96,10 +96,9 @@ export const handler = async (argv: any) => {
   );
 
   const changeReporter = new ChangeReporter(baseRevision, headRevision, outputDir, srcDir);
-  if (!reportRemoved) changeReporter.reportRemoved = false;
   await changeReporter.initialize();
 
-  const report = await changeReporter.report();
+  const report = await changeReporter.report(reportRemoved);
 
   if (deleteUnreferenced) {
     await changeReporter.deleteUnreferencedAppMaps();

--- a/packages/cli/src/cmds/compare/compare.ts
+++ b/packages/cli/src/cmds/compare/compare.ts
@@ -7,7 +7,7 @@ import detectRevisions from './detectRevisions';
 import { prepareOutputDir } from './prepareOutputDir';
 import { verbose } from '../../utils';
 import { writeFile } from 'fs/promises';
-import ChangeReporter from './ChangeReporter';
+import ChangeReporter, { ChangeReportOptions } from './ChangeReporter';
 
 export const command = 'compare';
 export const describe = 'Compare runtime code behavior between base and head revisions';
@@ -98,7 +98,9 @@ export const handler = async (argv: any) => {
   const changeReporter = new ChangeReporter(baseRevision, headRevision, outputDir, srcDir);
   await changeReporter.initialize();
 
-  const report = await changeReporter.report(reportRemoved);
+  const options = new ChangeReportOptions();
+  options.reportRemoved = reportRemoved;
+  const report = await changeReporter.report(options);
 
   if (deleteUnreferenced) {
     await changeReporter.deleteUnreferencedAppMaps();

--- a/packages/cli/src/cmds/compare/loadFindings.ts
+++ b/packages/cli/src/cmds/compare/loadFindings.ts
@@ -1,7 +1,7 @@
 import assert from 'assert';
 import { Finding } from '../../lib/findings';
 import { ArchiveMetadata } from '../archive/ArchiveMetadata';
-import { AppMapData } from './AppMapData';
+import { Paths } from './Paths';
 import { RevisionName } from './RevisionName';
 import { SemVer } from 'semver';
 import { executeCommand } from '../../lib/executeCommand';
@@ -9,12 +9,12 @@ import { readFile } from 'fs/promises';
 import { processNamedFiles } from '../../utils';
 
 export default async function loadFindings(
-  appmapData: AppMapData,
+  paths: Paths,
   revisionName: RevisionName,
   appMapDir: string
 ): Promise<Finding[]> {
   const manifest: ArchiveMetadata = JSON.parse(
-    await readFile(appmapData.manifestPath(revisionName), 'utf-8')
+    await readFile(paths.manifestPath(revisionName), 'utf-8')
   );
 
   const findings = new Array<Finding>();
@@ -30,7 +30,7 @@ export default async function loadFindings(
   assert(archiveVersion);
   if (archiveVersion.split('.').length === 2) archiveVersion += '.0';
   if (new SemVer(archiveVersion).compare('1.3.0') < 0) {
-    const workingDir = appmapData.revisionPath(revisionName);
+    const workingDir = paths.revisionPath(revisionName);
     console.info(
       `Scanning ${revisionName} revision for findings (archive version: ${archiveVersion}).`
     );
@@ -38,11 +38,11 @@ export default async function loadFindings(
     await executeCommand(command);
 
     // Pre-1.3.0 archive. Scan and load findings the old way.
-    const scanResults = JSON.parse(await readFile(appmapData.findingsPath(revisionName), 'utf-8'));
+    const scanResults = JSON.parse(await readFile(paths.findingsPath(revisionName), 'utf-8'));
     findings.push(...(scanResults.findings || []));
   } else {
     await processNamedFiles(
-      appmapData.revisionPath(revisionName),
+      paths.revisionPath(revisionName),
       'appmap-findings.json',
       collectFindings(findings)
     );

--- a/packages/cli/tests/unit/compare/isChanged.spec.ts
+++ b/packages/cli/tests/unit/compare/isChanged.spec.ts
@@ -1,0 +1,38 @@
+import { verbose } from '../../../src/utils';
+import { isChanged } from '../../../src/cmds/compare/ChangeReporter';
+import { Digests } from '../../../src/cmds/compare/Digests';
+import { RevisionName } from '../../../src/cmds/compare/RevisionName';
+import { AppMapName } from '../../../src/cmds/compare/ChangeReport';
+
+if (process.env.VERBOSE) verbose(true);
+
+describe('ChangeReporter.isChanged', () => {
+  let digests: Digests;
+
+  beforeEach(() => {
+    digests = {
+      appmapDigest: (_revisionName: RevisionName, _appmap: AppMapName) => 'digest-1',
+    } as Digests;
+  });
+  afterEach(() => jest.restoreAllMocks());
+
+  it('ignores non-test AppMaps', () => {
+    expect(isChanged(new Set(['theappmap']), () => false, digests)('theappmap')).toBeFalsy();
+  });
+
+  it('ignores test AppMaps with matching digests', () => {
+    expect(isChanged(new Set(['theappmap']), () => true, digests)('theappmap')).toBeFalsy();
+  });
+
+  it('ignores test AppMaps that are not in the base', () => {
+    expect(isChanged(new Set([]), () => true, digests)('theappmap')).toBeFalsy();
+  });
+
+  it('reports test AppMaps with different digests', () => {
+    jest
+      .spyOn(digests, 'appmapDigest')
+      .mockReturnValueOnce('digest-1')
+      .mockReturnValueOnce('digest-2');
+    expect(isChanged(new Set(['theappmap']), () => true, digests)('theappmap')).toBeTruthy();
+  });
+});

--- a/packages/cli/tests/unit/compare/isNew.spec.ts
+++ b/packages/cli/tests/unit/compare/isNew.spec.ts
@@ -1,0 +1,16 @@
+import { verbose } from '../../../src/utils';
+import { isNew } from '../../../src/cmds/compare/ChangeReporter';
+
+if (process.env.VERBOSE) verbose(true);
+
+describe('ChangeReporter.isNew', () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  it('ignores non-test AppMaps', () => {
+    expect(isNew(new Set(['theappmap']), () => false)('theappmap')).toBeFalsy();
+  });
+
+  it('reports test AppMaps that are not in the base', () => {
+    expect(isNew(new Set([]), () => true)('theappmap')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Only report "tests"-recorded AppMaps as new or changed.

If there are other types of AppMaps, such as requests recordings, in the AppMap archive, don't consider these when reporting new & changed AppMaps, because they don't have stable names.

Fixes #1274 