### PR TITLE
Update java agent jar instructions

### DIFF
--- a/packages/components/src/components/install-guide/ProjectPickerRow.vue
+++ b/packages/components/src/components/install-guide/ProjectPickerRow.vue
@@ -49,12 +49,12 @@
 
           <ol>
             <li>
-              The AppMap agent JAR (<code class="inline">appmap.jar</code>) must be available on
-              your machine.
+              The AppMap agent JAR (<code class="inline">~/.appmap/lib/java/appmap.jar</code>) must
+              be available on your machine.
             </li>
             <li>
               Application code and test cases use the JVM flag
-              <code class="inline">-Djavaagent=appmap.jar</code>.
+              <code class="inline">-javaagent:~/.appmap/lib/java/appmap.jar</code>.
             </li>
           </ol>
 

--- a/packages/components/src/components/install-guide/record-instructions/IntelliJ.vue
+++ b/packages/components/src/components/install-guide/record-instructions/IntelliJ.vue
@@ -7,8 +7,8 @@
     <br />
     <p>
       Using "Start with AppMap" ensures that your Java code runs with the JVM option
-      <code class="inline">-Djavaagent=appmap.jar</code>. This option is required to enable AppMap
-      recording.
+      <code class="inline">-javaagent:~/.appmap/lib/java/appmap.jar</code>. This option is required
+      to enable AppMap recording.
     </p>
     <br />
     <div id="IntelliJ-screenshot"><img src="../../../assets/run-with-appmap-menu-item.png" /></div>

--- a/packages/components/src/components/install-guide/record-instructions/Java.vue
+++ b/packages/components/src/components/install-guide/record-instructions/Java.vue
@@ -7,8 +7,8 @@
     <br />
     <p>
       This ensures that your Java code runs with the JVM option
-      <code class="inline">-javaagent:appmap.jar</code>. This option is required to enable AppMap
-      recording.
+      <code class="inline">-javaagent:~/.appmap/lib/java/appmap.jar</code>. This option is required
+      to enable AppMap recording.
     </p>
     <br />
     <div class="vscode-screenshot">


### PR DESCRIPTION
Fixes #1322 

Make sure the JVM flag in the instructions is correct.

Change from `-Djavaagent=appmap.jar` to `-javaagent:~/.appmap/lib/java/appmap.jar`.