### PR TITLE
feat: Export scanner types and "scan" function

### DIFF
--- a/packages/scanner/bin/front-matter.ts
+++ b/packages/scanner/bin/front-matter.ts
@@ -3,8 +3,8 @@
 import { readFile, writeFile } from 'fs/promises';
 import { dump } from 'js-yaml';
 
-import { Rule } from '../src/types';
 import { allRules } from './util';
+import RuleInstance from '../src/ruleInstance';
 
 function toTitleWord(word: string): string {
   if (['http', 'rpc', 'sql'].includes(word.toLowerCase())) {
@@ -36,11 +36,11 @@ async function writeFrontMatter(docFileName: string, frontMatter: any) {
   writeFile(docFileName, newDocBody);
 }
 
-const labelRules: Record<string, Rule[]> = {};
+const labelRules: Record<string, RuleInstance[]> = {};
 
 (async function () {
   Promise.all(
-    (await allRules()).map(async (rule: Rule) => {
+    (await allRules()).map(async (rule: RuleInstance) => {
       (rule.labels || []).forEach((label) => {
         if (!labelRules[label]) labelRules[label] = [];
 

--- a/packages/scanner/bin/util.ts
+++ b/packages/scanner/bin/util.ts
@@ -1,9 +1,9 @@
 import { lstatSync, readdir } from 'fs';
 import { join } from 'path';
 import { promisify } from 'util';
-import { Rule } from '../src/types';
+import RuleInstance from '../src/ruleInstance';
 
-export async function allRules(): Promise<Rule[]> {
+export async function allRules(): Promise<RuleInstance[]> {
   const fileRules = await Promise.all(
     (await promisify(readdir)('./src/rules'))
       .filter(isRuleFile)

--- a/packages/scanner/bin/verify-labels-doc.ts
+++ b/packages/scanner/bin/verify-labels-doc.ts
@@ -2,14 +2,14 @@
 
 import { readFile } from 'fs/promises';
 import { exit } from 'process';
-import { Rule } from '../src/types';
 import { allRules } from './util';
+import RuleInstance from '../src/ruleInstance';
 
 const labels = new Set<string>();
 const noDocLabels: string[] = [];
 (async function () {
   Promise.all(
-    (await allRules()).map(async (rule: Rule) => {
+    (await allRules()).map(async (rule: RuleInstance) => {
       (rule.labels || []).forEach((label) => labels.add(label));
     })
   )

--- a/packages/scanner/bin/verify-rules-doc.ts
+++ b/packages/scanner/bin/verify-rules-doc.ts
@@ -2,13 +2,13 @@
 
 import { readFile } from 'fs/promises';
 import { exit } from 'process';
-import { Rule } from '../src/types';
 import { allRules } from './util';
+import RuleInstance from '../src/ruleInstance';
 
 (async function () {
   const noDocRules: string[] = [];
   Promise.all(
-    (await allRules()).map(async (rule: Rule) => {
+    (await allRules()).map(async (rule: RuleInstance) => {
       const name = rule.id;
       const docFileName = `./doc/rules/${name}.md`;
       try {

--- a/packages/scanner/package.json
+++ b/packages/scanner/package.json
@@ -8,7 +8,7 @@
     "doc",
     "src/types.d.ts"
   ],
-  "types": "src/types.d.ts",
+  "types": "src/index.ts",
   "scripts": {
     "build": "node bin/preBuild.js && tsc -p tsconfig.build.json && yarn schema && yarn doc",
     "build-native": "yarn build && ./bin/build-native",

--- a/packages/scanner/package.json
+++ b/packages/scanner/package.json
@@ -3,6 +3,7 @@
   "version": "1.80.2",
   "description": "Analyze AppMaps for code flaws",
   "bin": "built/cli.js",
+  "main": "built/index.js",
   "files": [
     "built",
     "doc",

--- a/packages/scanner/src/check.ts
+++ b/packages/scanner/src/check.ts
@@ -1,6 +1,8 @@
 import { Event } from '@appland/models';
 import { verbose } from './rules/lib/util';
-import { AppMapIndex, EventFilter, ImpactDomain, Rule, ScopeName } from './types';
+import { ImpactDomain, ScopeName } from './index';
+import { AppMapIndex, EventFilter } from './types';
+import RuleInstance from './ruleInstance';
 
 export default class Check {
   public id: string;
@@ -12,7 +14,7 @@ export default class Check {
   public includeEvent: EventFilter[];
   public excludeEvent: EventFilter[];
 
-  constructor(public rule: Rule, options?: Record<string, unknown>) {
+  constructor(public rule: RuleInstance, options?: Record<string, unknown>) {
     function makeOptions() {
       return rule.Options ? new rule.Options() : {};
     }

--- a/packages/scanner/src/checkInstance.ts
+++ b/packages/scanner/src/checkInstance.ts
@@ -1,7 +1,8 @@
 import { Event } from '@appland/models';
 import Check from './check';
 import { verbose } from './rules/lib/util';
-import { AppMapIndex, ImpactDomain, RuleLogic, ScopeName } from './types';
+import { AppMapIndex, RuleLogic } from './types';
+import { ImpactDomain, ScopeName } from './index';
 
 export default class CheckInstance {
   check: Check;

--- a/packages/scanner/src/cli/scan.ts
+++ b/packages/scanner/src/cli/scan.ts
@@ -5,7 +5,7 @@ import { buildAppMap, Metadata } from '@appland/models';
 
 import Check from '../check';
 import RuleChecker from '../ruleChecker';
-import { Finding } from '../types';
+import { Finding } from '../index';
 
 import AppMapIndex from '../appMapIndex';
 import assert from 'node:assert';

--- a/packages/scanner/src/cli/scan/ui/interactiveProgess.ts
+++ b/packages/scanner/src/cli/scan/ui/interactiveProgess.ts
@@ -4,7 +4,8 @@ import EventEmitter from 'events';
 import AppMapIndex from '../../../appMapIndex';
 import Check from '../../../check';
 import ProgressReporter from '../../../progressReporter';
-import { MatchResult, ScopeName } from '../../../types';
+import { MatchResult } from '../../../types';
+import { ScopeName } from '../../../index';
 import { Breakpoint, ExecutionContext } from '../breakpoint';
 
 type ContextVariables = {

--- a/packages/scanner/src/cli/scan/ui/scanContext.ts
+++ b/packages/scanner/src/cli/scan/ui/scanContext.ts
@@ -5,7 +5,7 @@ import { readFile } from 'fs/promises';
 import AppMapIndex from '../../../appMapIndex';
 import Check from '../../../check';
 import RuleChecker from '../../../ruleChecker';
-import { Finding } from '../../../types';
+import { Finding } from '../../../index';
 import { Breakpoint } from '../breakpoint';
 import InteractiveProgress from './interactiveProgess';
 

--- a/packages/scanner/src/configuration/configurationProvider.ts
+++ b/packages/scanner/src/configuration/configurationProvider.ts
@@ -3,7 +3,7 @@ import Ajv from 'ajv';
 import yaml from 'js-yaml';
 import { exists, promises as fs } from 'fs';
 
-import { Rule, ScopeName } from '../types';
+import { ScopeName } from '../index';
 import Check from '../check';
 
 import { camelize, capitalize, dasherize, verbose } from '../rules/lib/util';
@@ -18,11 +18,12 @@ import CheckConfig from './types/checkConfig';
 import { URL } from 'url';
 import { promisify } from 'util';
 import { join } from 'path';
+import RuleInstance from '../ruleInstance';
 
 const ajv = new Ajv();
 ajv.addSchema(match_pattern_config_schema);
 
-function loadFromFile(ruleName: string): () => Promise<Rule | undefined> {
+function loadFromFile(ruleName: string): () => Promise<RuleInstance | undefined> {
   return async () => {
     let ruleSpec;
     try {
@@ -34,10 +35,10 @@ function loadFromFile(ruleName: string): () => Promise<Rule | undefined> {
   };
 }
 
-function loadFromDir(ruleName: string): () => Promise<Rule | undefined> {
+function loadFromDir(ruleName: string): () => Promise<RuleInstance | undefined> {
   return async () => {
     let metadata: Metadata;
-    let rule: Rule['build'];
+    let rule: RuleInstance['build'];
     let options: unknown;
     try {
       metadata = (await import(`../rules/${ruleName}/metadata`)).default;
@@ -81,7 +82,7 @@ function loadFromDir(ruleName: string): () => Promise<Rule | undefined> {
       references,
       Options: options,
       build: rule,
-    } as Rule;
+    } as RuleInstance;
   };
 }
 
@@ -152,9 +153,9 @@ const validate = (validator: ValidateFunction, data: unknown, context: string): 
   }
 };
 
-export async function loadRule(ruleName: string): Promise<Rule> {
+export async function loadRule(ruleName: string): Promise<RuleInstance> {
   const ruleId = dasherize(ruleName);
-  const rules: (Rule | undefined)[] = await Promise.all(
+  const rules: (RuleInstance | undefined)[] = await Promise.all(
     [
       loadFromDir(ruleId),
       loadFromFile(ruleId),

--- a/packages/scanner/src/findings.ts
+++ b/packages/scanner/src/findings.ts
@@ -1,5 +1,5 @@
 import { FindingStatusListItem } from '@appland/client/dist/src';
-import { Finding } from './types';
+import { Finding } from './index';
 
 export function newFindings(
   findings: Finding[],

--- a/packages/scanner/src/index.ts
+++ b/packages/scanner/src/index.ts
@@ -81,11 +81,18 @@ export interface Rule {
   references?: Record<string, URL>;
 }
 
+export interface Check {
+  id: string;
+  scope: ScopeName;
+  impactDomain: ImpactDomain;
+  rule: Rule;
+}
+
 export interface ScanResults {
   configuration: Configuration;
   appMapMetadata: Record<string, Metadata>;
   findings: Finding[];
-  rules: Rule[];
+  checks: Check[];
 }
 
 export { default as scan } from './scan';

--- a/packages/scanner/src/index.ts
+++ b/packages/scanner/src/index.ts
@@ -1,0 +1,91 @@
+import { Event, Metadata } from '@appland/models';
+
+import Configuration from './configuration/types/configuration';
+
+/**
+ * Each Rule in the scanner library wants to consider some set of events as it decides whether the code should be flagged or not.
+ * A Scope is a way of declaring how these "sets" are defined. A common scope is `http_server_request`. The rule will look at each HTTP
+ * server request separately; what happens in one request is irrelevant to the next. For example, when looking for authz_before_authn, each HTTP
+ * server request is considered separately.
+ *
+ * `http_server_request` is one example of a "command". Other types of commands are: CLI commands and background jobs. Each of these has a
+ * defined beginning and end, and is logically completely separate from any other command.
+ *
+ * Some rules are relevant only to HTTP server requests - such as `http500`. Others are applicable to any kind of command - such as `nPlusOneQuery`.
+ *
+ * Finally, other rules simply want to look for a certain condition regardless of where it occurs. For example, Too many SQL joins will flag any
+ * query anywhere in the AppMap, even if it's not part of a command. This rule uses the root scope, which yields a new scope for every root-level Event
+ * (root-level = "has no parent").
+ *
+ * Ideally, AppMaps would not contain any events that are not part of a command - because without knowing the command, we don't really have any context
+ * of what the code is trying to do. But, anticipating that this may sometimes happen, "root" scope is a good choice for a rule that may flag code
+ * anywhere in the AppMap.
+ */
+export type ScopeName =
+  | 'root'
+  | 'command'
+  | 'http_client_request'
+  | 'http_server_request'
+  | 'transaction';
+
+/**
+ * Indicates the aspect of software quality that is most relevant to a rule.
+ */
+export type ImpactDomain = 'Security' | 'Performance' | 'Maintainability' | 'Stability';
+
+/**
+ * Finding is the full data structure that is created when a Rule matches an Event.
+ *
+ * The Rule only needs to return a boolean, string, or MatchResult. The scanner framework
+ * adds the rest of the information to build the complete finding.
+ */
+export interface Finding {
+  appMapFile: string;
+  checkId: string;
+  ruleId: string;
+  ruleTitle: string;
+  event: Event;
+  hash: string; // Deprecated for local use. Still used to integrate local results with the server.
+  hash_v2: string;
+  scope: Event;
+  message: string;
+  stack: string[];
+  groupMessage?: string;
+  occurranceCount?: number;
+  relatedEvents?: Event[];
+  impactDomain?: ImpactDomain;
+  // Map of events by functional role name; for example, logEvent, secret, scope, etc.
+  participatingEvents?: Record<string, Event>;
+  scopeModifiedDate?: Date;
+  eventsModifiedDate?: Date;
+}
+
+export interface Rule {
+  // Unique id of the rule.
+  id: string;
+  // Simple text description of the rule.
+  title: string;
+  // Longer text description of the rule.
+  description: string;
+  // URL to the documentation.
+  url?: string;
+  // labels which the rule depends on.
+  labels?: string[];
+  // Specifies which sub-tree events will be identified as "root events of concern".
+  // Events which are outside of any scope will not be processed by the rule.
+  scope?: ScopeName;
+  // Whether to pass all the events in the scope to the matcher. If false, only the scope event
+  // is passed to the matcher, and the rule should traverse the scope as needed.
+  enumerateScope: boolean;
+  impactDomain?: ImpactDomain;
+  references?: Record<string, URL>;
+}
+
+export interface ScanResults {
+  configuration: Configuration;
+  appMapMetadata: Record<string, Metadata>;
+  findings: Finding[];
+  rules: Rule[];
+}
+
+export { default as scan } from './scan';

--- a/packages/scanner/src/progressReporter.ts
+++ b/packages/scanner/src/progressReporter.ts
@@ -1,6 +1,7 @@
 import { AppMap, Event } from '@appland/models';
 import Check from './check';
-import { AppMapIndex, MatchResult, ScopeName } from './types';
+import { AppMapIndex, MatchResult } from './types';
+import { ScopeName } from './index';
 
 export default interface ProgressReporter {
   beginAppMap(appMapFileName: string, appMap: AppMap): Promise<void>;

--- a/packages/scanner/src/report/findingsReport.ts
+++ b/packages/scanner/src/report/findingsReport.ts
@@ -1,7 +1,7 @@
 import { Metadata } from '@appland/models';
 import chalk from 'chalk';
 import { ideLink } from '../rules/lib/util';
-import { Finding } from '../types';
+import { Finding } from '../index';
 
 function writeln(text = ''): void {
   process.stdout.write(text);

--- a/packages/scanner/src/report/scanResults.ts
+++ b/packages/scanner/src/report/scanResults.ts
@@ -1,7 +1,7 @@
 import { Metadata } from '@appland/models';
 import Check from '../check';
 import Configuration from '../configuration/types/configuration';
-import { Finding } from '../types';
+import { Finding } from '../index';
 import { AppMapMetadata, ScanSummary } from './scanSummary';
 import Telemetry, { Git, GitState } from '../telemetry';
 

--- a/packages/scanner/src/report/summaryReport.ts
+++ b/packages/scanner/src/report/summaryReport.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 
-import { Finding } from '../types';
+import { Finding } from '../index';
 import { pluralize } from '../rules/lib/util';
 
 import { FindingSummary } from './findingSummary';

--- a/packages/scanner/src/ruleChecker.ts
+++ b/packages/scanner/src/ruleChecker.ts
@@ -1,7 +1,8 @@
 import { Event, EventNavigator } from '@appland/models';
 import Check from './check';
 import { AbortError } from './errors';
-import { AppMapIndex, Finding } from './types';
+import { AppMapIndex } from './types';
+import { Finding } from './index';
 import { fileExists, verbose } from './rules/lib/util';
 import ScopeIterator from './scope/scopeIterator';
 import RootScope from './scope/rootScope';

--- a/packages/scanner/src/ruleInstance.ts
+++ b/packages/scanner/src/ruleInstance.ts
@@ -1,0 +1,10 @@
+import { Rule } from './index';
+import { RuleLogic } from './types';
+
+export default interface RuleInstance extends Rule {
+  // User-defined options for the rule.
+  Options?: any; // FIXME
+
+  // Function to instantiate the rule logic from configured options.
+  build: (options: this['Options']) => RuleLogic;
+}

--- a/packages/scanner/src/rules/authzBeforeAuthn.ts
+++ b/packages/scanner/src/rules/authzBeforeAuthn.ts
@@ -1,8 +1,9 @@
 import { Event, EventNavigator } from '@appland/models';
 import { isTruthy, providesAuthentication } from './lib/util';
-import { MatcherResult, Rule, RuleLogic } from '../types.d';
+import { MatcherResult, RuleLogic } from '../types.d';
 import { URL } from 'url';
 import parseRuleDescription from './lib/parseRuleDescription';
+import RuleInstance from '../ruleInstance';
 
 function containsAuthentication(events: Generator<EventNavigator>) {
   for (const iter of events) {
@@ -42,7 +43,7 @@ function build(): RuleLogic {
 const SecurityAuthentication = 'security.authentication';
 const SecurityAuthorization = 'security.authorization';
 
-export default {
+const RULE: RuleInstance = {
   id: 'authz-before-authn',
   title: 'Authorization performed before authentication',
   labels: [SecurityAuthorization, SecurityAuthentication],
@@ -55,4 +56,5 @@ export default {
   description: parseRuleDescription('authzBeforeAuthn'),
   url: 'https://appland.com/docs/analysis/rules-reference.html#authz-before-authn',
   build,
-} as Rule;
+};
+export default RULE;

--- a/packages/scanner/src/rules/circularDependency.ts
+++ b/packages/scanner/src/rules/circularDependency.ts
@@ -1,5 +1,5 @@
 import { Event } from '@appland/models';
-import { MatchResult, Rule, RuleLogic, StringFilter } from '../types';
+import { MatchResult, RuleLogic, StringFilter } from '../types';
 import GraphEdge from '../algorithms/dataStructures/graph/GraphEdge';
 import GraphVertex from '../algorithms/dataStructures/graph/GraphVertex';
 import Graph from '../algorithms/dataStructures/graph/Graph';
@@ -11,6 +11,7 @@ import MatchPatternConfig from '../configuration/types/matchPatternConfig';
 import { buildFilters } from './lib/matchPattern';
 import { URL } from 'url';
 import parseRuleDescription from './lib/parseRuleDescription';
+import RuleInstance from '../ruleInstance';
 
 type PackageName = string;
 
@@ -227,7 +228,7 @@ function build(options: Options): RuleLogic {
   };
 }
 
-export default {
+const RULE: RuleInstance = {
   id: 'circular-dependency',
   title: 'Circular package dependency',
   Options,
@@ -239,4 +240,5 @@ export default {
   description: parseRuleDescription('circularDependency'),
   url: 'https://appland.com/docs/analysis/rules-reference.html#circular-dependency',
   build,
-} as Rule;
+};
+export default RULE;

--- a/packages/scanner/src/rules/deserializationOfUntrustedData.ts
+++ b/packages/scanner/src/rules/deserializationOfUntrustedData.ts
@@ -1,8 +1,9 @@
 import { Event } from '@appland/models';
-import { MatchResult, Rule } from '../types';
+import { MatchResult } from '../types';
 import { URL } from 'url';
 import parseRuleDescription from './lib/parseRuleDescription';
 import analyzeDataFlow, { TrackedValue } from './lib/analyzeDataFlow';
+import RuleInstance from '../ruleInstance';
 
 function valueHistory(value: TrackedValue): Event[] {
   const events: Event[] = [];
@@ -75,7 +76,7 @@ const DeserializeUnsafe = 'deserialize.unsafe';
 const DeserializeSafe = 'deserialize.safe';
 const DeserializeSanitize = 'deserialize.sanitize';
 
-export default {
+const RULE: RuleInstance = {
   id: 'deserialization-of-untrusted-data',
   title: 'Deserialization of untrusted data',
   labels: [DeserializeUnsafe, DeserializeSafe, DeserializeSanitize],
@@ -89,4 +90,5 @@ export default {
   description: parseRuleDescription('deserializationOfUntrustedData'),
   url: 'https://appland.com/docs/analysis/rules-reference.html#deserialization-of-untrusted-data',
   build: () => ({ matcher }),
-} as Rule;
+};
+export default RULE;

--- a/packages/scanner/src/rules/execOfUntrustedCommand.ts
+++ b/packages/scanner/src/rules/execOfUntrustedCommand.ts
@@ -1,9 +1,10 @@
 import { Event, EventNavigator } from '@appland/models';
 import { URL } from 'url';
-import { MatchResult, Rule, RuleLogic } from '../types';
+import { MatchResult, RuleLogic } from '../types';
 import parseRuleDescription from './lib/parseRuleDescription';
 import precedingEvents from './lib/precedingEvents';
 import sanitizesData from './lib/sanitizesData';
+import RuleInstance from '../ruleInstance';
 
 function allArgumentsSanitized(rootEvent: Event, event: Event): boolean {
   return (event.parameters || [])
@@ -48,7 +49,7 @@ const Exec = 'system.exec';
 const ExecSafe = 'system.exec.safe';
 const ExecSanitize = 'system.exec.sanitize';
 
-export default {
+const RULE: RuleInstance = {
   id: 'exec-of-untrusted-command',
   title: 'Execution of untrusted system command',
   labels: [Exec, ExecSafe, ExecSanitize],
@@ -60,4 +61,5 @@ export default {
   description: parseRuleDescription('execOfUntrustedCommand'),
   url: 'https://appland.com/docs/analysis/rules-reference.html#exec-of-untrusted-command',
   build,
-} as Rule;
+};
+export default RULE;

--- a/packages/scanner/src/rules/illegalPackageDependency.ts
+++ b/packages/scanner/src/rules/illegalPackageDependency.ts
@@ -1,10 +1,11 @@
 import { Event } from '@appland/models';
 import types from './types';
-import { MatchResult, Rule, RuleLogic } from '../types';
+import { MatchResult, RuleLogic } from '../types';
 import MatchPatternConfig from '../configuration/types/matchPatternConfig';
 import { buildFilter, buildFilters } from './lib/matchPattern';
 import { URL } from 'url';
 import parseRuleDescription from './lib/parseRuleDescription';
+import RuleInstance from '../ruleInstance';
 
 class Options implements types.IllegalPackageDependency.Options {
   public callerPackages: MatchPatternConfig[] = [];
@@ -48,7 +49,7 @@ function build(options: Options): RuleLogic {
   return { where, matcher };
 }
 
-export default {
+const RULE: RuleInstance = {
   id: 'illegal-package-dependency',
   title: 'Illegal use of code by a non-whitelisted package',
   // scope: //*[@command]
@@ -63,4 +64,5 @@ export default {
   url: 'https://appland.com/docs/analysis/rules-reference.html#illegal-package-dependency',
   Options,
   build,
-} as Rule;
+};
+export default RULE;

--- a/packages/scanner/src/rules/incompatibleHttpClientRequest.ts
+++ b/packages/scanner/src/rules/incompatibleHttpClientRequest.ts
@@ -1,12 +1,13 @@
 import { Event } from '@appland/models';
 import { forClientRequest, breakingChanges } from '../openapi';
-import { MatchResult, Rule, RuleLogic } from '../types';
+import { MatchResult, RuleLogic } from '../types';
 import * as types from './types';
 import OpenApiDiff from 'openapi-diff';
 import { OpenAPIV3 } from 'openapi-types';
 import parseRuleDescription from './lib/parseRuleDescription';
 import openapiProvider from './lib/openapiProvider';
 import assert from 'assert';
+import RuleInstance from '../ruleInstance';
 
 class Options implements types.IncompatibleHttpClientRequest.Options {
   public schemata: Record<string, string> = {};
@@ -51,7 +52,7 @@ function build(options: Options): RuleLogic {
   };
 }
 
-export default {
+const RULE: RuleInstance = {
   id: 'incompatible-http-client-request',
   title: 'Incompatible HTTP client request',
   // scope: //http_client_request
@@ -62,4 +63,5 @@ export default {
   url: 'https://appland.com/docs/analysis/rules-reference.html#incompatible-http-client-request',
   Options,
   build,
-} as Rule;
+};
+export default RULE;

--- a/packages/scanner/src/rules/insecureCompare.ts
+++ b/packages/scanner/src/rules/insecureCompare.ts
@@ -2,8 +2,9 @@ import { Event } from '@appland/models';
 import { URL } from 'url';
 import recordSecrets, { Secret } from '../analyzer/recordSecrets';
 import { looksSecret } from '../analyzer/secretsRegexes';
-import { Rule, RuleLogic } from '../types.d';
+import { RuleLogic } from '../types.d';
 import parseRuleDescription from './lib/parseRuleDescription';
+import RuleInstance from '../ruleInstance';
 
 const BCRYPT_REGEXP = /^[$]2[abxy]?[$](?:0[4-9]|[12][0-9]|3[01])[$][./0-9a-zA-Z]{53}$/;
 
@@ -59,7 +60,7 @@ function build(): RuleLogic {
 const Secret = 'secret';
 const StringEquals = 'string.equals';
 
-export default {
+const RULE: RuleInstance = {
   id: 'insecure-compare',
   title: 'Insecure comparison of secrets',
   labels: [Secret, StringEquals],
@@ -71,4 +72,5 @@ export default {
   description: parseRuleDescription('insecureCompare'),
   url: 'https://appland.com/docs/analysis/rules-reference.html#insecure-compare',
   build,
-} as Rule;
+};
+export default RULE;

--- a/packages/scanner/src/rules/jobNotCancelled.ts
+++ b/packages/scanner/src/rules/jobNotCancelled.ts
@@ -1,9 +1,10 @@
 import type { Event } from '@appland/models';
-import type { MatchResult, Rule, RuleLogic } from '../types';
+import type { MatchResult, RuleLogic } from '../types';
 import Labels from '../wellKnownLabels';
 import { hasTransactionDetails } from '../scope/sqlTransactionScope';
 import { URL } from 'url';
 import parseRuleDescription from './lib/parseRuleDescription';
+import RuleInstance from '../ruleInstance';
 
 function build(): RuleLogic {
   function matcher(event: Event): MatchResult[] | undefined {
@@ -36,7 +37,7 @@ function build(): RuleLogic {
   };
 }
 
-export default {
+const RULE: RuleInstance = {
   id: 'job-not-cancelled',
   title: 'Job created in a rolled back transaction and not cancelled',
   scope: 'transaction',
@@ -49,4 +50,5 @@ export default {
   description: parseRuleDescription('jobNotCancelled'),
   url: 'https://appland.com/docs/analysis/rules-reference.html#job-not-cancelled',
   build,
-} as Rule;
+};
+export default RULE;

--- a/packages/scanner/src/rules/jwtAlgorithmNone.ts
+++ b/packages/scanner/src/rules/jwtAlgorithmNone.ts
@@ -1,7 +1,8 @@
-import { MatchResult, Rule, RuleLogic } from '../types';
+import { MatchResult, RuleLogic } from '../types';
 import parseRuleDescription from './lib/parseRuleDescription';
 import { Event } from '@appland/models';
 import { URL } from 'url';
+import RuleInstance from '../ruleInstance';
 
 export enum Labels {
   JwtEncode = 'jwt.encode',
@@ -40,7 +41,7 @@ class JwtAlgoritmNoneLogic implements RuleLogic {
   }
 }
 
-class JwtAlgoritmNone implements Rule {
+class JwtAlgoritmNone implements RuleInstance {
   public readonly id = 'jwt-algorithm-none';
   public readonly title = "JWT 'none' algorithm";
   public readonly impactDomain = 'Security';

--- a/packages/scanner/src/rules/jwtUnverifiedSignature.ts
+++ b/packages/scanner/src/rules/jwtUnverifiedSignature.ts
@@ -1,6 +1,7 @@
-import { MatchResult, Rule, RuleLogic } from '../types';
+import { MatchResult, RuleLogic } from '../types';
 import parseRuleDescription from './lib/parseRuleDescription';
 import { Event, EventNavigator, ParameterObject } from '@appland/models';
+import RuleInstance from '../ruleInstance';
 
 export enum Labels {
   SignatureVerify = 'jwt.signature.verify',
@@ -78,7 +79,7 @@ class JwtUnverifiedSignatureLogic implements RuleLogic {
   }
 }
 
-class JwtUnverifiedSignature implements Rule {
+class JwtUnverifiedSignature implements RuleInstance {
   public readonly id = 'jwt-unverified-signature';
   public readonly title = 'Unverified signature';
   public readonly impactDomain = 'Security';

--- a/packages/scanner/src/rules/lib/metadata.ts
+++ b/packages/scanner/src/rules/lib/metadata.ts
@@ -1,4 +1,4 @@
-import { ImpactDomain, ScopeName } from '../../types';
+import { ImpactDomain, ScopeName } from '../../index';
 
 export type Metadata = {
   title: string;

--- a/packages/scanner/src/rules/logoutWithoutSessionReset.ts
+++ b/packages/scanner/src/rules/logoutWithoutSessionReset.ts
@@ -1,7 +1,8 @@
 import { Event, EventNavigator } from '@appland/models';
-import { MatchResult, Rule, RuleLogic } from '../types';
+import { MatchResult, RuleLogic } from '../types';
 import { URL } from 'url';
 import parseRuleDescription from './lib/parseRuleDescription';
+import RuleInstance from '../ruleInstance';
 
 function containsSessionClear(events: Generator<EventNavigator>) {
   for (const iter of events) {
@@ -41,7 +42,7 @@ function build(): RuleLogic {
 const SecurityLogout = 'security.logout';
 const HTTPSessionClear = 'http.session.clear';
 
-export default {
+const RULE: RuleInstance = {
   id: 'logout-without-session-reset',
   title: 'Logout without session reset',
   scope: 'http_server_request',
@@ -58,4 +59,5 @@ export default {
   description: parseRuleDescription('logoutWithoutSessionReset'),
   url: 'https://appland.com/docs/analysis/rules-reference.html#logout-without-session-reset',
   build,
-} as Rule;
+};
+export default RULE;

--- a/packages/scanner/src/rules/missingAuthentication.ts
+++ b/packages/scanner/src/rules/missingAuthentication.ts
@@ -1,12 +1,13 @@
 import { Event, EventNavigator } from '@appland/models';
 import { rpcRequestForEvent } from '@appland/openapi';
 import * as types from './types';
-import { MatchResult, Rule, RuleLogic, StringFilter } from '../types';
+import { MatchResult, RuleLogic, StringFilter } from '../types';
 import { providesAuthentication } from './lib/util';
 import MatchPatternConfig from '../configuration/types/matchPatternConfig';
 import { buildFilters } from './lib/matchPattern';
 import { URL } from 'url';
 import parseRuleDescription from './lib/parseRuleDescription';
+import RuleInstance from '../ruleInstance';
 
 function isPublic(event: Event): boolean {
   return event.labels.has(AccessPublic);
@@ -76,7 +77,7 @@ function build(options: Options = new Options()): RuleLogic {
 const AccessPublic = 'access.public';
 const SecurityAuthentication = 'security.authentication';
 
-export default {
+const RULE: RuleInstance = {
   id: 'missing-authentication',
   title: 'Unauthenticated HTTP server request',
   scope: 'http_server_request',
@@ -90,4 +91,5 @@ export default {
   url: 'https://appland.com/docs/analysis/rules-reference.html#missing-authentication',
   Options,
   build,
-} as Rule;
+};
+export default RULE;

--- a/packages/scanner/src/rules/missingContentType.ts
+++ b/packages/scanner/src/rules/missingContentType.ts
@@ -1,7 +1,8 @@
 import { Event } from '@appland/models';
-import { Rule, RuleLogic } from '../types';
+import { RuleLogic } from '../types';
 import { rpcRequestForEvent } from '@appland/openapi';
 import parseRuleDescription from './lib/parseRuleDescription';
+import RuleInstance from '../ruleInstance';
 
 const isRedirect = (status: number) => [301, 302, 303, 307, 308].includes(status);
 const hasContent = (status: number) => status !== 204;
@@ -25,7 +26,7 @@ function build(): RuleLogic {
   };
 }
 
-export default {
+const RULE: RuleInstance = {
   id: 'missing-content-type',
   title: 'HTTP server request without a Content-Type header',
   scope: 'http_server_request',
@@ -34,4 +35,5 @@ export default {
   description: parseRuleDescription('missingContentType'),
   url: 'https://appland.com/docs/analysis/rules-reference.html#missing-content-type',
   build,
-} as Rule;
+};
+export default RULE;

--- a/packages/scanner/src/rules/nPlusOneQuery.ts
+++ b/packages/scanner/src/rules/nPlusOneQuery.ts
@@ -1,9 +1,10 @@
 import { Event } from '@appland/models';
-import { AppMapIndex, EventFilter, Level, MatchResult, Rule, RuleLogic } from '../types';
+import { AppMapIndex, EventFilter, Level, MatchResult, RuleLogic } from '../types';
 import * as types from './types';
 import { SQLEvent, sqlStrings } from '../database';
 import { URL } from 'url';
 import parseRuleDescription from './lib/parseRuleDescription';
+import RuleInstance from '../ruleInstance';
 
 class Options implements types.NPlusOneQuery.Options {
   public warningLimit = 5;
@@ -86,7 +87,7 @@ function build(options: Options): RuleLogic {
   };
 }
 
-export default {
+const RULE: RuleInstance = {
   id: 'n-plus-one-query',
   title: 'N plus 1 SQL query',
   scope: 'command',
@@ -99,4 +100,5 @@ export default {
   description: parseRuleDescription('nPlusOneQuery'),
   url: 'https://appland.com/docs/analysis/rules-reference.html#n-plus-one-query',
   build,
-} as Rule;
+};
+export default RULE;

--- a/packages/scanner/src/rules/queryFromInvalidPackage.ts
+++ b/packages/scanner/src/rules/queryFromInvalidPackage.ts
@@ -1,10 +1,11 @@
 import { Event } from '@appland/models';
-import { MatchResult, Rule, RuleLogic } from '../types';
+import { MatchResult, RuleLogic } from '../types';
 import * as types from './types';
 import MatchPatternConfig from '../configuration/types/matchPatternConfig';
 import { buildFilters } from './lib/matchPattern';
 import { URL } from 'url';
 import parseRuleDescription from './lib/parseRuleDescription';
+import RuleInstance from '../ruleInstance';
 
 // TODO: Use the Query AST for this.
 const WHITELIST = [/\bBEGIN\b/i, /\bCOMMIT\b/i, /\bROLLBACK\b/i, /\bRELEASE\b/i, /\bSAVEPOINT\b/i];
@@ -45,7 +46,7 @@ function build(options: Options): RuleLogic {
   };
 }
 
-export default {
+const RULE: RuleInstance = {
   id: 'query-from-invalid-package',
   title: 'Queries from invalid packages',
   Options,
@@ -57,4 +58,5 @@ export default {
   description: parseRuleDescription('queryFromInvalidPackage'),
   url: 'https://appland.com/docs/analysis/rules-reference.html#query-from-invalid-package',
   build,
-} as Rule;
+};
+export default RULE;

--- a/packages/scanner/src/rules/queryFromView.ts
+++ b/packages/scanner/src/rules/queryFromView.ts
@@ -1,8 +1,9 @@
 import { Event, Label } from '@appland/models';
 import * as types from './types';
-import { Rule, RuleLogic } from '../types';
+import { RuleLogic } from '../types';
 import { URL } from 'url';
 import parseRuleDescription from './lib/parseRuleDescription';
+import RuleInstance from '../ruleInstance';
 
 class Options implements types.QueryFromView.Options {
   public forbiddenLabel: Label = 'mvc.template';
@@ -33,7 +34,7 @@ function build(options: Options = new Options()): RuleLogic {
   };
 }
 
-export default {
+const RULE: RuleInstance = {
   id: 'query-from-view',
   title: 'Queries from view',
   Options,
@@ -45,4 +46,5 @@ export default {
   description: parseRuleDescription('queryFromView'),
   url: 'https://appland.com/docs/analysis/rules-reference.html#query-from-view',
   build,
-} as Rule;
+};
+export default RULE;

--- a/packages/scanner/src/rules/rpcWithoutCircuitBreaker.ts
+++ b/packages/scanner/src/rules/rpcWithoutCircuitBreaker.ts
@@ -1,8 +1,9 @@
 import { Event, EventNavigator } from '@appland/models';
 import * as types from './types';
 import { RPCWithoutProtectionOptions, rpcWithoutProtection } from './lib/rpcWithoutProtection';
-import { Rule, RuleLogic } from '../types';
+import { RuleLogic } from '../types';
 import parseRuleDescription from './lib/parseRuleDescription';
+import RuleInstance from '../ruleInstance';
 
 class Options implements RPCWithoutProtectionOptions, types.RPCWithoutCircuitBreaker.Options {
   public expectedLabel: string = RPCCircuitBreaker;
@@ -21,7 +22,7 @@ function build(options: Options = new Options()): RuleLogic {
 
 const RPCCircuitBreaker = 'rpc.circuit_breaker';
 
-export default {
+const RULE: RuleInstance = {
   id: 'rpc-without-circuit-breaker',
   title: 'RPC without circuit breaker',
   Options,
@@ -31,4 +32,5 @@ export default {
   description: parseRuleDescription('rpcWithoutCircuitBreaker'),
   url: 'https://appland.com/docs/analysis/rules-reference.html#rpc-without-circuit-breaker',
   build,
-} as Rule;
+};
+export default RULE;

--- a/packages/scanner/src/rules/saveWithoutValidation.ts
+++ b/packages/scanner/src/rules/saveWithoutValidation.ts
@@ -1,7 +1,8 @@
 import { Event, EventNavigator } from '@appland/models';
 import { URL } from 'url';
-import { Rule, RuleLogic } from '../types';
+import { RuleLogic } from '../types';
 import parseRuleDescription from './lib/parseRuleDescription';
+import RuleInstance from '../ruleInstance';
 
 const validatedBy = (iterator: Iterator<EventNavigator>): boolean => {
   let i: IteratorResult<EventNavigator> = iterator.next();
@@ -25,7 +26,7 @@ function build(): RuleLogic {
   };
 }
 
-export default {
+const RULE: RuleInstance = {
   id: 'save-without-validation',
   title: 'Save without validation',
   enumerateScope: true,
@@ -36,4 +37,5 @@ export default {
   description: parseRuleDescription('saveWithoutValidation'),
   url: 'https://appland.com/docs/analysis/rules-reference.html#save-without-validation',
   build,
-} as Rule;
+};
+export default RULE;

--- a/packages/scanner/src/rules/secretInLog.ts
+++ b/packages/scanner/src/rules/secretInLog.ts
@@ -1,10 +1,11 @@
 import { Event } from '@appland/models';
-import { MatchResult, Rule, RuleLogic } from '../types';
+import { MatchResult, RuleLogic } from '../types';
 import SecretsRegexes, { looksSecret } from '../analyzer/secretsRegexes';
 import { emptyValue } from './lib/util';
 import recordSecrets, { Secret } from '../analyzer/recordSecrets';
 import { URL } from 'url';
 import parseRuleDescription from './lib/parseRuleDescription';
+import RuleInstance from '../ruleInstance';
 
 class Match {
   private constructor(
@@ -86,7 +87,7 @@ function build(): RuleLogic {
 const Secret = 'secret';
 const Log = 'log';
 
-export default {
+const RULE: RuleInstance = {
   id: 'secret-in-log',
   title: 'Secret in log',
   labels: [Secret, Log],
@@ -99,4 +100,5 @@ export default {
   description: parseRuleDescription('secretInLog'),
   url: 'https://appland.com/docs/analysis/rules-reference.html#secret-in-log',
   build,
-} as Rule;
+};
+export default RULE;

--- a/packages/scanner/src/rules/slowFunctionCall.ts
+++ b/packages/scanner/src/rules/slowFunctionCall.ts
@@ -1,8 +1,9 @@
-import { Rule, RuleLogic } from '../types';
+import { RuleLogic } from '../types';
 import * as types from './types';
 import MatchPatternConfig from '../configuration/types/matchPatternConfig';
 import { buildFilters } from './lib/matchPattern';
 import parseRuleDescription from './lib/parseRuleDescription';
+import RuleInstance from '../ruleInstance';
 
 class Options implements types.SlowFunctionCall.Options {
   public functions: MatchPatternConfig[] = [];
@@ -28,7 +29,7 @@ function build(options: Options): RuleLogic {
   };
 }
 
-export default {
+const RULE: RuleInstance = {
   id: 'slow-function-call',
   title: 'Slow function call',
   impactDomain: 'Performance',
@@ -37,4 +38,5 @@ export default {
   url: 'https://appland.com/docs/analysis/rules-reference.html#slow-function-call',
   Options,
   build,
-} as Rule;
+};
+export default RULE;

--- a/packages/scanner/src/rules/slowHttpServerRequest.ts
+++ b/packages/scanner/src/rules/slowHttpServerRequest.ts
@@ -1,6 +1,7 @@
-import { Rule, RuleLogic } from '../types';
+import { RuleLogic } from '../types';
 import * as types from './types';
 import parseRuleDescription from './lib/parseRuleDescription';
+import RuleInstance from '../ruleInstance';
 
 class Options implements types.SlowHTTPServerRequest.Options {
   public timeAllowed = 1;
@@ -14,7 +15,7 @@ function build(options: Options): RuleLogic {
   };
 }
 
-export default {
+const RULE: RuleInstance = {
   id: 'slow-http-server-request',
   title: 'Slow HTTP server request',
   scope: 'http_server_request',
@@ -24,4 +25,5 @@ export default {
   url: 'https://appland.com/docs/analysis/rules-reference.html#slow-http-server-request',
   Options,
   build,
-} as Rule;
+};
+export default RULE;

--- a/packages/scanner/src/rules/slowQuery.ts
+++ b/packages/scanner/src/rules/slowQuery.ts
@@ -1,6 +1,7 @@
-import { Rule, RuleLogic } from '../types';
+import { RuleLogic } from '../types';
 import * as types from './types';
 import parseRuleDescription from './lib/parseRuleDescription';
+import RuleInstance from '../ruleInstance';
 
 class Options implements types.SlowQuery.Options {
   public timeAllowed = 1;
@@ -13,7 +14,7 @@ function build(options: Options = new Options()): RuleLogic {
   };
 }
 
-export default {
+const RULE: RuleInstance = {
   id: 'slow-query',
   title: 'Slow SQL query',
   Options,
@@ -22,4 +23,5 @@ export default {
   description: parseRuleDescription('slowQuery'),
   url: 'https://appland.com/docs/analysis/rules-reference.html#slow-query',
   build,
-} as Rule;
+};
+export default RULE;

--- a/packages/scanner/src/rules/tooManyUpdates.ts
+++ b/packages/scanner/src/rules/tooManyUpdates.ts
@@ -1,8 +1,9 @@
 import { Event, EventNavigator } from '@appland/models';
-import { MatchResult, Rule, RuleLogic } from '../types';
+import { MatchResult, RuleLogic } from '../types';
 import { URL } from 'url';
 import * as types from './types';
 import parseRuleDescription from './lib/parseRuleDescription';
+import RuleInstance from '../ruleInstance';
 
 // TODO: Use the Query AST for this.
 const QueryIncludes: RegExp[] = [/\bINSERT\b/i, /\bUPDATE\b/i];
@@ -62,7 +63,7 @@ function build(options: Options): RuleLogic {
   };
 }
 
-export default {
+const RULE: RuleInstance = {
   id: 'too-many-updates',
   title: 'Too many SQL and RPC updates performed in one command',
   scope: 'command',
@@ -75,4 +76,5 @@ export default {
   url: 'https://appland.com/docs/analysis/rules-reference.html#too-many-updates',
   Options,
   build,
-} as Rule;
+};
+export default RULE;

--- a/packages/scanner/src/rules/unbatchedMaterializedQuery.ts
+++ b/packages/scanner/src/rules/unbatchedMaterializedQuery.ts
@@ -1,8 +1,9 @@
 import { Event } from '@appland/models';
-import { AppMapIndex, MatchResult, Rule, RuleLogic } from '../types';
+import { AppMapIndex, MatchResult, RuleLogic } from '../types';
 import { visit } from '../database/visit';
 import { URL } from 'url';
 import parseRuleDescription from './lib/parseRuleDescription';
+import RuleInstance from '../ruleInstance';
 
 function isMaterialized(e: Event): boolean {
   return e.ancestors().some(({ labels }) => labels.has(DAOMaterialize));
@@ -74,7 +75,7 @@ function build(): RuleLogic {
 // Example: ActiveRecord::Relation#records
 const DAOMaterialize = 'dao.materialize';
 
-export default {
+const RULE: RuleInstance = {
   id: 'unbatched-materialized-query',
   title: 'Unbatched materialized SQL query',
   labels: [DAOMaterialize],
@@ -86,4 +87,5 @@ export default {
   description: parseRuleDescription('unbatchedMaterializedQuery'),
   url: 'https://appland.com/docs/analysis/rules-reference.html#unbatched-materialized-query',
   build,
-} as Rule;
+};
+export default RULE;

--- a/packages/scanner/src/rules/updateInGetRequest.ts
+++ b/packages/scanner/src/rules/updateInGetRequest.ts
@@ -1,8 +1,9 @@
 import { Event } from '@appland/models';
-import { Rule, RuleLogic } from '../types';
+import { RuleLogic } from '../types';
 import { toRegExpArray } from './lib/util';
 import parseRuleDescription from './lib/parseRuleDescription';
 import assert from 'assert';
+import RuleInstance from '../ruleInstance';
 
 class Options {
   private _queryInclude: RegExp[];
@@ -70,7 +71,7 @@ function build(options: Options = new Options()): RuleLogic {
 
 const Audit = 'audit';
 
-export default {
+const RULE: RuleInstance = {
   id: 'update-in-get-request',
   title: 'Data update performed in GET or HEAD request',
   scope: 'http_server_request',
@@ -81,4 +82,5 @@ export default {
   url: 'https://appland.com/docs/analysis/rules-reference.html#update-in-get-request',
   Options,
   build,
-} as Rule;
+};
+export default RULE;

--- a/packages/scanner/src/scan.ts
+++ b/packages/scanner/src/scan.ts
@@ -1,3 +1,6 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+/* eslint-disable @typescript-eslint/naming-convention */
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import LRUCache from 'lru-cache';
 import assert from 'assert';
 import { readFile } from 'fs/promises';

--- a/packages/scanner/src/types.d.ts
+++ b/packages/scanner/src/types.d.ts
@@ -1,37 +1,5 @@
 import { AppMap, Event } from '@appland/models';
 import { SqliteParser } from '@appland/models/types/sqlite-parser';
-import { URL } from 'url';
-
-/**
- * Each Rule in the scanner library wants to consider some set of events as it decides whether the code should be flagged or not.
- * A Scope is a way of declaring how these "sets" are defined. A common scope is `http_server_request`. The rule will look at each HTTP
- * server request separately; what happens in one request is irrelevant to the next. For example, when looking for authz_before_authn, each HTTP
- * server request is considered separately.
- *
- * `http_server_request` is one example of a "command". Other types of commands are: CLI commands and background jobs. Each of these has a
- * defined beginning and end, and is logically completely separate from any other command.
- *
- * Some rules are relevant only to HTTP server requests - such as `http500`. Others are applicable to any kind of command - such as `nPlusOneQuery`.
- *
- * Finally, other rules simply want to look for a certain condition regardless of where it occurs. For example, Too many SQL joins will flag any
- * query anywhere in the AppMap, even if it's not part of a command. This rule uses the root scope, which yields a new scope for every root-level Event
- * (root-level = "has no parent").
- *
- * Ideally, AppMaps would not contain any events that are not part of a command - because without knowing the command, we don't really have any context
- * of what the code is trying to do. But, anticipating that this may sometimes happen, "root" scope is a good choice for a rule that may flag code
- * anywhere in the AppMap.
- */
-export type ScopeName =
-  | 'root'
-  | 'command'
-  | 'http_client_request'
-  | 'http_server_request'
-  | 'transaction';
-
-/**
- * Indicates the aspect of software quality that is most relevant to a rule.
- */
-export type ImpactDomain = 'Security' | 'Performance' | 'Maintainability' | 'Stability';
 
 /**
  * Scope provides an Event at the root of the scope, and a Generator to iterate over its descendants.
@@ -93,34 +61,7 @@ interface AppMapIndex {
  */
 type Matcher = (e: Event, appMapIndex: AppMapIndex, eventFilter: EventFilter) => MatcherResult;
 
-/**
- * Finding is the full data structure that is created when a Rule matches an Event.
- *
- * The Rule only needs to return a boolean, string, or MatchResult. The scanner framework
- * adds the rest of the information to build the complete finding.
- */
-interface Finding {
-  appMapFile: string;
-  checkId: string;
-  ruleId: string;
-  ruleTitle: string;
-  event: Event;
-  hash: string; // Deprecated for local use. Still used to integrate local results with the server.
-  hash_v2: string;
-  scope: Event;
-  message: string;
-  stack: string[];
-  groupMessage?: string;
-  occurranceCount?: number;
-  relatedEvents?: Event[];
-  impactDomain?: ImpactDomain;
-  // Map of events by functional role name; for example, logEvent, secret, scope, etc.
-  participatingEvents?: Record<string, Event>;
-  scopeModifiedDate?: Date;
-  eventsModifiedDate?: Date;
-}
-
-interface RuleLogic {
+export interface RuleLogic {
   // Tests an event in the scope see if it matches the rule conditions.
   matcher: Matcher;
   // When specified by the rule, only events which pass the where filter
@@ -129,35 +70,3 @@ interface RuleLogic {
   // When specified by the rule, provides a detailed message for a finding on a specific event.
   message?: (scope: Event, event: Event) => string;
 }
-
-interface Rule {
-  // Unique id of the rule.
-  id: string;
-  // Simple text description of the rule.
-  title: string;
-  // Longer text description of the rule.
-  description: string;
-  // URL to the documentation.
-  url?: string;
-  // labels which the rule depends on.
-  labels?: string[];
-  // Specifies which sub-tree events will be identified as "root events of concern".
-  // Events which are outside of any scope will not be processed by the rule.
-  scope?: ScopeName;
-  // Whether to pass all the events in the scope to the matcher. If false, only the scope event
-  // is passed to the matcher, and the rule should traverse the scope as needed.
-  enumerateScope: boolean;
-  impactDomain?: ImpactDomain;
-  references?: Record<string, URL>;
-  // User-defined options for the rule.
-  Options?: any; // FIXME
-  // Function to instantiate the rule logic from configured options.
-  build: (options: this['Options']) => RuleLogic;
-}
-
-export type Check = {
-  id: string;
-  scope: ScopeName;
-  impactDomain: ImpactDomain;
-  rule: Rule;
-};

--- a/packages/scanner/test/support/describeRule.ts
+++ b/packages/scanner/test/support/describeRule.ts
@@ -1,10 +1,10 @@
-import { Rule } from '../../src/types';
+import RuleInstance from '../../src/ruleInstance';
 import { TestMap } from './testMap';
 import testRule from './testRule';
 
 type RuleTestCase = [string, TestMap, number];
 
-export default function describeRule(rule: Rule, cases: RuleTestCase[]): void {
+export default function describeRule(rule: RuleInstance, cases: RuleTestCase[]): void {
   return describe(rule.title, () => {
     cases.map(([title, map, findingCount]) => {
       it(title, async () => {

--- a/packages/scanner/test/support/testRule.ts
+++ b/packages/scanner/test/support/testRule.ts
@@ -1,8 +1,9 @@
 import { scan } from '../util';
 import Check from '../../src/check';
 import testMap, { TestMap } from './testMap';
-import { Finding, Rule } from '../../src/types';
+import RuleInstance from '../../src/ruleInstance';
+import { Finding } from '../../src';
 
-export default async function testRule(rule: Rule, map: TestMap): Promise<Finding[]> {
+export default async function testRule(rule: RuleInstance, map: TestMap): Promise<Finding[]> {
   return (await scan(new Check(rule), 'test', testMap(map))).findings;
 }

--- a/packages/scanner/test/util.ts
+++ b/packages/scanner/test/util.ts
@@ -3,9 +3,9 @@ import { readFile } from 'fs/promises';
 import { join } from 'path';
 import RuleChecker from '../src/ruleChecker';
 import { fileExists, verbose } from '../src/rules/lib/util';
-import { Finding } from '../src/types';
 import Check from '../src/check';
 import AppMapIndex from '../src/appMapIndex';
+import { Finding } from '../src';
 
 if (process.env.VERBOSE_SCAN === 'true' || process.env.DEBUG === 'true') {
   verbose(true);


### PR DESCRIPTION
Export index.ts from the scanner, so that the project can be imported by other projects.

This will enable us to scan from any other project (such as the CLI). It will also enable us to remove some nasty hacking of types in other projects, and redefinition of scanner types such as Findings in the CLI and Components.

The primary reason for this change is to allow the `analysis` CLI command to scan directly, rather than invoking through `npx`. That way it has more control over the scan, and can implement parallel scanning via worker threads.

Externally facing types are moved into [index.ts](https://github.com/getappmap/appmap-js/pull/1305/files#diff-e1bd45839d343ae9e2c0d432c1366078ed586ab3c33b2f2b10c8fb0423cfce75).

Implementation details are not exported through this file. A `scan` function is also exported.

See also: https://github.com/getappmap/appmap-js/pull/1306

