### PR TITLE
feat: sequence-diagram --expand option

### DIFF
--- a/packages/cli/src/cmds/sequenceDiagram.ts
+++ b/packages/cli/src/cmds/sequenceDiagram.ts
@@ -58,6 +58,9 @@ export const builder = (args: yargs.Argv) => {
     describe: 'code objects to exclude from the diagram',
     deprecated: true,
   });
+  args.option('expand', {
+    describe: 'code objects to expand in the diagram',
+  });
 
   return args.strict();
 };
@@ -78,7 +81,7 @@ export const handler = async (argv: any) => {
     return;
   }
 
-  const { filter } = argv;
+  const { filter, expand } = argv;
 
   let browserRender: BrowserRenderer | undefined;
   if (argv.format === 'png') {
@@ -92,6 +95,7 @@ export const handler = async (argv: any) => {
     const specOptions = {
       loops: argv.loops,
     } as SequenceDiagramOptions;
+    if (expand) specOptions.expand = Array.isArray(expand) ? expand : [expand];
     if (argv.exclude)
       specOptions.exclude = Array.isArray(argv.exclude) ? argv.exclude : [argv.exclude];
 

--- a/packages/cli/tests/unit/sequenceDiagram.spec.ts
+++ b/packages/cli/tests/unit/sequenceDiagram.spec.ts
@@ -63,6 +63,54 @@ describe('sequence diagram command', () => {
       30 * 1000 // Allow time to install and run the headless browser
     );
   });
+  describe('PlantUML format', () => {
+    it('is generated', async () => {
+      await buildDiagram({
+        format: 'plantuml',
+        outputDir: OutputDir,
+        appmap: [appmapFile],
+      });
+
+      const pumlFile = path.join(OutputDir, 'revoke_api_key.sequence.uml');
+      expect(existsSync(pumlFile)).toBe(true);
+      const puml = (await readFile(pumlFile, 'utf8')).split('\n');
+      expect(puml).toContain(`participant app_models as "app/models"`);
+      expect(puml).toContain(`participant app_controllers as "app/controllers"`);
+      expect(puml).not.toContain(`participant ApiKey as "ApiKey"`);
+      expect(puml).not.toContain(`participant APIKeysController as "APIKeysController"`);
+    });
+
+    it('package can be expanded', async () => {
+      await buildDiagram({
+        format: 'plantuml',
+        outputDir: OutputDir,
+        appmap: [appmapFile],
+        expand: 'package:app/models',
+      });
+      const pumlFile = path.join(OutputDir, 'revoke_api_key.sequence.uml');
+      expect(existsSync(pumlFile)).toBe(true);
+      const puml = (await readFile(pumlFile, 'utf8')).split('\n');
+      expect(puml).not.toContain(`participant app_models as "app/models"`);
+      expect(puml).toContain(`participant app_controllers as "app/controllers"`);
+      expect(puml).toContain(`participant ApiKey as "ApiKey"`);
+      expect(puml).not.toContain(`participant APIKeysController as "APIKeysController"`);
+    });
+    it('package names can be expanded', async () => {
+      await buildDiagram({
+        format: 'plantuml',
+        outputDir: OutputDir,
+        appmap: [appmapFile],
+        expand: ['package:app/models', 'package:app/controllers'],
+      });
+      const pumlFile = path.join(OutputDir, 'revoke_api_key.sequence.uml');
+      expect(existsSync(pumlFile)).toBe(true);
+      const puml = (await readFile(pumlFile, 'utf8')).split('\n');
+      expect(puml).not.toContain(`participant app_models as "app/models"`);
+      expect(puml).not.toContain(`participant app_controllers as "app/controllers"`);
+      expect(puml).toContain(`participant ApiKey as "ApiKey"`);
+      expect(puml).toContain(`participant APIKeysController as "APIKeysController"`);
+    });
+  });
 });
 
 let cwd: string | undefined;


### PR DESCRIPTION
--expand specifies a code object to expand in the output diagram. The --expand option may be repeated.

Most commonly, --expand will specify a package.

Example:

--expand package:app/controllers