### PR TITLE
Print indexing events

### DIFF
--- a/packages/cli/doc/index-verbose.md
+++ b/packages/cli/doc/index-verbose.md
@@ -1,0 +1,27 @@
+# Verbose indexing output
+
+If `-v` or `--verbose` option is given to `index` command, the command prints more detailed status
+information on standard output. While the output is human-readable, some messages might have a
+simple well-defined format and are suitable for parsing.
+
+## `Indexed `
+
+Currently the only message with a well-defined format is emitted after an AppMap file has been
+successfully (re)indexed. The format is a line starting with `Indexed ` followed by the full path to
+the AppMap. The path is quoted (see below) if it contains newlines, quotation marks or null
+characters, otherwise it's verbatim. The message ends with a newline character.
+
+Examples:
+
+```
+Indexed /home/user/project/tmp/appmap/map1.appmap.json
+Indexed "/home/user/\"weird\0path\n!\"/tmp/appmap/map2.appmap.json"
+Indexed C:\Users\Emmanuel Goldstein\Projects\Contoso\tmp\appmap\test.appmap.json
+Indexed "C:\\Users\\user\\\"Important\" project\\tmp\\appmap\\test.appmap.json"
+```
+
+## Path quoting
+
+Path are quoted by replacing backslash characters with `\\`, newline characters with `\n`, null
+characters with `\0`, and quote marks with `\"`, then wrapping in quote marks. Note `Indexed `
+messages only quote the path when necessary.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -36,6 +36,7 @@
     "@appland/appmap-agent-js": "^13.9.0",
     "@craftamap/esbuild-plugin-html": "^0.4.0",
     "@octokit/types": "^11.1.0",
+    "@swc/core": "^1.3.76",
     "@types/fs-extra": "^9.0.13",
     "@types/gitconfiglocal": "^2.0.1",
     "@types/inquirer": "^9.0.3",

--- a/packages/cli/src/fingerprint/fingerprintWatchCommand.ts
+++ b/packages/cli/src/fingerprint/fingerprintWatchCommand.ts
@@ -9,6 +9,8 @@ import Telemetry from '../telemetry';
 import emitUsage from '../lib/emitUsage';
 import { FingerprintEvent } from './fingerprinter';
 import { Metadata } from '@appland/models';
