### PR TITLE
feat: Compare filter

### DIFF
--- a/packages/cli/jest.config.js
+++ b/packages/cli/jest.config.js
@@ -5,4 +5,7 @@ module.exports = {
   testTimeout: parseInt(process.env.TEST_TIMEOUT, 10) || 5000,
   silent: true,
   restoreMocks: true,
+  // There are test cases that change the process working directory, and that does
+  // not work with multiple workers.
+  maxWorkers: 1,
 };

--- a/packages/cli/src/cmds/archive/ArchiveMetadata.ts
+++ b/packages/cli/src/cmds/archive/ArchiveMetadata.ts
@@ -1,4 +1,4 @@
-import { AppMapConfig } from '../../lib/loadAppMapConfig';
+import { AppMapConfig, CompareFilter } from '../../lib/loadAppMapConfig';
 
 export type ArchiveMetadata = {
   versions: Record<'archive' | 'index' | string, string>;
@@ -11,5 +11,4 @@ export type ArchiveMetadata = {
   oversizedAppMaps?: string[];
   deletedAppMaps?: string[];
   config: AppMapConfig;
-  appMapFilter: Record<string, any>;
 };

--- a/packages/cli/src/cmds/archive/analyze.ts
+++ b/packages/cli/src/cmds/archive/analyze.ts
@@ -1,12 +1,12 @@
-import { AppMapFilter } from '@appland/models';
 import updateSequenceDiagrams from './updateSequenceDiagrams';
 import generateOpenAPI from './generateOpenAPI';
 import { indexAppMaps } from './indexAppMaps';
 import { scan } from './scan';
+import { CompareFilter } from '../../lib/loadAppMapConfig';
 
 export default async function analyze(
   maxAppMapSizeInBytes: number,
-  appMapFilter: AppMapFilter,
+  compareFilter: CompareFilter,
   appMapDir: string
 ): Promise<{ oversizedAppMaps: string[] }> {
   let oversizedAppMaps: string[];
@@ -19,7 +19,7 @@ export default async function analyze(
   }
   {
     console.log('Generating sequence diagrams...');
-    const result = await updateSequenceDiagrams(appMapDir, maxAppMapSizeInBytes, appMapFilter);
+    const result = await updateSequenceDiagrams(appMapDir, maxAppMapSizeInBytes, compareFilter);
     process.stdout.write(`done (${result.numGenerated})\n`);
     oversizedAppMaps = result.oversizedAppMaps;
   }

--- a/packages/cli/src/cmds/archive/archive.ts
+++ b/packages/cli/src/cmds/archive/archive.ts
@@ -11,8 +11,6 @@ import { VERSION as IndexVersion } from '../../fingerprint/fingerprinter';
 import chalk from 'chalk';
 import gitRevision from './gitRevision';
 import { ArchiveMetadata } from './ArchiveMetadata';
-import { serializeAppMapFilter } from './serializeAppMapFilter';
-import { deserializeFilter } from '@appland/models';
 import analyze from './analyze';
 
 // ## 1.3.0
@@ -109,7 +107,7 @@ export const handler = async (argv: any) => {
   const appMapDir = resolve(workingDirectory, suppliedAppMapDir);
 
   const compareConfig = appmapConfig.compare;
-  const appMapFilter = deserializeFilter(compareConfig?.filter);
+  const compareFilter = compareConfig?.filter || {};
 
   const {
     maxSize,
@@ -132,7 +130,7 @@ export const handler = async (argv: any) => {
 
   let oversizedAppMaps: string[] | undefined;
   if (doAnalyze) {
-    const analyzeResult = await analyze(maxAppMapSizeInBytes, appMapFilter, appMapDir);
+    const analyzeResult = await analyze(maxAppMapSizeInBytes, compareFilter, appMapDir);
     oversizedAppMaps = analyzeResult.oversizedAppMaps;
   }
 
@@ -147,7 +145,6 @@ export const handler = async (argv: any) => {
     timestamp: Date.now().toString(),
     oversizedAppMaps,
     config: appmapConfig,
-    appMapFilter: serializeAppMapFilter(appMapFilter),
   };
 
   let type: string;

--- a/packages/cli/src/cmds/archive/archiveStore.ts
+++ b/packages/cli/src/cmds/archive/archiveStore.ts
@@ -5,7 +5,6 @@ import { Octokit } from '@octokit/rest';
 import { mkdtemp, rm, rmdir, unlink } from 'fs/promises';
 import { createWriteStream } from 'fs';
 import { tmpdir } from 'os';
-import nodeFetch from 'node-fetch';
 import { executeCommand } from '../../lib/executeCommand';
 import assert from 'assert';
 import { get } from 'https';
@@ -77,9 +76,6 @@ export class GitHubArchiveStore implements ArchiveStore {
     this.repo = tokens.pop()!.split('.')[0]!;
     this.owner = tokens.pop()!;
     this.octokit = new Octokit({
-      request: {
-        fetch: nodeFetch,
-      },
       auth: this.token,
     });
   }

--- a/packages/cli/src/cmds/archive/buildFilter.ts
+++ b/packages/cli/src/cmds/archive/buildFilter.ts
@@ -1,0 +1,67 @@
+import { AppMapFilter, FilterState, deserializeFilter } from '@appland/models';
+import { CompareFilter, HideOption } from '../../lib/loadAppMapConfig';
+
+export type Language = 'ruby' | 'python' | 'java' | 'javascript';
+
+export const HIDE_OPTIONS: Record<HideOption, RegExp[]> = {
+  pragma: [/^query:PRAGMA\b/, /^query:[\s\S]*\bPRAGMA\b/],
+  savepoint: [/^query:SAVEPOINT\b/, /^query:[\s\S]*\bSAVEPOINT\b/],
+  selenium: [/^external-route:.*\bhttp:\/\/127\.0\.0\.1:\d+\/session\/[a-f0-9]{32,}\//],
+  pg_metadata: [/^query:[\s\S]*\bpg_attribute\b/],
+  sqlite_metadata: [/^query:[\s\S]*\bsqlite_master\b/],
+  ruby_included: [/^function:.*\.included$/],
+};
+
+export const HIDE_EXTERNAL: Record<Language, boolean> = {
+  ruby: true,
+  python: true,
+  java: false,
+  javascript: false,
+};
+
+export default function buildFilter(
+  language: Language,
+  compareFilter: CompareFilter
+): AppMapFilter {
+  const filterState: FilterState = {};
+
+  const pushHideNames = (names: string[]) => {
+    if (!filterState.hideName) filterState.hideName = [];
+    filterState.hideName.push(...names);
+  };
+
+  let filtersEnabled: HideOption[];
+  {
+    const hide = compareFilter.hide || (Object.keys(HIDE_OPTIONS) as HideOption[]);
+    const reveal = compareFilter.reveal || [];
+    filtersEnabled = hide.filter((key) => !reveal?.includes(key));
+  }
+
+  for (const item of filtersEnabled) {
+    const hideNames = HIDE_OPTIONS[item];
+    if (!hideNames) continue;
+
+    pushHideNames(hideNames.map((rexpg) => rexpg.toString()));
+  }
+
+  if (compareFilter.hide_name !== undefined) pushHideNames(compareFilter.hide_name);
+
+  filterState.dependencyFolders = compareFilter.dependency_folders;
+
+  if (compareFilter.dependency_folders !== undefined)
+    filterState.dependencyFolders = compareFilter.dependency_folders;
+
+  if (compareFilter.hide_external !== undefined) {
+    filterState.hideExternal = compareFilter.hide_external;
+  } else {
+    filterState.hideExternal = HIDE_EXTERNAL[language];
+  }
+
+  const filter = deserializeFilter(filterState);
+
+  if (filter.declutter.hideName.names) filter.declutter.hideName.names.sort();
+  if (filter.declutter.hideExternalPaths.dependencyFolders)
+    filter.declutter.hideExternalPaths.dependencyFolders.sort();
+
+  return filter;
+}

--- a/packages/cli/src/cmds/archive/indexAppMaps.ts
+++ b/packages/cli/src/cmds/archive/indexAppMaps.ts
@@ -1,5 +1,5 @@
 import Fingerprinter from '../../fingerprint/fingerprinter';
-import { processFiles } from '../../utils';
+import { ProcessFileOptions, processFiles } from '../../utils';
 import { CountNumProcessed } from './CountNumProcessed';
 import reportAppMapProcessingError from './reportAppMapProcessingError';
 
@@ -11,11 +11,13 @@ export async function indexAppMaps(
   handler.maxFileSizeInBytes = maxAppMapSizeInBytes;
 
   const counter = new CountNumProcessed();
+  const options = new ProcessFileOptions(appmapDir);
+  options.fileCountFn = counter.setCount();
+  options.errorFn = reportAppMapProcessingError('Index');
   await processFiles(
-    `${appmapDir}/**/*.appmap.json`,
+    '**/*.appmap.json',
     async (appmapFile) => await handler.fingerprint(appmapFile),
-    counter.setCount(),
-    reportAppMapProcessingError('Index')
+    options
   );
 
   return counter.count;

--- a/packages/cli/src/cmds/archive/parseFilterArgs.ts
+++ b/packages/cli/src/cmds/archive/parseFilterArgs.ts
@@ -1,0 +1,26 @@
+import { warn } from 'console';
+import { CompareFilter } from '../../lib/loadAppMapConfig';
+
+export default function parseFilterArgs(compareFilter: CompareFilter, filterArgs: string[]) {
+  const filters = new Map<string, string[]>();
+  for (const filter of filterArgs) {
+    const [key, v] = filter.split('=');
+    if (!filters.has(key)) filters.set(key, []);
+    filters.get(key)?.push(v);
+  }
+  for (const [key, values] of filters.entries()) {
+    if (key === 'hide_external') {
+      if (values.length !== 1) {
+        warn(`hide_external should not be repeated, got: ${values.join(', ')}`);
+        continue;
+      }
+      const value = values[0];
+      if (value === 'true') compareFilter[key] = true;
+      else if (value === 'false') compareFilter[key] = false;
+      else warn(`Invalid value for hide_external: ${value}`);
+    } else {
+      if (!compareFilter[key]) compareFilter[key] = [];
+      compareFilter[key].push(...values);
+    }
+  }
+}

--- a/packages/cli/src/cmds/archive/updateSequenceDiagrams.ts
+++ b/packages/cli/src/cmds/archive/updateSequenceDiagrams.ts
@@ -1,4 +1,4 @@
-import { AppMapFilter, buildAppMap } from '@appland/models';
+import { buildAppMap } from '@appland/models';
 import {
   buildDiagram,
   format,
@@ -12,11 +12,13 @@ import { processFiles } from '../../utils';
 import FileTooLargeError from '../../fingerprint/fileTooLargeError';
 import { CountNumProcessed } from './CountNumProcessed';
 import reportAppMapProcessingError from './reportAppMapProcessingError';
+import buildFilter, { Language } from './buildFilter';
+import { CompareFilter } from '../../lib/loadAppMapConfig';
 
 export default async function updateSequenceDiagrams(
   dir: string,
   maxAppMapSizeInBytes: number,
-  filter: AppMapFilter
+  compareFilter: CompareFilter
 ): Promise<{ numGenerated: number; oversizedAppMaps: string[] }> {
   const specOptions = {
     loops: true,
@@ -35,6 +37,9 @@ export default async function updateSequenceDiagrams(
     const fullAppMap = buildAppMap()
       .source(await readFile(appmapFileName, 'utf8'))
       .build();
+
+    const language = fullAppMap.metadata?.language?.name || 'unknown';
+    const filter = buildFilter(language as Language, compareFilter);
     const filteredAppMap = filter.filter(fullAppMap, []);
     const specification = Specification.build(filteredAppMap, specOptions);
     const diagram = buildDiagram(appmapFileName, filteredAppMap, specification);

--- a/packages/cli/src/cmds/archive/updateSequenceDiagrams.ts
+++ b/packages/cli/src/cmds/archive/updateSequenceDiagrams.ts
@@ -8,7 +8,7 @@ import {
 } from '@appland/sequence-diagram';
 import { readFile, stat, writeFile } from 'fs/promises';
 import { basename, dirname, join } from 'path';
-import { processFiles } from '../../utils';
+import { ProcessFileOptions, processFiles } from '../../utils';
 import FileTooLargeError from '../../fingerprint/fileTooLargeError';
 import { CountNumProcessed } from './CountNumProcessed';
 import reportAppMapProcessingError from './reportAppMapProcessingError';
@@ -50,12 +50,10 @@ export default async function updateSequenceDiagrams(
   };
 
   const counter = new CountNumProcessed();
-  await processFiles(
-    join(dir, '**', '*.appmap.json'),
-    generateDiagram,
-    counter.setCount(),
-    reportAppMapProcessingError('Sequence diagram')
-  );
+  const options = new ProcessFileOptions(dir);
+  options.fileCountFn = counter.setCount();
+  options.errorFn = reportAppMapProcessingError('Sequence diagram');
+  await processFiles('**/*.appmap.json', generateDiagram, options);
 
   return { numGenerated: counter.count, oversizedAppMaps };
 }

--- a/packages/cli/src/lib/loadAppMapConfig.ts
+++ b/packages/cli/src/lib/loadAppMapConfig.ts
@@ -1,9 +1,26 @@
-import { FilterState } from '@appland/models';
 import { readFile } from 'fs/promises';
 import { load } from 'js-yaml';
 
+export type HideOption =
+  | 'pragma'
+  | 'savepoint'
+  | 'pg_metadata'
+  | 'sqlite_metadata'
+  | 'selenium'
+  | 'ruby_included';
+
+// This type is similar to FilterState in @appland/models, but only contains the
+// fields that are likely to be used for creating a canonical sequence diagram.
+export type CompareFilter = {
+  hide_external?: boolean;
+  dependency_folders?: Array<string>;
+  hide_name?: Array<string>;
+  hide?: Array<HideOption>;
+  reveal?: Array<HideOption>;
+};
+
 export interface CompareConfig {
-  filter?: FilterState;
+  filter?: CompareFilter;
 }
 
 export interface UpdateConfig {

--- a/packages/cli/src/search/findCodeObjects.ts
+++ b/packages/cli/src/search/findCodeObjects.ts
@@ -7,7 +7,7 @@ import { codeObjectId } from '@appland/models';
 import { readFile } from 'fs/promises';
 import { basename, dirname } from 'path';
 import { inspect } from 'util';
-import { processFiles, verbose } from '../utils';
+import { ProcessFileOptions, processFiles, verbose } from '../utils';
 import DescentCodeObjectMatcher from './descentCodeObjectMatcher';
 import IterateCodeObjectMatcher from './iterateCodeObjectMatcher';
 import {
@@ -234,7 +234,9 @@ export default class FindCodeObjects {
       progressFn();
     };
 
-    await processFiles(`${this.appMapDir}/**/classMap.json`, checkClassMap.bind(this), fileCountFn);
+    const options = new ProcessFileOptions(this.appMapDir);
+    options.fileCountFn = fileCountFn;
+    await processFiles('**/classMap.json', checkClassMap.bind(this), options);
     return matches;
   }
 }

--- a/packages/cli/src/sequenceDiagram/analyzeAppMaps.ts
+++ b/packages/cli/src/sequenceDiagram/analyzeAppMaps.ts
@@ -1,6 +1,6 @@
 import FindCodeObjects from '../search/findCodeObjects';
 import { CodeObject } from '../search/types';
-import { processFiles } from '../utils';
+import { ProcessFileOptions, processFiles } from '../utils';
 import Specification from '@appland/sequence-diagram/dist/specification';
 import Priority from '@appland/sequence-diagram/dist/priority';
 
@@ -78,10 +78,15 @@ export default async function analyzeAppMaps(
       }
     }
   } else {
-    await processFiles(`${appmapDir}/**/*.appmap.json`, (file: string, cb: () => void) => {
-      appmaps?.add(file.slice(0, file.length - '.appmap.json'.length));
-      cb();
-    });
+    const options = new ProcessFileOptions(appmapDir);
+    await processFiles(
+      '**/*.appmap.json',
+      (file: string, cb: () => void) => {
+        appmaps?.add(file.slice(0, file.length - '.appmap.json'.length));
+        cb();
+      },
+      options
+    );
   }
 
   return {

--- a/packages/cli/tests/unit/analyze/compareFilter.spec.ts
+++ b/packages/cli/tests/unit/analyze/compareFilter.spec.ts
@@ -1,0 +1,115 @@
+import { AppMapFilter } from '@appland/models';
+import { CompareFilter } from '../../../src/lib/loadAppMapConfig';
+import { verbose } from '../../../src/utils';
+import buildFilter, { HIDE_OPTIONS, Language } from '../../../src/cmds/archive/buildFilter';
+
+if (process.env.VERBOSE) verbose(true);
+
+describe('CompareFilter', () => {
+  describe('merging with default filter', () => {
+    function testFilterMerge(
+      description: string,
+      language: Language,
+      compareFilter: CompareFilter,
+      configureFilter: (filter: AppMapFilter) => void
+    ) {
+      it(description, () => {
+        const expectedFilter = new AppMapFilter();
+        configureFilter(expectedFilter);
+        const filter = buildFilter(language, compareFilter);
+        expect(JSON.stringify(filter, null, 2)).toEqual(JSON.stringify(expectedFilter, null, 2));
+      });
+    }
+
+    describe('for Ruby', () => {
+      testFilterMerge(
+        'hide_external is on by default',
+        'ruby',
+        { hide: [] },
+        (filter) => (filter.declutter.hideExternalPaths.on = true)
+      );
+      testFilterMerge(
+        'merges dependency_folders',
+        'ruby',
+        { hide: [], dependency_folders: ['aaa'] },
+        (filter) => {
+          filter.declutter.hideExternalPaths.on = true;
+          filter.declutter.hideExternalPaths.dependencyFolders = ['aaa'];
+        }
+      );
+      testFilterMerge(
+        'hide_name can be explicitly specified',
+        'ruby',
+        { hide: [], hide_name: ['aaa'] },
+        (filter) => {
+          filter.declutter.hideExternalPaths.on = true;
+          filter.declutter.hideName.on = true;
+          filter.declutter.hideName.names = ['aaa'].sort();
+        }
+      );
+
+      testFilterMerge(
+        'hide_external can be disabled',
+        'ruby',
+        { hide: [], hide_external: false },
+        (filter) => (filter.declutter.hideExternalPaths.on = false)
+      );
+    });
+    describe('in Java', () => {
+      testFilterMerge(
+        'hide_external is disabled by default',
+        'java',
+        { hide: [] },
+        (filter) => filter
+      );
+      testFilterMerge(
+        'hide_external can be enabled',
+        'java',
+        { hide: [], hide_external: true },
+        (filter) => (filter.declutter.hideExternalPaths.on = true)
+      );
+      testFilterMerge(
+        'merges dependency_folders',
+        'java',
+        { hide: [], dependency_folders: ['aaa'] },
+        (filter) => {
+          filter.declutter.hideExternalPaths.on = false;
+          filter.declutter.hideExternalPaths.dependencyFolders = ['aaa'];
+        }
+      );
+      testFilterMerge(
+        'merges hide_external with dependency_folders',
+        'java',
+        { hide: [], hide_external: true, dependency_folders: ['aaa'] },
+        (filter) => {
+          filter.declutter.hideExternalPaths.on = true;
+          filter.declutter.hideExternalPaths.dependencyFolders = ['aaa'];
+        }
+      );
+    });
+    describe('hide options', () => {
+      const allHideNames = Object.values(HIDE_OPTIONS).flat();
+
+      it('are all on by default', () => {
+        const filter = buildFilter('java', {});
+        expect(filter.declutter.hideName.on).toEqual(true);
+        expect(filter.declutter.hideName.names.sort()).toEqual(
+          allHideNames.map((name) => name.toString()).sort()
+        );
+      });
+      testFilterMerge('can be selectively enabled', 'java', { hide: ['selenium'] }, (filter) => {
+        filter.declutter.hideName.on = true;
+        filter.declutter.hideName.names = HIDE_OPTIONS.selenium
+          .map((rexpg) => rexpg.toString())
+          .sort();
+      });
+      testFilterMerge('can be selectively disabled', 'java', { reveal: ['selenium'] }, (filter) => {
+        filter.declutter.hideName.on = true;
+        filter.declutter.hideName.names = allHideNames
+          .filter((name) => !HIDE_OPTIONS.selenium.includes(name))
+          .map((rexpg) => rexpg.toString())
+          .sort();
+      });
+    });
+  });
+});

--- a/packages/cli/tests/unit/analyze/parseFilterArgs.spec.ts
+++ b/packages/cli/tests/unit/analyze/parseFilterArgs.spec.ts
@@ -1,0 +1,56 @@
+import parseFilterArgs from '../../../src/cmds/archive/parseFilterArgs';
+import { CompareFilter } from '../../../src/lib/loadAppMapConfig';
+import { verbose } from '../../../src/utils';
+
+if (process.env.VERBOSE) verbose(true);
+
+describe('parseFilterArgs', () => {
+  function testFilterArgs(
+    description: string,
+    filterArgs: string[],
+    configureFilter: (filter: CompareFilter) => void
+  ) {
+    it(description, () => {
+      const expectedFilter: CompareFilter = {};
+      configureFilter(expectedFilter);
+      const filter: CompareFilter = {};
+      parseFilterArgs(filter, filterArgs);
+      expect(JSON.stringify(filter, null, 2)).toEqual(JSON.stringify(expectedFilter, null, 2));
+    });
+  }
+
+  testFilterArgs(
+    'handles hide_external',
+    ['hide_external=true'],
+    (filter) => (filter.hide_external = true)
+  );
+
+  testFilterArgs(
+    'ignores all repeated hide_external options',
+    ['hide_external=true', 'hide_external=false', 'hide_external=xxx'],
+    (filter) => filter
+  );
+
+  testFilterArgs('ignores invalid boolean option', ['hide_external=xxx'], (filter) => filter);
+
+  testFilterArgs(
+    'single dependency_folders',
+    ['dependency_folders=foo'],
+    (filter) => (filter.dependency_folders = ['foo'])
+  );
+
+  testFilterArgs(
+    'multiple dependency_folders',
+    ['dependency_folders=foo', 'dependency_folders=bar'],
+    (filter) => (filter.dependency_folders = ['foo', 'bar'])
+  );
+
+  testFilterArgs(
+    'mixture of hide and reveal, with repeats',
+    ['hide=pg_metadata', 'hide=selenium', 'reveal=sqlite_metadata'],
+    (filter) => {
+      filter.hide = ['pg_metadata', 'selenium'];
+      filter.reveal = ['sqlite_metadata'];
+    }
+  );
+});

--- a/packages/cli/tests/unit/archive/archive.spec.ts
+++ b/packages/cli/tests/unit/archive/archive.spec.ts
@@ -29,7 +29,6 @@ describe('archive command', () => {
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
-    process.chdir(originalWorkingDir);
     // Currently, scanning takes too long for these tests, so we'll stub it
     sandbox.stub(scanFile, 'scan').resolves();
   });
@@ -56,7 +55,7 @@ describe('archive command', () => {
     it('creates the expectecd appmap_archive.json', async () => {
       const expectedArchive = {
         workingDirectory: rubyFixturePath,
-        appMapDir: rubyFixturePath,
+        appMapDir: '.',
         commandArguments: {
           directory: rubyFixturePath,
           analyze: true,
@@ -94,7 +93,7 @@ describe('archive command', () => {
   it('fails when no appmaps are found', async () => {
     let err = {} as Error;
     try {
-      await handler({});
+      await handler({ directory: 'no/such/dir' });
     } catch (e) {
       err = e as Error;
     }
@@ -142,9 +141,7 @@ describe('archive command', () => {
 
     assert(existsSync(appmapArchiveJsonPath));
     const archive = JSON.parse(String(readFileSync(appmapArchiveJsonPath)));
-    const expectedOversized = ['revoke_api_key.appmap.json', 'user_page_scenario.appmap.json'].map(
-      (appmapName) => path.join(rubyFixturePath, appmapName)
-    );
-    assert.deepEqual(archive.oversizedAppMaps, expectedOversized);
+    const expectedOversized = ['revoke_api_key.appmap.json', 'user_page_scenario.appmap.json'];
+    assert.deepEqual(archive.oversizedAppMaps.sort(), expectedOversized);
   });
 });

--- a/packages/cli/tests/unit/inspect.spec.ts
+++ b/packages/cli/tests/unit/inspect.spec.ts
@@ -23,7 +23,7 @@ describe('Inspect', () => {
       JSON.stringify(
         [
           {
-            appmap: `${appMapDir}/revoke_api_key`,
+            appmap: join(appMapDir, 'revoke_api_key'),
             codeObject: {
               name: 'issue',
               type: 'function',
@@ -47,7 +47,7 @@ describe('Inspect', () => {
       JSON.stringify(
         [
           {
-            appmap: `${appMapDir}/revoke_api_key`,
+            appmap: join(appMapDir, 'revoke_api_key'),
             codeObject: {
               name: 'ApiKey',
               type: 'class',
@@ -70,7 +70,7 @@ describe('Inspect', () => {
       JSON.stringify(
         [
           {
-            appmap: `${appMapDir}/revoke_api_key`,
+            appmap: join(appMapDir, 'revoke_api_key'),
             codeObject: {
               name: 'app/models',
               type: 'package',
@@ -78,7 +78,7 @@ describe('Inspect', () => {
             },
           },
           {
-            appmap: `${appMapDir}/user_page_scenario`,
+            appmap: join(appMapDir, 'user_page_scenario'),
             codeObject: {
               name: 'app/models',
               type: 'package',

--- a/packages/cli/tests/unit/search/findCodeObjects.spec.ts
+++ b/packages/cli/tests/unit/search/findCodeObjects.spec.ts
@@ -23,7 +23,7 @@ describe('FindCodeObjects', () => {
       JSON.stringify(
         [
           {
-            appmap: `${appMapDir}/checkout_update_payment`,
+            appmap: join(appMapDir, 'checkout_update_payment'),
             codeObject: {
               type: 'external-service',
               name: 'api.stripe.com',
@@ -43,7 +43,7 @@ describe('FindCodeObjects', () => {
       JSON.stringify(
         [
           {
-            appmap: `${appMapDir}/checkout_update_payment`,
+            appmap: join(appMapDir, 'checkout_update_payment'),
             codeObject: {
               type: 'external-route',
               name: 'POST https://api.stripe.com/v1/customers',

--- a/packages/cli/tests/unit/search/findCodeObjects.spec.ts
+++ b/packages/cli/tests/unit/search/findCodeObjects.spec.ts
@@ -1,9 +1,7 @@
-import { copySync } from 'fs-extra';
 import { copyFile } from 'fs/promises';
 import { basename, join } from 'path';
 import tmp from 'tmp';
 import FindCodeObjects from '../../../src/search/findCodeObjects';
-import { verbose } from '../../../src/utils';
 import { indexDirectory, stripCodeObjectParents } from '../util';
 
 const checkoutDataFile = join(


### PR DESCRIPTION
Configure filters that trim noise from the canonical sequence diagrams used for CI analysis.

Filters can be configured in two ways:

1) Via a `compare.filter` option in appmap.yml
2) Via `--filter` arguments to the `appmap archive` command

The filter type is defined as:

```typescript
export type HideOption =
  | 'pragma'
  | 'savepoint'
  | 'pg_metadata'
  | 'sqlite_metadata'
  | 'selenium'
  | 'ruby_included';

// This type is similar to FilterState in @appland/models, but only contains the
// fields that are likely to be used for creating a canonical sequence diagram.
export type CompareFilter = {
  hide_external?: boolean;
  dependency_folders?: Array<string>;
  hide_name?: Array<string>;
  hide?: Array<HideOption>;
  reveal?: Array<HideOption>;
};
```

These options are related to the AppMapFilter and FilterState types used in the diagram filter UI. They are different in a couple of ways:

1) Not all FilterState options are available in CompareFilter - for example, FilterState provides `hide_elapsed_time_under` and CompareFilter doesn't.
2) CompareFilter provides some named "hide options" - pragma, savepoint, etc. Each of these is a symbolic name assigned to hide_name regular expressions which are built into the analyzer. At this time, those filters are:

```typescript
export const HIDE_OPTIONS: Record<HideOption, RegExp[]> = {
  pragma: [/^query:PRAGMA\b/, /^query:[\s\S]*\bPRAGMA\b/],
  savepoint: [/^query:SAVEPOINT\b/, /^query:[\s\S]*\bSAVEPOINT\b/],
  selenium: [/^external-route:.*\bhttp:\/\/127\.0\.0\.1:\d+\/session\/[a-f0-9]{32,}\//],
  pg_metadata: [/^query:[\s\S]*\bpg_attribute\b/],
  sqlite_metadata: [/^query:[\s\S]*\bsqlite_master\b/],
  ruby_included: [/^function:.*\.included$/],
};
```

Note that **all** hide options are enabled by default. To disable a hide option, either:

a) Pass a `reveal` option. The indicated hide option will be remove the corresponding regular expressions from the hide_name list.
b) Pass a `hide` option. The indicated hide option(s) will be the only one(s) applied. 

Both `reveal` and `hide` option can be repeated, as can `hide_name` and `dependency_folders`.

`hide_name` is a more specific way to add hide name filters, as compared to `hide` and `reveal`.

`dependency_folders` is, by default `[ 'vendor', 'node_modules' ]`. It's used to configure local directories in CI that contain bundle external dependencies. It's unlikely that it will need to be changed, but it's available in any case.



