### PR TITLE
Scanner does not rescan

### DIFF
--- a/packages/scanner/src/appMapIndex.ts
+++ b/packages/scanner/src/appMapIndex.ts
@@ -3,7 +3,7 @@ import { QueryAST } from './types';
 import LRUCache from 'lru-cache';
 
 const NormalizedSQLBySQLString = new LRUCache<string, string>({ max: 10000 });
-const ASTBySQLString = new LRUCache<string, QueryAST | 'parse-error'>({ max: 1000 });
+const ASTBySQLString = new LRUCache<string, QueryAST>({ max: 1000 });
 
 export default class AppMapIndex {
   constructor(public appMap: AppMap) {}
@@ -12,17 +12,12 @@ export default class AppMapIndex {
     if (!event.sql) throw new Error(`${event.fqid} is not a SQL query`);
 
     const sql = this.sqlNormalized(event);
-    let result: QueryAST | undefined;
-    const cachedAST = ASTBySQLString.get(sql);
-    if (cachedAST === 'parse-error') {
-      result = undefined;
-    } else if (cachedAST) {
-      result = cachedAST;
-    } else {
-      result = parseSQL(sql);
-      ASTBySQLString.set(sql, result ? result : 'parse-error');
+    let ast = ASTBySQLString.get(sql);
+    if (!ast) {
+      ast = parseSQL(sql);
+      ast ? ASTBySQLString.set(sql, ast) : ASTBySQLString.set(sql, null);
     }
-    return result;
+    return ast;
   }
 
   sqlNormalized(event: Event): string {


### PR DESCRIPTION
Fixes #1331 

A recent change to `@appland/scanner` caused a test in `vscode-appland` to fail most of the time in CI, which has been causing a lot of build failures (builds fail ~75% of the time):

```
1 failing
  1) Scanner
       is performed as AppMaps are modified:
     Error: No Diagnostics were created for Microposts_controller_can_get_microposts_as_JSON
  	at waitFor (out/test/waitFor.js:35:23)
  	at async repeatUntil (out/test/waitFor.js:7:9)
  	at async Context.<anonymous> (out/test/integration/scanner/performAsAppMapsAreModified.test.js:55:9)
```

After a lot of testing, I've traced this to `@appland/scanner` version `1.82.0`. The scanner is not re-scanning and is not regenerating the `appmap-findings.json` file in the test. I haven't been able to figure out exactly why this code change is causing this problem, but this is taking a long time to troubleshoot and it's difficult to run a custom version of the scanner in CI ([this PR](https://github.com/getappmap/vscode-appland/pull/781) has an attempt to use `appmap-js` as a `gitmodule` but it didn't work), so I think we should just revert the offending commit.