### PR TITLE
scrollfix-flamegraph

### DIFF
--- a/packages/components/src/components/flamegraph/FlamegraphMain.vue
+++ b/packages/components/src/components/flamegraph/FlamegraphMain.vue
@@ -237,13 +237,22 @@ export default {
 </script>
 
 <style lang="scss">
+.github-artifact {
+  background-color: #000;
+
+  #app {
+    height: 95vh;
+  }
+}
+
 .flamegraph-main {
   cursor: grab;
   display: flex;
   flex-direction: column;
   flex-grow: 1;
   flex-shrink: 1;
-  overflow: scroll;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .flamegraph-main-focusing {


### PR DESCRIPTION
adds fix for flame graph scrolling to IDE extension, so fixes will not be on [app.land only](https://github.com/getappmap/appmap-server/pull/1261)

Before:
![Screenshot 2023-07-28 at 3 48 38 PM](https://github.com/getappmap/appmap-js/assets/123787/83bda06c-ca13-46ca-b73b-acf402ca773a)

After:
![Screenshot 2023-07-28 at 3 47 31 PM](https://github.com/getappmap/appmap-js/assets/123787/51227d74-3564-4499-97d7-6779d657649b)
