### PR TITLE
fix: `appmap compare` retains new AppMaps

### DIFF
--- a/packages/cli/src/cmds/compare/ChangeReporter.ts
+++ b/packages/cli/src/cmds/compare/ChangeReporter.ts
@@ -198,6 +198,9 @@ export default class ChangeReporter {
     const newAppMaps = [...headAppMaps].filter(isNewFn);
     const changedAppMaps = [...headAppMaps].filter(isChangedFn).map((appmap) => ({ appmap }));
 
+    newAppMaps.forEach((appmap) => {
+      this.referencedAppMaps.add(RevisionName.Head, appmap);
+    });
     changedAppMaps.forEach(({ appmap }) => referenceAppMapFn(appmap));
 
     const failureFn = buildFailure(appMapMetadata, options.snippetWidth);

--- a/packages/cli/tests/unit/compare/ChangeReporter.spec.ts
+++ b/packages/cli/tests/unit/compare/ChangeReporter.spec.ts
@@ -1,0 +1,46 @@
+import type { AppMapName } from '../../../src/cmds/compare/ChangeReport';
+import type { AppMapMetadata } from '../../../src/cmds/compare/ChangeReporter';
+import ChangeReporter, {
+  ChangeReportOptions,
+  ReportFieldCalculator,
+} from '../../../src/cmds/compare/ChangeReporter';
+import { RevisionName } from '../../../src/cmds/compare/RevisionName';
+
+describe('ChangeReporter', () => {
+  describe('report', () => {
+    it('marks new AppMaps as referenced', async () => {
+      jest
+        .spyOn(ReportFieldCalculator.prototype, 'findingDiff')
+        .mockResolvedValue({ new: [], resolved: [] });
+      jest.spyOn(ReportFieldCalculator.prototype, 'apiDiff').mockResolvedValue(undefined);
+      jest.spyOn(ReportFieldCalculator.prototype, 'sequenceDiagramDiff').mockResolvedValue({});
+      jest.spyOn(ReportFieldCalculator.prototype, 'appMapMetadata').mockResolvedValue({
+        base: {},
+        head: {},
+      });
+
+      const changeReporter = new ChangeReporter('base', 'head', 'outputDir', 'srcDir');
+      changeReporter.appMapMetadata = {
+        base: new Map(),
+        head: new Map([
+          [
+            'example',
+            {
+              recorder: {
+                type: 'tests',
+              },
+            } as any,
+          ],
+        ]),
+      };
+      changeReporter.baseAppMaps = new Set<AppMapName>();
+      changeReporter.headAppMaps = new Set<AppMapName>(['example']);
+      changeReporter.failedAppMaps = new Set<AppMapName>();
+
+      const result = await changeReporter.report(new ChangeReportOptions());
+
+      expect(result.newAppMaps).toEqual(['example']);
+      expect(changeReporter.referencedAppMaps.test(RevisionName.Head, 'example')).toBeTruthy();
+    });
+  });
+});


### PR DESCRIPTION
Previously new AppMaps were not being referenced during compare and thus marked for deletion. When they'd later appear in a report, the links would be broken.