### PR TITLE
fix: Specify node version requirements for user-facing packages

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -3,6 +3,9 @@
   "version": "3.84.1",
   "description": "",
   "bin": "built/cli.js",
+  "engines": {
+    "node": ">15"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/scanner/package.json
+++ b/packages/scanner/package.json
@@ -91,6 +91,9 @@
     "tar-stream": "^2.2.0",
     "yargs": "^17.1.1"
   },
+  "engines": {
+    "node": ">15"
+  },
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
This should improve error messages when user tries to run `npx @appland/appmap@latest` with a deprecated node version.