### PR TITLE
fix: `git status` is now run with the porcelain flag

### DIFF
--- a/packages/telemetry/telemetry.spec.ts
+++ b/packages/telemetry/telemetry.spec.ts
@@ -196,14 +196,16 @@ describe('telemetry', () => {
     });
 
     describe('state', () => {
-      it('returns NotInstalled on error', () => {
-        jest.spyOn(child_process, 'spawn').mockImplementation(() => {
+      it('returns NotInstalled on error', async () => {
+        const spawn = jest.spyOn(child_process, 'spawn').mockImplementation(() => {
           const cp = new ChildProcess();
           nextTick(() => cp.emit('error', new Error('test error')));
           return cp;
         });
 
-        return expect(Git.state()).resolves.toEqual(GitState.NotInstalled);
+        const state = await Git.state();
+        expect(state).toEqual(GitState.NotInstalled);
+        expect(spawn).toBeCalledWith('git', ['status', '--porcelain'], expect.any(Object));
       });
     });
   });

--- a/packages/telemetry/telemetry.ts
+++ b/packages/telemetry/telemetry.ts
@@ -294,7 +294,7 @@ class GitProperties {
   static async state(cwd?: PathLike): Promise<GitState> {
     return new Promise<GitState>((resolve) => {
       try {
-        const commandProcess = spawn('git', ['status'], {
+        const commandProcess = spawn('git', ['status', '--porcelain'], {
           shell: true,
           cwd: cwd?.toString(),
           stdio: 'ignore',


### PR DESCRIPTION
The [porcelain](https://git-scm.com/docs/git-status#Documentation/git-status.txt---porcelainltversiongt) flag is intended to be used by scripts. It won't require stdin.

Fixes #1311