### PR TITLE
Release new version of components

### DIFF
--- a/packages/components/src/components/PopperMenu.vue
+++ b/packages/components/src/components/PopperMenu.vue
@@ -96,7 +96,6 @@ export default {
 
   &__body {
     border-radius: 0.5rem;
-    //border: 1px solid $light-purple;
     position: absolute;
     width: max-content;
     height: max-content;

--- a/packages/components/src/components/Tabs.vue
+++ b/packages/components/src/components/Tabs.vue
@@ -12,9 +12,6 @@
         >
         </v-tab-button>
       </div>
-      <!-- <div class="tabs__notification">
-        <slot name="notification" />
-      </div> -->
       <div class="tabs__controls">
         <slot name="controls" />
       </div>

--- a/packages/components/src/components/sequence/LoopAction.vue
+++ b/packages/components/src/components/sequence/LoopAction.vue
@@ -67,7 +67,7 @@ export default {
 <style scoped lang="scss">
 .loop {
   margin: 15px -20px 10px -20px;
-  border: 2px solid $gray2; //$actor-highlight; //#444e69;
+  border: 2px solid $gray2;
   position: relative;
   display: inline-block;
   font-weight: bold;
@@ -75,7 +75,7 @@ export default {
   border-radius: 0;
   .label-container {
     white-space: nowrap;
-    background-color: $gray2; //$actor-highlight; // #444e69;
+    background-color: $gray2;
     div {
       display: inline-block;
     }
@@ -83,9 +83,9 @@ export default {
     .label {
       padding: 5px;
       height: 28px;
-      background-color: $actor-highlight; // #444e69;
+      background-color: $actor-highlight;
       color: $white;
-      border-bottom: 2px solid $gray2; //$actor-highlight; // #444e69;
+      border-bottom: 2px solid $gray2;
       position: relative;
 
       .rhs-effect {

--- a/packages/components/src/components/trace/TraceEventBlock.vue
+++ b/packages/components/src/components/trace/TraceEventBlock.vue
@@ -254,7 +254,7 @@ export default {
   left: -74px;
   width: 74px;
   height: 4px;
-  background-color: $gray4; //#242c41;
+  background-color: $gray4;
   z-index: -1;
 }
 
@@ -266,7 +266,7 @@ export default {
   width: 37px;
   height: 37px;
   border-radius: 0 25px 0 0;
-  border: 4px solid $gray4; //#242c41;
+  border: 4px solid $gray4;
   border-bottom: 0;
   border-left: 0;
   z-index: -1;
@@ -285,7 +285,7 @@ export default {
     width: 33px;
     height: 37px;
     border-radius: 0 0 0 25px;
-    border: 4px solid $gray4; //#242c41;
+    border: 4px solid $gray4;
     border-top: 0;
     border-right: 0;
     z-index: -1;
@@ -298,7 +298,7 @@ export default {
   right: 100%;
   width: 37px;
   border-radius: 0 0 0 25px;
-  border: 4px solid $gray4; //#242c41;
+  border: 4px solid $gray4;
   border-top: 0;
   border-right: 0;
   z-index: -1;

--- a/packages/components/src/components/trace/TraceSummary.vue
+++ b/packages/components/src/components/trace/TraceSummary.vue
@@ -79,7 +79,7 @@ export default {
       width: 1.1rem;
       height: 4px;
       transform: translateY(-1px);
-      background-color: $gray4; //#242c41;
+      background-color: $gray4;
       z-index: -1;
     }
   }


### PR DESCRIPTION
Fixes #1314 

Ty's fix from [this issue](https://github.com/getappmap/appmap-js/issues/1289) ([this PR](https://github.com/getappmap/appmap-js/pull/1304)) did not trigger a release of `@appland/components` because there was not a commit with the prefix `feat:` or `fix:`.

This PR also removes some extraneous comments.