### PR TITLE
feat: Compare filter

### DIFF
--- a/packages/cli/src/cmds/archive/ArchiveMetadata.ts
+++ b/packages/cli/src/cmds/archive/ArchiveMetadata.ts
@@ -1,4 +1,4 @@
-import { AppMapConfig } from '../../lib/loadAppMapConfig';
+import { AppMapConfig, CompareFilter } from '../../lib/loadAppMapConfig';
 
 export type ArchiveMetadata = {
   versions: Record<'archive' | 'index' | string, string>;
@@ -11,5 +11,4 @@ export type ArchiveMetadata = {
   oversizedAppMaps?: string[];
   deletedAppMaps?: string[];
   config: AppMapConfig;
-  appMapFilter: Record<string, any>;
 };

--- a/packages/cli/src/cmds/archive/analyze.ts
+++ b/packages/cli/src/cmds/archive/analyze.ts
@@ -1,12 +1,12 @@
-import { AppMapFilter } from '@appland/models';
 import updateSequenceDiagrams from './updateSequenceDiagrams';
 import generateOpenAPI from './generateOpenAPI';
 import { indexAppMaps } from './indexAppMaps';
 import { scan } from './scan';
+import { CompareFilter } from '../../lib/loadAppMapConfig';
 
 export default async function analyze(
   maxAppMapSizeInBytes: number,
-  appMapFilter: AppMapFilter,
+  compareFilter: CompareFilter,
   appMapDir: string
 ): Promise<{ oversizedAppMaps: string[] }> {
   let oversizedAppMaps: string[];
@@ -19,7 +19,7 @@ export default async function analyze(
   }
   {
     console.log('Generating sequence diagrams...');
-    const result = await updateSequenceDiagrams(appMapDir, maxAppMapSizeInBytes, appMapFilter);
+    const result = await updateSequenceDiagrams(appMapDir, maxAppMapSizeInBytes, compareFilter);
     process.stdout.write(`done (${result.numGenerated})\n`);
     oversizedAppMaps = result.oversizedAppMaps;
   }

--- a/packages/cli/src/cmds/archive/archive.ts
+++ b/packages/cli/src/cmds/archive/archive.ts
@@ -11,8 +11,6 @@ import { VERSION as IndexVersion } from '../../fingerprint/fingerprinter';
 import chalk from 'chalk';
 import gitRevision from './gitRevision';
 import { ArchiveMetadata } from './ArchiveMetadata';
-import { serializeAppMapFilter } from './serializeAppMapFilter';
-import { deserializeFilter } from '@appland/models';
 import analyze from './analyze';
 
 // ## 1.3.0
@@ -109,7 +107,7 @@ export const handler = async (argv: any) => {
   const appMapDir = await locateAppMapDir();
 
   const compareConfig = appmapConfig.compare;
-  const appMapFilter = deserializeFilter(compareConfig?.filter);
+  const compareFilter = compareConfig?.filter || {};
 
   const {
     maxSize,
@@ -132,7 +130,7 @@ export const handler = async (argv: any) => {
 
   let oversizedAppMaps: string[] | undefined;
   if (doAnalyze) {
-    const analyzeResult = await analyze(maxAppMapSizeInBytes, appMapFilter, appMapDir);
+    const analyzeResult = await analyze(maxAppMapSizeInBytes, compareFilter, appMapDir);
     oversizedAppMaps = analyzeResult.oversizedAppMaps;
   }
 
@@ -147,7 +145,6 @@ export const handler = async (argv: any) => {
     timestamp: Date.now().toString(),
     oversizedAppMaps,
     config: appmapConfig,
-    appMapFilter: serializeAppMapFilter(appMapFilter),
   };
 
   let type: string;

--- a/packages/cli/src/cmds/archive/buildFilter.ts
+++ b/packages/cli/src/cmds/archive/buildFilter.ts
@@ -1,0 +1,67 @@
+import { AppMapFilter, FilterState, deserializeFilter } from '@appland/models';
+import { CompareFilter, HideOption } from '../../lib/loadAppMapConfig';
+
+export type Language = 'ruby' | 'python' | 'java' | 'javascript';
+
+export const HIDE_OPTIONS: Record<HideOption, RegExp[]> = {
+  pragma: [/^query:PRAGMA\b/, /^query:[\s\S]*\bPRAGMA\b/],
+  savepoint: [/^query:SAVEPOINT\b/, /^query:[\s\S]*\bSAVEPOINT\b/],
+  selenium: [/^external-route:.*\bhttp:\/\/127\.0\.0\.1:\d+\/session\/[a-f0-9]{32,}\//],
+  pg_metadata: [/^query:[\s\S]*\bpg_attribute\b/],
+  sqlite_metadata: [/^query:[\s\S]*\bsqlite_master\b/],
+  ruby_included: [/^function:.*\.included$/],
+};
+
+export const HIDE_EXTERNAL: Record<Language, boolean> = {
+  ruby: true,
+  python: true,
+  java: false,
+  javascript: false,
+};
+
+export default function buildFilter(
+  language: Language,
+  compareFilter: CompareFilter
+): AppMapFilter {
+  const filterState: FilterState = {};
+
+  const pushHideNames = (names: string[]) => {
+    if (!filterState.hideName) filterState.hideName = [];
+    filterState.hideName.push(...names);
+  };
+
+  let filtersEnabled: HideOption[];
+  {
+    const hide = compareFilter.hide || (Object.keys(HIDE_OPTIONS) as HideOption[]);
+    const reveal = compareFilter.reveal || [];
+    filtersEnabled = hide.filter((key) => !reveal?.includes(key));
+  }
+
+  for (const item of filtersEnabled) {
+    const hideNames = HIDE_OPTIONS[item];
+    if (!hideNames) continue;
+
+    pushHideNames(hideNames.map((rexpg) => rexpg.toString()));
+  }
+
+  if (compareFilter.hide_name !== undefined) pushHideNames(compareFilter.hide_name);
+
+  filterState.dependencyFolders = compareFilter.dependency_folders;
+
+  if (compareFilter.dependency_folders !== undefined)
+    filterState.dependencyFolders = compareFilter.dependency_folders;
+
+  if (compareFilter.hide_external !== undefined) {
+    filterState.hideExternal = compareFilter.hide_external;
+  } else {
+    filterState.hideExternal = HIDE_EXTERNAL[language];
+  }
+
+  const filter = deserializeFilter(filterState);
+
+  if (filter.declutter.hideName.names) filter.declutter.hideName.names.sort();
+  if (filter.declutter.hideExternalPaths.dependencyFolders)
+    filter.declutter.hideExternalPaths.dependencyFolders.sort();
+
+  return filter;
+}

--- a/packages/cli/src/lib/loadAppMapConfig.ts
+++ b/packages/cli/src/lib/loadAppMapConfig.ts
@@ -1,9 +1,26 @@
-import { FilterState } from '@appland/models';
 import { readFile } from 'fs/promises';
 import { load } from 'js-yaml';
 
+export type HideOption =
+  | 'pragma'
+  | 'savepoint'
+  | 'pg_metadata'
+  | 'sqlite_metadata'
+  | 'selenium'
+  | 'ruby_included';
+
+// This type is similar to FilterState in @appland/models, but only contains the
+// fields that are likely to be used for creating a canonical sequence diagram.
+export type CompareFilter = {
+  hide_external?: boolean;
+  dependency_folders?: Array<string>;
+  hide_name?: Array<string>;
+  hide?: Array<HideOption>;
+  reveal?: Array<HideOption>;
+};
+
 export interface CompareConfig {
-  filter?: FilterState;
+  filter?: CompareFilter;
 }
 
 export interface UpdateConfig {

--- a/packages/cli/tests/unit/analyze/compareFilter.spec.ts
+++ b/packages/cli/tests/unit/analyze/compareFilter.spec.ts
@@ -1,0 +1,115 @@
+import { AppMapFilter } from '@appland/models';
+import { CompareFilter } from '../../../src/lib/loadAppMapConfig';
+import { verbose } from '../../../src/utils';
+import buildFilter, { HIDE_OPTIONS, Language } from '../../../src/cmds/archive/buildFilter';
+
+if (process.env.VERBOSE) verbose(true);
+
+describe('CompareFilter', () => {
+  describe('merging with default filter', () => {
+    function testFilterMerge(
+      description: string,
+      language: Language,
+      compareFilter: CompareFilter,
+      configureFilter: (filter: AppMapFilter) => void
+    ) {
+      it(description, () => {
+        const expectedFilter = new AppMapFilter();
+        configureFilter(expectedFilter);
+        const filter = buildFilter(language, compareFilter);
+        expect(JSON.stringify(filter, null, 2)).toEqual(JSON.stringify(expectedFilter, null, 2));
+      });
+    }
+
+    describe('for Ruby', () => {
+      testFilterMerge(
+        'hide_external is on by default',
+        'ruby',
+        { hide: [] },
+        (filter) => (filter.declutter.hideExternalPaths.on = true)
+      );
+      testFilterMerge(
+        'merges dependency_folders',
+        'ruby',
+        { hide: [], dependency_folders: ['aaa'] },
+        (filter) => {
+          filter.declutter.hideExternalPaths.on = true;
+          filter.declutter.hideExternalPaths.dependencyFolders = ['aaa'];
+        }
+      );
+      testFilterMerge(
+        'hide_name can be explicitly specified',
+        'ruby',
+        { hide: [], hide_name: ['aaa'] },
+        (filter) => {
+          filter.declutter.hideExternalPaths.on = true;
+          filter.declutter.hideName.on = true;
+          filter.declutter.hideName.names = ['aaa'].sort();
+        }
+      );
+
+      testFilterMerge(
+        'hide_external can be disabled',
+        'ruby',
+        { hide: [], hide_external: false },
+        (filter) => (filter.declutter.hideExternalPaths.on = false)
+      );
+    });
+    describe('in Java', () => {
+      testFilterMerge(
+        'hide_external is disabled by default',
+        'java',
+        { hide: [] },
+        (filter) => filter
+      );
+      testFilterMerge(
+        'hide_external can be enabled',
+        'java',
+        { hide: [], hide_external: true },
+        (filter) => (filter.declutter.hideExternalPaths.on = true)
+      );
+      testFilterMerge(
+        'merges dependency_folders',
+        'java',
+        { hide: [], dependency_folders: ['aaa'] },
+        (filter) => {
+          filter.declutter.hideExternalPaths.on = false;
+          filter.declutter.hideExternalPaths.dependencyFolders = ['aaa'];
+        }
+      );
+      testFilterMerge(
+        'merges hide_external with dependency_folders',
+        'java',
+        { hide: [], hide_external: true, dependency_folders: ['aaa'] },
+        (filter) => {
+          filter.declutter.hideExternalPaths.on = true;
+          filter.declutter.hideExternalPaths.dependencyFolders = ['aaa'];
+        }
+      );
+    });
+    describe('hide options', () => {
+      const allHideNames = Object.values(HIDE_OPTIONS).flat();
+
+      it('are all on by default', () => {
+        const filter = buildFilter('java', {});
+        expect(filter.declutter.hideName.on).toEqual(true);
+        expect(filter.declutter.hideName.names.sort()).toEqual(
+          allHideNames.map((name) => name.toString()).sort()
+        );
+      });
+      testFilterMerge('can be selectively enabled', 'java', { hide: ['selenium'] }, (filter) => {
+        filter.declutter.hideName.on = true;
+        filter.declutter.hideName.names = HIDE_OPTIONS.selenium
+          .map((rexpg) => rexpg.toString())
+          .sort();
+      });
+      testFilterMerge('can be selectively disabled', 'java', { reveal: ['selenium'] }, (filter) => {
+        filter.declutter.hideName.on = true;
+        filter.declutter.hideName.names = allHideNames
+          .filter((name) => !HIDE_OPTIONS.selenium.includes(name))
+          .map((rexpg) => rexpg.toString())
+          .sort();
+      });
+    });
+  });
+});

--- a/packages/models/src/serialize.js
+++ b/packages/models/src/serialize.js
@@ -92,8 +92,9 @@ export function deserializeFilter(filterState) {
   const filter = new AppMapFilter();
   if (!filterState) return filter;
 
-  if ('rootObjects' in filterState) {
-    filter.declutter.rootObjects = filterState.rootObjects;
+
+  if ('rootObjects' in filterState && filterState.rootObjects !== false) {
+    filter.rootObjects = filterState.rootObjects;
   }
   if ('limitRootEvents' in filterState) {
     filter.declutter.limitRootEvents.on = filterState.limitRootEvents;

--- a/packages/models/src/serialize.js
+++ b/packages/models/src/serialize.js
@@ -93,7 +93,10 @@ export function deserializeFilter(filterState) {
   if (!filterState) return filter;
 
   for (const property in filterState) {
-    if (filterState.hasOwnProperty(property) && filterState[property] === undefined)
+    if (
+      Object.prototype.hasOwnProperty.call(filterState, property) &&
+      filterState[property] === undefined
+    )
       delete filterState[property];
   }
 

--- a/packages/models/src/serialize.js
+++ b/packages/models/src/serialize.js
@@ -92,6 +92,10 @@ export function deserializeFilter(filterState) {
   const filter = new AppMapFilter();
   if (!filterState) return filter;
 
+  for (const property in filterState) {
+    if (filterState.hasOwnProperty(property) && filterState[property] === undefined)
+      delete filterState[property];
+  }
 
   if ('rootObjects' in filterState && filterState.rootObjects !== false) {
     filter.rootObjects = filterState.rootObjects;

--- a/packages/models/src/serialize.js
+++ b/packages/models/src/serialize.js
@@ -4,7 +4,7 @@ import { base64UrlDecode } from './util';
 function mergeLists(a, b) {
   if (a === false && b === false) return false;
 
-  const result = [...new Set([...(a || []), ...(b || [])])].sort((a, b) => a.localeCompare(b));
+  const result = [...new Set([...(a || []), ...(b || [])])].sort();
   return result.length > 0 ? result : false;
 }
 

--- a/packages/models/tests/unit/serialize.spec.js
+++ b/packages/models/tests/unit/serialize.spec.js
@@ -54,6 +54,13 @@ describe('deserializeFilter', () => {
     expect(deserialized).toStrictEqual(expectedFilter);
   });
 
+  it('handles rootObjects', () => {
+    const deserialized = deserializeFilter({ rootObjects: ['a', 'b'] });
+    const expectedFilter = new AppMapFilter();
+    expectedFilter.rootObjects = ['a', 'b'];
+    expect(deserialized).toStrictEqual(expectedFilter);
+  });
+
   it('handles non-default values', () => {
     const deserialized = deserializeFilter(TEST_STATE);
 

--- a/packages/models/tests/unit/serialize.spec.js
+++ b/packages/models/tests/unit/serialize.spec.js
@@ -61,6 +61,24 @@ describe('deserializeFilter', () => {
     expect(deserialized).toStrictEqual(expectedFilter);
   });
 
+  it(`doesn't treat undefined as false`, () => {
+    {
+      const deserialized = deserializeFilter({ limitRootEvents: false, hideMediaRequests: false });
+      const expectedFilter = new AppMapFilter();
+      expectedFilter.declutter.limitRootEvents.on = false;
+      expectedFilter.declutter.hideMediaRequests.on = false;
+      expect(deserialized).toStrictEqual(expectedFilter);
+    }
+    {
+      const deserialized = deserializeFilter({
+        limitRootEvents: undefined,
+        hideMediaRequests: undefined,
+      });
+      const expectedFilter = new AppMapFilter();
+      expect(deserialized).toStrictEqual(expectedFilter);
+    }
+  });
+
   it('handles non-default values', () => {
     const deserialized = deserializeFilter(TEST_STATE);
 


### PR DESCRIPTION
Add default `compare` filters, reducing or eliminating the need to specify [compare options](https://github.com/land-of-apps/rails_tutorial_sample_app_7th_ed/pull/19/commits/b3b27de3b3d8f874226c1eb8341a3c7e61b82ba1) as part of the Preflight setup process.