+import { rm } from 'fs/promises';
+import AppMapIndex from './appmapIndex';
 
 export default class FingerprintWatchCommand {
   private pidfilePath: string | undefined;
@@ -225,7 +227,8 @@ export default class FingerprintWatchCommand {
   }
 
   removed(file: string) {
-    console.warn(`TODO: AppMap removed: ${file}`);
+    const { indexDir } = new AppMapIndex(file);
+    rm(indexDir, { force: true, recursive: true });
   }
 
   ready() {

--- a/packages/cli/src/fingerprint/fingerprinter.ts
+++ b/packages/cli/src/fingerprint/fingerprinter.ts
@@ -1,4 +1,4 @@
-import { join as joinPath, basename } from 'path';
+import { join as joinPath, basename, resolve } from 'path';
 import gracefulFs from 'graceful-fs';
 import { promisify } from 'util';
 import { buildAppMap, Metadata } from '@appland/models';
@@ -9,6 +9,7 @@ import { verbose, mtime } from '../utils';
 import { algorithms, canonicalize } from './canonicalize';
 import AppMapIndex from './appmapIndex';
 import EventEmitter from 'events';
+import quotePath from '../lib/quotePath';
 
 const renameFile = promisify(gracefulFs.rename);
 
@@ -137,6 +138,10 @@ class Fingerprinter extends EventEmitter {
     // But the mtime will match the file modification time, so the algorithm will
     // determine that the index is up-to-date.
     await renameFile(tempAppMapFileName, appMapFileName);
+
+    // Note: don't remove or modify the output below,
+    // it's machine-readable (see doc/index-verbose.md)
+    if (verbose()) console.log(`Indexed ${quotePath(resolve(appMapFileName))}`);
 
     this.emit('index', { path: appMapFileName, metadata: appmap.metadata, numEvents });
   }

--- a/packages/cli/src/lib/quotePath.ts
+++ b/packages/cli/src/lib/quotePath.ts
@@ -1,0 +1,13 @@
+const REPLACEMENTS = {
+  '\n': '\\n',
+  '\0': '\\0',
+  '"': '\\"',
+  '\\': '\\\\',
+};
+
+export default function quotePath(path: string, force = false): string {
+  if (!(force || path.match(/[\n\0"]/))) return path;
+
+  const quoted = path.replaceAll(/[\n\0\\"]/g, (ch) => REPLACEMENTS[ch]);
+  return `"${quoted}"`;
+}

--- a/packages/cli/tests/unit/lib/quotePath.spec.ts
+++ b/packages/cli/tests/unit/lib/quotePath.spec.ts
@@ -1,0 +1,17 @@
+import { boolean } from 'yargs';
+import quotePath from '../../../src/lib/quotePath';
+
+describe(quotePath, () => {
+  test.each<[[path: string, force?: boolean], string]>([
+    [['/tmp/appmap/map1.json'], '/tmp/appmap/map1.json'],
+    [['/tmp/appmap/map1.json', true], '"/tmp/appmap/map1.json"'],
+    [['/tmp/app\nmap.json'], '"/tmp/app\\nmap.json"'],
+    [['/tmp/appmap.json\n'], '"/tmp/appmap.json\\n"'],
+    [['/tmp/app\0map.json'], '"/tmp/app\\0map.json"'],
+    [['/tmp/app"map.json'], '"/tmp/app\\"map.json"'],
+    [['/tmp/app\\map.json'], '/tmp/app\\map.json'],
+    [['/tmp/app\\map.json', true], '"/tmp/app\\\\map.json"'],
+    [['/tmp/ap"p\nmap\0/ma\\p1.json'], '"/tmp/ap\\"p\\nmap\\0/ma\\\\p1.json"'],
+    [['/tmp/ap"p\nmap\0/ma\\p1.json', true], '"/tmp/ap\\"p\\nmap\\0/ma\\\\p1.json"'],
+  ])('with %o', (args, expected) => expect(quotePath.apply(undefined, args)).toEqual(expected));
+});

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -14,5 +14,8 @@
     "types": ["node", "jest"]
   },
   "include": ["src/**/*"],
-  "exclude": ["**/node_modules", "src/html"]
+  "exclude": ["**/node_modules", "src/html"],
+  "ts-node": {
+    "swc": true
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -133,6 +133,7 @@ __metadata:
     "@octokit/rest": ^20.0.1
     "@octokit/types": ^11.1.0
     "@sidvind/better-ajv-errors": ^0.9.1
+    "@swc/core": ^1.3.76
     "@types/fs-extra": ^9.0.13
     "@types/gitconfiglocal": ^2.0.1
     "@types/inquirer": ^9.0.3
@@ -7655,6 +7656,120 @@ __metadata:
     start-storybook: bin/index.js
     storybook-server: bin/index.js
   checksum: 5a811ede0d7c5dbd2cfcf48257f75dbb492d294b24f0e13c9d364a51010428fe5b6664c891b0d5670c803563d23b795582c31f746b18c2ca0d4bbcc4d5fd39e0
+  languageName: node
+  linkType: hard
+
+"@swc/core-darwin-arm64@npm:1.3.76":
+  version: 1.3.76
+  resolution: "@swc/core-darwin-arm64@npm:1.3.76"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@swc/core-darwin-x64@npm:1.3.76":
+  version: 1.3.76
+  resolution: "@swc/core-darwin-x64@npm:1.3.76"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@swc/core-linux-arm-gnueabihf@npm:1.3.76":
+  version: 1.3.76
+  resolution: "@swc/core-linux-arm-gnueabihf@npm:1.3.76"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@swc/core-linux-arm64-gnu@npm:1.3.76":
+  version: 1.3.76
+  resolution: "@swc/core-linux-arm64-gnu@npm:1.3.76"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@swc/core-linux-arm64-musl@npm:1.3.76":
+  version: 1.3.76
+  resolution: "@swc/core-linux-arm64-musl@npm:1.3.76"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@swc/core-linux-x64-gnu@npm:1.3.76":
+  version: 1.3.76
+  resolution: "@swc/core-linux-x64-gnu@npm:1.3.76"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@swc/core-linux-x64-musl@npm:1.3.76":
+  version: 1.3.76
+  resolution: "@swc/core-linux-x64-musl@npm:1.3.76"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@swc/core-win32-arm64-msvc@npm:1.3.76":
+  version: 1.3.76
+  resolution: "@swc/core-win32-arm64-msvc@npm:1.3.76"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@swc/core-win32-ia32-msvc@npm:1.3.76":
+  version: 1.3.76
+  resolution: "@swc/core-win32-ia32-msvc@npm:1.3.76"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@swc/core-win32-x64-msvc@npm:1.3.76":
+  version: 1.3.76
+  resolution: "@swc/core-win32-x64-msvc@npm:1.3.76"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@swc/core@npm:^1.3.76":
+  version: 1.3.76
+  resolution: "@swc/core@npm:1.3.76"
+  dependencies:
+    "@swc/core-darwin-arm64": 1.3.76
+    "@swc/core-darwin-x64": 1.3.76
+    "@swc/core-linux-arm-gnueabihf": 1.3.76
+    "@swc/core-linux-arm64-gnu": 1.3.76
+    "@swc/core-linux-arm64-musl": 1.3.76
+    "@swc/core-linux-x64-gnu": 1.3.76
+    "@swc/core-linux-x64-musl": 1.3.76
+    "@swc/core-win32-arm64-msvc": 1.3.76
+    "@swc/core-win32-ia32-msvc": 1.3.76
+    "@swc/core-win32-x64-msvc": 1.3.76
+  peerDependencies:
+    "@swc/helpers": ^0.5.0
+  dependenciesMeta:
+    "@swc/core-darwin-arm64":
+      optional: true
+    "@swc/core-darwin-x64":
+      optional: true
+    "@swc/core-linux-arm-gnueabihf":
+      optional: true
+    "@swc/core-linux-arm64-gnu":
+      optional: true
+    "@swc/core-linux-arm64-musl":
+      optional: true
+    "@swc/core-linux-x64-gnu":
+      optional: true
+    "@swc/core-linux-x64-musl":
+      optional: true
+    "@swc/core-win32-arm64-msvc":
+      optional: true
+    "@swc/core-win32-ia32-msvc":
+      optional: true
+    "@swc/core-win32-x64-msvc":
+      optional: true
+  peerDependenciesMeta:
+    "@swc/helpers":
+      optional: true
+  checksum: f0401ccdd9073fa597c90e2503e6d71fd593593120cd92e2796bafbb43b443e072dbae3349e00fa9ded0d2dd669e463bc8587c41da4979ba31434249a30c36c7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The events are also human-readable and are printed when `--verbose` switch is used:

```console
$ yarn start index -v --watch -d ~/projects/tmp/mocha-examples/packages/apollo-server-graphql-api/
Watching appmaps in /home/divide/projects/tmp/mocha-examples/packages/apollo-server-graphql-api/tmp/appmap
AppMap added: tmp/appmap/mocha/Create Apollo-Server.appmap.json
Indexing tmp/appmap/mocha/Create Apollo-Server.appmap.json
Read 4204 bytes from tmp/appmap/mocha/Create Apollo-Server.appmap.json
Read 4204 bytes from tmp/appmap/mocha/Create Apollo-Server.appmap.json
Indexed /home/divide/projects/tmp/mocha-examples/packages/apollo-server-graphql-api/tmp/appmap/mocha/Create Apollo-Server.appmap.json
AppMap changed: tmp/appmap/mocha/Create Apollo-Server.appmap.json
Indexing tmp/appmap/mocha/Create Apollo-Server.appmap.json
tmp/appmap/mocha/Create Apollo-Server created at 1692278787338.6897, indexed at 1692278787338.6897
Index is up to date. Skipping...
AppMap added: tmp/appmap/mocha/User Mutation.appmap.json
Indexing tmp/appmap/mocha/User Mutation.appmap.json
Read 10786 bytes from tmp/appmap/mocha/User Mutation.appmap.json
Read 10786 bytes from tmp/appmap/mocha/User Mutation.appmap.json
Indexed /home/divide/projects/tmp/mocha-examples/packages/apollo-server-graphql-api/tmp/appmap/mocha/User Mutation.appmap.json
```

Fixes #1307 