### PR TITLE
feat: Sequence diagram diff in appmap

### DIFF
--- a/packages/components/src/components/DetailsPanelFilters.vue
+++ b/packages/components/src/components/DetailsPanelFilters.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="details-panel-filters">
+  <div v-if="!isPrecomputedSequenceDiagram" class="details-panel-filters">
     <div class="details-panel-filters__head">
       <FilterIcon class="details-panel-filters__head-icon" />
       <span class="details-panel-filters__head-text">Filters</span>
@@ -23,6 +23,7 @@
 <script>
 import FilterIcon from '@/assets/filter.svg';
 import ResetIcon from '@/assets/reset.svg';
+import isPrecomputedSequenceDiagram from '@/lib/isPrecomputedSequenceDiagram';
 import { ADD_HIDDEN_NAME } from '@/store/vsCode';
 
 export default {
@@ -43,6 +44,11 @@ export default {
       required: false,
       default: false,
     },
+    filterDisabled: {
+      type: Boolean,
+      default: false,
+      readonly: true,
+    },
   },
 
   data() {
@@ -61,6 +67,7 @@ export default {
   },
 
   computed: {
+    isPrecomputedSequenceDiagram,
     filters() {
       const { filterItems } = this;
 

--- a/packages/components/src/components/DiagramSequence.vue
+++ b/packages/components/src/components/DiagramSequence.vue
@@ -13,6 +13,7 @@
             :row="1"
             :index="index"
             :height="diagramSpec.actions.length"
+            :filter-disabled="filterDisabled"
             :interactive="interactive"
             :selected-actor="selectedActor"
             :appMap="appMap"
@@ -54,7 +55,13 @@
 <script lang="ts">
 // @ts-nocheck
 import { AppMap, CodeObject } from '@appland/models';
-import { buildDiagram, unparseDiagram, Diagram, Specification } from '@appland/sequence-diagram';
+import {
+  buildDiagram,
+  unparseDiagram,
+  Diagram,
+  Specification,
+  Action,
+} from '@appland/sequence-diagram';
 import VLoopAction from '@/components/sequence/LoopAction.vue';
 import VCallAction from '@/components/sequence/CallAction.vue';
 import VReturnAction from '@/components/sequence/ReturnAction.vue';
@@ -79,6 +86,10 @@ export default {
     focusedEvent: {
       type: Object,
       default: null,
+    },
+    filterDisabled: {
+      type: Boolean,
+      default: false,
     },
     interactive: {
       type: Boolean,
@@ -131,6 +142,8 @@ export default {
       let result: Diagram | undefined;
       if (this.serializedDiagram) {
         result = unparseDiagram(this.serializedDiagram as Diagram);
+      } else if (this.$store?.state?.precomputedSequenceDiagram) {
+        result = this.$store.state.precomputedSequenceDiagram;
       } else if (this.appMap) {
         const appMapObj: AppMap | undefined = this.appMap as AppMap;
         const { priority, expand } = this;

--- a/packages/components/src/components/DiagramSequence.vue
+++ b/packages/components/src/components/DiagramSequence.vue
@@ -163,10 +163,15 @@ export default {
       // If a Diagram contains any actions in diff mode, expand all ancestors of every diff action,
       // and collapse all other actions.
       const expandedActions = new Set<number>();
+      let firstDiffAction: Action | undefined;
+
+      const eventIds = (action: Action) => (action.eventIds || []).filter((id) => id !== undefined);
+
       const markExpandedActions = (action: Action, ancestors = new Array<Action>()) => {
         if (action.diffMode) {
-          expandedActions.add(...action.eventIds);
-          for (const ancestor of ancestors) expandedActions.add(...ancestor.eventIds);
+          if (!firstDiffAction) firstDiffAction = action;
+          expandedActions.add(...eventIds(action));
+          for (const ancestor of ancestors) expandedActions.add(...eventIds(ancestor));
         }
         if (action.children && action.children.length > 0) {
           ancestors.push(action);
@@ -175,11 +180,12 @@ export default {
         }
         return ancestors;
       };
-      this.diagram?.rootActions.forEach((root) => markExpandedActions(root));
-      expandedActions.delete(undefined);
 
       const shouldExpand = (action: Action) =>
-        expandedActions.size === 0 || action.eventIds.some((id) => expandedActions.has(id));
+        expandedActions.size === 0 || eventIds(action).some((id) => expandedActions.has(id));
+
+      this.diagram?.rootActions.forEach((root) => markExpandedActions(root));
+      expandedActions.delete(undefined);
 
       for (let index = 0; index < result.actions.length; index++)
         this.$set(this.collapsedActions, index, !shouldExpand(result.actions[index]));

--- a/packages/components/src/components/DiagramSequence.vue
+++ b/packages/components/src/components/DiagramSequence.vue
@@ -68,6 +68,7 @@ import VReturnAction from '@/components/sequence/ReturnAction.vue';
 import VActor from '@/components/sequence/Actor.vue';
 import DiagramSpec from './sequence/DiagramSpec';
 import { ActionSpec } from './sequence/ActionSpec';
+import { SET_FOCUSED_EVENT } from '../store/vsCode';
 
 const SCROLL_OPTIONS = { behavior: 'smooth', block: 'center', inline: 'center' };
 
@@ -189,6 +190,13 @@ export default {
 
       for (let index = 0; index < result.actions.length; index++)
         this.$set(this.collapsedActions, index, !shouldExpand(result.actions[index]));
+
+      if (firstDiffAction && this.$store?.state) {
+        const eventId = eventIds(firstDiffAction).filter(Boolean)[0];
+        const { appMap } = this.$store.state;
+        const event = appMap.eventsById[eventId];
+        this.$store.commit(SET_FOCUSED_EVENT, event);
+      }
 
       return result;
     },

--- a/packages/components/src/components/DiagramSequence.vue
+++ b/packages/components/src/components/DiagramSequence.vue
@@ -13,7 +13,6 @@
             :row="1"
             :index="index"
             :height="diagramSpec.actions.length"
-            :filter-disabled="filterDisabled"
             :interactive="interactive"
             :selected-actor="selectedActor"
             :appMap="appMap"
@@ -87,10 +86,6 @@ export default {
     focusedEvent: {
       type: Object,
       default: null,
-    },
-    filterDisabled: {
-      type: Boolean,
-      default: false,
     },
     interactive: {
       type: Boolean,

--- a/packages/components/src/components/sequence/Actor.vue
+++ b/packages/components/src/components/sequence/Actor.vue
@@ -6,7 +6,7 @@
         <div class="sequence-actor" :data-actor-id="actor.id">
           <div ref="label_container" :class="labelClasses" @click="selectCodeObject">
             <div :class="['label', type]">
-              <template v-if="interactive && !filterDisabled">
+              <template v-if="interactive && !isPrecomputedSequenceDiagram">
                 <div class="control-wrap">
                   <span class="hide-container" @click.stop="hideCodeObject">
                     <XIcon />
@@ -56,6 +56,7 @@ import XIcon from '@/assets/x-icon.svg';
 import VPopper from '@/components/Popper.vue';
 import ExpandIcon from '@/assets/expand-icon.svg';
 import CollapseIcon from '@/assets/collapse-icon.svg';
+import isPrecomputedSequenceDiagram from '@/lib/isPrecomputedSequenceDiagram';
 
 export default {
   name: 'v-sequence-actor',
@@ -104,6 +105,7 @@ export default {
     },
   },
   computed: {
+    isPrecomputedSequenceDiagram,
     inlineStyle(): { [key: string]: string } {
       return {
         'grid-area': `1 / ${this.index + 1} / ${this.height + 2} / auto`,

--- a/packages/components/src/components/sequence/Actor.vue
+++ b/packages/components/src/components/sequence/Actor.vue
@@ -6,7 +6,7 @@
         <div class="sequence-actor" :data-actor-id="actor.id">
           <div ref="label_container" :class="labelClasses" @click="selectCodeObject">
             <div :class="['label', type]">
-              <template v-if="interactive">
+              <template v-if="interactive && !filterDisabled">
                 <div class="control-wrap">
                   <span class="hide-container" @click.stop="hideCodeObject">
                     <XIcon />
@@ -90,10 +90,14 @@ export default {
       required: true,
       readonly: true,
     },
+    filterDisabled: {
+      type: Boolean,
+      default: false,
+      readonly: true,
+    },
     interactive: {
       type: Boolean,
-      required: true,
-      readonly: true,
+      default: true,
     },
     appMap: {
       type: Object,

--- a/packages/components/src/lib/isPrecomputedSequenceDiagram.js
+++ b/packages/components/src/lib/isPrecomputedSequenceDiagram.js
@@ -1,0 +1,6 @@
+export default function isPrecomputedSequenceDiagram() {
+  // Standalone sequence diagram does not use a $store
+  if (this.$store === undefined) return false;
+
+  return !!this.$store.state.precomputedSequenceDiagram;
+}

--- a/packages/components/src/pages/VsCodeExtension.vue
+++ b/packages/components/src/pages/VsCodeExtension.vue
@@ -75,7 +75,7 @@
           <v-diagram-sequence
             ref="viewSequence_diagram"
             :app-map="filteredAppMap"
-            :filter-enabled="isFilterEnabled"
+            :filter-disabled="isPrecomputedSequenceDiagram"
             :focused-event="focusedEvent"
             :selected-events="selectedEvent"
           />
@@ -495,7 +495,10 @@ export default {
       handler(event) {
         if (event) {
           if (this.currentView === VIEW_COMPONENT) {
-            this.setView(this.defaultView === VIEW_SEQUENCE ? VIEW_SEQUENCE : VIEW_FLOW);
+            let { defaultView } = this;
+            if (this.isPrecomputedSequenceDiagram) defaultView = VIEW_SEQUENCE;
+
+            this.setView(defaultView === VIEW_SEQUENCE ? VIEW_SEQUENCE : VIEW_FLOW);
           }
           this.$nextTick(() => {
             Object.keys(this.$refs)

--- a/packages/components/src/pages/VsCodeExtension.vue
+++ b/packages/components/src/pages/VsCodeExtension.vue
@@ -75,6 +75,7 @@
           <v-diagram-sequence
             ref="viewSequence_diagram"
             :app-map="filteredAppMap"
+            :filter-enabled="isFilterEnabled"
             :focused-event="focusedEvent"
             :selected-events="selectedEvent"
           />
@@ -181,7 +182,10 @@
               <StatsIcon class="control-button__icon" />
             </button>
           </v-popper>
-          <v-popper-menu v-if="!isGiantAppMap" :isHighlight="filtersChanged">
+          <v-popper-menu
+            v-if="!isPrecomputedSequenceDiagram && !isGiantAppMap"
+            :isHighlight="filtersChanged"
+          >
             <template v-slot:icon>
               <v-popper
                 class="hover-text-popper"
@@ -331,6 +335,8 @@ import {
   base64UrlEncode,
   AppMapFilter,
 } from '@appland/models';
+import { unparseDiagram } from '@appland/sequence-diagram';
+
 import CopyIcon from '@/assets/copy-icon.svg';
 import CloseIcon from '@/assets/close.svg';
 import ReloadIcon from '@/assets/reload.svg';
@@ -754,6 +760,10 @@ export default {
       return this.$store.getters.canPopStack;
     },
 
+    isPrecomputedSequenceDiagram() {
+      return !!this.$store.state.precomputedSequenceDiagram;
+    },
+
     isEmptyAppMap() {
       const appMap = this.filteredAppMap;
       const hasEvents = Array.isArray(appMap.events) && appMap.events.length;
@@ -796,8 +806,13 @@ export default {
   },
 
   methods: {
-    loadData(data) {
-      this.$store.commit(SET_APPMAP_DATA, data);
+    loadData(appMap, sequenceDiagram) {
+      if (sequenceDiagram) {
+        appMap['sequenceDiagram'] = unparseDiagram(sequenceDiagram);
+      }
+
+      this.$store.commit(SET_APPMAP_DATA, appMap);
+
       this.initializeSavedFilters();
 
       const rootEvents = this.$store.state.appMap.rootEvents();

--- a/packages/components/src/pages/VsCodeExtension.vue
+++ b/packages/components/src/pages/VsCodeExtension.vue
@@ -75,7 +75,6 @@
           <v-diagram-sequence
             ref="viewSequence_diagram"
             :app-map="filteredAppMap"
-            :filter-disabled="isPrecomputedSequenceDiagram"
             :focused-event="focusedEvent"
             :selected-events="selectedEvent"
           />
@@ -388,6 +387,7 @@ import {
   SET_HIGHLIGHTED_EVENTS,
   SET_FOCUSED_EVENT,
 } from '../store/vsCode';
+import isPrecomputedSequenceDiagram from '@/lib/isPrecomputedSequenceDiagram';
 
 export default {
   name: 'VSCodeExtension',
@@ -537,6 +537,7 @@ export default {
   },
 
   computed: {
+    isPrecomputedSequenceDiagram,
     classes() {
       return this.isLoading ? 'app--loading' : '';
     },
@@ -761,10 +762,6 @@ export default {
 
     canGoBack() {
       return this.$store.getters.canPopStack;
-    },
-
-    isPrecomputedSequenceDiagram() {
-      return !!this.$store.state.precomputedSequenceDiagram;
     },
 
     isEmptyAppMap() {

--- a/packages/components/src/store/vsCode.js
+++ b/packages/components/src/store/vsCode.js
@@ -57,6 +57,7 @@ export function buildStore() {
   return new Vuex.Store({
     state: {
       appMap: new AppMap(),
+      precomputedSequenceDiagram: null,
       selectionStack: [],
       currentView: DEFAULT_VIEW,
       selectedLabel: null,
@@ -88,6 +89,7 @@ export function buildStore() {
       [SET_APPMAP_DATA](state, data) {
         state.selectionStack = [];
         state.appMap = buildAppMap().source(data).normalize().build();
+        if (data.sequenceDiagram) state.precomputedSequenceDiagram = data.sequenceDiagram;
 
         state.appMap.callTree.rootEvent.forEach((e) => {
           e.displayName = fullyQualifiedFunctionName(e.input);

--- a/packages/components/src/stories/DiagramSequence.stories.js
+++ b/packages/components/src/stories/DiagramSequence.stories.js
@@ -1,5 +1,5 @@
 import VDiagramSequence from '@/components/DiagramSequence.vue';
-import appland_api_key_diff from '@/stories/data/sequence/appland_api_key_diff.sequence.json';
+import micropost_diff from '@/stories/data/sequence/Users_profile_profile_display.diff.sequence.json';
 import create_api_key from '@/stories/data/sequence/create_api_key.sequence.json';
 import list_users from '@/stories/data/sequence/list_users.sequence.json';
 import list_users_prefetch from '@/stories/data/sequence/list_users_prefetch.sequence.json';
@@ -17,9 +17,9 @@ const Template = (args, { argTypes }) => ({
   template: '<v-diagram-sequence v-bind="$props"/>',
 });
 
-export const AppLandApiKeyDiff = Template.bind({});
-AppLandApiKeyDiff.args = {
-  serializedDiagram: appland_api_key_diff,
+export const MicropostUserProfileDiff = Template.bind({});
+MicropostUserProfileDiff.args = {
+  serializedDiagram: micropost_diff,
 };
 export const Empty = Template.bind({});
 

--- a/packages/components/src/stories/VsCodeExtension.stories.js
+++ b/packages/components/src/stories/VsCodeExtension.stories.js
@@ -7,6 +7,8 @@ import petClinicScenario from './data/java_scenario.json';
 import diffScenario from './data/diff_base.json';
 import appland1 from './data/Application_page_component_diagram_highlights_node_connections_upon_selection.appmap.json';
 import appland2 from './data/ApplicationsController_scenarios_list_when_the_user_is_anonymous_is_not_found.appmap.json';
+import diffAppMap from './data/sequence-diff/Users_profile_profile_display.appmap.json';
+import diffSequenceDiagram from './data/sequence-diff/Users_profile_profile_display.diff.sequence.json';
 import mapWithFindings from './data/appmap_with_finding.json';
 import mapWithTwoFindings from './data/appmap_with_two_findings.json';
 import patchNotes from './data/patch_notes_html';
@@ -21,8 +23,13 @@ const scenarioData = {
   'pet-clinic': petClinicScenario,
   appland1,
   appland2,
+  mapWithDiff: diffAppMap,
   mapWithFindings,
   mapWithTwoFindings,
+};
+
+const sequenceDiagramData = {
+  mapWithDiff: diffSequenceDiagram,
 };
 
 export default {
@@ -55,8 +62,9 @@ const Template = (args, { argTypes }) => ({
   template: '<v-vs-code-extension v-bind="$props" ref="vsCode" />',
   mounted() {
     const scenario = scenarioData[args.scenario];
+    const sequenceDiagram = sequenceDiagramData[args.scenario];
     if (scenario) {
-      this.$refs.vsCode.loadData(scenario);
+      this.$refs.vsCode.loadData(scenario, sequenceDiagram);
     }
 
     bindResolvePath(this);
@@ -68,6 +76,13 @@ export const extension = Template.bind({});
 export const extensionWithDefaultSequenceView = Template.bind({});
 extensionWithDefaultSequenceView.args = {
   defaultView: VIEW_SEQUENCE,
+};
+
+export const extensionWithSequenceDiff = Template.bind({});
+extensionWithSequenceDiff.args = {
+  defaultView: VIEW_SEQUENCE,
+  scenario: 'mapWithDiff',
+  interactive: false,
 };
 
 export const extensionWithSavedFilters = Template.bind({});

--- a/packages/components/src/stories/data/sequence-diff/Users_profile_profile_display.appmap.json
+++ b/packages/components/src/stories/data/sequence-diff/Users_profile_profile_display.appmap.json
@@ -1,0 +1,10426 @@
+{
+  "events": [
+    {
+      "id": 1,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionDispatch::Integration::Runner",
+      "method_id": "before_setup",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/testing/integration.rb",
+      "lineno": 329,
+      "static": false,
+      "receiver": {
+        "class": "UsersProfileTest",
+        "object_id": 159680,
+        "value": "#<UsersProfileTest:0x00007f33d67a1050>"
+      }
+    },
+    {
+      "id": 2,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActiveSupport::Callbacks::CallbackSequence",
+      "method_id": "invoke_before",
+      "path": "vendor/bundle/ruby/3.1.0/gems/activesupport-7.0.4/lib/active_support/callbacks.rb",
+      "lineno": 594,
+      "static": false,
+      "parameters": [
+        {
+          "name": "arg",
+          "class": "ActiveSupport::Callbacks::Filters::Environment",
+          "object_id": 159720,
+          "value": null,
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActiveSupport::Callbacks::CallbackSequence",
+        "object_id": 39700,
+        "value": "#<ActiveSupport::Callbacks::CallbackSequence:0x00007f33ddcbba98>"
+      }
+    },
+    {
+      "id": 3,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 2,
+      "elapsed": 0.000001499999996212864,
+      "elapsed_instrumentation": 0.00006630399997220593,
+      "return_value": {
+        "class": "Array",
+        "value": "[]",
+        "object_id": 39720,
+        "size": 0
+      }
+    },
+    {
+      "id": 4,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActiveSupport::Callbacks::CallbackSequence",
+      "method_id": "invoke_after",
+      "path": "vendor/bundle/ruby/3.1.0/gems/activesupport-7.0.4/lib/active_support/callbacks.rb",
+      "lineno": 598,
+      "static": false,
+      "parameters": [
+        {
+          "name": "arg",
+          "class": "ActiveSupport::Callbacks::Filters::Environment",
+          "object_id": 159720,
+          "value": null,
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActiveSupport::Callbacks::CallbackSequence",
+        "object_id": 39700,
+        "value": "#<ActiveSupport::Callbacks::CallbackSequence:0x00007f33ddcbba98>"
+      }
+    },
+    {
+      "id": 5,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 4,
+      "elapsed": 0.000006100000007336348,
+      "elapsed_instrumentation": 0.00004870200001505509,
+      "return_value": {
+        "class": "Array",
+        "value": "[#<Proc:0x00007f33ddcbb5c0 /home/runner/work/rails_tutorial_sample_app_7th_ed/rails_tutorial_sample_a]",
+        "object_id": 39740,
+        "size": 1
+      }
+    },
+    {
+      "id": 6,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "Logger::LogDevice",
+      "method_id": "write",
+      "path": "/opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/3.1.0/logger/log_device.rb",
+      "lineno": 31,
+      "static": false,
+      "parameters": [
+        {
+          "name": "message",
+          "class": "String",
+          "object_id": 159740,
+          "value": "  \u001b[1m\u001b[36mTRANSACTION (0.0ms)\u001b[0m  \u001b[1m\u001b[36mbegin transaction\u001b[0m\n",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "Logger::LogDevice",
+        "object_id": 9000,
+        "value": "#<Logger::LogDevice:0x00007f33dec8c058>"
+      }
+    },
+    {
+      "id": 7,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 6,
+      "elapsed": 0.000020000999995772872,
+      "elapsed_instrumentation": 0.000058203999998340805,
+      "return_value": {
+        "class": "Integer",
+        "value": "67",
+        "object_id": 135
+      }
+    },
+    {
+      "id": 8,
+      "event": "call",
+      "thread_id": 4480,
+      "sql_query": {
+        "sql": "begin transaction",
+        "database_type": "sqlite"
+      }
+    },
+    {
+      "id": 9,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 8,
+      "elapsed": 0.000168311,
+      "elapsed_instrumentation": 0.00003330199999140859
+    },
+    {
+      "id": 10,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "Logger::LogDevice",
+      "method_id": "write",
+      "path": "/opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/3.1.0/logger/log_device.rb",
+      "lineno": 31,
+      "static": false,
+      "parameters": [
+        {
+          "name": "message",
+          "class": "String",
+          "object_id": 159760,
+          "value": "--------------------------------------\n",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "Logger::LogDevice",
+        "object_id": 9000,
+        "value": "#<Logger::LogDevice:0x00007f33dec8c058>"
+      }
+    },
+    {
+      "id": 11,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 10,
+      "elapsed": 0.00001240099999222366,
+      "elapsed_instrumentation": 0.00006940499997654115,
+      "return_value": {
+        "class": "Integer",
+        "value": "39",
+        "object_id": 79
+      }
+    },
+    {
+      "id": 12,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "Logger::LogDevice",
+      "method_id": "write",
+      "path": "/opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/3.1.0/logger/log_device.rb",
+      "lineno": 31,
+      "static": false,
+      "parameters": [
+        {
+          "name": "message",
+          "class": "String",
+          "object_id": 159780,
+          "value": "UsersProfileTest: test_profile_display\n",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "Logger::LogDevice",
+        "object_id": 9000,
+        "value": "#<Logger::LogDevice:0x00007f33dec8c058>"
+      }
+    },
+    {
+      "id": 13,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 12,
+      "elapsed": 0.00000839999998447638,
+      "elapsed_instrumentation": 0.00004610400003457471,
+      "return_value": {
+        "class": "Integer",
+        "value": "39",
+        "object_id": 79
+      }
+    },
+    {
+      "id": 14,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "Logger::LogDevice",
+      "method_id": "write",
+      "path": "/opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/3.1.0/logger/log_device.rb",
+      "lineno": 31,
+      "static": false,
+      "parameters": [
+        {
+          "name": "message",
+          "class": "String",
+          "object_id": 159800,
+          "value": "--------------------------------------\n",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "Logger::LogDevice",
+        "object_id": 9000,
+        "value": "#<Logger::LogDevice:0x00007f33dec8c058>"
+      }
+    },
+    {
+      "id": 15,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 14,
+      "elapsed": 0.000008501000024807581,
+      "elapsed_instrumentation": 0.000044801999990795593,
+      "return_value": {
+        "class": "Integer",
+        "value": "39",
+        "object_id": 79
+      }
+    },
+    {
+      "id": 16,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActiveSupport::Callbacks::CallbackSequence",
+      "method_id": "invoke_before",
+      "path": "vendor/bundle/ruby/3.1.0/gems/activesupport-7.0.4/lib/active_support/callbacks.rb",
+      "lineno": 594,
+      "static": false,
+      "parameters": [
+        {
+          "name": "arg",
+          "class": "ActiveSupport::Callbacks::Filters::Environment",
+          "object_id": 159820,
+          "value": null,
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActiveSupport::Callbacks::CallbackSequence",
+        "object_id": 42580,
+        "value": "#<ActiveSupport::Callbacks::CallbackSequence:0x00007f33dcbe5250>"
+      }
+    },
+    {
+      "id": 17,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 16,
+      "elapsed": 0.0000371029999826078,
+      "elapsed_instrumentation": 0.00006910400003334871,
+      "return_value": {
+        "class": "Array",
+        "value": "[#<Proc:0x00007f33dcbe4e68 /home/runner/work/rails_tutorial_sample_app_7th_ed/rails_tutorial_sample_a, #<Proc:0x00007f33dcbe4fa8 /home/runner/work/rails_tutorial_sample_app_7th_ed/rails_tutorial_sample_a]",
+        "object_id": 42600,
+        "size": 2
+      }
+    },
+    {
+      "id": 18,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActiveSupport::Callbacks::CallbackSequence",
+      "method_id": "invoke_after",
+      "path": "vendor/bundle/ruby/3.1.0/gems/activesupport-7.0.4/lib/active_support/callbacks.rb",
+      "lineno": 598,
+      "static": false,
+      "parameters": [
+        {
+          "name": "arg",
+          "class": "ActiveSupport::Callbacks::Filters::Environment",
+          "object_id": 159820,
+          "value": null,
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActiveSupport::Callbacks::CallbackSequence",
+        "object_id": 42580,
+        "value": "#<ActiveSupport::Callbacks::CallbackSequence:0x00007f33dcbe5250>"
+      }
+    },
+    {
+      "id": 19,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 18,
+      "elapsed": 0.0000016000000186977559,
+      "elapsed_instrumentation": 0.00004110300002935219,
+      "return_value": {
+        "class": "Array",
+        "value": "[]",
+        "object_id": 42620,
+        "size": 0
+      }
+    },
+    {
+      "id": 20,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 1,
+      "elapsed": 0.000978464000013446,
+      "elapsed_instrumentation": 0.00005660300001864016,
+      "return_value": {
+        "class": "TrueClass",
+        "value": "true",
+        "object_id": 20
+      }
+    },
+    {
+      "id": 21,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "Logger::LogDevice",
+      "method_id": "write",
+      "path": "/opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/3.1.0/logger/log_device.rb",
+      "lineno": 31,
+      "static": false,
+      "parameters": [
+        {
+          "name": "message",
+          "class": "String",
+          "object_id": 159840,
+          "value": "  \u001b[1m\u001b[36mUser Load (0.1ms)\u001b[0m  \u001b[1m\u001b[34mSELECT \"users\".* FROM \"users\" WHERE \"users\".\"id\" = ? LIMI (...43 more characters)",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "Logger::LogDevice",
+        "object_id": 9000,
+        "value": "#<Logger::LogDevice:0x00007f33dec8c058>"
+      }
+    },
+    {
+      "id": 22,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 21,
+      "elapsed": 0.000017600999996147948,
+      "elapsed_instrumentation": 0.00008020600000691047,
+      "return_value": {
+        "class": "Integer",
+        "value": "143",
+        "object_id": 287
+      }
+    },
+    {
+      "id": 23,
+      "event": "call",
+      "thread_id": 4480,
+      "sql_query": {
+        "sql": "SELECT \"users\".* FROM \"users\" WHERE \"users\".\"id\" = ? LIMIT ?",
+        "database_type": "sqlite"
+      }
+    },
+    {
+      "id": 24,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 23,
+      "elapsed": 0.000251016,
+      "elapsed_instrumentation": 0.00003720199998724638
+    },
+    {
+      "id": 25,
+      "event": "call",
+      "thread_id": 4480,
+      "http_server_request": {
+        "request_method": "GET",
+        "path_info": "/users/762146111",
+        "normalized_path_info": "/users/{id}",
+        "headers": {
+          "Version": "HTTP/1.0",
+          "Host": "www.example.com",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Content-Length": "0"
+        }
+      }
+    },
+    {
+      "id": 26,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActiveSupport::Callbacks::CallbackSequence",
+      "method_id": "invoke_before",
+      "path": "vendor/bundle/ruby/3.1.0/gems/activesupport-7.0.4/lib/active_support/callbacks.rb",
+      "lineno": 594,
+      "static": false,
+      "parameters": [
+        {
+          "name": "arg",
+          "class": "ActiveSupport::Callbacks::Filters::Environment",
+          "object_id": 159860,
+          "value": null,
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActiveSupport::Callbacks::CallbackSequence",
+        "object_id": 42760,
+        "value": "#<ActiveSupport::Callbacks::CallbackSequence:0x00007f33dc4870f8>"
+      }
+    },
+    {
+      "id": 27,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 26,
+      "elapsed": 0.00003720299997667098,
+      "elapsed_instrumentation": 0.00022301399999946625,
+      "return_value": {
+        "class": "Array",
+        "value": "[#<Proc:0x00007f33dc486900 /home/runner/work/rails_tutorial_sample_app_7th_ed/rails_tutorial_sample_a, #<Proc:0x00007f33dc486a40 /home/runner/work/rails_tutorial_sample_app_7th_ed/rails_tutorial_sample_a, #<Proc:0x00007f33dc486b80 /home/runner/work/rails_tutorial_sample_app_7th_ed/rails_tutorial_sample_a, #<Proc:0x00007f33dc486d38 /home/runner/work/rails_tutorial_sample_app_7th_ed/rails_tutorial_sample_a]",
+        "object_id": 42780,
+        "size": 4
+      }
+    },
+    {
+      "id": 28,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActiveSupport::Callbacks::CallbackSequence",
+      "method_id": "invoke_after",
+      "path": "vendor/bundle/ruby/3.1.0/gems/activesupport-7.0.4/lib/active_support/callbacks.rb",
+      "lineno": 598,
+      "static": false,
+      "parameters": [
+        {
+          "name": "arg",
+          "class": "ActiveSupport::Callbacks::Filters::Environment",
+          "object_id": 159860,
+          "value": null,
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActiveSupport::Callbacks::CallbackSequence",
+        "object_id": 42760,
+        "value": "#<ActiveSupport::Callbacks::CallbackSequence:0x00007f33dc4870f8>"
+      }
+    },
+    {
+      "id": 29,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 28,
+      "elapsed": 0.0000018000000068241206,
+      "elapsed_instrumentation": 0.0000416029999996681,
+      "return_value": {
+        "class": "Array",
+        "value": "[]",
+        "object_id": 42800,
+        "size": 0
+      }
+    },
+    {
+      "id": 30,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "String",
+      "method_id": "unpack",
+      "path": "<internal:pack>",
+      "lineno": 275,
+      "static": false,
+      "parameters": [
+        {
+          "name": "fmt",
+          "class": "String",
+          "object_id": 42820,
+          "value": "NnnnnN",
+          "kind": "req"
+        },
+        {
+          "name": "offset",
+          "class": "NilClass",
+          "object_id": 8,
+          "value": null,
+          "kind": "key"
+        }
+      ],
+      "receiver": {
+        "class": "String",
+        "object_id": 159880,
+        "value": "|_D____\"__K_W_)\u001e"
+      }
+    },
+    {
+      "id": 31,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 30,
+      "elapsed": 0.000002900999987787145,
+      "elapsed_instrumentation": 0.00015660899998692912,
+      "return_value": {
+        "class": "Array",
+        "value": "[2096055528, 64192, 46626, 61058, 19356, 1470376222]",
+        "object_id": 159900,
+        "size": 6
+      }
+    },
+    {
+      "id": 32,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "Logger::LogDevice",
+      "method_id": "write",
+      "path": "/opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/3.1.0/logger/log_device.rb",
+      "lineno": 31,
+      "static": false,
+      "parameters": [
+        {
+          "name": "message",
+          "class": "String",
+          "object_id": 159920,
+          "value": "Started GET \"/users/762146111\" for 127.0.0.1 at 2023-08-16 19:09:11 +0000\n",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "Logger::LogDevice",
+        "object_id": 9000,
+        "value": "#<Logger::LogDevice:0x00007f33dec8c058>"
+      }
+    },
+    {
+      "id": 33,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 32,
+      "elapsed": 0.000018001000000822387,
+      "elapsed_instrumentation": 0.00006760499999813874,
+      "return_value": {
+        "class": "Integer",
+        "value": "74",
+        "object_id": 149
+      }
+    },
+    {
+      "id": 34,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "Logger::LogDevice",
+      "method_id": "write",
+      "path": "/opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/3.1.0/logger/log_device.rb",
+      "lineno": 31,
+      "static": false,
+      "parameters": [
+        {
+          "name": "message",
+          "class": "String",
+          "object_id": 159960,
+          "value": "Processing by UsersController#show as HTML\n",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "Logger::LogDevice",
+        "object_id": 9000,
+        "value": "#<Logger::LogDevice:0x00007f33dec8c058>"
+      }
+    },
+    {
+      "id": 35,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 34,
+      "elapsed": 0.000019201000014845704,
+      "elapsed_instrumentation": 0.00008760599999391161,
+      "return_value": {
+        "class": "Integer",
+        "value": "43",
+        "object_id": 87
+      }
+    },
+    {
+      "id": 36,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "Logger::LogDevice",
+      "method_id": "write",
+      "path": "/opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/3.1.0/logger/log_device.rb",
+      "lineno": 31,
+      "static": false,
+      "parameters": [
+        {
+          "name": "message",
+          "class": "String",
+          "object_id": 159980,
+          "value": "  Parameters: {\"id\"=>\"762146111\"}\n",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "Logger::LogDevice",
+        "object_id": 9000,
+        "value": "#<Logger::LogDevice:0x00007f33dec8c058>"
+      }
+    },
+    {
+      "id": 37,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 36,
+      "elapsed": 0.000009500999993861114,
+      "elapsed_instrumentation": 0.00004870200001505509,
+      "return_value": {
+        "class": "Integer",
+        "value": "34",
+        "object_id": 69
+      }
+    },
+    {
+      "id": 38,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActiveSupport::Callbacks::CallbackSequence",
+      "method_id": "invoke_before",
+      "path": "vendor/bundle/ruby/3.1.0/gems/activesupport-7.0.4/lib/active_support/callbacks.rb",
+      "lineno": 594,
+      "static": false,
+      "parameters": [
+        {
+          "name": "arg",
+          "class": "ActiveSupport::Callbacks::Filters::Environment",
+          "object_id": 160000,
+          "value": null,
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActiveSupport::Callbacks::CallbackSequence",
+        "object_id": 99300,
+        "value": "#<ActiveSupport::Callbacks::CallbackSequence:0x00007f33dc4531e0>"
+      }
+    },
+    {
+      "id": 39,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 38,
+      "elapsed": 0.00001990100000170969,
+      "elapsed_instrumentation": 0.00006170499997892875,
+      "return_value": {
+        "class": "Array",
+        "value": "[#<Proc:0x00007f33dc452e70 /home/runner/work/rails_tutorial_sample_app_7th_ed/rails_tutorial_sample_a]",
+        "object_id": 99320,
+        "size": 1
+      }
+    },
+    {
+      "id": 40,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActiveSupport::Callbacks::CallbackSequence",
+      "method_id": "invoke_before",
+      "path": "vendor/bundle/ruby/3.1.0/gems/activesupport-7.0.4/lib/active_support/callbacks.rb",
+      "lineno": 594,
+      "static": false,
+      "parameters": [
+        {
+          "name": "arg",
+          "class": "ActiveSupport::Callbacks::Filters::Environment",
+          "object_id": 160000,
+          "value": null,
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActiveSupport::Callbacks::CallbackSequence",
+        "object_id": 99340,
+        "value": "#<ActiveSupport::Callbacks::CallbackSequence:0x00007f33dc453d20>"
+      }
+    },
+    {
+      "id": 41,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 40,
+      "elapsed": 0.0001407089999929667,
+      "elapsed_instrumentation": 0.00008220500001243636,
+      "return_value": {
+        "class": "Array",
+        "value": "[#<Proc:0x00007f33dc453370 /home/runner/work/rails_tutorial_sample_app_7th_ed/rails_tutorial_sample_a, #<Proc:0x00007f33dc453500 /home/runner/work/rails_tutorial_sample_app_7th_ed/rails_tutorial_sample_a, #<Proc:0x00007f33dc453758 /home/runner/work/rails_tutorial_sample_app_7th_ed/rails_tutorial_sample_a, #<Proc:0x00007f33dc453988 /home/runner/work/rails_tutorial_sample_app_7th_ed/rails_tutorial_sample_a]",
+        "object_id": 99360,
+        "size": 4
+      }
+    },
+    {
+      "id": 42,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "UsersController",
+      "method_id": "show",
+      "path": "app/controllers/users_controller.rb",
+      "lineno": 11,
+      "static": false,
+      "receiver": {
+        "class": "UsersController",
+        "object_id": 160020,
+        "value": "#<UsersController:0x00007f33d67890e0>"
+      }
+    },
+    {
+      "id": 43,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "Logger::LogDevice",
+      "method_id": "write",
+      "path": "/opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/3.1.0/logger/log_device.rb",
+      "lineno": 31,
+      "static": false,
+      "parameters": [
+        {
+          "name": "message",
+          "class": "String",
+          "object_id": 160040,
+          "value": "  \u001b[1m\u001b[36mUser Load (0.1ms)\u001b[0m  \u001b[1m\u001b[34mSELECT \"users\".* FROM \"users\" WHERE \"users\".\"id\" = ? LIMI (...43 more characters)",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "Logger::LogDevice",
+        "object_id": 9000,
+        "value": "#<Logger::LogDevice:0x00007f33dec8c058>"
+      }
+    },
+    {
+      "id": 44,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 43,
+      "elapsed": 0.00002040199998987191,
+      "elapsed_instrumentation": 0.00007410400002072492,
+      "return_value": {
+        "class": "Integer",
+        "value": "143",
+        "object_id": 287
+      }
+    },
+    {
+      "id": 45,
+      "event": "call",
+      "thread_id": 4480,
+      "sql_query": {
+        "sql": "SELECT \"users\".* FROM \"users\" WHERE \"users\".\"id\" = ? LIMIT ?",
+        "database_type": "sqlite"
+      }
+    },
+    {
+      "id": 46,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 45,
+      "elapsed": 0.000220915,
+      "elapsed_instrumentation": 0.000036101999995707956
+    },
+    {
+      "id": 47,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 42,
+      "elapsed": 0.0010871709999946688,
+      "elapsed_instrumentation": 0.00007650400002034985,
+      "return_value": {
+        "class": "ActiveRecord::AssociationRelation",
+        "value": "#<Micropost::ActiveRecord_AssociationRelation:0x00007f33d6796a10>",
+        "object_id": 160060
+      }
+    },
+    {
+      "id": 48,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionView::Resolver",
+      "method_id": "find_all",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionview-7.0.4/lib/action_view/template/resolver.rb",
+      "lineno": 62,
+      "static": false,
+      "parameters": [
+        {
+          "name": "name",
+          "class": "String",
+          "object_id": 99440,
+          "value": "show",
+          "kind": "req"
+        },
+        {
+          "name": "prefix",
+          "class": "String",
+          "object_id": 99460,
+          "value": "users",
+          "kind": "opt"
+        },
+        {
+          "name": "partial",
+          "class": "FalseClass",
+          "object_id": 0,
+          "value": "false",
+          "kind": "opt"
+        },
+        {
+          "name": "details",
+          "class": "Hash",
+          "object_id": 160080,
+          "value": "{:locale=>[:en], :formats=>[:html], :variants=>[], :handlers=>[:raw, :erb, :html, :builder, :ruby, :jbuilder]}",
+          "kind": "opt",
+          "size": 4
+        },
+        {
+          "name": "key",
+          "class": "ActionView::TemplateDetails::Requested",
+          "object_id": 46160,
+          "value": "#<ActionView::TemplateDetails::Requested:0x00007f33df4904c0>",
+          "kind": "opt"
+        },
+        {
+          "name": "locals",
+          "class": "Array",
+          "object_id": 160100,
+          "value": "[]",
+          "kind": "opt",
+          "size": 0
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::FileSystemResolver",
+        "object_id": 46200,
+        "value": "/home/runner/work/rails_tutorial_sample_app_7th_ed/rails_tutorial_sample_app_7th_ed/app/views"
+      }
+    },
+    {
+      "id": 49,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 48,
+      "elapsed": 0.000018901000004234447,
+      "elapsed_instrumentation": 0.00028761900003360097,
+      "return_value": {
+        "class": "Array",
+        "value": "[#<ActionView::Template:0x00007f33dcc46cd0>]",
+        "object_id": 160120,
+        "size": 1
+      }
+    },
+    {
+      "id": 50,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionController::Renderers",
+      "method_id": "render_to_body",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_controller/metal/renderers.rb",
+      "lineno": 140,
+      "static": false,
+      "parameters": [
+        {
+          "name": "options",
+          "class": "Hash",
+          "object_id": 160140,
+          "value": "{:prefixes=>[users, application], :template=>show, :layout=>#<Proc:0x00007f33d679b510 /home/runner/work/rails_tutorial_sample_app_7th_ed/rails_tutorial_sample_a}",
+          "kind": "req",
+          "size": 3
+        }
+      ],
+      "receiver": {
+        "class": "UsersController",
+        "object_id": 160020,
+        "value": "#<UsersController:0x00007f33d67890e0>"
+      }
+    },
+    {
+      "id": 51,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "app_views_users_show_html_erb",
+      "method_id": "render",
+      "path": "app/views/users/show.html.erb",
+      "static": true,
+      "receiver": {
+        "class": "ActionView::TemplateRenderer",
+        "object_id": 163920,
+        "value": "#<ActionView::TemplateRenderer:0x00007f33d67996c0>"
+      }
+    },
+    {
+      "id": 52,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionView::Resolver",
+      "method_id": "find_all",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionview-7.0.4/lib/action_view/template/resolver.rb",
+      "lineno": 62,
+      "static": false,
+      "parameters": [
+        {
+          "name": "name",
+          "class": "String",
+          "object_id": 99440,
+          "value": "show",
+          "kind": "req"
+        },
+        {
+          "name": "prefix",
+          "class": "String",
+          "object_id": 99460,
+          "value": "users",
+          "kind": "opt"
+        },
+        {
+          "name": "partial",
+          "class": "FalseClass",
+          "object_id": 0,
+          "value": "false",
+          "kind": "opt"
+        },
+        {
+          "name": "details",
+          "class": "Hash",
+          "object_id": 160160,
+          "value": "{:locale=>[:en], :formats=>[:html], :variants=>[], :handlers=>[:raw, :erb, :html, :builder, :ruby, :jbuilder]}",
+          "kind": "opt",
+          "size": 4
+        },
+        {
+          "name": "key",
+          "class": "ActionView::TemplateDetails::Requested",
+          "object_id": 46160,
+          "value": "#<ActionView::TemplateDetails::Requested:0x00007f33df4904c0>",
+          "kind": "opt"
+        },
+        {
+          "name": "locals",
+          "class": "Array",
+          "object_id": 160180,
+          "value": "[]",
+          "kind": "opt",
+          "size": 0
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::FileSystemResolver",
+        "object_id": 46200,
+        "value": "/home/runner/work/rails_tutorial_sample_app_7th_ed/rails_tutorial_sample_app_7th_ed/app/views"
+      }
+    },
+    {
+      "id": 53,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 52,
+      "elapsed": 0.000011800999999422856,
+      "elapsed_instrumentation": 0.00023341499999673943,
+      "return_value": {
+        "class": "Array",
+        "value": "[#<ActionView::Template:0x00007f33dcc46cd0>]",
+        "object_id": 160200,
+        "size": 1
+      }
+    },
+    {
+      "id": 54,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionView::Resolver",
+      "method_id": "find_all",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionview-7.0.4/lib/action_view/template/resolver.rb",
+      "lineno": 62,
+      "static": false,
+      "parameters": [
+        {
+          "name": "name",
+          "class": "String",
+          "object_id": 99620,
+          "value": "users",
+          "kind": "req"
+        },
+        {
+          "name": "prefix",
+          "class": "String",
+          "object_id": 46360,
+          "value": "layouts",
+          "kind": "opt"
+        },
+        {
+          "name": "partial",
+          "class": "FalseClass",
+          "object_id": 0,
+          "value": "false",
+          "kind": "opt"
+        },
+        {
+          "name": "details",
+          "class": "Hash",
+          "object_id": 160220,
+          "value": "{:locale=>[:en], :formats=>[:html], :variants=>[], :handlers=>[:raw, :erb, :html, :builder, :ruby, :jbuilder]}",
+          "kind": "opt",
+          "size": 4
+        },
+        {
+          "name": "key",
+          "class": "ActionView::TemplateDetails::Requested",
+          "object_id": 46160,
+          "value": "#<ActionView::TemplateDetails::Requested:0x00007f33df4904c0>",
+          "kind": "opt"
+        },
+        {
+          "name": "locals",
+          "class": "Array",
+          "object_id": 160240,
+          "value": "[]",
+          "kind": "opt",
+          "size": 0
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::FileSystemResolver",
+        "object_id": 46200,
+        "value": "/home/runner/work/rails_tutorial_sample_app_7th_ed/rails_tutorial_sample_app_7th_ed/app/views"
+      }
+    },
+    {
+      "id": 55,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 54,
+      "elapsed": 0.00012910899999951653,
+      "elapsed_instrumentation": 0.00014760900000965194,
+      "return_value": {
+        "class": "Array",
+        "value": "[]",
+        "object_id": 160260,
+        "size": 0
+      }
+    },
+    {
+      "id": 56,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionView::Resolver",
+      "method_id": "find_all",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionview-7.0.4/lib/action_view/template/resolver.rb",
+      "lineno": 62,
+      "static": false,
+      "parameters": [
+        {
+          "name": "name",
+          "class": "String",
+          "object_id": 99620,
+          "value": "users",
+          "kind": "req"
+        },
+        {
+          "name": "prefix",
+          "class": "String",
+          "object_id": 46360,
+          "value": "layouts",
+          "kind": "opt"
+        },
+        {
+          "name": "partial",
+          "class": "FalseClass",
+          "object_id": 0,
+          "value": "false",
+          "kind": "opt"
+        },
+        {
+          "name": "details",
+          "class": "Hash",
+          "object_id": 160220,
+          "value": "{:locale=>[:en], :formats=>[:html], :variants=>[], :handlers=>[:raw, :erb, :html, :builder, :ruby, :jbuilder]}",
+          "kind": "opt",
+          "size": 4
+        },
+        {
+          "name": "key",
+          "class": "ActionView::TemplateDetails::Requested",
+          "object_id": 46160,
+          "value": "#<ActionView::TemplateDetails::Requested:0x00007f33df4904c0>",
+          "kind": "opt"
+        },
+        {
+          "name": "locals",
+          "class": "Array",
+          "object_id": 160240,
+          "value": "[]",
+          "kind": "opt",
+          "size": 0
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::FileSystemResolver",
+        "object_id": 46440,
+        "value": "/home/runner/work/rails_tutorial_sample_app_7th_ed/rails_tutorial_sample_app_7th_ed/vendor/bundle/ru"
+      }
+    },
+    {
+      "id": 57,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 56,
+      "elapsed": 0.000003999999989900971,
+      "elapsed_instrumentation": 0.0001299090000088654,
+      "return_value": {
+        "class": "Array",
+        "value": "[]",
+        "object_id": 160280,
+        "size": 0
+      }
+    },
+    {
+      "id": 58,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionView::Resolver",
+      "method_id": "find_all",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionview-7.0.4/lib/action_view/template/resolver.rb",
+      "lineno": 62,
+      "static": false,
+      "parameters": [
+        {
+          "name": "name",
+          "class": "String",
+          "object_id": 99620,
+          "value": "users",
+          "kind": "req"
+        },
+        {
+          "name": "prefix",
+          "class": "String",
+          "object_id": 46360,
+          "value": "layouts",
+          "kind": "opt"
+        },
+        {
+          "name": "partial",
+          "class": "FalseClass",
+          "object_id": 0,
+          "value": "false",
+          "kind": "opt"
+        },
+        {
+          "name": "details",
+          "class": "Hash",
+          "object_id": 160220,
+          "value": "{:locale=>[:en], :formats=>[:html], :variants=>[], :handlers=>[:raw, :erb, :html, :builder, :ruby, :jbuilder]}",
+          "kind": "opt",
+          "size": 4
+        },
+        {
+          "name": "key",
+          "class": "ActionView::TemplateDetails::Requested",
+          "object_id": 46160,
+          "value": "#<ActionView::TemplateDetails::Requested:0x00007f33df4904c0>",
+          "kind": "opt"
+        },
+        {
+          "name": "locals",
+          "class": "Array",
+          "object_id": 160240,
+          "value": "[]",
+          "kind": "opt",
+          "size": 0
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::FileSystemResolver",
+        "object_id": 46480,
+        "value": "/home/runner/work/rails_tutorial_sample_app_7th_ed/rails_tutorial_sample_app_7th_ed/vendor/bundle/ru"
+      }
+    },
+    {
+      "id": 59,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 58,
+      "elapsed": 0.000003500000019585059,
+      "elapsed_instrumentation": 0.00012070799996877213,
+      "return_value": {
+        "class": "Array",
+        "value": "[]",
+        "object_id": 160300,
+        "size": 0
+      }
+    },
+    {
+      "id": 60,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionView::Resolver",
+      "method_id": "find_all",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionview-7.0.4/lib/action_view/template/resolver.rb",
+      "lineno": 62,
+      "static": false,
+      "parameters": [
+        {
+          "name": "name",
+          "class": "String",
+          "object_id": 46520,
+          "value": "application",
+          "kind": "req"
+        },
+        {
+          "name": "prefix",
+          "class": "String",
+          "object_id": 46360,
+          "value": "layouts",
+          "kind": "opt"
+        },
+        {
+          "name": "partial",
+          "class": "FalseClass",
+          "object_id": 0,
+          "value": "false",
+          "kind": "opt"
+        },
+        {
+          "name": "details",
+          "class": "Hash",
+          "object_id": 160320,
+          "value": "{:locale=>[:en], :formats=>[:html], :variants=>[], :handlers=>[:raw, :erb, :html, :builder, :ruby, :jbuilder]}",
+          "kind": "opt",
+          "size": 4
+        },
+        {
+          "name": "key",
+          "class": "ActionView::TemplateDetails::Requested",
+          "object_id": 46160,
+          "value": "#<ActionView::TemplateDetails::Requested:0x00007f33df4904c0>",
+          "kind": "opt"
+        },
+        {
+          "name": "locals",
+          "class": "Array",
+          "object_id": 160340,
+          "value": "[]",
+          "kind": "opt",
+          "size": 0
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::FileSystemResolver",
+        "object_id": 46200,
+        "value": "/home/runner/work/rails_tutorial_sample_app_7th_ed/rails_tutorial_sample_app_7th_ed/app/views"
+      }
+    },
+    {
+      "id": 61,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 60,
+      "elapsed": 0.000008201000014196325,
+      "elapsed_instrumentation": 0.0002182130000107918,
+      "return_value": {
+        "class": "Array",
+        "value": "[#<ActionView::Template:0x00007f33dde30450>]",
+        "object_id": 160360,
+        "size": 1
+      }
+    },
+    {
+      "id": 62,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "Logger::LogDevice",
+      "method_id": "write",
+      "path": "/opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/3.1.0/logger/log_device.rb",
+      "lineno": 31,
+      "static": false,
+      "parameters": [
+        {
+          "name": "message",
+          "class": "String",
+          "object_id": 160380,
+          "value": "  Rendering layout layouts/application.html.erb\n",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "Logger::LogDevice",
+        "object_id": 9000,
+        "value": "#<Logger::LogDevice:0x00007f33dec8c058>"
+      }
+    },
+    {
+      "id": 63,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 62,
+      "elapsed": 0.00002000199998519747,
+      "elapsed_instrumentation": 0.00005530300001055366,
+      "return_value": {
+        "class": "Integer",
+        "value": "48",
+        "object_id": 97
+      }
+    },
+    {
+      "id": 64,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "Logger::LogDevice",
+      "method_id": "write",
+      "path": "/opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/3.1.0/logger/log_device.rb",
+      "lineno": 31,
+      "static": false,
+      "parameters": [
+        {
+          "name": "message",
+          "class": "String",
+          "object_id": 160400,
+          "value": "  Rendering users/show.html.erb within layouts/application\n",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "Logger::LogDevice",
+        "object_id": 9000,
+        "value": "#<Logger::LogDevice:0x00007f33dec8c058>"
+      }
+    },
+    {
+      "id": 65,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 64,
+      "elapsed": 0.000010900999996010796,
+      "elapsed_instrumentation": 0.00005010300000662937,
+      "return_value": {
+        "class": "Integer",
+        "value": "59",
+        "object_id": 119
+      }
+    },
+    {
+      "id": 66,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "UsersHelper",
+      "method_id": "gravatar_for",
+      "path": "app/helpers/users_helper.rb",
+      "lineno": 4,
+      "static": false,
+      "parameters": [
+        {
+          "name": "user",
+          "class": "User",
+          "object_id": 160420,
+          "value": "#<User:0x00007f33d6790ef8>",
+          "kind": "req"
+        },
+        {
+          "name": "options",
+          "class": "NilClass",
+          "object_id": 8,
+          "value": null,
+          "kind": "opt"
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 67,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 66,
+      "elapsed": 0.00007590500001697364,
+      "elapsed_instrumentation": 0.00009450699997159973,
+      "return_value": {
+        "class": "ActiveSupport::SafeBuffer",
+        "value": "<img alt=\"Michael Example\" class=\"gravatar\" src=\"https://secure.gravatar.com/avatar/03ea78c0884c9ac0 (...25 more characters)",
+        "object_id": 160460
+      }
+    },
+    {
+      "id": 68,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "app_views_shared__stats_html_erb",
+      "method_id": "render",
+      "path": "app/views/shared/_stats.html.erb",
+      "static": true,
+      "receiver": {
+        "class": "ActionView::PartialRenderer",
+        "object_id": 163940,
+        "value": "#<ActionView::PartialRenderer:0x00007f33d6778c18>"
+      }
+    },
+    {
+      "id": 69,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionView::Resolver",
+      "method_id": "find_all",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionview-7.0.4/lib/action_view/template/resolver.rb",
+      "lineno": 62,
+      "static": false,
+      "parameters": [
+        {
+          "name": "name",
+          "class": "String",
+          "object_id": 160480,
+          "value": "stats",
+          "kind": "req"
+        },
+        {
+          "name": "prefix",
+          "class": "String",
+          "object_id": 160500,
+          "value": "shared",
+          "kind": "opt"
+        },
+        {
+          "name": "partial",
+          "class": "TrueClass",
+          "object_id": 20,
+          "value": "true",
+          "kind": "opt"
+        },
+        {
+          "name": "details",
+          "class": "Hash",
+          "object_id": 160160,
+          "value": "{:locale=>[:en], :formats=>[:html], :variants=>[], :handlers=>[:raw, :erb, :html, :builder, :ruby, :jbuilder]}",
+          "kind": "opt",
+          "size": 4
+        },
+        {
+          "name": "key",
+          "class": "ActionView::TemplateDetails::Requested",
+          "object_id": 46160,
+          "value": "#<ActionView::TemplateDetails::Requested:0x00007f33df4904c0>",
+          "kind": "opt"
+        },
+        {
+          "name": "locals",
+          "class": "Array",
+          "object_id": 160520,
+          "value": "[]",
+          "kind": "opt",
+          "size": 0
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::FileSystemResolver",
+        "object_id": 46200,
+        "value": "/home/runner/work/rails_tutorial_sample_app_7th_ed/rails_tutorial_sample_app_7th_ed/app/views"
+      }
+    },
+    {
+      "id": 70,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 69,
+      "elapsed": 0.0000128009999968981,
+      "elapsed_instrumentation": 0.00024031599997442754,
+      "return_value": {
+        "class": "Array",
+        "value": "[#<ActionView::Template:0x00007f33ddde0a40>]",
+        "object_id": 160540,
+        "size": 1
+      }
+    },
+    {
+      "id": 71,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "Logger::LogDevice",
+      "method_id": "write",
+      "path": "/opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/3.1.0/logger/log_device.rb",
+      "lineno": 31,
+      "static": false,
+      "parameters": [
+        {
+          "name": "message",
+          "class": "String",
+          "object_id": 160560,
+          "value": "  \u001b[1m\u001b[36mUser Count (0.1ms)\u001b[0m  \u001b[1m\u001b[34mSELECT COUNT(*) FROM \"users\" INNER JOIN \"relationships\"  (...122 more characters)",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "Logger::LogDevice",
+        "object_id": 9000,
+        "value": "#<Logger::LogDevice:0x00007f33dec8c058>"
+      }
+    },
+    {
+      "id": 72,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 71,
+      "elapsed": 0.00002170199999795841,
+      "elapsed_instrumentation": 0.00008800599999858605,
+      "return_value": {
+        "class": "Integer",
+        "value": "222",
+        "object_id": 445
+      }
+    },
+    {
+      "id": 73,
+      "event": "call",
+      "thread_id": 4480,
+      "sql_query": {
+        "sql": "SELECT COUNT(*) FROM \"users\" INNER JOIN \"relationships\" ON \"users\".\"id\" = \"relationships\".\"followed_id\" WHERE \"relationships\".\"follower_id\" = ?",
+        "database_type": "sqlite"
+      }
+    },
+    {
+      "id": 74,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 73,
+      "elapsed": 0.000294319,
+      "elapsed_instrumentation": 0.000040103000003455236
+    },
+    {
+      "id": 75,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "Logger::LogDevice",
+      "method_id": "write",
+      "path": "/opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/3.1.0/logger/log_device.rb",
+      "lineno": 31,
+      "static": false,
+      "parameters": [
+        {
+          "name": "message",
+          "class": "String",
+          "object_id": 160580,
+          "value": "  \u001b[1m\u001b[36mUser Count (0.1ms)\u001b[0m  \u001b[1m\u001b[34mSELECT COUNT(*) FROM \"users\" INNER JOIN \"relationships\"  (...122 more characters)",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "Logger::LogDevice",
+        "object_id": 9000,
+        "value": "#<Logger::LogDevice:0x00007f33dec8c058>"
+      }
+    },
+    {
+      "id": 76,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 75,
+      "elapsed": 0.000019202000004270303,
+      "elapsed_instrumentation": 0.00007920400000216432,
+      "return_value": {
+        "class": "Integer",
+        "value": "222",
+        "object_id": 445
+      }
+    },
+    {
+      "id": 77,
+      "event": "call",
+      "thread_id": 4480,
+      "sql_query": {
+        "sql": "SELECT COUNT(*) FROM \"users\" INNER JOIN \"relationships\" ON \"users\".\"id\" = \"relationships\".\"follower_id\" WHERE \"relationships\".\"followed_id\" = ?",
+        "database_type": "sqlite"
+      }
+    },
+    {
+      "id": 78,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 77,
+      "elapsed": 0.000292219,
+      "elapsed_instrumentation": 0.00003760199999192082
+    },
+    {
+      "id": 79,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "Logger::LogDevice",
+      "method_id": "write",
+      "path": "/opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/3.1.0/logger/log_device.rb",
+      "lineno": 31,
+      "static": false,
+      "parameters": [
+        {
+          "name": "message",
+          "class": "String",
+          "object_id": 160600,
+          "value": "  Rendered shared/_stats.html.erb (Duration: 2.6ms | Allocations: 1191)\n",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "Logger::LogDevice",
+        "object_id": 9000,
+        "value": "#<Logger::LogDevice:0x00007f33dec8c058>"
+      }
+    },
+    {
+      "id": 80,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 79,
+      "elapsed": 0.000013601000006246977,
+      "elapsed_instrumentation": 0.000056403999991516685,
+      "return_value": {
+        "class": "Integer",
+        "value": "72",
+        "object_id": 145
+      }
+    },
+    {
+      "id": 81,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 68,
+      "elapsed": 0.002972492999987253,
+      "elapsed_instrumentation": 0.000025501999999733016
+    },
+    {
+      "id": 82,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "SessionsHelper",
+      "method_id": "logged_in?",
+      "path": "app/helpers/sessions_helper.rb",
+      "lineno": 42,
+      "static": false,
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 83,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "SessionsHelper",
+      "method_id": "current_user",
+      "path": "app/helpers/sessions_helper.rb",
+      "lineno": 19,
+      "static": false,
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 84,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionDispatch::Request::Session",
+      "method_id": "[]",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/request/session.rb",
+      "lineno": 110,
+      "static": false,
+      "parameters": [
+        {
+          "name": "key",
+          "class": "Symbol",
+          "object_id": 3107868,
+          "value": ":user_id",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionDispatch::Request::Session",
+        "object_id": 160620,
+        "value": "#<ActionDispatch::Request::Session:0x00007f33d6789e00>"
+      }
+    },
+    {
+      "id": 85,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionDispatch::Cookies::CookieJar",
+      "method_id": "update",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/middleware/cookies.rb",
+      "lineno": 352,
+      "static": false,
+      "parameters": [
+        {
+          "name": "other_hash",
+          "class": "Hash",
+          "object_id": 160640,
+          "value": "{}",
+          "kind": "req",
+          "size": 0
+        }
+      ],
+      "receiver": {
+        "class": "ActionDispatch::Cookies::CookieJar",
+        "object_id": 160660,
+        "value": "#<ActionDispatch::Cookies::CookieJar:0x00007f33d675ed68>"
+      }
+    },
+    {
+      "id": 86,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 85,
+      "elapsed": 0.000002599999987751289,
+      "elapsed_instrumentation": 0.00005040400000666523,
+      "return_value": {
+        "class": "ActionDispatch::Cookies::CookieJar",
+        "value": "#<ActionDispatch::Cookies::CookieJar:0x00007f33d675ed68>",
+        "object_id": 160660
+      }
+    },
+    {
+      "id": 87,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionDispatch::Cookies::CookieJar",
+      "method_id": "[]",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/middleware/cookies.rb",
+      "lineno": 336,
+      "static": false,
+      "parameters": [
+        {
+          "name": "name",
+          "class": "String",
+          "object_id": 43420,
+          "value": "_sample_app_session",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionDispatch::Cookies::CookieJar",
+        "object_id": 160660,
+        "value": "#<ActionDispatch::Cookies::CookieJar:0x00007f33d675ed68>"
+      }
+    },
+    {
+      "id": 88,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 87,
+      "elapsed": 0.0000020009999843750848,
+      "elapsed_instrumentation": 0.00003930200000468176
+    },
+    {
+      "id": 89,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 84,
+      "elapsed": 0.00020681300000546798,
+      "elapsed_instrumentation": 0.00003600299999106937
+    },
+    {
+      "id": 90,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionDispatch::Cookies::CookieJar",
+      "method_id": "[]",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/middleware/cookies.rb",
+      "lineno": 336,
+      "static": false,
+      "parameters": [
+        {
+          "name": "name",
+          "class": "String",
+          "object_id": 160680,
+          "value": "user_id",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionDispatch::Cookies::CookieJar",
+        "object_id": 160660,
+        "value": "#<ActionDispatch::Cookies::CookieJar:0x00007f33d675ed68>"
+      }
+    },
+    {
+      "id": 91,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 90,
+      "elapsed": 0.0000015999999902760464,
+      "elapsed_instrumentation": 0.0000346020000279168
+    },
+    {
+      "id": 92,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 83,
+      "elapsed": 0.00030431900000849055,
+      "elapsed_instrumentation": 0.000027603000006592993
+    },
+    {
+      "id": 93,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 82,
+      "elapsed": 0.00034142199999109835,
+      "elapsed_instrumentation": 0.000035101999998232714
+    },
+    {
+      "id": 94,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "Logger::LogDevice",
+      "method_id": "write",
+      "path": "/opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/3.1.0/logger/log_device.rb",
+      "lineno": 31,
+      "static": false,
+      "parameters": [
+        {
+          "name": "message",
+          "class": "String",
+          "object_id": 160700,
+          "value": "  \u001b[1m\u001b[36mMicropost Exists? (0.1ms)\u001b[0m  \u001b[1m\u001b[34mSELECT 1 AS one FROM \"microposts\" WHERE \"micropos (...70 more characters)",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "Logger::LogDevice",
+        "object_id": 9000,
+        "value": "#<Logger::LogDevice:0x00007f33dec8c058>"
+      }
+    },
+    {
+      "id": 95,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 94,
+      "elapsed": 0.000017001000003347144,
+      "elapsed_instrumentation": 0.00008410500001332366,
+      "return_value": {
+        "class": "Integer",
+        "value": "170",
+        "object_id": 341
+      }
+    },
+    {
+      "id": 96,
+      "event": "call",
+      "thread_id": 4480,
+      "sql_query": {
+        "sql": "SELECT 1 AS one FROM \"microposts\" WHERE \"microposts\".\"user_id\" = ? LIMIT ?",
+        "database_type": "sqlite"
+      }
+    },
+    {
+      "id": 97,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 96,
+      "elapsed": 0.000252917,
+      "elapsed_instrumentation": 0.00003260200000454461
+    },
+    {
+      "id": 98,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "Logger::LogDevice",
+      "method_id": "write",
+      "path": "/opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/3.1.0/logger/log_device.rb",
+      "lineno": 31,
+      "static": false,
+      "parameters": [
+        {
+          "name": "message",
+          "class": "String",
+          "object_id": 160720,
+          "value": "  \u001b[1m\u001b[36mMicropost Count (0.1ms)\u001b[0m  \u001b[1m\u001b[34mSELECT COUNT(*) FROM \"microposts\" WHERE \"microposts (...46 more characters)",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "Logger::LogDevice",
+        "object_id": 9000,
+        "value": "#<Logger::LogDevice:0x00007f33dec8c058>"
+      }
+    },
+    {
+      "id": 99,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 98,
+      "elapsed": 0.00007630499999322637,
+      "elapsed_instrumentation": 0.00007010500002024855,
+      "return_value": {
+        "class": "Integer",
+        "value": "146",
+        "object_id": 293
+      }
+    },
+    {
+      "id": 100,
+      "event": "call",
+      "thread_id": 4480,
+      "sql_query": {
+        "sql": "SELECT COUNT(*) FROM \"microposts\" WHERE \"microposts\".\"user_id\" = ?",
+        "database_type": "sqlite"
+      }
+    },
+    {
+      "id": 101,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 100,
+      "elapsed": 0.000279418,
+      "elapsed_instrumentation": 0.00003420300001266696
+    },
+    {
+      "id": 102,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "Logger::LogDevice",
+      "method_id": "write",
+      "path": "/opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/3.1.0/logger/log_device.rb",
+      "lineno": 31,
+      "static": false,
+      "parameters": [
+        {
+          "name": "message",
+          "class": "String",
+          "object_id": 160740,
+          "value": "  \u001b[1m\u001b[36mMicropost Load (0.1ms)\u001b[0m  \u001b[1m\u001b[34mSELECT \"microposts\".* FROM \"microposts\" WHERE \"micro (...138 more characters)",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "Logger::LogDevice",
+        "object_id": 9000,
+        "value": "#<Logger::LogDevice:0x00007f33dec8c058>"
+      }
+    },
+    {
+      "id": 103,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 102,
+      "elapsed": 0.000018301000011433644,
+      "elapsed_instrumentation": 0.00007400500001608634,
+      "return_value": {
+        "class": "Integer",
+        "value": "238",
+        "object_id": 477
+      }
+    },
+    {
+      "id": 104,
+      "event": "call",
+      "thread_id": 4480,
+      "sql_query": {
+        "sql": "SELECT \"microposts\".* FROM \"microposts\" WHERE \"microposts\".\"user_id\" = ? ORDER BY \"microposts\".\"created_at\" DESC LIMIT ? OFFSET ?",
+        "database_type": "sqlite"
+      }
+    },
+    {
+      "id": 105,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 104,
+      "elapsed": 0.000282719,
+      "elapsed_instrumentation": 0.00003350199997953496
+    },
+    {
+      "id": 106,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionView::Resolver",
+      "method_id": "find_all",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionview-7.0.4/lib/action_view/template/resolver.rb",
+      "lineno": 62,
+      "static": false,
+      "parameters": [
+        {
+          "name": "name",
+          "class": "String",
+          "object_id": 160760,
+          "value": "micropost",
+          "kind": "req"
+        },
+        {
+          "name": "prefix",
+          "class": "String",
+          "object_id": 160780,
+          "value": "microposts",
+          "kind": "opt"
+        },
+        {
+          "name": "partial",
+          "class": "TrueClass",
+          "object_id": 20,
+          "value": "true",
+          "kind": "opt"
+        },
+        {
+          "name": "details",
+          "class": "Hash",
+          "object_id": 160160,
+          "value": "{:locale=>[:en], :formats=>[:html], :variants=>[], :handlers=>[:raw, :erb, :html, :builder, :ruby, :jbuilder]}",
+          "kind": "opt",
+          "size": 4
+        },
+        {
+          "name": "key",
+          "class": "ActionView::TemplateDetails::Requested",
+          "object_id": 46160,
+          "value": "#<ActionView::TemplateDetails::Requested:0x00007f33df4904c0>",
+          "kind": "opt"
+        },
+        {
+          "name": "locals",
+          "class": "Array",
+          "object_id": 160800,
+          "value": "[:micropost, :micropost_counter, :micropost_iteration]",
+          "kind": "opt",
+          "size": 3
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::FileSystemResolver",
+        "object_id": 46200,
+        "value": "/home/runner/work/rails_tutorial_sample_app_7th_ed/rails_tutorial_sample_app_7th_ed/app/views"
+      }
+    },
+    {
+      "id": 107,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 106,
+      "elapsed": 0.00015781099997980164,
+      "elapsed_instrumentation": 0.00027371700002731814,
+      "return_value": {
+        "class": "Array",
+        "value": "[#<ActionView::Template:0x00007f33ddd5f468>]",
+        "object_id": 160820,
+        "size": 1
+      }
+    },
+    {
+      "id": 108,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "UsersHelper",
+      "method_id": "gravatar_for",
+      "path": "app/helpers/users_helper.rb",
+      "lineno": 4,
+      "static": false,
+      "parameters": [
+        {
+          "name": "user",
+          "class": "User",
+          "object_id": 160420,
+          "value": "#<User:0x00007f33d6790ef8>",
+          "kind": "req"
+        },
+        {
+          "name": "options",
+          "class": "Hash",
+          "object_id": 160840,
+          "value": "{:size=>50}",
+          "kind": "opt",
+          "size": 1
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 109,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 108,
+      "elapsed": 0.000048003000017615705,
+      "elapsed_instrumentation": 0.00010090699998954733,
+      "return_value": {
+        "class": "ActiveSupport::SafeBuffer",
+        "value": "<img alt=\"Michael Example\" class=\"gravatar\" src=\"https://secure.gravatar.com/avatar/03ea78c0884c9ac0 (...25 more characters)",
+        "object_id": 160860
+      }
+    },
+    {
+      "id": 110,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "Logger::LogDevice",
+      "method_id": "write",
+      "path": "/opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/3.1.0/logger/log_device.rb",
+      "lineno": 31,
+      "static": false,
+      "parameters": [
+        {
+          "name": "message",
+          "class": "String",
+          "object_id": 160880,
+          "value": "  \u001b[1m\u001b[36mActiveStorage::Attachment Load (0.1ms)\u001b[0m  \u001b[1m\u001b[34mSELECT \"active_storage_attachments\". (...285 more characters)",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "Logger::LogDevice",
+        "object_id": 9000,
+        "value": "#<Logger::LogDevice:0x00007f33dec8c058>"
+      }
+    },
+    {
+      "id": 111,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 110,
+      "elapsed": 0.000016602000016519014,
+      "elapsed_instrumentation": 0.00007320399998889116,
+      "return_value": {
+        "class": "Integer",
+        "value": "385",
+        "object_id": 771
+      }
+    },
+    {
+      "id": 112,
+      "event": "call",
+      "thread_id": 4480,
+      "sql_query": {
+        "sql": "SELECT \"active_storage_attachments\".* FROM \"active_storage_attachments\" WHERE \"active_storage_attachments\".\"record_id\" = ? AND \"active_storage_attachments\".\"record_type\" = ? AND \"active_storage_attachments\".\"name\" = ? LIMIT ?",
+        "database_type": "sqlite"
+      }
+    },
+    {
+      "id": 113,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 112,
+      "elapsed": 0.00029572,
+      "elapsed_instrumentation": 0.00005340299998124465
+    },
+    {
+      "id": 114,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "SessionsHelper",
+      "method_id": "current_user?",
+      "path": "app/helpers/sessions_helper.rb",
+      "lineno": 37,
+      "static": false,
+      "parameters": [
+        {
+          "name": "user",
+          "class": "User",
+          "object_id": 160420,
+          "value": "#<User:0x00007f33d6790ef8>",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 115,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "SessionsHelper",
+      "method_id": "current_user",
+      "path": "app/helpers/sessions_helper.rb",
+      "lineno": 19,
+      "static": false,
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 116,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionDispatch::Request::Session",
+      "method_id": "[]",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/request/session.rb",
+      "lineno": 110,
+      "static": false,
+      "parameters": [
+        {
+          "name": "key",
+          "class": "Symbol",
+          "object_id": 3107868,
+          "value": ":user_id",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionDispatch::Request::Session",
+        "object_id": 160620,
+        "value": "#<ActionDispatch::Request::Session:0x00007f33d6789e00>"
+      }
+    },
+    {
+      "id": 117,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 116,
+      "elapsed": 0.00001150100001723331,
+      "elapsed_instrumentation": 0.00004680300000359239
+    },
+    {
+      "id": 118,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionDispatch::Cookies::CookieJar",
+      "method_id": "[]",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/middleware/cookies.rb",
+      "lineno": 336,
+      "static": false,
+      "parameters": [
+        {
+          "name": "name",
+          "class": "String",
+          "object_id": 160900,
+          "value": "user_id",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionDispatch::Cookies::CookieJar",
+        "object_id": 160660,
+        "value": "#<ActionDispatch::Cookies::CookieJar:0x00007f33d675ed68>"
+      }
+    },
+    {
+      "id": 119,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 118,
+      "elapsed": 0.000002300000005561742,
+      "elapsed_instrumentation": 0.00004410299999335621
+    },
+    {
+      "id": 120,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 115,
+      "elapsed": 0.0001325080000071921,
+      "elapsed_instrumentation": 0.00006260399999291621
+    },
+    {
+      "id": 121,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 114,
+      "elapsed": 0.00021221400001536495,
+      "elapsed_instrumentation": 0.004303079999999682
+    },
+    {
+      "id": 122,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "UsersHelper",
+      "method_id": "gravatar_for",
+      "path": "app/helpers/users_helper.rb",
+      "lineno": 4,
+      "static": false,
+      "parameters": [
+        {
+          "name": "user",
+          "class": "User",
+          "object_id": 160420,
+          "value": "#<User:0x00007f33d6790ef8>",
+          "kind": "req"
+        },
+        {
+          "name": "options",
+          "class": "Hash",
+          "object_id": 160920,
+          "value": "{:size=>50}",
+          "kind": "opt",
+          "size": 1
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 123,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 122,
+      "elapsed": 0.00005390300000840398,
+      "elapsed_instrumentation": 0.0001254080000023805,
+      "return_value": {
+        "class": "ActiveSupport::SafeBuffer",
+        "value": "<img alt=\"Michael Example\" class=\"gravatar\" src=\"https://secure.gravatar.com/avatar/03ea78c0884c9ac0 (...25 more characters)",
+        "object_id": 160940
+      }
+    },
+    {
+      "id": 124,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "Logger::LogDevice",
+      "method_id": "write",
+      "path": "/opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/3.1.0/logger/log_device.rb",
+      "lineno": 31,
+      "static": false,
+      "parameters": [
+        {
+          "name": "message",
+          "class": "String",
+          "object_id": 160960,
+          "value": "  \u001b[1m\u001b[36mActiveStorage::Attachment Load (0.1ms)\u001b[0m  \u001b[1m\u001b[34mSELECT \"active_storage_attachments\". (...285 more characters)",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "Logger::LogDevice",
+        "object_id": 9000,
+        "value": "#<Logger::LogDevice:0x00007f33dec8c058>"
+      }
+    },
+    {
+      "id": 125,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 124,
+      "elapsed": 0.0000986070000124073,
+      "elapsed_instrumentation": 0.00009810599999582337,
+      "return_value": {
+        "class": "Integer",
+        "value": "385",
+        "object_id": 771
+      }
+    },
+    {
+      "id": 126,
+      "event": "call",
+      "thread_id": 4480,
+      "sql_query": {
+        "sql": "SELECT \"active_storage_attachments\".* FROM \"active_storage_attachments\" WHERE \"active_storage_attachments\".\"record_id\" = ? AND \"active_storage_attachments\".\"record_type\" = ? AND \"active_storage_attachments\".\"name\" = ? LIMIT ?",
+        "database_type": "sqlite"
+      }
+    },
+    {
+      "id": 127,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 126,
+      "elapsed": 0.000385125,
+      "elapsed_instrumentation": 0.00004210200000898112
+    },
+    {
+      "id": 128,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "SessionsHelper",
+      "method_id": "current_user?",
+      "path": "app/helpers/sessions_helper.rb",
+      "lineno": 37,
+      "static": false,
+      "parameters": [
+        {
+          "name": "user",
+          "class": "User",
+          "object_id": 160420,
+          "value": "#<User:0x00007f33d6790ef8>",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 129,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "SessionsHelper",
+      "method_id": "current_user",
+      "path": "app/helpers/sessions_helper.rb",
+      "lineno": 19,
+      "static": false,
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 130,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionDispatch::Request::Session",
+      "method_id": "[]",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/request/session.rb",
+      "lineno": 110,
+      "static": false,
+      "parameters": [
+        {
+          "name": "key",
+          "class": "Symbol",
+          "object_id": 3107868,
+          "value": ":user_id",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionDispatch::Request::Session",
+        "object_id": 160620,
+        "value": "#<ActionDispatch::Request::Session:0x00007f33d6789e00>"
+      }
+    },
+    {
+      "id": 131,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 130,
+      "elapsed": 0.000010500999991336357,
+      "elapsed_instrumentation": 0.000040502000018705075
+    },
+    {
+      "id": 132,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionDispatch::Cookies::CookieJar",
+      "method_id": "[]",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/middleware/cookies.rb",
+      "lineno": 336,
+      "static": false,
+      "parameters": [
+        {
+          "name": "name",
+          "class": "String",
+          "object_id": 160980,
+          "value": "user_id",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionDispatch::Cookies::CookieJar",
+        "object_id": 160660,
+        "value": "#<ActionDispatch::Cookies::CookieJar:0x00007f33d675ed68>"
+      }
+    },
+    {
+      "id": 133,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 132,
+      "elapsed": 0.0000019999999949504854,
+      "elapsed_instrumentation": 0.000040902999984382404
+    },
+    {
+      "id": 134,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 129,
+      "elapsed": 0.00011990799998784496,
+      "elapsed_instrumentation": 0.000033801999990146214
+    },
+    {
+      "id": 135,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 128,
+      "elapsed": 0.00016541100001177256,
+      "elapsed_instrumentation": 0.00008370500000864922
+    },
+    {
+      "id": 136,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "UsersHelper",
+      "method_id": "gravatar_for",
+      "path": "app/helpers/users_helper.rb",
+      "lineno": 4,
+      "static": false,
+      "parameters": [
+        {
+          "name": "user",
+          "class": "User",
+          "object_id": 160420,
+          "value": "#<User:0x00007f33d6790ef8>",
+          "kind": "req"
+        },
+        {
+          "name": "options",
+          "class": "Hash",
+          "object_id": 161000,
+          "value": "{:size=>50}",
+          "kind": "opt",
+          "size": 1
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 137,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 136,
+      "elapsed": 0.00005010300000662937,
+      "elapsed_instrumentation": 0.00013170900001568953,
+      "return_value": {
+        "class": "ActiveSupport::SafeBuffer",
+        "value": "<img alt=\"Michael Example\" class=\"gravatar\" src=\"https://secure.gravatar.com/avatar/03ea78c0884c9ac0 (...25 more characters)",
+        "object_id": 161020
+      }
+    },
+    {
+      "id": 138,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "Logger::LogDevice",
+      "method_id": "write",
+      "path": "/opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/3.1.0/logger/log_device.rb",
+      "lineno": 31,
+      "static": false,
+      "parameters": [
+        {
+          "name": "message",
+          "class": "String",
+          "object_id": 161040,
+          "value": "  \u001b[1m\u001b[36mActiveStorage::Attachment Load (0.1ms)\u001b[0m  \u001b[1m\u001b[34mSELECT \"active_storage_attachments\". (...284 more characters)",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "Logger::LogDevice",
+        "object_id": 9000,
+        "value": "#<Logger::LogDevice:0x00007f33dec8c058>"
+      }
+    },
+    {
+      "id": 139,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 138,
+      "elapsed": 0.000021801000002596993,
+      "elapsed_instrumentation": 0.0000902059999816629,
+      "return_value": {
+        "class": "Integer",
+        "value": "384",
+        "object_id": 769
+      }
+    },
+    {
+      "id": 140,
+      "event": "call",
+      "thread_id": 4480,
+      "sql_query": {
+        "sql": "SELECT \"active_storage_attachments\".* FROM \"active_storage_attachments\" WHERE \"active_storage_attachments\".\"record_id\" = ? AND \"active_storage_attachments\".\"record_type\" = ? AND \"active_storage_attachments\".\"name\" = ? LIMIT ?",
+        "database_type": "sqlite"
+      }
+    },
+    {
+      "id": 141,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 140,
+      "elapsed": 0.000283418,
+      "elapsed_instrumentation": 0.00003930200000468176
+    },
+    {
+      "id": 142,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "SessionsHelper",
+      "method_id": "current_user?",
+      "path": "app/helpers/sessions_helper.rb",
+      "lineno": 37,
+      "static": false,
+      "parameters": [
+        {
+          "name": "user",
+          "class": "User",
+          "object_id": 160420,
+          "value": "#<User:0x00007f33d6790ef8>",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 143,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "SessionsHelper",
+      "method_id": "current_user",
+      "path": "app/helpers/sessions_helper.rb",
+      "lineno": 19,
+      "static": false,
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 144,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionDispatch::Request::Session",
+      "method_id": "[]",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/request/session.rb",
+      "lineno": 110,
+      "static": false,
+      "parameters": [
+        {
+          "name": "key",
+          "class": "Symbol",
+          "object_id": 3107868,
+          "value": ":user_id",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionDispatch::Request::Session",
+        "object_id": 160620,
+        "value": "#<ActionDispatch::Request::Session:0x00007f33d6789e00>"
+      }
+    },
+    {
+      "id": 145,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 144,
+      "elapsed": 0.0010875709999993433,
+      "elapsed_instrumentation": 0.00004940299999134368
+    },
+    {
+      "id": 146,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionDispatch::Cookies::CookieJar",
+      "method_id": "[]",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/middleware/cookies.rb",
+      "lineno": 336,
+      "static": false,
+      "parameters": [
+        {
+          "name": "name",
+          "class": "String",
+          "object_id": 161060,
+          "value": "user_id",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionDispatch::Cookies::CookieJar",
+        "object_id": 160660,
+        "value": "#<ActionDispatch::Cookies::CookieJar:0x00007f33d675ed68>"
+      }
+    },
+    {
+      "id": 147,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 146,
+      "elapsed": 0.0000028000000042993634,
+      "elapsed_instrumentation": 0.0000755050000122992
+    },
+    {
+      "id": 148,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 143,
+      "elapsed": 0.0012493819999974676,
+      "elapsed_instrumentation": 0.00006630400000062764
+    },
+    {
+      "id": 149,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 142,
+      "elapsed": 0.0028683859999887318,
+      "elapsed_instrumentation": 0.00007600399999319052
+    },
+    {
+      "id": 150,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "UsersHelper",
+      "method_id": "gravatar_for",
+      "path": "app/helpers/users_helper.rb",
+      "lineno": 4,
+      "static": false,
+      "parameters": [
+        {
+          "name": "user",
+          "class": "User",
+          "object_id": 160420,
+          "value": "#<User:0x00007f33d6790ef8>",
+          "kind": "req"
+        },
+        {
+          "name": "options",
+          "class": "Hash",
+          "object_id": 161080,
+          "value": "{:size=>50}",
+          "kind": "opt",
+          "size": 1
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 151,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 150,
+      "elapsed": 0.00005300399999441652,
+      "elapsed_instrumentation": 0.00010830599998712387,
+      "return_value": {
+        "class": "ActiveSupport::SafeBuffer",
+        "value": "<img alt=\"Michael Example\" class=\"gravatar\" src=\"https://secure.gravatar.com/avatar/03ea78c0884c9ac0 (...25 more characters)",
+        "object_id": 161100
+      }
+    },
+    {
+      "id": 152,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "Logger::LogDevice",
+      "method_id": "write",
+      "path": "/opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/3.1.0/logger/log_device.rb",
+      "lineno": 31,
+      "static": false,
+      "parameters": [
+        {
+          "name": "message",
+          "class": "String",
+          "object_id": 161120,
+          "value": "  \u001b[1m\u001b[36mActiveStorage::Attachment Load (0.1ms)\u001b[0m  \u001b[1m\u001b[34mSELECT \"active_storage_attachments\". (...286 more characters)",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "Logger::LogDevice",
+        "object_id": 9000,
+        "value": "#<Logger::LogDevice:0x00007f33dec8c058>"
+      }
+    },
+    {
+      "id": 153,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 152,
+      "elapsed": 0.00002210100001320825,
+      "elapsed_instrumentation": 0.00010800699996593721,
+      "return_value": {
+        "class": "Integer",
+        "value": "386",
+        "object_id": 773
+      }
+    },
+    {
+      "id": 154,
+      "event": "call",
+      "thread_id": 4480,
+      "sql_query": {
+        "sql": "SELECT \"active_storage_attachments\".* FROM \"active_storage_attachments\" WHERE \"active_storage_attachments\".\"record_id\" = ? AND \"active_storage_attachments\".\"record_type\" = ? AND \"active_storage_attachments\".\"name\" = ? LIMIT ?",
+        "database_type": "sqlite"
+      }
+    },
+    {
+      "id": 155,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 154,
+      "elapsed": 0.000276918,
+      "elapsed_instrumentation": 0.00003990200002590427
+    },
+    {
+      "id": 156,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "SessionsHelper",
+      "method_id": "current_user?",
+      "path": "app/helpers/sessions_helper.rb",
+      "lineno": 37,
+      "static": false,
+      "parameters": [
+        {
+          "name": "user",
+          "class": "User",
+          "object_id": 160420,
+          "value": "#<User:0x00007f33d6790ef8>",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 157,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "SessionsHelper",
+      "method_id": "current_user",
+      "path": "app/helpers/sessions_helper.rb",
+      "lineno": 19,
+      "static": false,
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 158,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionDispatch::Request::Session",
+      "method_id": "[]",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/request/session.rb",
+      "lineno": 110,
+      "static": false,
+      "parameters": [
+        {
+          "name": "key",
+          "class": "Symbol",
+          "object_id": 3107868,
+          "value": ":user_id",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionDispatch::Request::Session",
+        "object_id": 160620,
+        "value": "#<ActionDispatch::Request::Session:0x00007f33d6789e00>"
+      }
+    },
+    {
+      "id": 159,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 158,
+      "elapsed": 0.0000102009999807251,
+      "elapsed_instrumentation": 0.0000397020000093562
+    },
+    {
+      "id": 160,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionDispatch::Cookies::CookieJar",
+      "method_id": "[]",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/middleware/cookies.rb",
+      "lineno": 336,
+      "static": false,
+      "parameters": [
+        {
+          "name": "name",
+          "class": "String",
+          "object_id": 161140,
+          "value": "user_id",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionDispatch::Cookies::CookieJar",
+        "object_id": 160660,
+        "value": "#<ActionDispatch::Cookies::CookieJar:0x00007f33d675ed68>"
+      }
+    },
+    {
+      "id": 161,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 160,
+      "elapsed": 0.000004100000012385863,
+      "elapsed_instrumentation": 0.003684639999960382
+    },
+    {
+      "id": 162,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 157,
+      "elapsed": 0.0037673449999999775,
+      "elapsed_instrumentation": 0.00003240199998799653
+    },
+    {
+      "id": 163,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 156,
+      "elapsed": 0.0038119470000026467,
+      "elapsed_instrumentation": 0.00007540500001823602
+    },
+    {
+      "id": 164,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "UsersHelper",
+      "method_id": "gravatar_for",
+      "path": "app/helpers/users_helper.rb",
+      "lineno": 4,
+      "static": false,
+      "parameters": [
+        {
+          "name": "user",
+          "class": "User",
+          "object_id": 160420,
+          "value": "#<User:0x00007f33d6790ef8>",
+          "kind": "req"
+        },
+        {
+          "name": "options",
+          "class": "Hash",
+          "object_id": 161160,
+          "value": "{:size=>50}",
+          "kind": "opt",
+          "size": 1
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 165,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 164,
+      "elapsed": 0.00005490399999530382,
+      "elapsed_instrumentation": 0.00012170700000524448,
+      "return_value": {
+        "class": "ActiveSupport::SafeBuffer",
+        "value": "<img alt=\"Michael Example\" class=\"gravatar\" src=\"https://secure.gravatar.com/avatar/03ea78c0884c9ac0 (...25 more characters)",
+        "object_id": 161180
+      }
+    },
+    {
+      "id": 166,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "Logger::LogDevice",
+      "method_id": "write",
+      "path": "/opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/3.1.0/logger/log_device.rb",
+      "lineno": 31,
+      "static": false,
+      "parameters": [
+        {
+          "name": "message",
+          "class": "String",
+          "object_id": 161200,
+          "value": "  \u001b[1m\u001b[36mActiveStorage::Attachment Load (0.1ms)\u001b[0m  \u001b[1m\u001b[34mSELECT \"active_storage_attachments\". (...285 more characters)",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "Logger::LogDevice",
+        "object_id": 9000,
+        "value": "#<Logger::LogDevice:0x00007f33dec8c058>"
+      }
+    },
+    {
+      "id": 167,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 166,
+      "elapsed": 0.000022900999994135418,
+      "elapsed_instrumentation": 0.00008460600000148588,
+      "return_value": {
+        "class": "Integer",
+        "value": "385",
+        "object_id": 771
+      }
+    },
+    {
+      "id": 168,
+      "event": "call",
+      "thread_id": 4480,
+      "sql_query": {
+        "sql": "SELECT \"active_storage_attachments\".* FROM \"active_storage_attachments\" WHERE \"active_storage_attachments\".\"record_id\" = ? AND \"active_storage_attachments\".\"record_type\" = ? AND \"active_storage_attachments\".\"name\" = ? LIMIT ?",
+        "database_type": "sqlite"
+      }
+    },
+    {
+      "id": 169,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 168,
+      "elapsed": 0.000275918,
+      "elapsed_instrumentation": 0.00003950300001065443
+    },
+    {
+      "id": 170,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "SessionsHelper",
+      "method_id": "current_user?",
+      "path": "app/helpers/sessions_helper.rb",
+      "lineno": 37,
+      "static": false,
+      "parameters": [
+        {
+          "name": "user",
+          "class": "User",
+          "object_id": 160420,
+          "value": "#<User:0x00007f33d6790ef8>",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 171,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "SessionsHelper",
+      "method_id": "current_user",
+      "path": "app/helpers/sessions_helper.rb",
+      "lineno": 19,
+      "static": false,
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 172,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionDispatch::Request::Session",
+      "method_id": "[]",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/request/session.rb",
+      "lineno": 110,
+      "static": false,
+      "parameters": [
+        {
+          "name": "key",
+          "class": "Symbol",
+          "object_id": 3107868,
+          "value": ":user_id",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionDispatch::Request::Session",
+        "object_id": 160620,
+        "value": "#<ActionDispatch::Request::Session:0x00007f33d6789e00>"
+      }
+    },
+    {
+      "id": 173,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 172,
+      "elapsed": 0.000010301000003209992,
+      "elapsed_instrumentation": 0.00003920199998219687
+    },
+    {
+      "id": 174,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionDispatch::Cookies::CookieJar",
+      "method_id": "[]",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/middleware/cookies.rb",
+      "lineno": 336,
+      "static": false,
+      "parameters": [
+        {
+          "name": "name",
+          "class": "String",
+          "object_id": 161220,
+          "value": "user_id",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionDispatch::Cookies::CookieJar",
+        "object_id": 160660,
+        "value": "#<ActionDispatch::Cookies::CookieJar:0x00007f33d675ed68>"
+      }
+    },
+    {
+      "id": 175,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 174,
+      "elapsed": 0.0000017999999784024112,
+      "elapsed_instrumentation": 0.000040102000014030637
+    },
+    {
+      "id": 176,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 171,
+      "elapsed": 0.0001171080000119673,
+      "elapsed_instrumentation": 0.000031202000002394925
+    },
+    {
+      "id": 177,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 170,
+      "elapsed": 0.00016010999999593878,
+      "elapsed_instrumentation": 0.00007390400000417685
+    },
+    {
+      "id": 178,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "UsersHelper",
+      "method_id": "gravatar_for",
+      "path": "app/helpers/users_helper.rb",
+      "lineno": 4,
+      "static": false,
+      "parameters": [
+        {
+          "name": "user",
+          "class": "User",
+          "object_id": 160420,
+          "value": "#<User:0x00007f33d6790ef8>",
+          "kind": "req"
+        },
+        {
+          "name": "options",
+          "class": "Hash",
+          "object_id": 161240,
+          "value": "{:size=>50}",
+          "kind": "opt",
+          "size": 1
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 179,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 178,
+      "elapsed": 0.0000499029999900813,
+      "elapsed_instrumentation": 0.00009610600000087288,
+      "return_value": {
+        "class": "ActiveSupport::SafeBuffer",
+        "value": "<img alt=\"Michael Example\" class=\"gravatar\" src=\"https://secure.gravatar.com/avatar/03ea78c0884c9ac0 (...25 more characters)",
+        "object_id": 161260
+      }
+    },
+    {
+      "id": 180,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "Logger::LogDevice",
+      "method_id": "write",
+      "path": "/opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/3.1.0/logger/log_device.rb",
+      "lineno": 31,
+      "static": false,
+      "parameters": [
+        {
+          "name": "message",
+          "class": "String",
+          "object_id": 161280,
+          "value": "  \u001b[1m\u001b[36mActiveStorage::Attachment Load (0.1ms)\u001b[0m  \u001b[1m\u001b[34mSELECT \"active_storage_attachments\". (...285 more characters)",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "Logger::LogDevice",
+        "object_id": 9000,
+        "value": "#<Logger::LogDevice:0x00007f33dec8c058>"
+      }
+    },
+    {
+      "id": 181,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 180,
+      "elapsed": 0.00001950099999703525,
+      "elapsed_instrumentation": 0.00007760500002973458,
+      "return_value": {
+        "class": "Integer",
+        "value": "385",
+        "object_id": 771
+      }
+    },
+    {
+      "id": 182,
+      "event": "call",
+      "thread_id": 4480,
+      "sql_query": {
+        "sql": "SELECT \"active_storage_attachments\".* FROM \"active_storage_attachments\" WHERE \"active_storage_attachments\".\"record_id\" = ? AND \"active_storage_attachments\".\"record_type\" = ? AND \"active_storage_attachments\".\"name\" = ? LIMIT ?",
+        "database_type": "sqlite"
+      }
+    },
+    {
+      "id": 183,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 182,
+      "elapsed": 0.000231515,
+      "elapsed_instrumentation": 0.00003620199998977114
+    },
+    {
+      "id": 184,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "SessionsHelper",
+      "method_id": "current_user?",
+      "path": "app/helpers/sessions_helper.rb",
+      "lineno": 37,
+      "static": false,
+      "parameters": [
+        {
+          "name": "user",
+          "class": "User",
+          "object_id": 160420,
+          "value": "#<User:0x00007f33d6790ef8>",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 185,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "SessionsHelper",
+      "method_id": "current_user",
+      "path": "app/helpers/sessions_helper.rb",
+      "lineno": 19,
+      "static": false,
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 186,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionDispatch::Request::Session",
+      "method_id": "[]",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/request/session.rb",
+      "lineno": 110,
+      "static": false,
+      "parameters": [
+        {
+          "name": "key",
+          "class": "Symbol",
+          "object_id": 3107868,
+          "value": ":user_id",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionDispatch::Request::Session",
+        "object_id": 160620,
+        "value": "#<ActionDispatch::Request::Session:0x00007f33d6789e00>"
+      }
+    },
+    {
+      "id": 187,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 186,
+      "elapsed": 0.000009000999995123493,
+      "elapsed_instrumentation": 0.000036501999971960686
+    },
+    {
+      "id": 188,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionDispatch::Cookies::CookieJar",
+      "method_id": "[]",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/middleware/cookies.rb",
+      "lineno": 336,
+      "static": false,
+      "parameters": [
+        {
+          "name": "name",
+          "class": "String",
+          "object_id": 161300,
+          "value": "user_id",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionDispatch::Cookies::CookieJar",
+        "object_id": 160660,
+        "value": "#<ActionDispatch::Cookies::CookieJar:0x00007f33d675ed68>"
+      }
+    },
+    {
+      "id": 189,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 188,
+      "elapsed": 0.000002099999989013668,
+      "elapsed_instrumentation": 0.00005660400000806476
+    },
+    {
+      "id": 190,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 185,
+      "elapsed": 0.0001274090000151773,
+      "elapsed_instrumentation": 0.000029901999994308426
+    },
+    {
+      "id": 191,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 184,
+      "elapsed": 0.00016811099999358703,
+      "elapsed_instrumentation": 0.00007040500003085981
+    },
+    {
+      "id": 192,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "UsersHelper",
+      "method_id": "gravatar_for",
+      "path": "app/helpers/users_helper.rb",
+      "lineno": 4,
+      "static": false,
+      "parameters": [
+        {
+          "name": "user",
+          "class": "User",
+          "object_id": 160420,
+          "value": "#<User:0x00007f33d6790ef8>",
+          "kind": "req"
+        },
+        {
+          "name": "options",
+          "class": "Hash",
+          "object_id": 161320,
+          "value": "{:size=>50}",
+          "kind": "opt",
+          "size": 1
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 193,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 192,
+      "elapsed": 0.00004950300001382857,
+      "elapsed_instrumentation": 0.00009590500002332192,
+      "return_value": {
+        "class": "ActiveSupport::SafeBuffer",
+        "value": "<img alt=\"Michael Example\" class=\"gravatar\" src=\"https://secure.gravatar.com/avatar/03ea78c0884c9ac0 (...25 more characters)",
+        "object_id": 161340
+      }
+    },
+    {
+      "id": 194,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "Logger::LogDevice",
+      "method_id": "write",
+      "path": "/opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/3.1.0/logger/log_device.rb",
+      "lineno": 31,
+      "static": false,
+      "parameters": [
+        {
+          "name": "message",
+          "class": "String",
+          "object_id": 161360,
+          "value": "  \u001b[1m\u001b[36mActiveStorage::Attachment Load (0.1ms)\u001b[0m  \u001b[1m\u001b[34mSELECT \"active_storage_attachments\". (...285 more characters)",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "Logger::LogDevice",
+        "object_id": 9000,
+        "value": "#<Logger::LogDevice:0x00007f33dec8c058>"
+      }
+    },
+    {
+      "id": 195,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 194,
+      "elapsed": 0.000019801000007646508,
+      "elapsed_instrumentation": 0.0000845060000074227,
+      "return_value": {
+        "class": "Integer",
+        "value": "385",
+        "object_id": 771
+      }
+    },
+    {
+      "id": 196,
+      "event": "call",
+      "thread_id": 4480,
+      "sql_query": {
+        "sql": "SELECT \"active_storage_attachments\".* FROM \"active_storage_attachments\" WHERE \"active_storage_attachments\".\"record_id\" = ? AND \"active_storage_attachments\".\"record_type\" = ? AND \"active_storage_attachments\".\"name\" = ? LIMIT ?",
+        "database_type": "sqlite"
+      }
+    },
+    {
+      "id": 197,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 196,
+      "elapsed": 0.000244715,
+      "elapsed_instrumentation": 0.000037301999981309564
+    },
+    {
+      "id": 198,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "SessionsHelper",
+      "method_id": "current_user?",
+      "path": "app/helpers/sessions_helper.rb",
+      "lineno": 37,
+      "static": false,
+      "parameters": [
+        {
+          "name": "user",
+          "class": "User",
+          "object_id": 160420,
+          "value": "#<User:0x00007f33d6790ef8>",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 199,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "SessionsHelper",
+      "method_id": "current_user",
+      "path": "app/helpers/sessions_helper.rb",
+      "lineno": 19,
+      "static": false,
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 200,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionDispatch::Request::Session",
+      "method_id": "[]",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/request/session.rb",
+      "lineno": 110,
+      "static": false,
+      "parameters": [
+        {
+          "name": "key",
+          "class": "Symbol",
+          "object_id": 3107868,
+          "value": ":user_id",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionDispatch::Request::Session",
+        "object_id": 160620,
+        "value": "#<ActionDispatch::Request::Session:0x00007f33d6789e00>"
+      }
+    },
+    {
+      "id": 201,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 200,
+      "elapsed": 0.000008200999985774615,
+      "elapsed_instrumentation": 0.0000576030000161154
+    },
+    {
+      "id": 202,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionDispatch::Cookies::CookieJar",
+      "method_id": "[]",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/middleware/cookies.rb",
+      "lineno": 336,
+      "static": false,
+      "parameters": [
+        {
+          "name": "name",
+          "class": "String",
+          "object_id": 161380,
+          "value": "user_id",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionDispatch::Cookies::CookieJar",
+        "object_id": 160660,
+        "value": "#<ActionDispatch::Cookies::CookieJar:0x00007f33d675ed68>"
+      }
+    },
+    {
+      "id": 203,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 202,
+      "elapsed": 0.0000015999999902760464,
+      "elapsed_instrumentation": 0.00003230100000450875
+    },
+    {
+      "id": 204,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 199,
+      "elapsed": 0.00012040800001500429,
+      "elapsed_instrumentation": 0.000029102000013381257
+    },
+    {
+      "id": 205,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 198,
+      "elapsed": 0.00015951000000313797,
+      "elapsed_instrumentation": 0.0001715109999622655
+    },
+    {
+      "id": 206,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "UsersHelper",
+      "method_id": "gravatar_for",
+      "path": "app/helpers/users_helper.rb",
+      "lineno": 4,
+      "static": false,
+      "parameters": [
+        {
+          "name": "user",
+          "class": "User",
+          "object_id": 160420,
+          "value": "#<User:0x00007f33d6790ef8>",
+          "kind": "req"
+        },
+        {
+          "name": "options",
+          "class": "Hash",
+          "object_id": 161400,
+          "value": "{:size=>50}",
+          "kind": "opt",
+          "size": 1
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 207,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 206,
+      "elapsed": 0.000041401999993695426,
+      "elapsed_instrumentation": 0.00007940499997971529,
+      "return_value": {
+        "class": "ActiveSupport::SafeBuffer",
+        "value": "<img alt=\"Michael Example\" class=\"gravatar\" src=\"https://secure.gravatar.com/avatar/03ea78c0884c9ac0 (...25 more characters)",
+        "object_id": 161420
+      }
+    },
+    {
+      "id": 208,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "Logger::LogDevice",
+      "method_id": "write",
+      "path": "/opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/3.1.0/logger/log_device.rb",
+      "lineno": 31,
+      "static": false,
+      "parameters": [
+        {
+          "name": "message",
+          "class": "String",
+          "object_id": 161440,
+          "value": "  \u001b[1m\u001b[36mActiveStorage::Attachment Load (0.1ms)\u001b[0m  \u001b[1m\u001b[34mSELECT \"active_storage_attachments\". (...285 more characters)",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "Logger::LogDevice",
+        "object_id": 9000,
+        "value": "#<Logger::LogDevice:0x00007f33dec8c058>"
+      }
+    },
+    {
+      "id": 209,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 208,
+      "elapsed": 0.000020101000018257764,
+      "elapsed_instrumentation": 0.00008110600001032253,
+      "return_value": {
+        "class": "Integer",
+        "value": "385",
+        "object_id": 771
+      }
+    },
+    {
+      "id": 210,
+      "event": "call",
+      "thread_id": 4480,
+      "sql_query": {
+        "sql": "SELECT \"active_storage_attachments\".* FROM \"active_storage_attachments\" WHERE \"active_storage_attachments\".\"record_id\" = ? AND \"active_storage_attachments\".\"record_type\" = ? AND \"active_storage_attachments\".\"name\" = ? LIMIT ?",
+        "database_type": "sqlite"
+      }
+    },
+    {
+      "id": 211,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 210,
+      "elapsed": 0.000266517,
+      "elapsed_instrumentation": 0.00003810199999065844
+    },
+    {
+      "id": 212,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "SessionsHelper",
+      "method_id": "current_user?",
+      "path": "app/helpers/sessions_helper.rb",
+      "lineno": 37,
+      "static": false,
+      "parameters": [
+        {
+          "name": "user",
+          "class": "User",
+          "object_id": 160420,
+          "value": "#<User:0x00007f33d6790ef8>",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 213,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "SessionsHelper",
+      "method_id": "current_user",
+      "path": "app/helpers/sessions_helper.rb",
+      "lineno": 19,
+      "static": false,
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 214,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionDispatch::Request::Session",
+      "method_id": "[]",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/request/session.rb",
+      "lineno": 110,
+      "static": false,
+      "parameters": [
+        {
+          "name": "key",
+          "class": "Symbol",
+          "object_id": 3107868,
+          "value": ":user_id",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionDispatch::Request::Session",
+        "object_id": 160620,
+        "value": "#<ActionDispatch::Request::Session:0x00007f33d6789e00>"
+      }
+    },
+    {
+      "id": 215,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 214,
+      "elapsed": 0.00000930099997731304,
+      "elapsed_instrumentation": 0.00003850199999533288
+    },
+    {
+      "id": 216,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionDispatch::Cookies::CookieJar",
+      "method_id": "[]",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/middleware/cookies.rb",
+      "lineno": 336,
+      "static": false,
+      "parameters": [
+        {
+          "name": "name",
+          "class": "String",
+          "object_id": 161460,
+          "value": "user_id",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionDispatch::Cookies::CookieJar",
+        "object_id": 160660,
+        "value": "#<ActionDispatch::Cookies::CookieJar:0x00007f33d675ed68>"
+      }
+    },
+    {
+      "id": 217,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 216,
+      "elapsed": 0.000001900000000887303,
+      "elapsed_instrumentation": 0.00003990299998690716
+    },
+    {
+      "id": 218,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 213,
+      "elapsed": 0.00011400799999705669,
+      "elapsed_instrumentation": 0.000031601999978647655
+    },
+    {
+      "id": 219,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 212,
+      "elapsed": 0.00015661000000477543,
+      "elapsed_instrumentation": 0.00007280500000206303
+    },
+    {
+      "id": 220,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "UsersHelper",
+      "method_id": "gravatar_for",
+      "path": "app/helpers/users_helper.rb",
+      "lineno": 4,
+      "static": false,
+      "parameters": [
+        {
+          "name": "user",
+          "class": "User",
+          "object_id": 160420,
+          "value": "#<User:0x00007f33d6790ef8>",
+          "kind": "req"
+        },
+        {
+          "name": "options",
+          "class": "Hash",
+          "object_id": 161480,
+          "value": "{:size=>50}",
+          "kind": "opt",
+          "size": 1
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 221,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 220,
+      "elapsed": 0.000049703000001954933,
+      "elapsed_instrumentation": 0.00009580599999026163,
+      "return_value": {
+        "class": "ActiveSupport::SafeBuffer",
+        "value": "<img alt=\"Michael Example\" class=\"gravatar\" src=\"https://secure.gravatar.com/avatar/03ea78c0884c9ac0 (...25 more characters)",
+        "object_id": 161500
+      }
+    },
+    {
+      "id": 222,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "Logger::LogDevice",
+      "method_id": "write",
+      "path": "/opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/3.1.0/logger/log_device.rb",
+      "lineno": 31,
+      "static": false,
+      "parameters": [
+        {
+          "name": "message",
+          "class": "String",
+          "object_id": 161520,
+          "value": "  \u001b[1m\u001b[36mActiveStorage::Attachment Load (0.1ms)\u001b[0m  \u001b[1m\u001b[34mSELECT \"active_storage_attachments\". (...285 more characters)",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "Logger::LogDevice",
+        "object_id": 9000,
+        "value": "#<Logger::LogDevice:0x00007f33dec8c058>"
+      }
+    },
+    {
+      "id": 223,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 222,
+      "elapsed": 0.000019200999986423994,
+      "elapsed_instrumentation": 0.00009130600000162303,
+      "return_value": {
+        "class": "Integer",
+        "value": "385",
+        "object_id": 771
+      }
+    },
+    {
+      "id": 224,
+      "event": "call",
+      "thread_id": 4480,
+      "sql_query": {
+        "sql": "SELECT \"active_storage_attachments\".* FROM \"active_storage_attachments\" WHERE \"active_storage_attachments\".\"record_id\" = ? AND \"active_storage_attachments\".\"record_type\" = ? AND \"active_storage_attachments\".\"name\" = ? LIMIT ?",
+        "database_type": "sqlite"
+      }
+    },
+    {
+      "id": 225,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 224,
+      "elapsed": 0.000247716,
+      "elapsed_instrumentation": 0.00003530200001478079
+    },
+    {
+      "id": 226,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "SessionsHelper",
+      "method_id": "current_user?",
+      "path": "app/helpers/sessions_helper.rb",
+      "lineno": 37,
+      "static": false,
+      "parameters": [
+        {
+          "name": "user",
+          "class": "User",
+          "object_id": 160420,
+          "value": "#<User:0x00007f33d6790ef8>",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 227,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "SessionsHelper",
+      "method_id": "current_user",
+      "path": "app/helpers/sessions_helper.rb",
+      "lineno": 19,
+      "static": false,
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 228,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionDispatch::Request::Session",
+      "method_id": "[]",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/request/session.rb",
+      "lineno": 110,
+      "static": false,
+      "parameters": [
+        {
+          "name": "key",
+          "class": "Symbol",
+          "object_id": 3107868,
+          "value": ":user_id",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionDispatch::Request::Session",
+        "object_id": 160620,
+        "value": "#<ActionDispatch::Request::Session:0x00007f33d6789e00>"
+      }
+    },
+    {
+      "id": 229,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 228,
+      "elapsed": 0.000009601000016346006,
+      "elapsed_instrumentation": 0.000038702000011880955
+    },
+    {
+      "id": 230,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionDispatch::Cookies::CookieJar",
+      "method_id": "[]",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/middleware/cookies.rb",
+      "lineno": 336,
+      "static": false,
+      "parameters": [
+        {
+          "name": "name",
+          "class": "String",
+          "object_id": 161540,
+          "value": "user_id",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionDispatch::Cookies::CookieJar",
+        "object_id": 160660,
+        "value": "#<ActionDispatch::Cookies::CookieJar:0x00007f33d675ed68>"
+      }
+    },
+    {
+      "id": 231,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 230,
+      "elapsed": 0.0000019999999949504854,
+      "elapsed_instrumentation": 0.00015571000000136337
+    },
+    {
+      "id": 232,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 227,
+      "elapsed": 0.00023091500000305132,
+      "elapsed_instrumentation": 0.0000314010000295184
+    },
+    {
+      "id": 233,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 226,
+      "elapsed": 0.0002738180000108059,
+      "elapsed_instrumentation": 0.00007560499997794068
+    },
+    {
+      "id": 234,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "UsersHelper",
+      "method_id": "gravatar_for",
+      "path": "app/helpers/users_helper.rb",
+      "lineno": 4,
+      "static": false,
+      "parameters": [
+        {
+          "name": "user",
+          "class": "User",
+          "object_id": 160420,
+          "value": "#<User:0x00007f33d6790ef8>",
+          "kind": "req"
+        },
+        {
+          "name": "options",
+          "class": "Hash",
+          "object_id": 161560,
+          "value": "{:size=>50}",
+          "kind": "opt",
+          "size": 1
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 235,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 234,
+      "elapsed": 0.0000499029999900813,
+      "elapsed_instrumentation": 0.00009770700000899524,
+      "return_value": {
+        "class": "ActiveSupport::SafeBuffer",
+        "value": "<img alt=\"Michael Example\" class=\"gravatar\" src=\"https://secure.gravatar.com/avatar/03ea78c0884c9ac0 (...25 more characters)",
+        "object_id": 161580
+      }
+    },
+    {
+      "id": 236,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "Logger::LogDevice",
+      "method_id": "write",
+      "path": "/opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/3.1.0/logger/log_device.rb",
+      "lineno": 31,
+      "static": false,
+      "parameters": [
+        {
+          "name": "message",
+          "class": "String",
+          "object_id": 161600,
+          "value": "  \u001b[1m\u001b[36mActiveStorage::Attachment Load (0.1ms)\u001b[0m  \u001b[1m\u001b[34mSELECT \"active_storage_attachments\". (...285 more characters)",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "Logger::LogDevice",
+        "object_id": 9000,
+        "value": "#<Logger::LogDevice:0x00007f33dec8c058>"
+      }
+    },
+    {
+      "id": 237,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 236,
+      "elapsed": 0.00002120100000979619,
+      "elapsed_instrumentation": 0.00008240599998998732,
+      "return_value": {
+        "class": "Integer",
+        "value": "385",
+        "object_id": 771
+      }
+    },
+    {
+      "id": 238,
+      "event": "call",
+      "thread_id": 4480,
+      "sql_query": {
+        "sql": "SELECT \"active_storage_attachments\".* FROM \"active_storage_attachments\" WHERE \"active_storage_attachments\".\"record_id\" = ? AND \"active_storage_attachments\".\"record_type\" = ? AND \"active_storage_attachments\".\"name\" = ? LIMIT ?",
+        "database_type": "sqlite"
+      }
+    },
+    {
+      "id": 239,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 238,
+      "elapsed": 0.000265918,
+      "elapsed_instrumentation": 0.0000384020000012697
+    },
+    {
+      "id": 240,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "SessionsHelper",
+      "method_id": "current_user?",
+      "path": "app/helpers/sessions_helper.rb",
+      "lineno": 37,
+      "static": false,
+      "parameters": [
+        {
+          "name": "user",
+          "class": "User",
+          "object_id": 160420,
+          "value": "#<User:0x00007f33d6790ef8>",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 241,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "SessionsHelper",
+      "method_id": "current_user",
+      "path": "app/helpers/sessions_helper.rb",
+      "lineno": 19,
+      "static": false,
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 242,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionDispatch::Request::Session",
+      "method_id": "[]",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/request/session.rb",
+      "lineno": 110,
+      "static": false,
+      "parameters": [
+        {
+          "name": "key",
+          "class": "Symbol",
+          "object_id": 3107868,
+          "value": ":user_id",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionDispatch::Request::Session",
+        "object_id": 160620,
+        "value": "#<ActionDispatch::Request::Session:0x00007f33d6789e00>"
+      }
+    },
+    {
+      "id": 243,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 242,
+      "elapsed": 0.000009200000022246968,
+      "elapsed_instrumentation": 0.00003860299997882066
+    },
+    {
+      "id": 244,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionDispatch::Cookies::CookieJar",
+      "method_id": "[]",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/middleware/cookies.rb",
+      "lineno": 336,
+      "static": false,
+      "parameters": [
+        {
+          "name": "name",
+          "class": "String",
+          "object_id": 161620,
+          "value": "user_id",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionDispatch::Cookies::CookieJar",
+        "object_id": 160660,
+        "value": "#<ActionDispatch::Cookies::CookieJar:0x00007f33d675ed68>"
+      }
+    },
+    {
+      "id": 245,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 244,
+      "elapsed": 0.000001900000000887303,
+      "elapsed_instrumentation": 0.00003940199999874494
+    },
+    {
+      "id": 246,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 241,
+      "elapsed": 0.00011290699998767195,
+      "elapsed_instrumentation": 0.000031602000007069364
+    },
+    {
+      "id": 247,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 240,
+      "elapsed": 0.000155510000013237,
+      "elapsed_instrumentation": 0.00007410599999957412
+    },
+    {
+      "id": 248,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "UsersHelper",
+      "method_id": "gravatar_for",
+      "path": "app/helpers/users_helper.rb",
+      "lineno": 4,
+      "static": false,
+      "parameters": [
+        {
+          "name": "user",
+          "class": "User",
+          "object_id": 160420,
+          "value": "#<User:0x00007f33d6790ef8>",
+          "kind": "req"
+        },
+        {
+          "name": "options",
+          "class": "Hash",
+          "object_id": 161640,
+          "value": "{:size=>50}",
+          "kind": "opt",
+          "size": 1
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 249,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 248,
+      "elapsed": 0.000050603000005366994,
+      "elapsed_instrumentation": 0.00009500699999875906,
+      "return_value": {
+        "class": "ActiveSupport::SafeBuffer",
+        "value": "<img alt=\"Michael Example\" class=\"gravatar\" src=\"https://secure.gravatar.com/avatar/03ea78c0884c9ac0 (...25 more characters)",
+        "object_id": 161660
+      }
+    },
+    {
+      "id": 250,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "Logger::LogDevice",
+      "method_id": "write",
+      "path": "/opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/3.1.0/logger/log_device.rb",
+      "lineno": 31,
+      "static": false,
+      "parameters": [
+        {
+          "name": "message",
+          "class": "String",
+          "object_id": 161680,
+          "value": "  \u001b[1m\u001b[36mActiveStorage::Attachment Load (0.1ms)\u001b[0m  \u001b[1m\u001b[34mSELECT \"active_storage_attachments\". (...285 more characters)",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "Logger::LogDevice",
+        "object_id": 9000,
+        "value": "#<Logger::LogDevice:0x00007f33dec8c058>"
+      }
+    },
+    {
+      "id": 251,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 250,
+      "elapsed": 0.000028502000020580454,
+      "elapsed_instrumentation": 0.00008280599996624005,
+      "return_value": {
+        "class": "Integer",
+        "value": "385",
+        "object_id": 771
+      }
+    },
+    {
+      "id": 252,
+      "event": "call",
+      "thread_id": 4480,
+      "sql_query": {
+        "sql": "SELECT \"active_storage_attachments\".* FROM \"active_storage_attachments\" WHERE \"active_storage_attachments\".\"record_id\" = ? AND \"active_storage_attachments\".\"record_type\" = ? AND \"active_storage_attachments\".\"name\" = ? LIMIT ?",
+        "database_type": "sqlite"
+      }
+    },
+    {
+      "id": 253,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 252,
+      "elapsed": 0.000251116,
+      "elapsed_instrumentation": 0.000038302000007206516
+    },
+    {
+      "id": 254,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "SessionsHelper",
+      "method_id": "current_user?",
+      "path": "app/helpers/sessions_helper.rb",
+      "lineno": 37,
+      "static": false,
+      "parameters": [
+        {
+          "name": "user",
+          "class": "User",
+          "object_id": 160420,
+          "value": "#<User:0x00007f33d6790ef8>",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 255,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "SessionsHelper",
+      "method_id": "current_user",
+      "path": "app/helpers/sessions_helper.rb",
+      "lineno": 19,
+      "static": false,
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 256,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionDispatch::Request::Session",
+      "method_id": "[]",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/request/session.rb",
+      "lineno": 110,
+      "static": false,
+      "parameters": [
+        {
+          "name": "key",
+          "class": "Symbol",
+          "object_id": 3107868,
+          "value": ":user_id",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionDispatch::Request::Session",
+        "object_id": 160620,
+        "value": "#<ActionDispatch::Request::Session:0x00007f33d6789e00>"
+      }
+    },
+    {
+      "id": 257,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 256,
+      "elapsed": 0.00000930100000573475,
+      "elapsed_instrumentation": 0.00003940199997032323
+    },
+    {
+      "id": 258,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionDispatch::Cookies::CookieJar",
+      "method_id": "[]",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/middleware/cookies.rb",
+      "lineno": 336,
+      "static": false,
+      "parameters": [
+        {
+          "name": "name",
+          "class": "String",
+          "object_id": 161700,
+          "value": "user_id",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionDispatch::Cookies::CookieJar",
+        "object_id": 160660,
+        "value": "#<ActionDispatch::Cookies::CookieJar:0x00007f33d675ed68>"
+      }
+    },
+    {
+      "id": 259,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 258,
+      "elapsed": 0.00000180099999624872,
+      "elapsed_instrumentation": 0.00003950200002122983
+    },
+    {
+      "id": 260,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 255,
+      "elapsed": 0.00011430800000766794,
+      "elapsed_instrumentation": 0.000031601999978647655
+    },
+    {
+      "id": 261,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 254,
+      "elapsed": 0.00015720999999757623,
+      "elapsed_instrumentation": 0.0000736050000114119
+    },
+    {
+      "id": 262,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "UsersHelper",
+      "method_id": "gravatar_for",
+      "path": "app/helpers/users_helper.rb",
+      "lineno": 4,
+      "static": false,
+      "parameters": [
+        {
+          "name": "user",
+          "class": "User",
+          "object_id": 160420,
+          "value": "#<User:0x00007f33d6790ef8>",
+          "kind": "req"
+        },
+        {
+          "name": "options",
+          "class": "Hash",
+          "object_id": 161720,
+          "value": "{:size=>50}",
+          "kind": "opt",
+          "size": 1
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 263,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 262,
+      "elapsed": 0.00008920600001260937,
+      "elapsed_instrumentation": 0.00009880599998268735,
+      "return_value": {
+        "class": "ActiveSupport::SafeBuffer",
+        "value": "<img alt=\"Michael Example\" class=\"gravatar\" src=\"https://secure.gravatar.com/avatar/03ea78c0884c9ac0 (...25 more characters)",
+        "object_id": 161740
+      }
+    },
+    {
+      "id": 264,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "Logger::LogDevice",
+      "method_id": "write",
+      "path": "/opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/3.1.0/logger/log_device.rb",
+      "lineno": 31,
+      "static": false,
+      "parameters": [
+        {
+          "name": "message",
+          "class": "String",
+          "object_id": 161760,
+          "value": "  \u001b[1m\u001b[36mActiveStorage::Attachment Load (0.1ms)\u001b[0m  \u001b[1m\u001b[34mSELECT \"active_storage_attachments\". (...285 more characters)",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "Logger::LogDevice",
+        "object_id": 9000,
+        "value": "#<Logger::LogDevice:0x00007f33dec8c058>"
+      }
+    },
+    {
+      "id": 265,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 264,
+      "elapsed": 0.000020500999994510494,
+      "elapsed_instrumentation": 0.00008370600002649553,
+      "return_value": {
+        "class": "Integer",
+        "value": "385",
+        "object_id": 771
+      }
+    },
+    {
+      "id": 266,
+      "event": "call",
+      "thread_id": 4480,
+      "sql_query": {
+        "sql": "SELECT \"active_storage_attachments\".* FROM \"active_storage_attachments\" WHERE \"active_storage_attachments\".\"record_id\" = ? AND \"active_storage_attachments\".\"record_type\" = ? AND \"active_storage_attachments\".\"name\" = ? LIMIT ?",
+        "database_type": "sqlite"
+      }
+    },
+    {
+      "id": 267,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 266,
+      "elapsed": 0.000247216,
+      "elapsed_instrumentation": 0.00004440300000396746
+    },
+    {
+      "id": 268,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "SessionsHelper",
+      "method_id": "current_user?",
+      "path": "app/helpers/sessions_helper.rb",
+      "lineno": 37,
+      "static": false,
+      "parameters": [
+        {
+          "name": "user",
+          "class": "User",
+          "object_id": 160420,
+          "value": "#<User:0x00007f33d6790ef8>",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 269,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "SessionsHelper",
+      "method_id": "current_user",
+      "path": "app/helpers/sessions_helper.rb",
+      "lineno": 19,
+      "static": false,
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 270,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionDispatch::Request::Session",
+      "method_id": "[]",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/request/session.rb",
+      "lineno": 110,
+      "static": false,
+      "parameters": [
+        {
+          "name": "key",
+          "class": "Symbol",
+          "object_id": 3107868,
+          "value": ":user_id",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionDispatch::Request::Session",
+        "object_id": 160620,
+        "value": "#<ActionDispatch::Request::Session:0x00007f33d6789e00>"
+      }
+    },
+    {
+      "id": 271,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 270,
+      "elapsed": 0.00000930100000573475,
+      "elapsed_instrumentation": 0.00003940199999874494
+    },
+    {
+      "id": 272,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionDispatch::Cookies::CookieJar",
+      "method_id": "[]",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/middleware/cookies.rb",
+      "lineno": 336,
+      "static": false,
+      "parameters": [
+        {
+          "name": "name",
+          "class": "String",
+          "object_id": 161780,
+          "value": "user_id",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionDispatch::Cookies::CookieJar",
+        "object_id": 160660,
+        "value": "#<ActionDispatch::Cookies::CookieJar:0x00007f33d675ed68>"
+      }
+    },
+    {
+      "id": 273,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 272,
+      "elapsed": 0.000001900000000887303,
+      "elapsed_instrumentation": 0.0000397029999987808
+    },
+    {
+      "id": 274,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 269,
+      "elapsed": 0.00011370799998644543,
+      "elapsed_instrumentation": 0.00003100199998584685
+    },
+    {
+      "id": 275,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 268,
+      "elapsed": 0.000155510000013237,
+      "elapsed_instrumentation": 0.00007410500001014952
+    },
+    {
+      "id": 276,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "UsersHelper",
+      "method_id": "gravatar_for",
+      "path": "app/helpers/users_helper.rb",
+      "lineno": 4,
+      "static": false,
+      "parameters": [
+        {
+          "name": "user",
+          "class": "User",
+          "object_id": 160420,
+          "value": "#<User:0x00007f33d6790ef8>",
+          "kind": "req"
+        },
+        {
+          "name": "options",
+          "class": "Hash",
+          "object_id": 161800,
+          "value": "{:size=>50}",
+          "kind": "opt",
+          "size": 1
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 277,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 276,
+      "elapsed": 0.00004950299998540686,
+      "elapsed_instrumentation": 0.00013550900001746413,
+      "return_value": {
+        "class": "ActiveSupport::SafeBuffer",
+        "value": "<img alt=\"Michael Example\" class=\"gravatar\" src=\"https://secure.gravatar.com/avatar/03ea78c0884c9ac0 (...25 more characters)",
+        "object_id": 161820
+      }
+    },
+    {
+      "id": 278,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "Logger::LogDevice",
+      "method_id": "write",
+      "path": "/opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/3.1.0/logger/log_device.rb",
+      "lineno": 31,
+      "static": false,
+      "parameters": [
+        {
+          "name": "message",
+          "class": "String",
+          "object_id": 161840,
+          "value": "  \u001b[1m\u001b[36mActiveStorage::Attachment Load (0.1ms)\u001b[0m  \u001b[1m\u001b[34mSELECT \"active_storage_attachments\". (...285 more characters)",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "Logger::LogDevice",
+        "object_id": 9000,
+        "value": "#<Logger::LogDevice:0x00007f33dec8c058>"
+      }
+    },
+    {
+      "id": 279,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 278,
+      "elapsed": 0.000018302000000858243,
+      "elapsed_instrumentation": 0.00007970499999032654,
+      "return_value": {
+        "class": "Integer",
+        "value": "385",
+        "object_id": 771
+      }
+    },
+    {
+      "id": 280,
+      "event": "call",
+      "thread_id": 4480,
+      "sql_query": {
+        "sql": "SELECT \"active_storage_attachments\".* FROM \"active_storage_attachments\" WHERE \"active_storage_attachments\".\"record_id\" = ? AND \"active_storage_attachments\".\"record_type\" = ? AND \"active_storage_attachments\".\"name\" = ? LIMIT ?",
+        "database_type": "sqlite"
+      }
+    },
+    {
+      "id": 281,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 280,
+      "elapsed": 0.000262317,
+      "elapsed_instrumentation": 0.000036902999994481434
+    },
+    {
+      "id": 282,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "SessionsHelper",
+      "method_id": "current_user?",
+      "path": "app/helpers/sessions_helper.rb",
+      "lineno": 37,
+      "static": false,
+      "parameters": [
+        {
+          "name": "user",
+          "class": "User",
+          "object_id": 160420,
+          "value": "#<User:0x00007f33d6790ef8>",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 283,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "SessionsHelper",
+      "method_id": "current_user",
+      "path": "app/helpers/sessions_helper.rb",
+      "lineno": 19,
+      "static": false,
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 284,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionDispatch::Request::Session",
+      "method_id": "[]",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/request/session.rb",
+      "lineno": 110,
+      "static": false,
+      "parameters": [
+        {
+          "name": "key",
+          "class": "Symbol",
+          "object_id": 3107868,
+          "value": ":user_id",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionDispatch::Request::Session",
+        "object_id": 160620,
+        "value": "#<ActionDispatch::Request::Session:0x00007f33d6789e00>"
+      }
+    },
+    {
+      "id": 285,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 284,
+      "elapsed": 0.00000879999998915082,
+      "elapsed_instrumentation": 0.000036902999994481434
+    },
+    {
+      "id": 286,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionDispatch::Cookies::CookieJar",
+      "method_id": "[]",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/middleware/cookies.rb",
+      "lineno": 336,
+      "static": false,
+      "parameters": [
+        {
+          "name": "name",
+          "class": "String",
+          "object_id": 161860,
+          "value": "user_id",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionDispatch::Cookies::CookieJar",
+        "object_id": 160660,
+        "value": "#<ActionDispatch::Cookies::CookieJar:0x00007f33d675ed68>"
+      }
+    },
+    {
+      "id": 287,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 286,
+      "elapsed": 0.0000017010000021855376,
+      "elapsed_instrumentation": 0.00003670199998850876
+    },
+    {
+      "id": 288,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 283,
+      "elapsed": 0.00010720700001343175,
+      "elapsed_instrumentation": 0.000030301999970561155
+    },
+    {
+      "id": 289,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 282,
+      "elapsed": 0.00014750900001558875,
+      "elapsed_instrumentation": 0.00006870499996125545
+    },
+    {
+      "id": 290,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "UsersHelper",
+      "method_id": "gravatar_for",
+      "path": "app/helpers/users_helper.rb",
+      "lineno": 4,
+      "static": false,
+      "parameters": [
+        {
+          "name": "user",
+          "class": "User",
+          "object_id": 160420,
+          "value": "#<User:0x00007f33d6790ef8>",
+          "kind": "req"
+        },
+        {
+          "name": "options",
+          "class": "Hash",
+          "object_id": 161880,
+          "value": "{:size=>50}",
+          "kind": "opt",
+          "size": 1
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 291,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 290,
+      "elapsed": 0.00004600299999424351,
+      "elapsed_instrumentation": 0.0000877060000163965,
+      "return_value": {
+        "class": "ActiveSupport::SafeBuffer",
+        "value": "<img alt=\"Michael Example\" class=\"gravatar\" src=\"https://secure.gravatar.com/avatar/03ea78c0884c9ac0 (...25 more characters)",
+        "object_id": 161900
+      }
+    },
+    {
+      "id": 292,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "Logger::LogDevice",
+      "method_id": "write",
+      "path": "/opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/3.1.0/logger/log_device.rb",
+      "lineno": 31,
+      "static": false,
+      "parameters": [
+        {
+          "name": "message",
+          "class": "String",
+          "object_id": 161920,
+          "value": "  \u001b[1m\u001b[36mActiveStorage::Attachment Load (0.1ms)\u001b[0m  \u001b[1m\u001b[34mSELECT \"active_storage_attachments\". (...285 more characters)",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "Logger::LogDevice",
+        "object_id": 9000,
+        "value": "#<Logger::LogDevice:0x00007f33dec8c058>"
+      }
+    },
+    {
+      "id": 293,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 292,
+      "elapsed": 0.000021102000005157606,
+      "elapsed_instrumentation": 0.00008330499997555307,
+      "return_value": {
+        "class": "Integer",
+        "value": "385",
+        "object_id": 771
+      }
+    },
+    {
+      "id": 294,
+      "event": "call",
+      "thread_id": 4480,
+      "sql_query": {
+        "sql": "SELECT \"active_storage_attachments\".* FROM \"active_storage_attachments\" WHERE \"active_storage_attachments\".\"record_id\" = ? AND \"active_storage_attachments\".\"record_type\" = ? AND \"active_storage_attachments\".\"name\" = ? LIMIT ?",
+        "database_type": "sqlite"
+      }
+    },
+    {
+      "id": 295,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 294,
+      "elapsed": 0.000248816,
+      "elapsed_instrumentation": 0.00003850299998475748
+    },
+    {
+      "id": 296,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "SessionsHelper",
+      "method_id": "current_user?",
+      "path": "app/helpers/sessions_helper.rb",
+      "lineno": 37,
+      "static": false,
+      "parameters": [
+        {
+          "name": "user",
+          "class": "User",
+          "object_id": 160420,
+          "value": "#<User:0x00007f33d6790ef8>",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 297,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "SessionsHelper",
+      "method_id": "current_user",
+      "path": "app/helpers/sessions_helper.rb",
+      "lineno": 19,
+      "static": false,
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 298,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionDispatch::Request::Session",
+      "method_id": "[]",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/request/session.rb",
+      "lineno": 110,
+      "static": false,
+      "parameters": [
+        {
+          "name": "key",
+          "class": "Symbol",
+          "object_id": 3107868,
+          "value": ":user_id",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionDispatch::Request::Session",
+        "object_id": 160620,
+        "value": "#<ActionDispatch::Request::Session:0x00007f33d6789e00>"
+      }
+    },
+    {
+      "id": 299,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 298,
+      "elapsed": 0.000009201000011671567,
+      "elapsed_instrumentation": 0.00003990199999748256
+    },
+    {
+      "id": 300,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionDispatch::Cookies::CookieJar",
+      "method_id": "[]",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/middleware/cookies.rb",
+      "lineno": 336,
+      "static": false,
+      "parameters": [
+        {
+          "name": "name",
+          "class": "String",
+          "object_id": 161940,
+          "value": "user_id",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionDispatch::Cookies::CookieJar",
+        "object_id": 160660,
+        "value": "#<ActionDispatch::Cookies::CookieJar:0x00007f33d675ed68>"
+      }
+    },
+    {
+      "id": 301,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 300,
+      "elapsed": 0.0000018000000068241206,
+      "elapsed_instrumentation": 0.00004120300002341537
+    },
+    {
+      "id": 302,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 297,
+      "elapsed": 0.00011600800002042888,
+      "elapsed_instrumentation": 0.00003140199999052129
+    },
+    {
+      "id": 303,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 296,
+      "elapsed": 0.00015860999999972591,
+      "elapsed_instrumentation": 0.00007290499999612621
+    },
+    {
+      "id": 304,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "UsersHelper",
+      "method_id": "gravatar_for",
+      "path": "app/helpers/users_helper.rb",
+      "lineno": 4,
+      "static": false,
+      "parameters": [
+        {
+          "name": "user",
+          "class": "User",
+          "object_id": 160420,
+          "value": "#<User:0x00007f33d6790ef8>",
+          "kind": "req"
+        },
+        {
+          "name": "options",
+          "class": "Hash",
+          "object_id": 161960,
+          "value": "{:size=>50}",
+          "kind": "opt",
+          "size": 1
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 305,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 304,
+      "elapsed": 0.00005050300001130381,
+      "elapsed_instrumentation": 0.00009620599999493606,
+      "return_value": {
+        "class": "ActiveSupport::SafeBuffer",
+        "value": "<img alt=\"Michael Example\" class=\"gravatar\" src=\"https://secure.gravatar.com/avatar/03ea78c0884c9ac0 (...25 more characters)",
+        "object_id": 161980
+      }
+    },
+    {
+      "id": 306,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "Logger::LogDevice",
+      "method_id": "write",
+      "path": "/opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/3.1.0/logger/log_device.rb",
+      "lineno": 31,
+      "static": false,
+      "parameters": [
+        {
+          "name": "message",
+          "class": "String",
+          "object_id": 162000,
+          "value": "  \u001b[1m\u001b[36mActiveStorage::Attachment Load (0.1ms)\u001b[0m  \u001b[1m\u001b[34mSELECT \"active_storage_attachments\". (...285 more characters)",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "Logger::LogDevice",
+        "object_id": 9000,
+        "value": "#<Logger::LogDevice:0x00007f33dec8c058>"
+      }
+    },
+    {
+      "id": 307,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 306,
+      "elapsed": 0.000020501000022932203,
+      "elapsed_instrumentation": 0.00008100599998783764,
+      "return_value": {
+        "class": "Integer",
+        "value": "385",
+        "object_id": 771
+      }
+    },
+    {
+      "id": 308,
+      "event": "call",
+      "thread_id": 4480,
+      "sql_query": {
+        "sql": "SELECT \"active_storage_attachments\".* FROM \"active_storage_attachments\" WHERE \"active_storage_attachments\".\"record_id\" = ? AND \"active_storage_attachments\".\"record_type\" = ? AND \"active_storage_attachments\".\"name\" = ? LIMIT ?",
+        "database_type": "sqlite"
+      }
+    },
+    {
+      "id": 309,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 308,
+      "elapsed": 0.000241716,
+      "elapsed_instrumentation": 0.00003810200001908015
+    },
+    {
+      "id": 310,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "SessionsHelper",
+      "method_id": "current_user?",
+      "path": "app/helpers/sessions_helper.rb",
+      "lineno": 37,
+      "static": false,
+      "parameters": [
+        {
+          "name": "user",
+          "class": "User",
+          "object_id": 160420,
+          "value": "#<User:0x00007f33d6790ef8>",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 311,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "SessionsHelper",
+      "method_id": "current_user",
+      "path": "app/helpers/sessions_helper.rb",
+      "lineno": 19,
+      "static": false,
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 312,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionDispatch::Request::Session",
+      "method_id": "[]",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/request/session.rb",
+      "lineno": 110,
+      "static": false,
+      "parameters": [
+        {
+          "name": "key",
+          "class": "Symbol",
+          "object_id": 3107868,
+          "value": ":user_id",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionDispatch::Request::Session",
+        "object_id": 160620,
+        "value": "#<ActionDispatch::Request::Session:0x00007f33d6789e00>"
+      }
+    },
+    {
+      "id": 313,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 312,
+      "elapsed": 0.000009400999999797932,
+      "elapsed_instrumentation": 0.0000384020000012697
+    },
+    {
+      "id": 314,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionDispatch::Cookies::CookieJar",
+      "method_id": "[]",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/middleware/cookies.rb",
+      "lineno": 336,
+      "static": false,
+      "parameters": [
+        {
+          "name": "name",
+          "class": "String",
+          "object_id": 162020,
+          "value": "user_id",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionDispatch::Cookies::CookieJar",
+        "object_id": 160660,
+        "value": "#<ActionDispatch::Cookies::CookieJar:0x00007f33d675ed68>"
+      }
+    },
+    {
+      "id": 315,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 314,
+      "elapsed": 0.0000019009999903119024,
+      "elapsed_instrumentation": 0.00003950199999280812
+    },
+    {
+      "id": 316,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 311,
+      "elapsed": 0.00011300700001015684,
+      "elapsed_instrumentation": 0.000031600999960801346
+    },
+    {
+      "id": 317,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 310,
+      "elapsed": 0.00015511000000856257,
+      "elapsed_instrumentation": 0.0000730050000186111
+    },
+    {
+      "id": 318,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "UsersHelper",
+      "method_id": "gravatar_for",
+      "path": "app/helpers/users_helper.rb",
+      "lineno": 4,
+      "static": false,
+      "parameters": [
+        {
+          "name": "user",
+          "class": "User",
+          "object_id": 160420,
+          "value": "#<User:0x00007f33d6790ef8>",
+          "kind": "req"
+        },
+        {
+          "name": "options",
+          "class": "Hash",
+          "object_id": 162040,
+          "value": "{:size=>50}",
+          "kind": "opt",
+          "size": 1
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 319,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 318,
+      "elapsed": 0.000049302999997280494,
+      "elapsed_instrumentation": 0.0000954070000034335,
+      "return_value": {
+        "class": "ActiveSupport::SafeBuffer",
+        "value": "<img alt=\"Michael Example\" class=\"gravatar\" src=\"https://secure.gravatar.com/avatar/03ea78c0884c9ac0 (...25 more characters)",
+        "object_id": 162060
+      }
+    },
+    {
+      "id": 320,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "Logger::LogDevice",
+      "method_id": "write",
+      "path": "/opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/3.1.0/logger/log_device.rb",
+      "lineno": 31,
+      "static": false,
+      "parameters": [
+        {
+          "name": "message",
+          "class": "String",
+          "object_id": 162080,
+          "value": "  \u001b[1m\u001b[36mActiveStorage::Attachment Load (0.1ms)\u001b[0m  \u001b[1m\u001b[34mSELECT \"active_storage_attachments\". (...285 more characters)",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "Logger::LogDevice",
+        "object_id": 9000,
+        "value": "#<Logger::LogDevice:0x00007f33dec8c058>"
+      }
+    },
+    {
+      "id": 321,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 320,
+      "elapsed": 0.00002000199998519747,
+      "elapsed_instrumentation": 0.0000825040000052013,
+      "return_value": {
+        "class": "Integer",
+        "value": "385",
+        "object_id": 771
+      }
+    },
+    {
+      "id": 322,
+      "event": "call",
+      "thread_id": 4480,
+      "sql_query": {
+        "sql": "SELECT \"active_storage_attachments\".* FROM \"active_storage_attachments\" WHERE \"active_storage_attachments\".\"record_id\" = ? AND \"active_storage_attachments\".\"record_type\" = ? AND \"active_storage_attachments\".\"name\" = ? LIMIT ?",
+        "database_type": "sqlite"
+      }
+    },
+    {
+      "id": 323,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 322,
+      "elapsed": 0.000242316,
+      "elapsed_instrumentation": 0.000037402999993219055
+    },
+    {
+      "id": 324,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "SessionsHelper",
+      "method_id": "current_user?",
+      "path": "app/helpers/sessions_helper.rb",
+      "lineno": 37,
+      "static": false,
+      "parameters": [
+        {
+          "name": "user",
+          "class": "User",
+          "object_id": 160420,
+          "value": "#<User:0x00007f33d6790ef8>",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 325,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "SessionsHelper",
+      "method_id": "current_user",
+      "path": "app/helpers/sessions_helper.rb",
+      "lineno": 19,
+      "static": false,
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 326,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionDispatch::Request::Session",
+      "method_id": "[]",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/request/session.rb",
+      "lineno": 110,
+      "static": false,
+      "parameters": [
+        {
+          "name": "key",
+          "class": "Symbol",
+          "object_id": 3107868,
+          "value": ":user_id",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionDispatch::Request::Session",
+        "object_id": 160620,
+        "value": "#<ActionDispatch::Request::Session:0x00007f33d6789e00>"
+      }
+    },
+    {
+      "id": 327,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 326,
+      "elapsed": 0.000009199999993825259,
+      "elapsed_instrumentation": 0.0000397020000093562
+    },
+    {
+      "id": 328,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionDispatch::Cookies::CookieJar",
+      "method_id": "[]",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/middleware/cookies.rb",
+      "lineno": 336,
+      "static": false,
+      "parameters": [
+        {
+          "name": "name",
+          "class": "String",
+          "object_id": 162100,
+          "value": "user_id",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionDispatch::Cookies::CookieJar",
+        "object_id": 160660,
+        "value": "#<ActionDispatch::Cookies::CookieJar:0x00007f33d675ed68>"
+      }
+    },
+    {
+      "id": 329,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 328,
+      "elapsed": 0.000001900000000887303,
+      "elapsed_instrumentation": 0.000040502000018705075
+    },
+    {
+      "id": 330,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 325,
+      "elapsed": 0.00011570699999197132,
+      "elapsed_instrumentation": 0.00003370199999608303
+    },
+    {
+      "id": 331,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 324,
+      "elapsed": 0.0001606099999946764,
+      "elapsed_instrumentation": 0.0001894130000152927
+    },
+    {
+      "id": 332,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "UsersHelper",
+      "method_id": "gravatar_for",
+      "path": "app/helpers/users_helper.rb",
+      "lineno": 4,
+      "static": false,
+      "parameters": [
+        {
+          "name": "user",
+          "class": "User",
+          "object_id": 160420,
+          "value": "#<User:0x00007f33d6790ef8>",
+          "kind": "req"
+        },
+        {
+          "name": "options",
+          "class": "Hash",
+          "object_id": 162120,
+          "value": "{:size=>50}",
+          "kind": "opt",
+          "size": 1
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 333,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 332,
+      "elapsed": 0.00005090300001597825,
+      "elapsed_instrumentation": 0.00011920899999040557,
+      "return_value": {
+        "class": "ActiveSupport::SafeBuffer",
+        "value": "<img alt=\"Michael Example\" class=\"gravatar\" src=\"https://secure.gravatar.com/avatar/03ea78c0884c9ac0 (...25 more characters)",
+        "object_id": 162140
+      }
+    },
+    {
+      "id": 334,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "Logger::LogDevice",
+      "method_id": "write",
+      "path": "/opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/3.1.0/logger/log_device.rb",
+      "lineno": 31,
+      "static": false,
+      "parameters": [
+        {
+          "name": "message",
+          "class": "String",
+          "object_id": 162160,
+          "value": "  \u001b[1m\u001b[36mActiveStorage::Attachment Load (0.1ms)\u001b[0m  \u001b[1m\u001b[34mSELECT \"active_storage_attachments\". (...285 more characters)",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "Logger::LogDevice",
+        "object_id": 9000,
+        "value": "#<Logger::LogDevice:0x00007f33dec8c058>"
+      }
+    },
+    {
+      "id": 335,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 334,
+      "elapsed": 0.000020202000001745546,
+      "elapsed_instrumentation": 0.00008440499999551321,
+      "return_value": {
+        "class": "Integer",
+        "value": "385",
+        "object_id": 771
+      }
+    },
+    {
+      "id": 336,
+      "event": "call",
+      "thread_id": 4480,
+      "sql_query": {
+        "sql": "SELECT \"active_storage_attachments\".* FROM \"active_storage_attachments\" WHERE \"active_storage_attachments\".\"record_id\" = ? AND \"active_storage_attachments\".\"record_type\" = ? AND \"active_storage_attachments\".\"name\" = ? LIMIT ?",
+        "database_type": "sqlite"
+      }
+    },
+    {
+      "id": 337,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 336,
+      "elapsed": 0.000257517,
+      "elapsed_instrumentation": 0.00003760300000976713
+    },
+    {
+      "id": 338,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "SessionsHelper",
+      "method_id": "current_user?",
+      "path": "app/helpers/sessions_helper.rb",
+      "lineno": 37,
+      "static": false,
+      "parameters": [
+        {
+          "name": "user",
+          "class": "User",
+          "object_id": 160420,
+          "value": "#<User:0x00007f33d6790ef8>",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 339,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "SessionsHelper",
+      "method_id": "current_user",
+      "path": "app/helpers/sessions_helper.rb",
+      "lineno": 19,
+      "static": false,
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 340,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionDispatch::Request::Session",
+      "method_id": "[]",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/request/session.rb",
+      "lineno": 110,
+      "static": false,
+      "parameters": [
+        {
+          "name": "key",
+          "class": "Symbol",
+          "object_id": 3107868,
+          "value": ":user_id",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionDispatch::Request::Session",
+        "object_id": 160620,
+        "value": "#<ActionDispatch::Request::Session:0x00007f33d6789e00>"
+      }
+    },
+    {
+      "id": 341,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 340,
+      "elapsed": 0.000009599999998499698,
+      "elapsed_instrumentation": 0.000039603999994142214
+    },
+    {
+      "id": 342,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionDispatch::Cookies::CookieJar",
+      "method_id": "[]",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/middleware/cookies.rb",
+      "lineno": 336,
+      "static": false,
+      "parameters": [
+        {
+          "name": "name",
+          "class": "String",
+          "object_id": 162180,
+          "value": "user_id",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionDispatch::Cookies::CookieJar",
+        "object_id": 160660,
+        "value": "#<ActionDispatch::Cookies::CookieJar:0x00007f33d675ed68>"
+      }
+    },
+    {
+      "id": 343,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 342,
+      "elapsed": 0.0000019999999949504854,
+      "elapsed_instrumentation": 0.00004060300000219286
+    },
+    {
+      "id": 344,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 339,
+      "elapsed": 0.00011680700001193145,
+      "elapsed_instrumentation": 0.000032101999977385276
+    },
+    {
+      "id": 345,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 338,
+      "elapsed": 0.00015961099998662576,
+      "elapsed_instrumentation": 0.00008040500000561224
+    },
+    {
+      "id": 346,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "UsersHelper",
+      "method_id": "gravatar_for",
+      "path": "app/helpers/users_helper.rb",
+      "lineno": 4,
+      "static": false,
+      "parameters": [
+        {
+          "name": "user",
+          "class": "User",
+          "object_id": 160420,
+          "value": "#<User:0x00007f33d6790ef8>",
+          "kind": "req"
+        },
+        {
+          "name": "options",
+          "class": "Hash",
+          "object_id": 162200,
+          "value": "{:size=>50}",
+          "kind": "opt",
+          "size": 1
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 347,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 346,
+      "elapsed": 0.00005050400000072841,
+      "elapsed_instrumentation": 0.00009630499999957465,
+      "return_value": {
+        "class": "ActiveSupport::SafeBuffer",
+        "value": "<img alt=\"Michael Example\" class=\"gravatar\" src=\"https://secure.gravatar.com/avatar/03ea78c0884c9ac0 (...25 more characters)",
+        "object_id": 162220
+      }
+    },
+    {
+      "id": 348,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "Logger::LogDevice",
+      "method_id": "write",
+      "path": "/opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/3.1.0/logger/log_device.rb",
+      "lineno": 31,
+      "static": false,
+      "parameters": [
+        {
+          "name": "message",
+          "class": "String",
+          "object_id": 162240,
+          "value": "  \u001b[1m\u001b[36mActiveStorage::Attachment Load (0.1ms)\u001b[0m  \u001b[1m\u001b[34mSELECT \"active_storage_attachments\". (...285 more characters)",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "Logger::LogDevice",
+        "object_id": 9000,
+        "value": "#<Logger::LogDevice:0x00007f33dec8c058>"
+      }
+    },
+    {
+      "id": 349,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 348,
+      "elapsed": 0.000020200999983899237,
+      "elapsed_instrumentation": 0.00008280599999466176,
+      "return_value": {
+        "class": "Integer",
+        "value": "385",
+        "object_id": 771
+      }
+    },
+    {
+      "id": 350,
+      "event": "call",
+      "thread_id": 4480,
+      "sql_query": {
+        "sql": "SELECT \"active_storage_attachments\".* FROM \"active_storage_attachments\" WHERE \"active_storage_attachments\".\"record_id\" = ? AND \"active_storage_attachments\".\"record_type\" = ? AND \"active_storage_attachments\".\"name\" = ? LIMIT ?",
+        "database_type": "sqlite"
+      }
+    },
+    {
+      "id": 351,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 350,
+      "elapsed": 0.000241416,
+      "elapsed_instrumentation": 0.00003680200001099365
+    },
+    {
+      "id": 352,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "SessionsHelper",
+      "method_id": "current_user?",
+      "path": "app/helpers/sessions_helper.rb",
+      "lineno": 37,
+      "static": false,
+      "parameters": [
+        {
+          "name": "user",
+          "class": "User",
+          "object_id": 160420,
+          "value": "#<User:0x00007f33d6790ef8>",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 353,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "SessionsHelper",
+      "method_id": "current_user",
+      "path": "app/helpers/sessions_helper.rb",
+      "lineno": 19,
+      "static": false,
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 354,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionDispatch::Request::Session",
+      "method_id": "[]",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/request/session.rb",
+      "lineno": 110,
+      "static": false,
+      "parameters": [
+        {
+          "name": "key",
+          "class": "Symbol",
+          "object_id": 3107868,
+          "value": ":user_id",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionDispatch::Request::Session",
+        "object_id": 160620,
+        "value": "#<ActionDispatch::Request::Session:0x00007f33d6789e00>"
+      }
+    },
+    {
+      "id": 355,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 354,
+      "elapsed": 0.000009099999999762076,
+      "elapsed_instrumentation": 0.000039603000004717615
+    },
+    {
+      "id": 356,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionDispatch::Cookies::CookieJar",
+      "method_id": "[]",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/middleware/cookies.rb",
+      "lineno": 336,
+      "static": false,
+      "parameters": [
+        {
+          "name": "name",
+          "class": "String",
+          "object_id": 162260,
+          "value": "user_id",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionDispatch::Cookies::CookieJar",
+        "object_id": 160660,
+        "value": "#<ActionDispatch::Cookies::CookieJar:0x00007f33d675ed68>"
+      }
+    },
+    {
+      "id": 357,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 356,
+      "elapsed": 0.000002000000023372195,
+      "elapsed_instrumentation": 0.00016241099999092512
+    },
+    {
+      "id": 358,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 353,
+      "elapsed": 0.00023731499999257721,
+      "elapsed_instrumentation": 0.00003240300000584284
+    },
+    {
+      "id": 359,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 352,
+      "elapsed": 0.00028051900000036767,
+      "elapsed_instrumentation": 0.00007950499997377847
+    },
+    {
+      "id": 360,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "UsersHelper",
+      "method_id": "gravatar_for",
+      "path": "app/helpers/users_helper.rb",
+      "lineno": 4,
+      "static": false,
+      "parameters": [
+        {
+          "name": "user",
+          "class": "User",
+          "object_id": 160420,
+          "value": "#<User:0x00007f33d6790ef8>",
+          "kind": "req"
+        },
+        {
+          "name": "options",
+          "class": "Hash",
+          "object_id": 162280,
+          "value": "{:size=>50}",
+          "kind": "opt",
+          "size": 1
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 361,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 360,
+      "elapsed": 0.00004940299999134368,
+      "elapsed_instrumentation": 0.00009900599999923543,
+      "return_value": {
+        "class": "ActiveSupport::SafeBuffer",
+        "value": "<img alt=\"Michael Example\" class=\"gravatar\" src=\"https://secure.gravatar.com/avatar/03ea78c0884c9ac0 (...25 more characters)",
+        "object_id": 162300
+      }
+    },
+    {
+      "id": 362,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "Logger::LogDevice",
+      "method_id": "write",
+      "path": "/opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/3.1.0/logger/log_device.rb",
+      "lineno": 31,
+      "static": false,
+      "parameters": [
+        {
+          "name": "message",
+          "class": "String",
+          "object_id": 162320,
+          "value": "  \u001b[1m\u001b[36mActiveStorage::Attachment Load (0.1ms)\u001b[0m  \u001b[1m\u001b[34mSELECT \"active_storage_attachments\". (...285 more characters)",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "Logger::LogDevice",
+        "object_id": 9000,
+        "value": "#<Logger::LogDevice:0x00007f33dec8c058>"
+      }
+    },
+    {
+      "id": 363,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 362,
+      "elapsed": 0.000020601000016995386,
+      "elapsed_instrumentation": 0.00008200499999588828,
+      "return_value": {
+        "class": "Integer",
+        "value": "385",
+        "object_id": 771
+      }
+    },
+    {
+      "id": 364,
+      "event": "call",
+      "thread_id": 4480,
+      "sql_query": {
+        "sql": "SELECT \"active_storage_attachments\".* FROM \"active_storage_attachments\" WHERE \"active_storage_attachments\".\"record_id\" = ? AND \"active_storage_attachments\".\"record_type\" = ? AND \"active_storage_attachments\".\"name\" = ? LIMIT ?",
+        "database_type": "sqlite"
+      }
+    },
+    {
+      "id": 365,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 364,
+      "elapsed": 0.000257917,
+      "elapsed_instrumentation": 0.00003800199999659526
+    },
+    {
+      "id": 366,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "SessionsHelper",
+      "method_id": "current_user?",
+      "path": "app/helpers/sessions_helper.rb",
+      "lineno": 37,
+      "static": false,
+      "parameters": [
+        {
+          "name": "user",
+          "class": "User",
+          "object_id": 160420,
+          "value": "#<User:0x00007f33d6790ef8>",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 367,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "SessionsHelper",
+      "method_id": "current_user",
+      "path": "app/helpers/sessions_helper.rb",
+      "lineno": 19,
+      "static": false,
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 368,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionDispatch::Request::Session",
+      "method_id": "[]",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/request/session.rb",
+      "lineno": 110,
+      "static": false,
+      "parameters": [
+        {
+          "name": "key",
+          "class": "Symbol",
+          "object_id": 3107868,
+          "value": ":user_id",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionDispatch::Request::Session",
+        "object_id": 160620,
+        "value": "#<ActionDispatch::Request::Session:0x00007f33d6789e00>"
+      }
+    },
+    {
+      "id": 369,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 368,
+      "elapsed": 0.000009500999993861114,
+      "elapsed_instrumentation": 0.00004070200000683144
+    },
+    {
+      "id": 370,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionDispatch::Cookies::CookieJar",
+      "method_id": "[]",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/middleware/cookies.rb",
+      "lineno": 336,
+      "static": false,
+      "parameters": [
+        {
+          "name": "name",
+          "class": "String",
+          "object_id": 162340,
+          "value": "user_id",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionDispatch::Cookies::CookieJar",
+        "object_id": 160660,
+        "value": "#<ActionDispatch::Cookies::CookieJar:0x00007f33d675ed68>"
+      }
+    },
+    {
+      "id": 371,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 370,
+      "elapsed": 0.000002099999989013668,
+      "elapsed_instrumentation": 0.00004110300000093048
+    },
+    {
+      "id": 372,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 367,
+      "elapsed": 0.00011820700001408113,
+      "elapsed_instrumentation": 0.00003330199999140859
+    },
+    {
+      "id": 373,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 366,
+      "elapsed": 0.00016291099998966274,
+      "elapsed_instrumentation": 0.0000870060000011108
+    },
+    {
+      "id": 374,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "UsersHelper",
+      "method_id": "gravatar_for",
+      "path": "app/helpers/users_helper.rb",
+      "lineno": 4,
+      "static": false,
+      "parameters": [
+        {
+          "name": "user",
+          "class": "User",
+          "object_id": 160420,
+          "value": "#<User:0x00007f33d6790ef8>",
+          "kind": "req"
+        },
+        {
+          "name": "options",
+          "class": "Hash",
+          "object_id": 162360,
+          "value": "{:size=>50}",
+          "kind": "opt",
+          "size": 1
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 375,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 374,
+      "elapsed": 0.000053703999981280504,
+      "elapsed_instrumentation": 0.00013100800001097923,
+      "return_value": {
+        "class": "ActiveSupport::SafeBuffer",
+        "value": "<img alt=\"Michael Example\" class=\"gravatar\" src=\"https://secure.gravatar.com/avatar/03ea78c0884c9ac0 (...25 more characters)",
+        "object_id": 162380
+      }
+    },
+    {
+      "id": 376,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "Logger::LogDevice",
+      "method_id": "write",
+      "path": "/opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/3.1.0/logger/log_device.rb",
+      "lineno": 31,
+      "static": false,
+      "parameters": [
+        {
+          "name": "message",
+          "class": "String",
+          "object_id": 162400,
+          "value": "  \u001b[1m\u001b[36mActiveStorage::Attachment Load (0.1ms)\u001b[0m  \u001b[1m\u001b[34mSELECT \"active_storage_attachments\". (...285 more characters)",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "Logger::LogDevice",
+        "object_id": 9000,
+        "value": "#<Logger::LogDevice:0x00007f33dec8c058>"
+      }
+    },
+    {
+      "id": 377,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 376,
+      "elapsed": 0.000021101000015733007,
+      "elapsed_instrumentation": 0.00008270600000059858,
+      "return_value": {
+        "class": "Integer",
+        "value": "385",
+        "object_id": 771
+      }
+    },
+    {
+      "id": 378,
+      "event": "call",
+      "thread_id": 4480,
+      "sql_query": {
+        "sql": "SELECT \"active_storage_attachments\".* FROM \"active_storage_attachments\" WHERE \"active_storage_attachments\".\"record_id\" = ? AND \"active_storage_attachments\".\"record_type\" = ? AND \"active_storage_attachments\".\"name\" = ? LIMIT ?",
+        "database_type": "sqlite"
+      }
+    },
+    {
+      "id": 379,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 378,
+      "elapsed": 0.000244416,
+      "elapsed_instrumentation": 0.00003860199998939606
+    },
+    {
+      "id": 380,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "SessionsHelper",
+      "method_id": "current_user?",
+      "path": "app/helpers/sessions_helper.rb",
+      "lineno": 37,
+      "static": false,
+      "parameters": [
+        {
+          "name": "user",
+          "class": "User",
+          "object_id": 160420,
+          "value": "#<User:0x00007f33d6790ef8>",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 381,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "SessionsHelper",
+      "method_id": "current_user",
+      "path": "app/helpers/sessions_helper.rb",
+      "lineno": 19,
+      "static": false,
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 382,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionDispatch::Request::Session",
+      "method_id": "[]",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/request/session.rb",
+      "lineno": 110,
+      "static": false,
+      "parameters": [
+        {
+          "name": "key",
+          "class": "Symbol",
+          "object_id": 3107868,
+          "value": ":user_id",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionDispatch::Request::Session",
+        "object_id": 160620,
+        "value": "#<ActionDispatch::Request::Session:0x00007f33d6789e00>"
+      }
+    },
+    {
+      "id": 383,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 382,
+      "elapsed": 0.00000969999999256288,
+      "elapsed_instrumentation": 0.00004210399998783032
+    },
+    {
+      "id": 384,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionDispatch::Cookies::CookieJar",
+      "method_id": "[]",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/middleware/cookies.rb",
+      "lineno": 336,
+      "static": false,
+      "parameters": [
+        {
+          "name": "name",
+          "class": "String",
+          "object_id": 162420,
+          "value": "user_id",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionDispatch::Cookies::CookieJar",
+        "object_id": 160660,
+        "value": "#<ActionDispatch::Cookies::CookieJar:0x00007f33d675ed68>"
+      }
+    },
+    {
+      "id": 385,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 384,
+      "elapsed": 0.0000019999999949504854,
+      "elapsed_instrumentation": 0.00004120300002341537
+    },
+    {
+      "id": 386,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 381,
+      "elapsed": 0.00012060699998528435,
+      "elapsed_instrumentation": 0.000033903000002055705
+    },
+    {
+      "id": 387,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 380,
+      "elapsed": 0.00016551100000583574,
+      "elapsed_instrumentation": 0.00008660599996801466
+    },
+    {
+      "id": 388,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "UsersHelper",
+      "method_id": "gravatar_for",
+      "path": "app/helpers/users_helper.rb",
+      "lineno": 4,
+      "static": false,
+      "parameters": [
+        {
+          "name": "user",
+          "class": "User",
+          "object_id": 160420,
+          "value": "#<User:0x00007f33d6790ef8>",
+          "kind": "req"
+        },
+        {
+          "name": "options",
+          "class": "Hash",
+          "object_id": 162440,
+          "value": "{:size=>50}",
+          "kind": "opt",
+          "size": 1
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 389,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 388,
+      "elapsed": 0.000059104000001752866,
+      "elapsed_instrumentation": 0.002921689999965338,
+      "return_value": {
+        "class": "ActiveSupport::SafeBuffer",
+        "value": "<img alt=\"Michael Example\" class=\"gravatar\" src=\"https://secure.gravatar.com/avatar/03ea78c0884c9ac0 (...25 more characters)",
+        "object_id": 162460
+      }
+    },
+    {
+      "id": 390,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "Logger::LogDevice",
+      "method_id": "write",
+      "path": "/opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/3.1.0/logger/log_device.rb",
+      "lineno": 31,
+      "static": false,
+      "parameters": [
+        {
+          "name": "message",
+          "class": "String",
+          "object_id": 162480,
+          "value": "  \u001b[1m\u001b[36mActiveStorage::Attachment Load (0.1ms)\u001b[0m  \u001b[1m\u001b[34mSELECT \"active_storage_attachments\". (...285 more characters)",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "Logger::LogDevice",
+        "object_id": 9000,
+        "value": "#<Logger::LogDevice:0x00007f33dec8c058>"
+      }
+    },
+    {
+      "id": 391,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 390,
+      "elapsed": 0.000021801999992021592,
+      "elapsed_instrumentation": 0.00008400600003710679,
+      "return_value": {
+        "class": "Integer",
+        "value": "385",
+        "object_id": 771
+      }
+    },
+    {
+      "id": 392,
+      "event": "call",
+      "thread_id": 4480,
+      "sql_query": {
+        "sql": "SELECT \"active_storage_attachments\".* FROM \"active_storage_attachments\" WHERE \"active_storage_attachments\".\"record_id\" = ? AND \"active_storage_attachments\".\"record_type\" = ? AND \"active_storage_attachments\".\"name\" = ? LIMIT ?",
+        "database_type": "sqlite"
+      }
+    },
+    {
+      "id": 393,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 392,
+      "elapsed": 0.000264817,
+      "elapsed_instrumentation": 0.0000390029999834951
+    },
+    {
+      "id": 394,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "SessionsHelper",
+      "method_id": "current_user?",
+      "path": "app/helpers/sessions_helper.rb",
+      "lineno": 37,
+      "static": false,
+      "parameters": [
+        {
+          "name": "user",
+          "class": "User",
+          "object_id": 160420,
+          "value": "#<User:0x00007f33d6790ef8>",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 395,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "SessionsHelper",
+      "method_id": "current_user",
+      "path": "app/helpers/sessions_helper.rb",
+      "lineno": 19,
+      "static": false,
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 396,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionDispatch::Request::Session",
+      "method_id": "[]",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/request/session.rb",
+      "lineno": 110,
+      "static": false,
+      "parameters": [
+        {
+          "name": "key",
+          "class": "Symbol",
+          "object_id": 3107868,
+          "value": ":user_id",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionDispatch::Request::Session",
+        "object_id": 160620,
+        "value": "#<ActionDispatch::Request::Session:0x00007f33d6789e00>"
+      }
+    },
+    {
+      "id": 397,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 396,
+      "elapsed": 0.000009900999998535553,
+      "elapsed_instrumentation": 0.00003950199999280812
+    },
+    {
+      "id": 398,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionDispatch::Cookies::CookieJar",
+      "method_id": "[]",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/middleware/cookies.rb",
+      "lineno": 336,
+      "static": false,
+      "parameters": [
+        {
+          "name": "name",
+          "class": "String",
+          "object_id": 162500,
+          "value": "user_id",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionDispatch::Cookies::CookieJar",
+        "object_id": 160660,
+        "value": "#<ActionDispatch::Cookies::CookieJar:0x00007f33d675ed68>"
+      }
+    },
+    {
+      "id": 399,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 398,
+      "elapsed": 0.000002099999989013668,
+      "elapsed_instrumentation": 0.00006240400000478985
+    },
+    {
+      "id": 400,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 395,
+      "elapsed": 0.00013830899999334179,
+      "elapsed_instrumentation": 0.000032102000034228695
+    },
+    {
+      "id": 401,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 394,
+      "elapsed": 0.00018101200001297002,
+      "elapsed_instrumentation": 0.0000736049999829902
+    },
+    {
+      "id": 402,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "UsersHelper",
+      "method_id": "gravatar_for",
+      "path": "app/helpers/users_helper.rb",
+      "lineno": 4,
+      "static": false,
+      "parameters": [
+        {
+          "name": "user",
+          "class": "User",
+          "object_id": 160420,
+          "value": "#<User:0x00007f33d6790ef8>",
+          "kind": "req"
+        },
+        {
+          "name": "options",
+          "class": "Hash",
+          "object_id": 162520,
+          "value": "{:size=>50}",
+          "kind": "opt",
+          "size": 1
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 403,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 402,
+      "elapsed": 0.000050603000005366994,
+      "elapsed_instrumentation": 0.00009720600002083302,
+      "return_value": {
+        "class": "ActiveSupport::SafeBuffer",
+        "value": "<img alt=\"Michael Example\" class=\"gravatar\" src=\"https://secure.gravatar.com/avatar/03ea78c0884c9ac0 (...25 more characters)",
+        "object_id": 162540
+      }
+    },
+    {
+      "id": 404,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "Logger::LogDevice",
+      "method_id": "write",
+      "path": "/opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/3.1.0/logger/log_device.rb",
+      "lineno": 31,
+      "static": false,
+      "parameters": [
+        {
+          "name": "message",
+          "class": "String",
+          "object_id": 162560,
+          "value": "  \u001b[1m\u001b[36mActiveStorage::Attachment Load (0.1ms)\u001b[0m  \u001b[1m\u001b[34mSELECT \"active_storage_attachments\". (...285 more characters)",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "Logger::LogDevice",
+        "object_id": 9000,
+        "value": "#<Logger::LogDevice:0x00007f33dec8c058>"
+      }
+    },
+    {
+      "id": 405,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 404,
+      "elapsed": 0.00002030100000638413,
+      "elapsed_instrumentation": 0.00008760500003290872,
+      "return_value": {
+        "class": "Integer",
+        "value": "385",
+        "object_id": 771
+      }
+    },
+    {
+      "id": 406,
+      "event": "call",
+      "thread_id": 4480,
+      "sql_query": {
+        "sql": "SELECT \"active_storage_attachments\".* FROM \"active_storage_attachments\" WHERE \"active_storage_attachments\".\"record_id\" = ? AND \"active_storage_attachments\".\"record_type\" = ? AND \"active_storage_attachments\".\"name\" = ? LIMIT ?",
+        "database_type": "sqlite"
+      }
+    },
+    {
+      "id": 407,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 406,
+      "elapsed": 0.000268717,
+      "elapsed_instrumentation": 0.000040502000018705075
+    },
+    {
+      "id": 408,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "SessionsHelper",
+      "method_id": "current_user?",
+      "path": "app/helpers/sessions_helper.rb",
+      "lineno": 37,
+      "static": false,
+      "parameters": [
+        {
+          "name": "user",
+          "class": "User",
+          "object_id": 160420,
+          "value": "#<User:0x00007f33d6790ef8>",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 409,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "SessionsHelper",
+      "method_id": "current_user",
+      "path": "app/helpers/sessions_helper.rb",
+      "lineno": 19,
+      "static": false,
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 410,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionDispatch::Request::Session",
+      "method_id": "[]",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/request/session.rb",
+      "lineno": 110,
+      "static": false,
+      "parameters": [
+        {
+          "name": "key",
+          "class": "Symbol",
+          "object_id": 3107868,
+          "value": ":user_id",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionDispatch::Request::Session",
+        "object_id": 160620,
+        "value": "#<ActionDispatch::Request::Session:0x00007f33d6789e00>"
+      }
+    },
+    {
+      "id": 411,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 410,
+      "elapsed": 0.000009601000016346006,
+      "elapsed_instrumentation": 0.000039601999986871306
+    },
+    {
+      "id": 412,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionDispatch::Cookies::CookieJar",
+      "method_id": "[]",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/middleware/cookies.rb",
+      "lineno": 336,
+      "static": false,
+      "parameters": [
+        {
+          "name": "name",
+          "class": "String",
+          "object_id": 162580,
+          "value": "user_id",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionDispatch::Cookies::CookieJar",
+        "object_id": 160660,
+        "value": "#<ActionDispatch::Cookies::CookieJar:0x00007f33d675ed68>"
+      }
+    },
+    {
+      "id": 413,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 412,
+      "elapsed": 0.000002000000023372195,
+      "elapsed_instrumentation": 0.000040102999975033526
+    },
+    {
+      "id": 414,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 409,
+      "elapsed": 0.00011600800002042888,
+      "elapsed_instrumentation": 0.00003330199999140859
+    },
+    {
+      "id": 415,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 408,
+      "elapsed": 0.00016051000000061322,
+      "elapsed_instrumentation": 0.00007530400000632653
+    },
+    {
+      "id": 416,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "UsersHelper",
+      "method_id": "gravatar_for",
+      "path": "app/helpers/users_helper.rb",
+      "lineno": 4,
+      "static": false,
+      "parameters": [
+        {
+          "name": "user",
+          "class": "User",
+          "object_id": 160420,
+          "value": "#<User:0x00007f33d6790ef8>",
+          "kind": "req"
+        },
+        {
+          "name": "options",
+          "class": "Hash",
+          "object_id": 162600,
+          "value": "{:size=>50}",
+          "kind": "opt",
+          "size": 1
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 417,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 416,
+      "elapsed": 0.00005130299999223098,
+      "elapsed_instrumentation": 0.0001043070000150692,
+      "return_value": {
+        "class": "ActiveSupport::SafeBuffer",
+        "value": "<img alt=\"Michael Example\" class=\"gravatar\" src=\"https://secure.gravatar.com/avatar/03ea78c0884c9ac0 (...25 more characters)",
+        "object_id": 162620
+      }
+    },
+    {
+      "id": 418,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "Logger::LogDevice",
+      "method_id": "write",
+      "path": "/opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/3.1.0/logger/log_device.rb",
+      "lineno": 31,
+      "static": false,
+      "parameters": [
+        {
+          "name": "message",
+          "class": "String",
+          "object_id": 162640,
+          "value": "  \u001b[1m\u001b[36mActiveStorage::Attachment Load (0.2ms)\u001b[0m  \u001b[1m\u001b[34mSELECT \"active_storage_attachments\". (...285 more characters)",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "Logger::LogDevice",
+        "object_id": 9000,
+        "value": "#<Logger::LogDevice:0x00007f33dec8c058>"
+      }
+    },
+    {
+      "id": 419,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 418,
+      "elapsed": 0.00002040199998987191,
+      "elapsed_instrumentation": 0.00008310399999800211,
+      "return_value": {
+        "class": "Integer",
+        "value": "385",
+        "object_id": 771
+      }
+    },
+    {
+      "id": 420,
+      "event": "call",
+      "thread_id": 4480,
+      "sql_query": {
+        "sql": "SELECT \"active_storage_attachments\".* FROM \"active_storage_attachments\" WHERE \"active_storage_attachments\".\"record_id\" = ? AND \"active_storage_attachments\".\"record_type\" = ? AND \"active_storage_attachments\".\"name\" = ? LIMIT ?",
+        "database_type": "sqlite"
+      }
+    },
+    {
+      "id": 421,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 420,
+      "elapsed": 0.000366224,
+      "elapsed_instrumentation": 0.00004020299999751842
+    },
+    {
+      "id": 422,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "SessionsHelper",
+      "method_id": "current_user?",
+      "path": "app/helpers/sessions_helper.rb",
+      "lineno": 37,
+      "static": false,
+      "parameters": [
+        {
+          "name": "user",
+          "class": "User",
+          "object_id": 160420,
+          "value": "#<User:0x00007f33d6790ef8>",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 423,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "SessionsHelper",
+      "method_id": "current_user",
+      "path": "app/helpers/sessions_helper.rb",
+      "lineno": 19,
+      "static": false,
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 424,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionDispatch::Request::Session",
+      "method_id": "[]",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/request/session.rb",
+      "lineno": 110,
+      "static": false,
+      "parameters": [
+        {
+          "name": "key",
+          "class": "Symbol",
+          "object_id": 3107868,
+          "value": ":user_id",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionDispatch::Request::Session",
+        "object_id": 160620,
+        "value": "#<ActionDispatch::Request::Session:0x00007f33d6789e00>"
+      }
+    },
+    {
+      "id": 425,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 424,
+      "elapsed": 0.000009599999998499698,
+      "elapsed_instrumentation": 0.000040503000008129675
+    },
+    {
+      "id": 426,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionDispatch::Cookies::CookieJar",
+      "method_id": "[]",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/middleware/cookies.rb",
+      "lineno": 336,
+      "static": false,
+      "parameters": [
+        {
+          "name": "name",
+          "class": "String",
+          "object_id": 162660,
+          "value": "user_id",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionDispatch::Cookies::CookieJar",
+        "object_id": 160660,
+        "value": "#<ActionDispatch::Cookies::CookieJar:0x00007f33d675ed68>"
+      }
+    },
+    {
+      "id": 427,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 426,
+      "elapsed": 0.000002000000023372195,
+      "elapsed_instrumentation": 0.000049303999986705094
+    },
+    {
+      "id": 428,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 423,
+      "elapsed": 0.00012680800000453019,
+      "elapsed_instrumentation": 0.00003280199999267097
+    },
+    {
+      "id": 429,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 422,
+      "elapsed": 0.00017061100001569685,
+      "elapsed_instrumentation": 0.000074204999975791
+    },
+    {
+      "id": 430,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "UsersHelper",
+      "method_id": "gravatar_for",
+      "path": "app/helpers/users_helper.rb",
+      "lineno": 4,
+      "static": false,
+      "parameters": [
+        {
+          "name": "user",
+          "class": "User",
+          "object_id": 160420,
+          "value": "#<User:0x00007f33d6790ef8>",
+          "kind": "req"
+        },
+        {
+          "name": "options",
+          "class": "Hash",
+          "object_id": 162680,
+          "value": "{:size=>50}",
+          "kind": "opt",
+          "size": 1
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 431,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 430,
+      "elapsed": 0.00005010300000662937,
+      "elapsed_instrumentation": 0.00009750699999244716,
+      "return_value": {
+        "class": "ActiveSupport::SafeBuffer",
+        "value": "<img alt=\"Michael Example\" class=\"gravatar\" src=\"https://secure.gravatar.com/avatar/03ea78c0884c9ac0 (...25 more characters)",
+        "object_id": 162700
+      }
+    },
+    {
+      "id": 432,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "Logger::LogDevice",
+      "method_id": "write",
+      "path": "/opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/3.1.0/logger/log_device.rb",
+      "lineno": 31,
+      "static": false,
+      "parameters": [
+        {
+          "name": "message",
+          "class": "String",
+          "object_id": 162720,
+          "value": "  \u001b[1m\u001b[36mActiveStorage::Attachment Load (0.1ms)\u001b[0m  \u001b[1m\u001b[34mSELECT \"active_storage_attachments\". (...285 more characters)",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "Logger::LogDevice",
+        "object_id": 9000,
+        "value": "#<Logger::LogDevice:0x00007f33dec8c058>"
+      }
+    },
+    {
+      "id": 433,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 432,
+      "elapsed": 0.000020702000000483167,
+      "elapsed_instrumentation": 0.00008480499997176594,
+      "return_value": {
+        "class": "Integer",
+        "value": "385",
+        "object_id": 771
+      }
+    },
+    {
+      "id": 434,
+      "event": "call",
+      "thread_id": 4480,
+      "sql_query": {
+        "sql": "SELECT \"active_storage_attachments\".* FROM \"active_storage_attachments\" WHERE \"active_storage_attachments\".\"record_id\" = ? AND \"active_storage_attachments\".\"record_type\" = ? AND \"active_storage_attachments\".\"name\" = ? LIMIT ?",
+        "database_type": "sqlite"
+      }
+    },
+    {
+      "id": 435,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 434,
+      "elapsed": 0.000249516,
+      "elapsed_instrumentation": 0.00003770300000383031
+    },
+    {
+      "id": 436,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "SessionsHelper",
+      "method_id": "current_user?",
+      "path": "app/helpers/sessions_helper.rb",
+      "lineno": 37,
+      "static": false,
+      "parameters": [
+        {
+          "name": "user",
+          "class": "User",
+          "object_id": 160420,
+          "value": "#<User:0x00007f33d6790ef8>",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 437,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "SessionsHelper",
+      "method_id": "current_user",
+      "path": "app/helpers/sessions_helper.rb",
+      "lineno": 19,
+      "static": false,
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 438,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionDispatch::Request::Session",
+      "method_id": "[]",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/request/session.rb",
+      "lineno": 110,
+      "static": false,
+      "parameters": [
+        {
+          "name": "key",
+          "class": "Symbol",
+          "object_id": 3107868,
+          "value": ":user_id",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionDispatch::Request::Session",
+        "object_id": 160620,
+        "value": "#<ActionDispatch::Request::Session:0x00007f33d6789e00>"
+      }
+    },
+    {
+      "id": 439,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 438,
+      "elapsed": 0.000009801000004472371,
+      "elapsed_instrumentation": 0.00003950200002122983
+    },
+    {
+      "id": 440,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionDispatch::Cookies::CookieJar",
+      "method_id": "[]",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/middleware/cookies.rb",
+      "lineno": 336,
+      "static": false,
+      "parameters": [
+        {
+          "name": "name",
+          "class": "String",
+          "object_id": 162740,
+          "value": "user_id",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionDispatch::Cookies::CookieJar",
+        "object_id": 160660,
+        "value": "#<ActionDispatch::Cookies::CookieJar:0x00007f33d675ed68>"
+      }
+    },
+    {
+      "id": 441,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 440,
+      "elapsed": 0.000001900000000887303,
+      "elapsed_instrumentation": 0.00004040299998564478
+    },
+    {
+      "id": 442,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 437,
+      "elapsed": 0.00011660800001322968,
+      "elapsed_instrumentation": 0.000034302000017305545
+    },
+    {
+      "id": 443,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 436,
+      "elapsed": 0.00016181000000869972,
+      "elapsed_instrumentation": 0.00007340400000543923
+    },
+    {
+      "id": 444,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "UsersHelper",
+      "method_id": "gravatar_for",
+      "path": "app/helpers/users_helper.rb",
+      "lineno": 4,
+      "static": false,
+      "parameters": [
+        {
+          "name": "user",
+          "class": "User",
+          "object_id": 160420,
+          "value": "#<User:0x00007f33d6790ef8>",
+          "kind": "req"
+        },
+        {
+          "name": "options",
+          "class": "Hash",
+          "object_id": 162760,
+          "value": "{:size=>50}",
+          "kind": "opt",
+          "size": 1
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 445,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 444,
+      "elapsed": 0.00009620599999493606,
+      "elapsed_instrumentation": 0.00010390699998197306,
+      "return_value": {
+        "class": "ActiveSupport::SafeBuffer",
+        "value": "<img alt=\"Michael Example\" class=\"gravatar\" src=\"https://secure.gravatar.com/avatar/03ea78c0884c9ac0 (...25 more characters)",
+        "object_id": 162780
+      }
+    },
+    {
+      "id": 446,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "Logger::LogDevice",
+      "method_id": "write",
+      "path": "/opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/3.1.0/logger/log_device.rb",
+      "lineno": 31,
+      "static": false,
+      "parameters": [
+        {
+          "name": "message",
+          "class": "String",
+          "object_id": 162800,
+          "value": "  \u001b[1m\u001b[36mActiveStorage::Attachment Load (0.1ms)\u001b[0m  \u001b[1m\u001b[34mSELECT \"active_storage_attachments\". (...285 more characters)",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "Logger::LogDevice",
+        "object_id": 9000,
+        "value": "#<Logger::LogDevice:0x00007f33dec8c058>"
+      }
+    },
+    {
+      "id": 447,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 446,
+      "elapsed": 0.000020900999999184933,
+      "elapsed_instrumentation": 0.00008540600001083476,
+      "return_value": {
+        "class": "Integer",
+        "value": "385",
+        "object_id": 771
+      }
+    },
+    {
+      "id": 448,
+      "event": "call",
+      "thread_id": 4480,
+      "sql_query": {
+        "sql": "SELECT \"active_storage_attachments\".* FROM \"active_storage_attachments\" WHERE \"active_storage_attachments\".\"record_id\" = ? AND \"active_storage_attachments\".\"record_type\" = ? AND \"active_storage_attachments\".\"name\" = ? LIMIT ?",
+        "database_type": "sqlite"
+      }
+    },
+    {
+      "id": 449,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 448,
+      "elapsed": 0.000279518,
+      "elapsed_instrumentation": 0.0000397029999987808
+    },
+    {
+      "id": 450,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "SessionsHelper",
+      "method_id": "current_user?",
+      "path": "app/helpers/sessions_helper.rb",
+      "lineno": 37,
+      "static": false,
+      "parameters": [
+        {
+          "name": "user",
+          "class": "User",
+          "object_id": 160420,
+          "value": "#<User:0x00007f33d6790ef8>",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 451,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "SessionsHelper",
+      "method_id": "current_user",
+      "path": "app/helpers/sessions_helper.rb",
+      "lineno": 19,
+      "static": false,
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 452,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionDispatch::Request::Session",
+      "method_id": "[]",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/request/session.rb",
+      "lineno": 110,
+      "static": false,
+      "parameters": [
+        {
+          "name": "key",
+          "class": "Symbol",
+          "object_id": 3107868,
+          "value": ":user_id",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionDispatch::Request::Session",
+        "object_id": 160620,
+        "value": "#<ActionDispatch::Request::Session:0x00007f33d6789e00>"
+      }
+    },
+    {
+      "id": 453,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 452,
+      "elapsed": 0.000009500999993861114,
+      "elapsed_instrumentation": 0.00004070199997840973
+    },
+    {
+      "id": 454,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionDispatch::Cookies::CookieJar",
+      "method_id": "[]",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/middleware/cookies.rb",
+      "lineno": 336,
+      "static": false,
+      "parameters": [
+        {
+          "name": "name",
+          "class": "String",
+          "object_id": 162820,
+          "value": "user_id",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionDispatch::Cookies::CookieJar",
+        "object_id": 160660,
+        "value": "#<ActionDispatch::Cookies::CookieJar:0x00007f33d675ed68>"
+      }
+    },
+    {
+      "id": 455,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 454,
+      "elapsed": 0.0000019999999949504854,
+      "elapsed_instrumentation": 0.00003990300001532887
+    },
+    {
+      "id": 456,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 451,
+      "elapsed": 0.0001165080000191665,
+      "elapsed_instrumentation": 0.000036001999973223064
+    },
+    {
+      "id": 457,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 450,
+      "elapsed": 0.0003020190000029288,
+      "elapsed_instrumentation": 0.00007300400000076479
+    },
+    {
+      "id": 458,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "UsersHelper",
+      "method_id": "gravatar_for",
+      "path": "app/helpers/users_helper.rb",
+      "lineno": 4,
+      "static": false,
+      "parameters": [
+        {
+          "name": "user",
+          "class": "User",
+          "object_id": 160420,
+          "value": "#<User:0x00007f33d6790ef8>",
+          "kind": "req"
+        },
+        {
+          "name": "options",
+          "class": "Hash",
+          "object_id": 162840,
+          "value": "{:size=>50}",
+          "kind": "opt",
+          "size": 1
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 459,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 458,
+      "elapsed": 0.000052404000001615714,
+      "elapsed_instrumentation": 0.00009710599999834812,
+      "return_value": {
+        "class": "ActiveSupport::SafeBuffer",
+        "value": "<img alt=\"Michael Example\" class=\"gravatar\" src=\"https://secure.gravatar.com/avatar/03ea78c0884c9ac0 (...25 more characters)",
+        "object_id": 162860
+      }
+    },
+    {
+      "id": 460,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "Logger::LogDevice",
+      "method_id": "write",
+      "path": "/opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/3.1.0/logger/log_device.rb",
+      "lineno": 31,
+      "static": false,
+      "parameters": [
+        {
+          "name": "message",
+          "class": "String",
+          "object_id": 162880,
+          "value": "  \u001b[1m\u001b[36mActiveStorage::Attachment Load (0.1ms)\u001b[0m  \u001b[1m\u001b[34mSELECT \"active_storage_attachments\". (...285 more characters)",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "Logger::LogDevice",
+        "object_id": 9000,
+        "value": "#<Logger::LogDevice:0x00007f33dec8c058>"
+      }
+    },
+    {
+      "id": 461,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 460,
+      "elapsed": 0.00002880200000277,
+      "elapsed_instrumentation": 0.00010070700000142097,
+      "return_value": {
+        "class": "Integer",
+        "value": "385",
+        "object_id": 771
+      }
+    },
+    {
+      "id": 462,
+      "event": "call",
+      "thread_id": 4480,
+      "sql_query": {
+        "sql": "SELECT \"active_storage_attachments\".* FROM \"active_storage_attachments\" WHERE \"active_storage_attachments\".\"record_id\" = ? AND \"active_storage_attachments\".\"record_type\" = ? AND \"active_storage_attachments\".\"name\" = ? LIMIT ?",
+        "database_type": "sqlite"
+      }
+    },
+    {
+      "id": 463,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 462,
+      "elapsed": 0.000286918,
+      "elapsed_instrumentation": 0.00003930200000468176
+    },
+    {
+      "id": 464,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "SessionsHelper",
+      "method_id": "current_user?",
+      "path": "app/helpers/sessions_helper.rb",
+      "lineno": 37,
+      "static": false,
+      "parameters": [
+        {
+          "name": "user",
+          "class": "User",
+          "object_id": 160420,
+          "value": "#<User:0x00007f33d6790ef8>",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 465,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "SessionsHelper",
+      "method_id": "current_user",
+      "path": "app/helpers/sessions_helper.rb",
+      "lineno": 19,
+      "static": false,
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 466,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionDispatch::Request::Session",
+      "method_id": "[]",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/request/session.rb",
+      "lineno": 110,
+      "static": false,
+      "parameters": [
+        {
+          "name": "key",
+          "class": "Symbol",
+          "object_id": 3107868,
+          "value": ":user_id",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionDispatch::Request::Session",
+        "object_id": 160620,
+        "value": "#<ActionDispatch::Request::Session:0x00007f33d6789e00>"
+      }
+    },
+    {
+      "id": 467,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 466,
+      "elapsed": 0.000009400999999797932,
+      "elapsed_instrumentation": 0.00003850200002375459
+    },
+    {
+      "id": 468,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionDispatch::Cookies::CookieJar",
+      "method_id": "[]",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/middleware/cookies.rb",
+      "lineno": 336,
+      "static": false,
+      "parameters": [
+        {
+          "name": "name",
+          "class": "String",
+          "object_id": 162900,
+          "value": "user_id",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionDispatch::Cookies::CookieJar",
+        "object_id": 160660,
+        "value": "#<ActionDispatch::Cookies::CookieJar:0x00007f33d675ed68>"
+      }
+    },
+    {
+      "id": 469,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 468,
+      "elapsed": 0.000002099999989013668,
+      "elapsed_instrumentation": 0.000040102000014030637
+    },
+    {
+      "id": 470,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 465,
+      "elapsed": 0.0001152069999932337,
+      "elapsed_instrumentation": 0.00003150100002358158
+    },
+    {
+      "id": 471,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 464,
+      "elapsed": 0.00015770999999631385,
+      "elapsed_instrumentation": 0.00007350600003519503
+    },
+    {
+      "id": 472,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "UsersHelper",
+      "method_id": "gravatar_for",
+      "path": "app/helpers/users_helper.rb",
+      "lineno": 4,
+      "static": false,
+      "parameters": [
+        {
+          "name": "user",
+          "class": "User",
+          "object_id": 160420,
+          "value": "#<User:0x00007f33d6790ef8>",
+          "kind": "req"
+        },
+        {
+          "name": "options",
+          "class": "Hash",
+          "object_id": 162920,
+          "value": "{:size=>50}",
+          "kind": "opt",
+          "size": 1
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 473,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 472,
+      "elapsed": 0.00005030299999475574,
+      "elapsed_instrumentation": 0.0000953069999809486,
+      "return_value": {
+        "class": "ActiveSupport::SafeBuffer",
+        "value": "<img alt=\"Michael Example\" class=\"gravatar\" src=\"https://secure.gravatar.com/avatar/03ea78c0884c9ac0 (...25 more characters)",
+        "object_id": 162940
+      }
+    },
+    {
+      "id": 474,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "Logger::LogDevice",
+      "method_id": "write",
+      "path": "/opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/3.1.0/logger/log_device.rb",
+      "lineno": 31,
+      "static": false,
+      "parameters": [
+        {
+          "name": "message",
+          "class": "String",
+          "object_id": 162960,
+          "value": "  \u001b[1m\u001b[36mActiveStorage::Attachment Load (0.1ms)\u001b[0m  \u001b[1m\u001b[34mSELECT \"active_storage_attachments\". (...285 more characters)",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "Logger::LogDevice",
+        "object_id": 9000,
+        "value": "#<Logger::LogDevice:0x00007f33dec8c058>"
+      }
+    },
+    {
+      "id": 475,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 474,
+      "elapsed": 0.000019300999980487177,
+      "elapsed_instrumentation": 0.00007730499999070162,
+      "return_value": {
+        "class": "Integer",
+        "value": "385",
+        "object_id": 771
+      }
+    },
+    {
+      "id": 476,
+      "event": "call",
+      "thread_id": 4480,
+      "sql_query": {
+        "sql": "SELECT \"active_storage_attachments\".* FROM \"active_storage_attachments\" WHERE \"active_storage_attachments\".\"record_id\" = ? AND \"active_storage_attachments\".\"record_type\" = ? AND \"active_storage_attachments\".\"name\" = ? LIMIT ?",
+        "database_type": "sqlite"
+      }
+    },
+    {
+      "id": 477,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 476,
+      "elapsed": 0.000226915,
+      "elapsed_instrumentation": 0.00003500300002201584
+    },
+    {
+      "id": 478,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "SessionsHelper",
+      "method_id": "current_user?",
+      "path": "app/helpers/sessions_helper.rb",
+      "lineno": 37,
+      "static": false,
+      "parameters": [
+        {
+          "name": "user",
+          "class": "User",
+          "object_id": 160420,
+          "value": "#<User:0x00007f33d6790ef8>",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 479,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "SessionsHelper",
+      "method_id": "current_user",
+      "path": "app/helpers/sessions_helper.rb",
+      "lineno": 19,
+      "static": false,
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 480,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionDispatch::Request::Session",
+      "method_id": "[]",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/request/session.rb",
+      "lineno": 110,
+      "static": false,
+      "parameters": [
+        {
+          "name": "key",
+          "class": "Symbol",
+          "object_id": 3107868,
+          "value": ":user_id",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionDispatch::Request::Session",
+        "object_id": 160620,
+        "value": "#<ActionDispatch::Request::Session:0x00007f33d6789e00>"
+      }
+    },
+    {
+      "id": 481,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 480,
+      "elapsed": 0.00000840000001289809,
+      "elapsed_instrumentation": 0.00003630200001225603
+    },
+    {
+      "id": 482,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionDispatch::Cookies::CookieJar",
+      "method_id": "[]",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/middleware/cookies.rb",
+      "lineno": 336,
+      "static": false,
+      "parameters": [
+        {
+          "name": "name",
+          "class": "String",
+          "object_id": 162980,
+          "value": "user_id",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionDispatch::Cookies::CookieJar",
+        "object_id": 160660,
+        "value": "#<ActionDispatch::Cookies::CookieJar:0x00007f33d675ed68>"
+      }
+    },
+    {
+      "id": 483,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 482,
+      "elapsed": 0.0000016999999843392288,
+      "elapsed_instrumentation": 0.000037402999993219055
+    },
+    {
+      "id": 484,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 479,
+      "elapsed": 0.00010680700000875731,
+      "elapsed_instrumentation": 0.000029002000019318075
+    },
+    {
+      "id": 485,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 478,
+      "elapsed": 0.00014630900000156544,
+      "elapsed_instrumentation": 0.00006830400002399983
+    },
+    {
+      "id": 486,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "UsersHelper",
+      "method_id": "gravatar_for",
+      "path": "app/helpers/users_helper.rb",
+      "lineno": 4,
+      "static": false,
+      "parameters": [
+        {
+          "name": "user",
+          "class": "User",
+          "object_id": 160420,
+          "value": "#<User:0x00007f33d6790ef8>",
+          "kind": "req"
+        },
+        {
+          "name": "options",
+          "class": "Hash",
+          "object_id": 163000,
+          "value": "{:size=>50}",
+          "kind": "opt",
+          "size": 1
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 487,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 486,
+      "elapsed": 0.000051502999980357345,
+      "elapsed_instrumentation": 0.0002719180000099186,
+      "return_value": {
+        "class": "ActiveSupport::SafeBuffer",
+        "value": "<img alt=\"Michael Example\" class=\"gravatar\" src=\"https://secure.gravatar.com/avatar/03ea78c0884c9ac0 (...25 more characters)",
+        "object_id": 163020
+      }
+    },
+    {
+      "id": 488,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "Logger::LogDevice",
+      "method_id": "write",
+      "path": "/opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/3.1.0/logger/log_device.rb",
+      "lineno": 31,
+      "static": false,
+      "parameters": [
+        {
+          "name": "message",
+          "class": "String",
+          "object_id": 163040,
+          "value": "  \u001b[1m\u001b[36mActiveStorage::Attachment Load (0.1ms)\u001b[0m  \u001b[1m\u001b[34mSELECT \"active_storage_attachments\". (...285 more characters)",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "Logger::LogDevice",
+        "object_id": 9000,
+        "value": "#<Logger::LogDevice:0x00007f33dec8c058>"
+      }
+    },
+    {
+      "id": 489,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 488,
+      "elapsed": 0.000021602000003895228,
+      "elapsed_instrumentation": 0.00008210500001837318,
+      "return_value": {
+        "class": "Integer",
+        "value": "385",
+        "object_id": 771
+      }
+    },
+    {
+      "id": 490,
+      "event": "call",
+      "thread_id": 4480,
+      "sql_query": {
+        "sql": "SELECT \"active_storage_attachments\".* FROM \"active_storage_attachments\" WHERE \"active_storage_attachments\".\"record_id\" = ? AND \"active_storage_attachments\".\"record_type\" = ? AND \"active_storage_attachments\".\"name\" = ? LIMIT ?",
+        "database_type": "sqlite"
+      }
+    },
+    {
+      "id": 491,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 490,
+      "elapsed": 0.000266417,
+      "elapsed_instrumentation": 0.00003770300000383031
+    },
+    {
+      "id": 492,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "SessionsHelper",
+      "method_id": "current_user?",
+      "path": "app/helpers/sessions_helper.rb",
+      "lineno": 37,
+      "static": false,
+      "parameters": [
+        {
+          "name": "user",
+          "class": "User",
+          "object_id": 160420,
+          "value": "#<User:0x00007f33d6790ef8>",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 493,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "SessionsHelper",
+      "method_id": "current_user",
+      "path": "app/helpers/sessions_helper.rb",
+      "lineno": 19,
+      "static": false,
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 494,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionDispatch::Request::Session",
+      "method_id": "[]",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/request/session.rb",
+      "lineno": 110,
+      "static": false,
+      "parameters": [
+        {
+          "name": "key",
+          "class": "Symbol",
+          "object_id": 3107868,
+          "value": ":user_id",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionDispatch::Request::Session",
+        "object_id": 160620,
+        "value": "#<ActionDispatch::Request::Session:0x00007f33d6789e00>"
+      }
+    },
+    {
+      "id": 495,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 494,
+      "elapsed": 0.000009299999987888441,
+      "elapsed_instrumentation": 0.00003900300004033852
+    },
+    {
+      "id": 496,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionDispatch::Cookies::CookieJar",
+      "method_id": "[]",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/middleware/cookies.rb",
+      "lineno": 336,
+      "static": false,
+      "parameters": [
+        {
+          "name": "name",
+          "class": "String",
+          "object_id": 163060,
+          "value": "user_id",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionDispatch::Cookies::CookieJar",
+        "object_id": 160660,
+        "value": "#<ActionDispatch::Cookies::CookieJar:0x00007f33d675ed68>"
+      }
+    },
+    {
+      "id": 497,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 496,
+      "elapsed": 0.0000017999999784024112,
+      "elapsed_instrumentation": 0.00003990299998690716
+    },
+    {
+      "id": 498,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 493,
+      "elapsed": 0.00011370699999702083,
+      "elapsed_instrumentation": 0.000031303000014304416
+    },
+    {
+      "id": 499,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 492,
+      "elapsed": 0.0001556100000073002,
+      "elapsed_instrumentation": 0.00007200400000328955
+    },
+    {
+      "id": 500,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "UsersHelper",
+      "method_id": "gravatar_for",
+      "path": "app/helpers/users_helper.rb",
+      "lineno": 4,
+      "static": false,
+      "parameters": [
+        {
+          "name": "user",
+          "class": "User",
+          "object_id": 160420,
+          "value": "#<User:0x00007f33d6790ef8>",
+          "kind": "req"
+        },
+        {
+          "name": "options",
+          "class": "Hash",
+          "object_id": 163080,
+          "value": "{:size=>50}",
+          "kind": "opt",
+          "size": 1
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 501,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 500,
+      "elapsed": 0.000049404000009189986,
+      "elapsed_instrumentation": 0.00009640599998306243,
+      "return_value": {
+        "class": "ActiveSupport::SafeBuffer",
+        "value": "<img alt=\"Michael Example\" class=\"gravatar\" src=\"https://secure.gravatar.com/avatar/03ea78c0884c9ac0 (...25 more characters)",
+        "object_id": 163100
+      }
+    },
+    {
+      "id": 502,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "Logger::LogDevice",
+      "method_id": "write",
+      "path": "/opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/3.1.0/logger/log_device.rb",
+      "lineno": 31,
+      "static": false,
+      "parameters": [
+        {
+          "name": "message",
+          "class": "String",
+          "object_id": 163120,
+          "value": "  \u001b[1m\u001b[36mActiveStorage::Attachment Load (0.1ms)\u001b[0m  \u001b[1m\u001b[34mSELECT \"active_storage_attachments\". (...285 more characters)",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "Logger::LogDevice",
+        "object_id": 9000,
+        "value": "#<Logger::LogDevice:0x00007f33dec8c058>"
+      }
+    },
+    {
+      "id": 503,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 502,
+      "elapsed": 0.000020301999995808728,
+      "elapsed_instrumentation": 0.00008270499998275227,
+      "return_value": {
+        "class": "Integer",
+        "value": "385",
+        "object_id": 771
+      }
+    },
+    {
+      "id": 504,
+      "event": "call",
+      "thread_id": 4480,
+      "sql_query": {
+        "sql": "SELECT \"active_storage_attachments\".* FROM \"active_storage_attachments\" WHERE \"active_storage_attachments\".\"record_id\" = ? AND \"active_storage_attachments\".\"record_type\" = ? AND \"active_storage_attachments\".\"name\" = ? LIMIT ?",
+        "database_type": "sqlite"
+      }
+    },
+    {
+      "id": 505,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 504,
+      "elapsed": 0.000240816,
+      "elapsed_instrumentation": 0.000037402999993219055
+    },
+    {
+      "id": 506,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "SessionsHelper",
+      "method_id": "current_user?",
+      "path": "app/helpers/sessions_helper.rb",
+      "lineno": 37,
+      "static": false,
+      "parameters": [
+        {
+          "name": "user",
+          "class": "User",
+          "object_id": 160420,
+          "value": "#<User:0x00007f33d6790ef8>",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 507,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "SessionsHelper",
+      "method_id": "current_user",
+      "path": "app/helpers/sessions_helper.rb",
+      "lineno": 19,
+      "static": false,
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 508,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionDispatch::Request::Session",
+      "method_id": "[]",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/request/session.rb",
+      "lineno": 110,
+      "static": false,
+      "parameters": [
+        {
+          "name": "key",
+          "class": "Symbol",
+          "object_id": 3107868,
+          "value": ":user_id",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionDispatch::Request::Session",
+        "object_id": 160620,
+        "value": "#<ActionDispatch::Request::Session:0x00007f33d6789e00>"
+      }
+    },
+    {
+      "id": 509,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 508,
+      "elapsed": 0.000009199999993825259,
+      "elapsed_instrumentation": 0.00003850400000260379
+    },
+    {
+      "id": 510,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionDispatch::Cookies::CookieJar",
+      "method_id": "[]",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/middleware/cookies.rb",
+      "lineno": 336,
+      "static": false,
+      "parameters": [
+        {
+          "name": "name",
+          "class": "String",
+          "object_id": 163140,
+          "value": "user_id",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionDispatch::Cookies::CookieJar",
+        "object_id": 160660,
+        "value": "#<ActionDispatch::Cookies::CookieJar:0x00007f33d675ed68>"
+      }
+    },
+    {
+      "id": 511,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 510,
+      "elapsed": 0.0000018000000068241206,
+      "elapsed_instrumentation": 0.00004150300000560492
+    },
+    {
+      "id": 512,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 507,
+      "elapsed": 0.00011440700001230653,
+      "elapsed_instrumentation": 0.00003150300000243078
+    },
+    {
+      "id": 513,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 506,
+      "elapsed": 0.00015661099999420003,
+      "elapsed_instrumentation": 0.00007280400001263843
+    },
+    {
+      "id": 514,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "UsersHelper",
+      "method_id": "gravatar_for",
+      "path": "app/helpers/users_helper.rb",
+      "lineno": 4,
+      "static": false,
+      "parameters": [
+        {
+          "name": "user",
+          "class": "User",
+          "object_id": 160420,
+          "value": "#<User:0x00007f33d6790ef8>",
+          "kind": "req"
+        },
+        {
+          "name": "options",
+          "class": "Hash",
+          "object_id": 163160,
+          "value": "{:size=>50}",
+          "kind": "opt",
+          "size": 1
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 515,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 514,
+      "elapsed": 0.00004590300000018033,
+      "elapsed_instrumentation": 0.00008870600001387174,
+      "return_value": {
+        "class": "ActiveSupport::SafeBuffer",
+        "value": "<img alt=\"Michael Example\" class=\"gravatar\" src=\"https://secure.gravatar.com/avatar/03ea78c0884c9ac0 (...25 more characters)",
+        "object_id": 163180
+      }
+    },
+    {
+      "id": 516,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "Logger::LogDevice",
+      "method_id": "write",
+      "path": "/opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/3.1.0/logger/log_device.rb",
+      "lineno": 31,
+      "static": false,
+      "parameters": [
+        {
+          "name": "message",
+          "class": "String",
+          "object_id": 163200,
+          "value": "  \u001b[1m\u001b[36mActiveStorage::Attachment Load (0.0ms)\u001b[0m  \u001b[1m\u001b[34mSELECT \"active_storage_attachments\". (...284 more characters)",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "Logger::LogDevice",
+        "object_id": 9000,
+        "value": "#<Logger::LogDevice:0x00007f33dec8c058>"
+      }
+    },
+    {
+      "id": 517,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 516,
+      "elapsed": 0.000019800999979224798,
+      "elapsed_instrumentation": 0.00007870500002127301,
+      "return_value": {
+        "class": "Integer",
+        "value": "384",
+        "object_id": 769
+      }
+    },
+    {
+      "id": 518,
+      "event": "call",
+      "thread_id": 4480,
+      "sql_query": {
+        "sql": "SELECT \"active_storage_attachments\".* FROM \"active_storage_attachments\" WHERE \"active_storage_attachments\".\"record_id\" = ? AND \"active_storage_attachments\".\"record_type\" = ? AND \"active_storage_attachments\".\"name\" = ? LIMIT ?",
+        "database_type": "sqlite"
+      }
+    },
+    {
+      "id": 519,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 518,
+      "elapsed": 0.000252916,
+      "elapsed_instrumentation": 0.00003580200001351841
+    },
+    {
+      "id": 520,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "SessionsHelper",
+      "method_id": "current_user?",
+      "path": "app/helpers/sessions_helper.rb",
+      "lineno": 37,
+      "static": false,
+      "parameters": [
+        {
+          "name": "user",
+          "class": "User",
+          "object_id": 160420,
+          "value": "#<User:0x00007f33d6790ef8>",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 521,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "SessionsHelper",
+      "method_id": "current_user",
+      "path": "app/helpers/sessions_helper.rb",
+      "lineno": 19,
+      "static": false,
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 522,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionDispatch::Request::Session",
+      "method_id": "[]",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/request/session.rb",
+      "lineno": 110,
+      "static": false,
+      "parameters": [
+        {
+          "name": "key",
+          "class": "Symbol",
+          "object_id": 3107868,
+          "value": ":user_id",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionDispatch::Request::Session",
+        "object_id": 160620,
+        "value": "#<ActionDispatch::Request::Session:0x00007f33d6789e00>"
+      }
+    },
+    {
+      "id": 523,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 522,
+      "elapsed": 0.00000890100000106031,
+      "elapsed_instrumentation": 0.000037001999999120017
+    },
+    {
+      "id": 524,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionDispatch::Cookies::CookieJar",
+      "method_id": "[]",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/middleware/cookies.rb",
+      "lineno": 336,
+      "static": false,
+      "parameters": [
+        {
+          "name": "name",
+          "class": "String",
+          "object_id": 163220,
+          "value": "user_id",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionDispatch::Cookies::CookieJar",
+        "object_id": 160660,
+        "value": "#<ActionDispatch::Cookies::CookieJar:0x00007f33d675ed68>"
+      }
+    },
+    {
+      "id": 525,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 524,
+      "elapsed": 0.0000017000000127609383,
+      "elapsed_instrumentation": 0.00003630199998383432
+    },
+    {
+      "id": 526,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 521,
+      "elapsed": 0.00010710699999094686,
+      "elapsed_instrumentation": 0.000029501000028631097
+    },
+    {
+      "id": 527,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 520,
+      "elapsed": 0.00014670999999566448,
+      "elapsed_instrumentation": 0.00007000400000833906
+    },
+    {
+      "id": 528,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "Logger::LogDevice",
+      "method_id": "write",
+      "path": "/opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/3.1.0/logger/log_device.rb",
+      "lineno": 31,
+      "static": false,
+      "parameters": [
+        {
+          "name": "message",
+          "class": "String",
+          "object_id": 163240,
+          "value": "  Rendered collection of microposts/_micropost.html.erb [30 times] (Duration: 87.1ms | Allocations:  (...7 more characters)",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "Logger::LogDevice",
+        "object_id": 9000,
+        "value": "#<Logger::LogDevice:0x00007f33dec8c058>"
+      }
+    },
+    {
+      "id": 529,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 528,
+      "elapsed": 0.000016901000009283962,
+      "elapsed_instrumentation": 0.00005000300001256619,
+      "return_value": {
+        "class": "Integer",
+        "value": "107",
+        "object_id": 215
+      }
+    },
+    {
+      "id": 530,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "Logger::LogDevice",
+      "method_id": "write",
+      "path": "/opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/3.1.0/logger/log_device.rb",
+      "lineno": 31,
+      "static": false,
+      "parameters": [
+        {
+          "name": "message",
+          "class": "String",
+          "object_id": 163260,
+          "value": "  \u001b[1m\u001b[36mCACHE Micropost Count (0.0ms)\u001b[0m  \u001b[1m\u001b[34mSELECT COUNT(*) FROM \"microposts\" WHERE \"micr (...52 more characters)",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "Logger::LogDevice",
+        "object_id": 9000,
+        "value": "#<Logger::LogDevice:0x00007f33dec8c058>"
+      }
+    },
+    {
+      "id": 531,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 530,
+      "elapsed": 0.000016200999993998266,
+      "elapsed_instrumentation": 0.00006670499999472668,
+      "return_value": {
+        "class": "Integer",
+        "value": "152",
+        "object_id": 305
+      }
+    },
+    {
+      "id": 532,
+      "event": "call",
+      "thread_id": 4480,
+      "sql_query": {
+        "sql": "SELECT COUNT(*) FROM \"microposts\" WHERE \"microposts\".\"user_id\" = ?",
+        "database_type": "sqlite"
+      }
+    },
+    {
+      "id": 533,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 532,
+      "elapsed": 0.00015681,
+      "elapsed_instrumentation": 0.00003540200000884397
+    },
+    {
+      "id": 534,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "Logger::LogDevice",
+      "method_id": "write",
+      "path": "/opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/3.1.0/logger/log_device.rb",
+      "lineno": 31,
+      "static": false,
+      "parameters": [
+        {
+          "name": "message",
+          "class": "String",
+          "object_id": 163280,
+          "value": "  Rendered users/show.html.erb within layouts/application (Duration: 94.9ms | Allocations: 37300)\n",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "Logger::LogDevice",
+        "object_id": 9000,
+        "value": "#<Logger::LogDevice:0x00007f33dec8c058>"
+      }
+    },
+    {
+      "id": 535,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 534,
+      "elapsed": 0.000017001000003347144,
+      "elapsed_instrumentation": 0.00006220500000608808,
+      "return_value": {
+        "class": "Integer",
+        "value": "98",
+        "object_id": 197
+      }
+    },
+    {
+      "id": 536,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ApplicationHelper",
+      "method_id": "full_title",
+      "path": "app/helpers/application_helper.rb",
+      "lineno": 4,
+      "static": false,
+      "parameters": [
+        {
+          "name": "page_title",
+          "class": "ActiveSupport::SafeBuffer",
+          "object_id": 163300,
+          "value": "Michael Example",
+          "kind": "opt"
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 537,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 536,
+      "elapsed": 0.0000038999999958377884,
+      "elapsed_instrumentation": 0.00005410400001437665,
+      "return_value": {
+        "class": "String",
+        "value": "Michael Example | Ruby on Rails Tutorial Sample App",
+        "object_id": 163320
+      }
+    },
+    {
+      "id": 538,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "app_views_layouts__shim_html_erb",
+      "method_id": "render",
+      "path": "app/views/layouts/_shim.html.erb",
+      "static": true,
+      "receiver": {
+        "class": "ActionView::PartialRenderer",
+        "object_id": 163960,
+        "value": "#<ActionView::PartialRenderer:0x00007f33d65faeb8>"
+      }
+    },
+    {
+      "id": 539,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionView::Resolver",
+      "method_id": "find_all",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionview-7.0.4/lib/action_view/template/resolver.rb",
+      "lineno": 62,
+      "static": false,
+      "parameters": [
+        {
+          "name": "name",
+          "class": "String",
+          "object_id": 163340,
+          "value": "shim",
+          "kind": "req"
+        },
+        {
+          "name": "prefix",
+          "class": "String",
+          "object_id": 163360,
+          "value": "layouts",
+          "kind": "opt"
+        },
+        {
+          "name": "partial",
+          "class": "TrueClass",
+          "object_id": 20,
+          "value": "true",
+          "kind": "opt"
+        },
+        {
+          "name": "details",
+          "class": "Hash",
+          "object_id": 160160,
+          "value": "{:locale=>[:en], :formats=>[:html], :variants=>[], :handlers=>[:raw, :erb, :html, :builder, :ruby, :jbuilder]}",
+          "kind": "opt",
+          "size": 4
+        },
+        {
+          "name": "key",
+          "class": "ActionView::TemplateDetails::Requested",
+          "object_id": 46160,
+          "value": "#<ActionView::TemplateDetails::Requested:0x00007f33df4904c0>",
+          "kind": "opt"
+        },
+        {
+          "name": "locals",
+          "class": "Array",
+          "object_id": 163380,
+          "value": "[]",
+          "kind": "opt",
+          "size": 0
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::FileSystemResolver",
+        "object_id": 46200,
+        "value": "/home/runner/work/rails_tutorial_sample_app_7th_ed/rails_tutorial_sample_app_7th_ed/app/views"
+      }
+    },
+    {
+      "id": 540,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 539,
+      "elapsed": 0.000017400999979599874,
+      "elapsed_instrumentation": 0.00029651899998839326,
+      "return_value": {
+        "class": "Array",
+        "value": "[#<ActionView::Template:0x00007f33dcacbf68>]",
+        "object_id": 163400,
+        "size": 1
+      }
+    },
+    {
+      "id": 541,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "Logger::LogDevice",
+      "method_id": "write",
+      "path": "/opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/3.1.0/logger/log_device.rb",
+      "lineno": 31,
+      "static": false,
+      "parameters": [
+        {
+          "name": "message",
+          "class": "String",
+          "object_id": 163420,
+          "value": "  Rendered layouts/_shim.html.erb (Duration: 0.0ms | Allocations: 15)\n",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "Logger::LogDevice",
+        "object_id": 9000,
+        "value": "#<Logger::LogDevice:0x00007f33dec8c058>"
+      }
+    },
+    {
+      "id": 542,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 541,
+      "elapsed": 0.0000186020000114695,
+      "elapsed_instrumentation": 0.0000767039999800545,
+      "return_value": {
+        "class": "Integer",
+        "value": "70",
+        "object_id": 141
+      }
+    },
+    {
+      "id": 543,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 538,
+      "elapsed": 0.0005487360000131503,
+      "elapsed_instrumentation": 0.000038702000011880955
+    },
+    {
+      "id": 544,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "app_views_layouts__header_html_erb",
+      "method_id": "render",
+      "path": "app/views/layouts/_header.html.erb",
+      "static": true,
+      "receiver": {
+        "class": "ActionView::PartialRenderer",
+        "object_id": 163980,
+        "value": "#<ActionView::PartialRenderer:0x00007f33d65fe810>"
+      }
+    },
+    {
+      "id": 545,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionView::Resolver",
+      "method_id": "find_all",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionview-7.0.4/lib/action_view/template/resolver.rb",
+      "lineno": 62,
+      "static": false,
+      "parameters": [
+        {
+          "name": "name",
+          "class": "String",
+          "object_id": 163440,
+          "value": "header",
+          "kind": "req"
+        },
+        {
+          "name": "prefix",
+          "class": "String",
+          "object_id": 163460,
+          "value": "layouts",
+          "kind": "opt"
+        },
+        {
+          "name": "partial",
+          "class": "TrueClass",
+          "object_id": 20,
+          "value": "true",
+          "kind": "opt"
+        },
+        {
+          "name": "details",
+          "class": "Hash",
+          "object_id": 160160,
+          "value": "{:locale=>[:en], :formats=>[:html], :variants=>[], :handlers=>[:raw, :erb, :html, :builder, :ruby, :jbuilder]}",
+          "kind": "opt",
+          "size": 4
+        },
+        {
+          "name": "key",
+          "class": "ActionView::TemplateDetails::Requested",
+          "object_id": 46160,
+          "value": "#<ActionView::TemplateDetails::Requested:0x00007f33df4904c0>",
+          "kind": "opt"
+        },
+        {
+          "name": "locals",
+          "class": "Array",
+          "object_id": 163480,
+          "value": "[]",
+          "kind": "opt",
+          "size": 0
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::FileSystemResolver",
+        "object_id": 46200,
+        "value": "/home/runner/work/rails_tutorial_sample_app_7th_ed/rails_tutorial_sample_app_7th_ed/app/views"
+      }
+    },
+    {
+      "id": 546,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 545,
+      "elapsed": 0.000013500999983762085,
+      "elapsed_instrumentation": 0.00022621500002628636,
+      "return_value": {
+        "class": "Array",
+        "value": "[#<ActionView::Template:0x00007f33dcacd520>]",
+        "object_id": 163500,
+        "size": 1
+      }
+    },
+    {
+      "id": 547,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "SessionsHelper",
+      "method_id": "logged_in?",
+      "path": "app/helpers/sessions_helper.rb",
+      "lineno": 42,
+      "static": false,
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 548,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "SessionsHelper",
+      "method_id": "current_user",
+      "path": "app/helpers/sessions_helper.rb",
+      "lineno": 19,
+      "static": false,
+      "receiver": {
+        "class": "ActionView::Base",
+        "object_id": 160440,
+        "value": "#<#<Class:0x00007f33dcc4bcd0>:0x00007f33d6799918>"
+      }
+    },
+    {
+      "id": 549,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionDispatch::Request::Session",
+      "method_id": "[]",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/request/session.rb",
+      "lineno": 110,
+      "static": false,
+      "parameters": [
+        {
+          "name": "key",
+          "class": "Symbol",
+          "object_id": 3107868,
+          "value": ":user_id",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionDispatch::Request::Session",
+        "object_id": 160620,
+        "value": "#<ActionDispatch::Request::Session:0x00007f33d6789e00>"
+      }
+    },
+    {
+      "id": 550,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 549,
+      "elapsed": 0.00000930000001631015,
+      "elapsed_instrumentation": 0.000038303999986055715
+    },
+    {
+      "id": 551,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionDispatch::Cookies::CookieJar",
+      "method_id": "[]",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/middleware/cookies.rb",
+      "lineno": 336,
+      "static": false,
+      "parameters": [
+        {
+          "name": "name",
+          "class": "String",
+          "object_id": 163520,
+          "value": "user_id",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionDispatch::Cookies::CookieJar",
+        "object_id": 160660,
+        "value": "#<ActionDispatch::Cookies::CookieJar:0x00007f33d675ed68>"
+      }
+    },
+    {
+      "id": 552,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 551,
+      "elapsed": 0.0000018000000068241206,
+      "elapsed_instrumentation": 0.00003910300000597999
+    },
+    {
+      "id": 553,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 548,
+      "elapsed": 0.00011150700001394398,
+      "elapsed_instrumentation": 0.000031202000002394925
+    },
+    {
+      "id": 554,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 547,
+      "elapsed": 0.0001522089999923537,
+      "elapsed_instrumentation": 0.00004470300001457872
+    },
+    {
+      "id": 555,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "Logger::LogDevice",
+      "method_id": "write",
+      "path": "/opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/3.1.0/logger/log_device.rb",
+      "lineno": 31,
+      "static": false,
+      "parameters": [
+        {
+          "name": "message",
+          "class": "String",
+          "object_id": 163540,
+          "value": "  Rendered layouts/_header.html.erb (Duration: 0.4ms | Allocations: 422)\n",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "Logger::LogDevice",
+        "object_id": 9000,
+        "value": "#<Logger::LogDevice:0x00007f33dec8c058>"
+      }
+    },
+    {
+      "id": 556,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 555,
+      "elapsed": 0.00001820200000679506,
+      "elapsed_instrumentation": 0.00006900299999301751,
+      "return_value": {
+        "class": "Integer",
+        "value": "73",
+        "object_id": 147
+      }
+    },
+    {
+      "id": 557,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 544,
+      "elapsed": 0.0008442549999756466,
+      "elapsed_instrumentation": 0.000021001000021669824
+    },
+    {
+      "id": 558,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionDispatch::Request::Session",
+      "method_id": "[]",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/request/session.rb",
+      "lineno": 110,
+      "static": false,
+      "parameters": [
+        {
+          "name": "key",
+          "class": "String",
+          "object_id": 85200,
+          "value": "flash",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActionDispatch::Request::Session",
+        "object_id": 160620,
+        "value": "#<ActionDispatch::Request::Session:0x00007f33d6789e00>"
+      }
+    },
+    {
+      "id": 559,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 558,
+      "elapsed": 0.000007699999997612395,
+      "elapsed_instrumentation": 0.00003990299998690716
+    },
+    {
+      "id": 560,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "app_views_layouts__footer_html_erb",
+      "method_id": "render",
+      "path": "app/views/layouts/_footer.html.erb",
+      "static": true,
+      "receiver": {
+        "class": "ActionView::PartialRenderer",
+        "object_id": 164000,
+        "value": "#<ActionView::PartialRenderer:0x00007f33d6604ff8>"
+      }
+    },
+    {
+      "id": 561,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActionView::Resolver",
+      "method_id": "find_all",
+      "path": "vendor/bundle/ruby/3.1.0/gems/actionview-7.0.4/lib/action_view/template/resolver.rb",
+      "lineno": 62,
+      "static": false,
+      "parameters": [
+        {
+          "name": "name",
+          "class": "String",
+          "object_id": 163560,
+          "value": "footer",
+          "kind": "req"
+        },
+        {
+          "name": "prefix",
+          "class": "String",
+          "object_id": 163580,
+          "value": "layouts",
+          "kind": "opt"
+        },
+        {
+          "name": "partial",
+          "class": "TrueClass",
+          "object_id": 20,
+          "value": "true",
+          "kind": "opt"
+        },
+        {
+          "name": "details",
+          "class": "Hash",
+          "object_id": 160160,
+          "value": "{:locale=>[:en], :formats=>[:html], :variants=>[], :handlers=>[:raw, :erb, :html, :builder, :ruby, :jbuilder]}",
+          "kind": "opt",
+          "size": 4
+        },
+        {
+          "name": "key",
+          "class": "ActionView::TemplateDetails::Requested",
+          "object_id": 46160,
+          "value": "#<ActionView::TemplateDetails::Requested:0x00007f33df4904c0>",
+          "kind": "opt"
+        },
+        {
+          "name": "locals",
+          "class": "Array",
+          "object_id": 163600,
+          "value": "[]",
+          "kind": "opt",
+          "size": 0
+        }
+      ],
+      "receiver": {
+        "class": "ActionView::FileSystemResolver",
+        "object_id": 46200,
+        "value": "/home/runner/work/rails_tutorial_sample_app_7th_ed/rails_tutorial_sample_app_7th_ed/app/views"
+      }
+    },
+    {
+      "id": 562,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 561,
+      "elapsed": 0.000011499999999387,
+      "elapsed_instrumentation": 0.0003527240000380516,
+      "return_value": {
+        "class": "Array",
+        "value": "[#<ActionView::Template:0x00007f33df304ea8>]",
+        "object_id": 163620,
+        "size": 1
+      }
+    },
+    {
+      "id": 563,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "Logger::LogDevice",
+      "method_id": "write",
+      "path": "/opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/3.1.0/logger/log_device.rb",
+      "lineno": 31,
+      "static": false,
+      "parameters": [
+        {
+          "name": "message",
+          "class": "String",
+          "object_id": 163640,
+          "value": "  Rendered layouts/_footer.html.erb (Duration: 0.2ms | Allocations: 69)\n",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "Logger::LogDevice",
+        "object_id": 9000,
+        "value": "#<Logger::LogDevice:0x00007f33dec8c058>"
+      }
+    },
+    {
+      "id": 564,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 563,
+      "elapsed": 0.000018500999999560008,
+      "elapsed_instrumentation": 0.00007520500000168795,
+      "return_value": {
+        "class": "Integer",
+        "value": "72",
+        "object_id": 145
+      }
+    },
+    {
+      "id": 565,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 560,
+      "elapsed": 0.0006908450000082667,
+      "elapsed_instrumentation": 0.00002160099998604892
+    },
+    {
+      "id": 566,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "Logger::LogDevice",
+      "method_id": "write",
+      "path": "/opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/3.1.0/logger/log_device.rb",
+      "lineno": 31,
+      "static": false,
+      "parameters": [
+        {
+          "name": "message",
+          "class": "String",
+          "object_id": 163660,
+          "value": "  Rendered layout layouts/application.html.erb (Duration: 98.7ms | Allocations: 40888)\n",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "Logger::LogDevice",
+        "object_id": 9000,
+        "value": "#<Logger::LogDevice:0x00007f33dec8c058>"
+      }
+    },
+    {
+      "id": 567,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 566,
+      "elapsed": 0.000011001000018495688,
+      "elapsed_instrumentation": 0.00005030299999475574,
+      "return_value": {
+        "class": "Integer",
+        "value": "87",
+        "object_id": 175
+      }
+    },
+    {
+      "id": 568,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 51,
+      "elapsed": 0.10010930799998619,
+      "elapsed_instrumentation": 0.000024600999978474647
+    },
+    {
+      "id": 569,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 50,
+      "elapsed": 0.10023971600000436,
+      "elapsed_instrumentation": 0.0001735110000140594,
+      "return_value": {
+        "class": "ActionView::OutputBuffer",
+        "value": "<!DOCTYPE html>\n<html>\n  <head>\n    <title>Michael Example | Ruby on Rails Tutorial Sample App</titl (...16962 more characters)",
+        "object_id": 163680
+      }
+    },
+    {
+      "id": 570,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActiveSupport::Callbacks::CallbackSequence",
+      "method_id": "invoke_after",
+      "path": "vendor/bundle/ruby/3.1.0/gems/activesupport-7.0.4/lib/active_support/callbacks.rb",
+      "lineno": 598,
+      "static": false,
+      "parameters": [
+        {
+          "name": "arg",
+          "class": "ActiveSupport::Callbacks::Filters::Environment",
+          "object_id": 160000,
+          "value": null,
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActiveSupport::Callbacks::CallbackSequence",
+        "object_id": 99340,
+        "value": "#<ActiveSupport::Callbacks::CallbackSequence:0x00007f33dc453d20>"
+      }
+    },
+    {
+      "id": 571,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 570,
+      "elapsed": 0.000002500000022109816,
+      "elapsed_instrumentation": 0.000052903999971931626,
+      "return_value": {
+        "class": "Array",
+        "value": "[]",
+        "object_id": 101600,
+        "size": 0
+      }
+    },
+    {
+      "id": 572,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActiveSupport::Callbacks::CallbackSequence",
+      "method_id": "invoke_after",
+      "path": "vendor/bundle/ruby/3.1.0/gems/activesupport-7.0.4/lib/active_support/callbacks.rb",
+      "lineno": 598,
+      "static": false,
+      "parameters": [
+        {
+          "name": "arg",
+          "class": "ActiveSupport::Callbacks::Filters::Environment",
+          "object_id": 160000,
+          "value": null,
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActiveSupport::Callbacks::CallbackSequence",
+        "object_id": 99300,
+        "value": "#<ActiveSupport::Callbacks::CallbackSequence:0x00007f33dc4531e0>"
+      }
+    },
+    {
+      "id": 573,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 572,
+      "elapsed": 0.000016000999977450192,
+      "elapsed_instrumentation": 0.000052403000012191114,
+      "return_value": {
+        "class": "Array",
+        "value": "[#<Proc:0x00007f33dc453000 /home/runner/work/rails_tutorial_sample_app_7th_ed/rails_tutorial_sample_a]",
+        "object_id": 101620,
+        "size": 1
+      }
+    },
+    {
+      "id": 574,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "Logger::LogDevice",
+      "method_id": "write",
+      "path": "/opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/3.1.0/logger/log_device.rb",
+      "lineno": 31,
+      "static": false,
+      "parameters": [
+        {
+          "name": "message",
+          "class": "String",
+          "object_id": 163700,
+          "value": "Completed 200 OK in 103ms (Views: 98.1ms | ActiveRecord: 2.5ms | Allocations: 43949)\n",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "Logger::LogDevice",
+        "object_id": 9000,
+        "value": "#<Logger::LogDevice:0x00007f33dec8c058>"
+      }
+    },
+    {
+      "id": 575,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 574,
+      "elapsed": 0.00001460100000372222,
+      "elapsed_instrumentation": 0.000053703999981280504,
+      "return_value": {
+        "class": "Integer",
+        "value": "85",
+        "object_id": 171
+      }
+    },
+    {
+      "id": 576,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 25,
+      "elapsed": 0.10447039199999608,
+      "elapsed_instrumentation": 0.0003116199999908531,
+      "http_server_response": {
+        "status_code": 200,
+        "headers": {
+          "X-Frame-Options": "SAMEORIGIN",
+          "X-XSS-Protection": "0",
+          "X-Content-Type-Options": "nosniff",
+          "X-Download-Options": "noopen",
+          "X-Permitted-Cross-Domain-Policies": "none",
+          "Referrer-Policy": "strict-origin-when-cross-origin",
+          "Link": "</assets/application-cdc3bed7911b8306994a416a4c2682e340e553fd434035cdc35c53e1200df70a.css>; rel=preload; as=style; nopush,</assets/es-module-shims.min-606ae9c3279013fe751cee30f719a592f759e705edb66496812f3d9dbce3d850.js>; rel=preload; as=script; nopush",
+          "Content-Type": "text/html; charset=utf-8",
+          "ETag": "W/\"1d662db5e13276ef330271e0bbee0f10\"",
+          "Cache-Control": "max-age=0, private, must-revalidate",
+          "X-Request-Id": "7cef44e8-fac0-4622-ae82-4b9c57a4291e",
+          "X-Runtime": "0.104122"
+        }
+      }
+    },
+    {
+      "id": 577,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActiveSupport::Callbacks::CallbackSequence",
+      "method_id": "invoke_before",
+      "path": "vendor/bundle/ruby/3.1.0/gems/activesupport-7.0.4/lib/active_support/callbacks.rb",
+      "lineno": 594,
+      "static": false,
+      "parameters": [
+        {
+          "name": "arg",
+          "class": "ActiveSupport::Callbacks::Filters::Environment",
+          "object_id": 163740,
+          "value": null,
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActiveSupport::Callbacks::CallbackSequence",
+        "object_id": 45160,
+        "value": "#<ActiveSupport::Callbacks::CallbackSequence:0x00007f33dd29e290>"
+      }
+    },
+    {
+      "id": 578,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 577,
+      "elapsed": 0.000056803000006766524,
+      "elapsed_instrumentation": 0.00010100599999418591,
+      "return_value": {
+        "class": "Array",
+        "value": "[#<Proc:0x00007f33dd29dbb0 /home/runner/work/rails_tutorial_sample_app_7th_ed/rails_tutorial_sample_a, #<Proc:0x00007f33dd29dcf0 /home/runner/work/rails_tutorial_sample_app_7th_ed/rails_tutorial_sample_a, #<Proc:0x00007f33dd29de30 /home/runner/work/rails_tutorial_sample_app_7th_ed/rails_tutorial_sample_a, #<Proc:0x00007f33dd29dfe8 /home/runner/work/rails_tutorial_sample_app_7th_ed/rails_tutorial_sample_a]",
+        "object_id": 45180,
+        "size": 4
+      }
+    },
+    {
+      "id": 579,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActiveSupport::Callbacks::CallbackSequence",
+      "method_id": "invoke_after",
+      "path": "vendor/bundle/ruby/3.1.0/gems/activesupport-7.0.4/lib/active_support/callbacks.rb",
+      "lineno": 598,
+      "static": false,
+      "parameters": [
+        {
+          "name": "arg",
+          "class": "ActiveSupport::Callbacks::Filters::Environment",
+          "object_id": 163740,
+          "value": null,
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActiveSupport::Callbacks::CallbackSequence",
+        "object_id": 45160,
+        "value": "#<ActiveSupport::Callbacks::CallbackSequence:0x00007f33dd29e290>"
+      }
+    },
+    {
+      "id": 580,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 579,
+      "elapsed": 0.0000015999999902760464,
+      "elapsed_instrumentation": 0.00004260200003614045,
+      "return_value": {
+        "class": "Array",
+        "value": "[]",
+        "object_id": 45200,
+        "size": 0
+      }
+    },
+    {
+      "id": 581,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ApplicationHelper",
+      "method_id": "full_title",
+      "path": "app/helpers/application_helper.rb",
+      "lineno": 4,
+      "static": false,
+      "parameters": [
+        {
+          "name": "page_title",
+          "class": "String",
+          "object_id": 163780,
+          "value": "Michael Example",
+          "kind": "opt"
+        }
+      ],
+      "receiver": {
+        "class": "UsersProfileTest",
+        "object_id": 159680,
+        "value": "#<UsersProfileTest:0x00007f33d67a1050>"
+      }
+    },
+    {
+      "id": 582,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 581,
+      "elapsed": 0.000004300000000512227,
+      "elapsed_instrumentation": 0.00006240500002263616,
+      "return_value": {
+        "class": "String",
+        "value": "Michael Example | Ruby on Rails Tutorial Sample App",
+        "object_id": 163800
+      }
+    },
+    {
+      "id": 583,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "Logger::LogDevice",
+      "method_id": "write",
+      "path": "/opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/3.1.0/logger/log_device.rb",
+      "lineno": 31,
+      "static": false,
+      "parameters": [
+        {
+          "name": "message",
+          "class": "String",
+          "object_id": 163820,
+          "value": "  \u001b[1m\u001b[36mCACHE Micropost Count (0.0ms)\u001b[0m  \u001b[1m\u001b[34mSELECT COUNT(*) FROM \"microposts\" WHERE \"micr (...52 more characters)",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "Logger::LogDevice",
+        "object_id": 9000,
+        "value": "#<Logger::LogDevice:0x00007f33dec8c058>"
+      }
+    },
+    {
+      "id": 584,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 583,
+      "elapsed": 0.000019701000013583325,
+      "elapsed_instrumentation": 0.00008840600000326049,
+      "return_value": {
+        "class": "Integer",
+        "value": "152",
+        "object_id": 305
+      }
+    },
+    {
+      "id": 585,
+      "event": "call",
+      "thread_id": 4480,
+      "sql_query": {
+        "sql": "SELECT COUNT(*) FROM \"microposts\" WHERE \"microposts\".\"user_id\" = ?",
+        "database_type": "sqlite"
+      }
+    },
+    {
+      "id": 586,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 585,
+      "elapsed": 0.000183612,
+      "elapsed_instrumentation": 0.00003530300000420539
+    },
+    {
+      "id": 587,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "Logger::LogDevice",
+      "method_id": "write",
+      "path": "/opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/3.1.0/logger/log_device.rb",
+      "lineno": 31,
+      "static": false,
+      "parameters": [
+        {
+          "name": "message",
+          "class": "String",
+          "object_id": 163840,
+          "value": "  \u001b[1m\u001b[36mCACHE Micropost Load (0.0ms)\u001b[0m  \u001b[1m\u001b[34mSELECT \"microposts\".* FROM \"microposts\" WHERE  (...144 more characters)",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "Logger::LogDevice",
+        "object_id": 9000,
+        "value": "#<Logger::LogDevice:0x00007f33dec8c058>"
+      }
+    },
+    {
+      "id": 588,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 587,
+      "elapsed": 0.000019600999991098433,
+      "elapsed_instrumentation": 0.00007840500001066175,
+      "return_value": {
+        "class": "Integer",
+        "value": "244",
+        "object_id": 489
+      }
+    },
+    {
+      "id": 589,
+      "event": "call",
+      "thread_id": 4480,
+      "sql_query": {
+        "sql": "SELECT \"microposts\".* FROM \"microposts\" WHERE \"microposts\".\"user_id\" = ? ORDER BY \"microposts\".\"created_at\" DESC LIMIT ? OFFSET ?",
+        "database_type": "sqlite"
+      }
+    },
+    {
+      "id": 590,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 589,
+      "elapsed": 0.000191713,
+      "elapsed_instrumentation": 0.00003480199998762146
+    },
+    {
+      "id": 591,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActiveSupport::Callbacks::CallbackSequence",
+      "method_id": "invoke_before",
+      "path": "vendor/bundle/ruby/3.1.0/gems/activesupport-7.0.4/lib/active_support/callbacks.rb",
+      "lineno": 594,
+      "static": false,
+      "parameters": [
+        {
+          "name": "arg",
+          "class": "ActiveSupport::Callbacks::Filters::Environment",
+          "object_id": 163860,
+          "value": null,
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActiveSupport::Callbacks::CallbackSequence",
+        "object_id": 102180,
+        "value": "#<ActiveSupport::Callbacks::CallbackSequence:0x00007f33dcae49c8>"
+      }
+    },
+    {
+      "id": 592,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 591,
+      "elapsed": 0.0000018000000068241206,
+      "elapsed_instrumentation": 0.000053702000002431305,
+      "return_value": {
+        "class": "Array",
+        "value": "[]",
+        "object_id": 102200,
+        "size": 0
+      }
+    },
+    {
+      "id": 593,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActiveSupport::Callbacks::CallbackSequence",
+      "method_id": "invoke_after",
+      "path": "vendor/bundle/ruby/3.1.0/gems/activesupport-7.0.4/lib/active_support/callbacks.rb",
+      "lineno": 598,
+      "static": false,
+      "parameters": [
+        {
+          "name": "arg",
+          "class": "ActiveSupport::Callbacks::Filters::Environment",
+          "object_id": 163860,
+          "value": null,
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActiveSupport::Callbacks::CallbackSequence",
+        "object_id": 102180,
+        "value": "#<ActiveSupport::Callbacks::CallbackSequence:0x00007f33dcae49c8>"
+      }
+    },
+    {
+      "id": 594,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 593,
+      "elapsed": 0.000025101999995058577,
+      "elapsed_instrumentation": 0.00008620500000233733,
+      "return_value": {
+        "class": "Array",
+        "value": "[#<Proc:0x00007f33dcae4720 /home/runner/work/rails_tutorial_sample_app_7th_ed/rails_tutorial_sample_a, #<Proc:0x00007f33dcae45e0 /home/runner/work/rails_tutorial_sample_app_7th_ed/rails_tutorial_sample_a]",
+        "object_id": 102220,
+        "size": 2
+      }
+    },
+    {
+      "id": 595,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "Logger::LogDevice",
+      "method_id": "write",
+      "path": "/opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/3.1.0/logger/log_device.rb",
+      "lineno": 31,
+      "static": false,
+      "parameters": [
+        {
+          "name": "message",
+          "class": "String",
+          "object_id": 163880,
+          "value": "  \u001b[1m\u001b[36mTRANSACTION (0.1ms)\u001b[0m  \u001b[1m\u001b[31mrollback transaction\u001b[0m\n",
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "Logger::LogDevice",
+        "object_id": 9000,
+        "value": "#<Logger::LogDevice:0x00007f33dec8c058>"
+      }
+    },
+    {
+      "id": 596,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 595,
+      "elapsed": 0.00001950099999703525,
+      "elapsed_instrumentation": 0.0000697049999871524,
+      "return_value": {
+        "class": "Integer",
+        "value": "70",
+        "object_id": 141
+      }
+    },
+    {
+      "id": 597,
+      "event": "call",
+      "thread_id": 4480,
+      "sql_query": {
+        "sql": "rollback transaction",
+        "database_type": "sqlite"
+      }
+    },
+    {
+      "id": 598,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 597,
+      "elapsed": 0.000218214,
+      "elapsed_instrumentation": 0.000036502000000382395
+    },
+    {
+      "id": 599,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActiveSupport::Callbacks::CallbackSequence",
+      "method_id": "invoke_before",
+      "path": "vendor/bundle/ruby/3.1.0/gems/activesupport-7.0.4/lib/active_support/callbacks.rb",
+      "lineno": 594,
+      "static": false,
+      "parameters": [
+        {
+          "name": "arg",
+          "class": "ActiveSupport::Callbacks::Filters::Environment",
+          "object_id": 163900,
+          "value": null,
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActiveSupport::Callbacks::CallbackSequence",
+        "object_id": 102280,
+        "value": "#<ActiveSupport::Callbacks::CallbackSequence:0x00007f33ddcbf9e0>"
+      }
+    },
+    {
+      "id": 600,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 599,
+      "elapsed": 0.000001900000000887303,
+      "elapsed_instrumentation": 0.00005480400000124064,
+      "return_value": {
+        "class": "Array",
+        "value": "[]",
+        "object_id": 102300,
+        "size": 0
+      }
+    },
+    {
+      "id": 601,
+      "event": "call",
+      "thread_id": 4480,
+      "defined_class": "ActiveSupport::Callbacks::CallbackSequence",
+      "method_id": "invoke_after",
+      "path": "vendor/bundle/ruby/3.1.0/gems/activesupport-7.0.4/lib/active_support/callbacks.rb",
+      "lineno": 598,
+      "static": false,
+      "parameters": [
+        {
+          "name": "arg",
+          "class": "ActiveSupport::Callbacks::Filters::Environment",
+          "object_id": 163900,
+          "value": null,
+          "kind": "req"
+        }
+      ],
+      "receiver": {
+        "class": "ActiveSupport::Callbacks::CallbackSequence",
+        "object_id": 102280,
+        "value": "#<ActiveSupport::Callbacks::CallbackSequence:0x00007f33ddcbf9e0>"
+      }
+    },
+    {
+      "id": 602,
+      "event": "return",
+      "thread_id": 4480,
+      "parent_id": 601,
+      "elapsed": 0.000011499999999387,
+      "elapsed_instrumentation": 0.00006180500000141365,
+      "return_value": {
+        "class": "Array",
+        "value": "[#<Proc:0x00007f33ddcbf7d8 /home/runner/work/rails_tutorial_sample_app_7th_ed/rails_tutorial_sample_a, #<Proc:0x00007f33ddcbf698 /home/runner/work/rails_tutorial_sample_app_7th_ed/rails_tutorial_sample_a]",
+        "object_id": 102320,
+        "size": 2
+      }
+    }
+  ],
+  "version": "1.12.0",
+  "metadata": {
+    "app": "rails_tutorial_sample_app_7th_ed",
+    "language": {
+      "name": "ruby",
+      "engine": "ruby",
+      "version": "3.1.2"
+    },
+    "client": {
+      "name": "appmap",
+      "url": "https://github.com/applandinc/appmap-ruby",
+      "version": "0.99.4"
+    },
+    "frameworks": [
+      {
+        "name": "rails",
+        "version": "7.0.4"
+      },
+      {
+        "name": "minitest",
+        "version": "5.15.0"
+      }
+    ],
+    "git": {
+      "repository": "https://github.com/land-of-apps/rails_tutorial_sample_app_7th_ed",
+      "branch": "HEAD",
+      "commit": "1964c0659be3d44359d8136d492c5c28a20fbbab",
+      "status": [
+        "M .gitignore"
+      ],
+      "git_last_annotated_tag": null,
+      "git_last_tag": null,
+      "git_commits_since_last_annotated_tag": null,
+      "git_commits_since_last_tag": null
+    },
+    "name": "Users_profile profile display",
+    "source_location": "test/integration/users_profile_test.rb:10",
+    "recorder": {
+      "name": "minitest",
+      "type": "tests"
+    },
+    "test_status": "succeeded"
+  },
+  "classMap": [
+    {
+      "name": "actionpack",
+      "type": "package",
+      "children": [
+        {
+          "name": "ActionDispatch",
+          "type": "class",
+          "children": [
+            {
+              "name": "Integration",
+              "type": "class",
+              "children": [
+                {
+                  "name": "Runner",
+                  "type": "class",
+                  "children": [
+                    {
+                      "name": "before_setup",
+                      "type": "function",
+                      "labels": [
+                        "deserialize.safe",
+                        "lang.eval.safe"
+                      ],
+                      "static": false,
+                      "location": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/testing/integration.rb:329"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "Request",
+              "type": "class",
+              "children": [
+                {
+                  "name": "Session",
+                  "type": "class",
+                  "children": [
+                    {
+                      "name": "[]",
+                      "type": "function",
+                      "labels": [
+                        "http.session.read"
+                      ],
+                      "static": false,
+                      "location": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/request/session.rb:110"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "Cookies",
+              "type": "class",
+              "children": [
+                {
+                  "name": "CookieJar",
+                  "type": "class",
+                  "children": [
+                    {
+                      "name": "update",
+                      "type": "function",
+                      "labels": [
+                        "http.session.write"
+                      ],
+                      "static": false,
+                      "location": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/middleware/cookies.rb:352"
+                    },
+                    {
+                      "name": "[]",
+                      "type": "function",
+                      "labels": [
+                        "http.session.read"
+                      ],
+                      "static": false,
+                      "location": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/middleware/cookies.rb:336"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "ActionController",
+          "type": "class",
+          "children": [
+            {
+              "name": "Renderers",
+              "type": "class",
+              "children": [
+                {
+                  "name": "render_to_body",
+                  "type": "function",
+                  "labels": [
+                    "mvc.render"
+                  ],
+                  "static": false,
+                  "location": "vendor/bundle/ruby/3.1.0/gems/actionpack-7.0.4/lib/action_controller/metal/renderers.rb:140"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "activesupport",
+      "type": "package",
+      "children": [
+        {
+          "name": "ActiveSupport",
+          "type": "class",
+          "children": [
+            {
+              "name": "Callbacks",
+              "type": "class",
+              "children": [
+                {
+                  "name": "CallbackSequence",
+                  "type": "class",
+                  "children": [
+                    {
+                      "name": "invoke_before",
+                      "type": "function",
+                      "labels": [
+                        "mvc.before_action"
+                      ],
+                      "static": false,
+                      "location": "vendor/bundle/ruby/3.1.0/gems/activesupport-7.0.4/lib/active_support/callbacks.rb:594"
+                    },
+                    {
+                      "name": "invoke_after",
+                      "type": "function",
+                      "labels": [
+                        "mvc.after_action"
+                      ],
+                      "static": false,
+                      "location": "vendor/bundle/ruby/3.1.0/gems/activesupport-7.0.4/lib/active_support/callbacks.rb:598"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "logger",
+      "type": "package",
+      "children": [
+        {
+          "name": "Logger",
+          "type": "class",
+          "children": [
+            {
+              "name": "LogDevice",
+              "type": "class",
+              "children": [
+                {
+                  "name": "write",
+                  "type": "function",
+                  "labels": [
+                    "log"
+                  ],
+                  "static": false,
+                  "location": "/opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/3.1.0/logger/log_device.rb:31"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "ruby",
+      "type": "package",
+      "children": [
+        {
+          "name": "String",
+          "type": "class",
+          "children": [
+            {
+              "name": "unpack",
+              "type": "function",
+              "labels": [
+                "string.unpack"
+              ],
+              "static": false,
+              "location": "<internal:pack>:275"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "app",
+      "type": "package",
+      "children": [
+        {
+          "name": "controllers",
+          "type": "package",
+          "children": [
+            {
+              "name": "UsersController",
+              "type": "class",
+              "children": [
+                {
+                  "name": "show",
+                  "type": "function",
+                  "static": false,
+                  "location": "app/controllers/users_controller.rb:11"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "views",
+          "type": "package",
+          "children": [
+            {
+              "name": "app_views_users_show_html_erb",
+              "type": "class",
+              "children": [
+                {
+                  "name": "render",
+                  "type": "function",
+                  "labels": [
+                    "mvc.template"
+                  ],
+                  "static": true,
+                  "location": "app/views/users/show.html.erb"
+                }
+              ]
+            },
+            {
+              "name": "app_views_shared__stats_html_erb",
+              "type": "class",
+              "children": [
+                {
+                  "name": "render",
+                  "type": "function",
+                  "labels": [
+                    "mvc.template"
+                  ],
+                  "static": true,
+                  "location": "app/views/shared/_stats.html.erb"
+                }
+              ]
+            },
+            {
+              "name": "app_views_layouts__shim_html_erb",
+              "type": "class",
+              "children": [
+                {
+                  "name": "render",
+                  "type": "function",
+                  "labels": [
+                    "mvc.template"
+                  ],
+                  "static": true,
+                  "location": "app/views/layouts/_shim.html.erb"
+                }
+              ]
+            },
+            {
+              "name": "app_views_layouts__header_html_erb",
+              "type": "class",
+              "children": [
+                {
+                  "name": "render",
+                  "type": "function",
+                  "labels": [
+                    "mvc.template"
+                  ],
+                  "static": true,
+                  "location": "app/views/layouts/_header.html.erb"
+                }
+              ]
+            },
+            {
+              "name": "app_views_layouts__footer_html_erb",
+              "type": "class",
+              "children": [
+                {
+                  "name": "render",
+                  "type": "function",
+                  "labels": [
+                    "mvc.template"
+                  ],
+                  "static": true,
+                  "location": "app/views/layouts/_footer.html.erb"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "helpers",
+          "type": "package",
+          "children": [
+            {
+              "name": "UsersHelper",
+              "type": "class",
+              "children": [
+                {
+                  "name": "gravatar_for",
+                  "type": "function",
+                  "static": false,
+                  "location": "app/helpers/users_helper.rb:4"
+                }
+              ]
+            },
+            {
+              "name": "SessionsHelper",
+              "type": "class",
+              "children": [
+                {
+                  "name": "logged_in?",
+                  "type": "function",
+                  "static": false,
+                  "location": "app/helpers/sessions_helper.rb:42"
+                },
+                {
+                  "name": "current_user",
+                  "type": "function",
+                  "static": false,
+                  "location": "app/helpers/sessions_helper.rb:19"
+                },
+                {
+                  "name": "current_user?",
+                  "type": "function",
+                  "static": false,
+                  "location": "app/helpers/sessions_helper.rb:37"
+                }
+              ]
+            },
+            {
+              "name": "ApplicationHelper",
+              "type": "class",
+              "children": [
+                {
+                  "name": "full_title",
+                  "type": "function",
+                  "static": false,
+                  "location": "app/helpers/application_helper.rb:4"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "actionview",
+      "type": "package",
+      "children": [
+        {
+          "name": "ActionView",
+          "type": "class",
+          "children": [
+            {
+              "name": "Resolver",
+              "type": "class",
+              "children": [
+                {
+                  "name": "find_all",
+                  "type": "function",
+                  "labels": [
+                    "mvc.template.resolver"
+                  ],
+                  "static": false,
+                  "location": "vendor/bundle/ruby/3.1.0/gems/actionview-7.0.4/lib/action_view/template/resolver.rb:62"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "database",
+      "name": "Database",
+      "children": [
+        {
+          "type": "query",
+          "name": "begin transaction"
+        },
+        {
+          "type": "query",
+          "name": "SELECT \"users\".* FROM \"users\" WHERE \"users\".\"id\" = ? LIMIT ?"
+        },
+        {
+          "type": "query",
+          "name": "SELECT COUNT(*) FROM \"users\" INNER JOIN \"relationships\" ON \"users\".\"id\" = \"relationships\".\"followed_id\" WHERE \"relationships\".\"follower_id\" = ?"
+        },
+        {
+          "type": "query",
+          "name": "SELECT COUNT(*) FROM \"users\" INNER JOIN \"relationships\" ON \"users\".\"id\" = \"relationships\".\"follower_id\" WHERE \"relationships\".\"followed_id\" = ?"
+        },
+        {
+          "type": "query",
+          "name": "SELECT 1 AS one FROM \"microposts\" WHERE \"microposts\".\"user_id\" = ? LIMIT ?"
+        },
+        {
+          "type": "query",
+          "name": "SELECT COUNT(*) FROM \"microposts\" WHERE \"microposts\".\"user_id\" = ?"
+        },
+        {
+          "type": "query",
+          "name": "SELECT \"microposts\".* FROM \"microposts\" WHERE \"microposts\".\"user_id\" = ? ORDER BY \"microposts\".\"created_at\" DESC LIMIT ? OFFSET ?"
+        },
+        {
+          "type": "query",
+          "name": "SELECT \"active_storage_attachments\".* FROM \"active_storage_attachments\" WHERE \"active_storage_attachments\".\"record_id\" = ? AND \"active_storage_attachments\".\"record_type\" = ? AND \"active_storage_attachments\".\"name\" = ? LIMIT ?"
+        },
+        {
+          "type": "query",
+          "name": "rollback transaction"
+        }
+      ]
+    },
+    {
+      "type": "http",
+      "name": "HTTP server requests",
+      "children": [
+        {
+          "type": "route",
+          "name": "GET /users/{id}"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/components/src/stories/data/sequence-diff/Users_profile_profile_display.diff.sequence.json
+++ b/packages/components/src/stories/data/sequence-diff/Users_profile_profile_display.diff.sequence.json
@@ -1,0 +1,650 @@
+{
+  "actors": [
+    {
+      "id": "http:HTTP server requests",
+      "name": "HTTP server requests",
+      "order": 0
+    },
+    {
+      "id": "package:app/controllers",
+      "name": "controllers",
+      "order": 1000
+    },
+    {
+      "id": "package:app/views",
+      "name": "views",
+      "order": 2000
+    },
+    {
+      "id": "package:app/helpers",
+      "name": "helpers",
+      "order": 3000
+    },
+    {
+      "id": "database:Database",
+      "name": "Database",
+      "order": 6000
+    }
+  ],
+  "rootActions": [
+    {
+      "nodeType": 4,
+      "callee": "http:HTTP server requests",
+      "route": "GET /users/{id}",
+      "status": 200,
+      "digest": "f73ae15250f45020dd686aefceee302b9f578947736f9adb11d1abbfbe47217c",
+      "subtreeDigest": "unknown",
+      "children": [
+        {
+          "nodeType": 3,
+          "caller": "http:HTTP server requests",
+          "callee": "package:app/controllers",
+          "name": "show",
+          "static": false,
+          "digest": "74f5604aacab5d82d41a46aa815ab7ab15e58f2f3d0e131a61d97ae8707c781f",
+          "subtreeDigest": "unknown",
+          "stableProperties": {
+            "event_type": "function",
+            "id": "app/controllers/UsersController#show",
+            "raises_exception": false
+          },
+          "returnValue": {
+            "returnValueType": {
+              "name": "ActiveRecord::AssociationRelation"
+            },
+            "raisesException": false
+          },
+          "children": [
+            {
+              "nodeType": 6,
+              "caller": "package:app/controllers",
+              "callee": "database:Database",
+              "query": "SELECT \"users\".* FROM \"users\" WHERE \"users\".\"id\" = ? LIMIT ?",
+              "digest": "d3215148ca0ab75b7a269bcfb8bbf9e50385569eb0fba0fdbcca10da78011030",
+              "subtreeDigest": "unknown",
+              "children": [],
+              "elapsed": 0.000220915,
+              "eventIds": [
+                45
+              ]
+            }
+          ],
+          "elapsed": 0.0010871709999946688,
+          "eventIds": [
+            42
+          ]
+        },
+        {
+          "nodeType": 3,
+          "caller": "http:HTTP server requests",
+          "callee": "package:app/views",
+          "name": "render",
+          "static": true,
+          "digest": "62d98fa0db60cd4288bf76a6204e7b20f61e13862f1e05c769dd86e952245a6c",
+          "subtreeDigest": "unknown",
+          "stableProperties": {
+            "event_type": "function",
+            "id": "app/views/app_views_users_show_html_erb.render",
+            "raises_exception": false
+          },
+          "returnValue": {
+            "returnValueType": {
+              "name": "void"
+            },
+            "raisesException": false
+          },
+          "children": [
+            {
+              "nodeType": 3,
+              "caller": "package:app/views",
+              "callee": "package:app/helpers",
+              "name": "gravatar_for",
+              "static": false,
+              "digest": "5ff1bfc2a21871ef1ea4c8455f3723347e6f7e782e6402f1d6b339cc513a8476",
+              "subtreeDigest": "unknown",
+              "stableProperties": {
+                "event_type": "function",
+                "id": "app/helpers/UsersHelper#gravatar_for",
+                "raises_exception": false
+              },
+              "returnValue": {
+                "returnValueType": {
+                  "name": "ActiveSupport::SafeBuffer"
+                },
+                "raisesException": false
+              },
+              "children": [],
+              "elapsed": 0.00007590500001697364,
+              "eventIds": [
+                66
+              ]
+            },
+            {
+              "nodeType": 3,
+              "caller": "package:app/views",
+              "callee": "package:app/views",
+              "name": "render",
+              "static": true,
+              "digest": "8e18aef5ea89591739f74bd4df0cac0e9ff8f82fff7c8d75bda368f44e2b053c",
+              "subtreeDigest": "unknown",
+              "stableProperties": {
+                "event_type": "function",
+                "id": "app/views/app_views_shared__stats_html_erb.render",
+                "raises_exception": false
+              },
+              "returnValue": {
+                "returnValueType": {
+                  "name": "void"
+                },
+                "raisesException": false
+              },
+              "children": [
+                {
+                  "nodeType": 6,
+                  "caller": "package:app/views",
+                  "callee": "database:Database",
+                  "query": "SELECT COUNT(*) FROM \"users\" INNER JOIN \"relationships\" ON \"users\".\"id\" = \"relationships\".\"followed_id\" WHERE \"relationships\".\"follower_id\" = ?",
+                  "digest": "8a345505b3941e0f4906e48e2d219860fa022aaa4d4a4b788602fe6a0ab6a2af",
+                  "subtreeDigest": "unknown",
+                  "children": [],
+                  "elapsed": 0.000294319,
+                  "eventIds": [
+                    73
+                  ]
+                },
+                {
+                  "nodeType": 6,
+                  "caller": "package:app/views",
+                  "callee": "database:Database",
+                  "query": "SELECT COUNT(*) FROM \"users\" INNER JOIN \"relationships\" ON \"users\".\"id\" = \"relationships\".\"follower_id\" WHERE \"relationships\".\"followed_id\" = ?",
+                  "digest": "0b21465b7b46abb916524effe611b800ea8b5642559d3857bec7e1e319200899",
+                  "subtreeDigest": "unknown",
+                  "children": [],
+                  "elapsed": 0.000292219,
+                  "eventIds": [
+                    77
+                  ]
+                }
+              ],
+              "elapsed": 0.002972492999987253,
+              "eventIds": [
+                68
+              ]
+            },
+            {
+              "nodeType": 3,
+              "caller": "package:app/views",
+              "callee": "package:app/helpers",
+              "name": "logged_in?",
+              "static": false,
+              "digest": "77ba104e4ac11aaffbd62768cc00961bc71badb260963485b9897fbad354a39c",
+              "subtreeDigest": "unknown",
+              "stableProperties": {
+                "event_type": "function",
+                "id": "app/helpers/SessionsHelper#logged_in?",
+                "raises_exception": false
+              },
+              "returnValue": {
+                "returnValueType": {
+                  "name": "void"
+                },
+                "raisesException": false
+              },
+              "children": [
+                {
+                  "nodeType": 3,
+                  "caller": "package:app/helpers",
+                  "callee": "package:app/helpers",
+                  "name": "current_user",
+                  "static": false,
+                  "digest": "f2fde231b0994ff4256ad0e5188d0308c1a6148f09070dc9de9afaa808d8cd73",
+                  "subtreeDigest": "unknown",
+                  "stableProperties": {
+                    "event_type": "function",
+                    "id": "app/helpers/SessionsHelper#current_user",
+                    "raises_exception": false
+                  },
+                  "returnValue": {
+                    "returnValueType": {
+                      "name": "void"
+                    },
+                    "raisesException": false
+                  },
+                  "children": [],
+                  "elapsed": 0.00030431900000849055,
+                  "eventIds": [
+                    83
+                  ]
+                }
+              ],
+              "elapsed": 0.00034142199999109835,
+              "eventIds": [
+                82
+              ]
+            },
+            {
+              "nodeType": 6,
+              "caller": "package:app/views",
+              "callee": "database:Database",
+              "query": "SELECT 1 AS one FROM \"microposts\" WHERE \"microposts\".\"user_id\" = ? LIMIT ?",
+              "digest": "8e7658cc55f04124152ee4729500f556a4c625a9206d9454d43da5754d957f28",
+              "subtreeDigest": "unknown",
+              "children": [],
+              "elapsed": 0.000252917,
+              "eventIds": [
+                96
+              ]
+            },
+            {
+              "nodeType": 6,
+              "caller": "package:app/views",
+              "callee": "database:Database",
+              "query": "SELECT COUNT(*) FROM \"microposts\" WHERE \"microposts\".\"user_id\" = ?",
+              "digest": "e1f3459e5ab185d533ff4a74856412ce48b234520639d2544fdf4efd57b62323",
+              "subtreeDigest": "unknown",
+              "children": [],
+              "elapsed": 0.000279418,
+              "eventIds": [
+                100
+              ]
+            },
+            {
+              "nodeType": 6,
+              "caller": "package:app/views",
+              "callee": "database:Database",
+              "query": "SELECT \"microposts\".* FROM \"microposts\" WHERE \"microposts\".\"user_id\" = ? ORDER BY \"microposts\".\"created_at\" DESC LIMIT ? OFFSET ?",
+              "digest": "19bc023ca792487c0257cd408be3a4ddc9c5d42aa35e4e8d6b2af664e5f91809",
+              "subtreeDigest": "unknown",
+              "children": [],
+              "elapsed": 0.000282719,
+              "eventIds": [
+                104
+              ]
+            },
+            {
+              "nodeType": 6,
+              "caller": "package:app/views",
+              "callee": "database:Database",
+              "query": "SELECT \"active_storage_attachments\".* FROM \"active_storage_attachments\" WHERE \"active_storage_attachments\".\"record_type\" = ? AND \"active_storage_attachments\".\"name\" = ? AND \"active_storage_attachments\".\"record_id\" IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+              "digest": "delete:d031fc0625c610d8b9047d7afc547a644adfe51395d06f73e9d19b413384cf48",
+              "subtreeDigest": "unknown",
+              "children": [],
+              "elapsed": 0.000471202,
+              "eventIds": [
+                108
+              ],
+              "diffMode": 2
+            },
+            {
+              "nodeType": 1,
+              "count": 30,
+              "digest": "loop",
+              "subtreeDigest": "unknown",
+              "children": [
+                {
+                  "nodeType": 3,
+                  "caller": "package:app/views",
+                  "callee": "package:app/helpers",
+                  "name": "gravatar_for",
+                  "static": false,
+                  "digest": "5ff1bfc2a21871ef1ea4c8455f3723347e6f7e782e6402f1d6b339cc513a8476",
+                  "subtreeDigest": "unknown",
+                  "stableProperties": {
+                    "event_type": "function",
+                    "id": "app/helpers/UsersHelper#gravatar_for",
+                    "raises_exception": false
+                  },
+                  "returnValue": {
+                    "returnValueType": {
+                      "name": "ActiveSupport::SafeBuffer"
+                    },
+                    "raisesException": false
+                  },
+                  "children": [],
+                  "elapsed": 0.0015968019999945682,
+                  "eventIds": [
+                    108,
+                    122,
+                    136,
+                    150,
+                    164,
+                    178,
+                    192,
+                    206,
+                    220,
+                    234,
+                    248,
+                    262,
+                    276,
+                    290,
+                    304,
+                    318,
+                    332,
+                    346,
+                    360,
+                    374,
+                    388,
+                    402,
+                    416,
+                    430,
+                    444,
+                    458,
+                    472,
+                    486,
+                    500,
+                    514
+                  ]
+                },
+                {
+                  "nodeType": 6,
+                  "caller": "package:app/views",
+                  "callee": "database:Database",
+                  "query": "SELECT \"active_storage_attachments\".* FROM \"active_storage_attachments\" WHERE \"active_storage_attachments\".\"record_id\" = ? AND \"active_storage_attachments\".\"record_type\" = ? AND \"active_storage_attachments\".\"name\" = ? LIMIT ?",
+                  "digest": "dc0970d40da095c45e53e50c788edd77b994cabdd5ca2826131b3afdfbb64fb9",
+                  "subtreeDigest": "unknown",
+                  "children": [],
+                  "elapsed": 0.007971016999999999,
+                  "eventIds": [
+                    112,
+                    126,
+                    140,
+                    154,
+                    168,
+                    182,
+                    196,
+                    210,
+                    224,
+                    238,
+                    252,
+                    266,
+                    280,
+                    294,
+                    308,
+                    322,
+                    336,
+                    350,
+                    364,
+                    378,
+                    392,
+                    406,
+                    420,
+                    434,
+                    448,
+                    462,
+                    476,
+                    490,
+                    504,
+                    518
+                  ],
+                  "diffMode": 1
+                },
+                {
+                  "nodeType": 3,
+                  "caller": "package:app/views",
+                  "callee": "package:app/helpers",
+                  "name": "current_user?",
+                  "static": false,
+                  "digest": "dbef797d2a0a8556f531d01acd2f8591a9ea6fd301fe70a393db0861e4155175",
+                  "subtreeDigest": "unknown",
+                  "stableProperties": {
+                    "event_type": "function",
+                    "id": "app/helpers/SessionsHelper#current_user?",
+                    "raises_exception": false
+                  },
+                  "returnValue": {
+                    "returnValueType": {
+                      "name": "void"
+                    },
+                    "raisesException": false
+                  },
+                  "children": [
+                    {
+                      "nodeType": 3,
+                      "caller": "package:app/helpers",
+                      "callee": "package:app/helpers",
+                      "name": "current_user",
+                      "static": false,
+                      "digest": "f2fde231b0994ff4256ad0e5188d0308c1a6148f09070dc9de9afaa808d8cd73",
+                      "subtreeDigest": "unknown",
+                      "stableProperties": {
+                        "event_type": "function",
+                        "id": "app/helpers/SessionsHelper#current_user",
+                        "raises_exception": false
+                      },
+                      "returnValue": {
+                        "returnValueType": {
+                          "name": "void"
+                        },
+                        "raisesException": false
+                      },
+                      "children": [],
+                      "elapsed": 0.00853625500010935,
+                      "eventIds": [
+                        115,
+                        129,
+                        143,
+                        157,
+                        171,
+                        185,
+                        199,
+                        213,
+                        227,
+                        241,
+                        255,
+                        269,
+                        283,
+                        297,
+                        311,
+                        325,
+                        339,
+                        353,
+                        367,
+                        381,
+                        395,
+                        409,
+                        423,
+                        437,
+                        451,
+                        465,
+                        479,
+                        493,
+                        507,
+                        521
+                      ]
+                    }
+                  ],
+                  "elapsed": 0.01157365000008781,
+                  "eventIds": [
+                    114,
+                    128,
+                    142,
+                    156,
+                    170,
+                    184,
+                    198,
+                    212,
+                    226,
+                    240,
+                    254,
+                    268,
+                    282,
+                    296,
+                    310,
+                    324,
+                    338,
+                    352,
+                    366,
+                    380,
+                    394,
+                    408,
+                    422,
+                    436,
+                    450,
+                    464,
+                    478,
+                    492,
+                    506,
+                    520
+                  ]
+                }
+              ],
+              "elapsed": 0.021141469000082375,
+              "eventIds": []
+            },
+            {
+              "nodeType": 6,
+              "caller": "package:app/views",
+              "callee": "database:Database",
+              "query": "SELECT COUNT(*) FROM \"microposts\" WHERE \"microposts\".\"user_id\" = ?",
+              "digest": "e1f3459e5ab185d533ff4a74856412ce48b234520639d2544fdf4efd57b62323",
+              "subtreeDigest": "unknown",
+              "children": [],
+              "elapsed": 0.00015681,
+              "eventIds": [
+                532
+              ]
+            },
+            {
+              "nodeType": 3,
+              "caller": "package:app/views",
+              "callee": "package:app/helpers",
+              "name": "full_title",
+              "static": false,
+              "digest": "6428a5b259bbf6313835680ae71302835d39681d81cd69e41c710da42e1d99f7",
+              "subtreeDigest": "unknown",
+              "stableProperties": {
+                "event_type": "function",
+                "id": "app/helpers/ApplicationHelper#full_title",
+                "raises_exception": false
+              },
+              "returnValue": {
+                "returnValueType": {
+                  "name": "string"
+                },
+                "raisesException": false
+              },
+              "children": [],
+              "elapsed": 0.0000038999999958377884,
+              "eventIds": [
+                536
+              ]
+            },
+            {
+              "nodeType": 3,
+              "caller": "package:app/views",
+              "callee": "package:app/views",
+              "name": "render",
+              "static": true,
+              "digest": "8b9ec9f22e5fd30edef15949402dd291692d065f0c826216741d476d3afaa5d9",
+              "subtreeDigest": "unknown",
+              "stableProperties": {
+                "event_type": "function",
+                "id": "app/views/app_views_layouts__shim_html_erb.render",
+                "raises_exception": false
+              },
+              "returnValue": {
+                "returnValueType": {
+                  "name": "void"
+                },
+                "raisesException": false
+              },
+              "children": [],
+              "elapsed": 0.0005487360000131503,
+              "eventIds": [
+                538
+              ]
+            },
+            {
+              "nodeType": 3,
+              "caller": "package:app/views",
+              "callee": "package:app/views",
+              "name": "render",
+              "static": true,
+              "digest": "delete:a067a33c75f6a3a7014f32072c87f4c12afb634a4141d6c1d757b8f345269315",
+              "subtreeDigest": "unknown",
+              "stableProperties": {
+                "event_type": "function",
+                "id": "app/views/app_views_layouts__header_html_erb.render",
+                "raises_exception": false
+              },
+              "returnValue": {
+                "returnValueType": {
+                  "name": "void"
+                },
+                "raisesException": false
+              },
+              "children": [
+                {
+                  "nodeType": 3,
+                  "caller": "package:app/views",
+                  "callee": "package:app/helpers",
+                  "name": "logged_in?",
+                  "static": false,
+                  "digest": "delete:77ba104e4ac11aaffbd62768cc00961bc71badb260963485b9897fbad354a39c",
+                  "subtreeDigest": "unknown",
+                  "stableProperties": {
+                    "event_type": "function",
+                    "id": "app/helpers/SessionsHelper#logged_in?",
+                    "raises_exception": false
+                  },
+                  "returnValue": {
+                    "returnValueType": {
+                      "name": "void"
+                    },
+                    "raisesException": false
+                  },
+                  "children": [
+                    {
+                      "nodeType": 3,
+                      "caller": "package:app/helpers",
+                      "callee": "package:app/helpers",
+                      "name": "current_user",
+                      "static": false,
+                      "digest": "delete:f2fde231b0994ff4256ad0e5188d0308c1a6148f09070dc9de9afaa808d8cd73",
+                      "subtreeDigest": "unknown",
+                      "stableProperties": {
+                        "event_type": "function",
+                        "id": "app/helpers/SessionsHelper#current_user",
+                        "raises_exception": false
+                      },
+                      "returnValue": {
+                        "returnValueType": {
+                          "name": "void"
+                        },
+                        "raisesException": false
+                      },
+                      "children": [],
+                      "elapsed": 0.0001012999999971953,
+                      "eventIds": [
+                        432
+                      ],
+                      "diffMode": 2
+                    }
+                  ],
+                  "elapsed": 0.00013940100001264,
+                  "eventIds": [
+                    431
+                  ],
+                  "diffMode": 2
+                }
+              ],
+              "elapsed": 0.0007040039999992587,
+              "eventIds": [
+                428
+              ],
+              "diffMode": 2
+            }
+          ],
+          "elapsed": 0.10010930799998619,
+          "eventIds": [
+            51
+          ]
+        }
+      ],
+      "elapsed": 0.10447039199999608,
+      "eventIds": [
+        25
+      ]
+    }
+  ]
+}

--- a/packages/components/src/stories/data/sequence/Users_profile_profile_display.diff.sequence.json
+++ b/packages/components/src/stories/data/sequence/Users_profile_profile_display.diff.sequence.json
@@ -1,0 +1,650 @@
+{
+  "actors": [
+    {
+      "id": "http:HTTP server requests",
+      "name": "HTTP server requests",
+      "order": 0
+    },
+    {
+      "id": "package:app/controllers",
+      "name": "controllers",
+      "order": 1000
+    },
+    {
+      "id": "package:app/views",
+      "name": "views",
+      "order": 2000
+    },
+    {
+      "id": "package:app/helpers",
+      "name": "helpers",
+      "order": 3000
+    },
+    {
+      "id": "database:Database",
+      "name": "Database",
+      "order": 6000
+    }
+  ],
+  "rootActions": [
+    {
+      "nodeType": 4,
+      "callee": "http:HTTP server requests",
+      "route": "GET /users/{id}",
+      "status": 200,
+      "digest": "f73ae15250f45020dd686aefceee302b9f578947736f9adb11d1abbfbe47217c",
+      "subtreeDigest": "unknown",
+      "children": [
+        {
+          "nodeType": 3,
+          "caller": "http:HTTP server requests",
+          "callee": "package:app/controllers",
+          "name": "show",
+          "static": false,
+          "digest": "74f5604aacab5d82d41a46aa815ab7ab15e58f2f3d0e131a61d97ae8707c781f",
+          "subtreeDigest": "unknown",
+          "stableProperties": {
+            "event_type": "function",
+            "id": "app/controllers/UsersController#show",
+            "raises_exception": false
+          },
+          "returnValue": {
+            "returnValueType": {
+              "name": "ActiveRecord::AssociationRelation"
+            },
+            "raisesException": false
+          },
+          "children": [
+            {
+              "nodeType": 6,
+              "caller": "package:app/controllers",
+              "callee": "database:Database",
+              "query": "SELECT \"users\".* FROM \"users\" WHERE \"users\".\"id\" = ? LIMIT ?",
+              "digest": "d3215148ca0ab75b7a269bcfb8bbf9e50385569eb0fba0fdbcca10da78011030",
+              "subtreeDigest": "unknown",
+              "children": [],
+              "elapsed": 0.000220915,
+              "eventIds": [
+                45
+              ]
+            }
+          ],
+          "elapsed": 0.0010871709999946688,
+          "eventIds": [
+            42
+          ]
+        },
+        {
+          "nodeType": 3,
+          "caller": "http:HTTP server requests",
+          "callee": "package:app/views",
+          "name": "render",
+          "static": true,
+          "digest": "62d98fa0db60cd4288bf76a6204e7b20f61e13862f1e05c769dd86e952245a6c",
+          "subtreeDigest": "unknown",
+          "stableProperties": {
+            "event_type": "function",
+            "id": "app/views/app_views_users_show_html_erb.render",
+            "raises_exception": false
+          },
+          "returnValue": {
+            "returnValueType": {
+              "name": "void"
+            },
+            "raisesException": false
+          },
+          "children": [
+            {
+              "nodeType": 3,
+              "caller": "package:app/views",
+              "callee": "package:app/helpers",
+              "name": "gravatar_for",
+              "static": false,
+              "digest": "5ff1bfc2a21871ef1ea4c8455f3723347e6f7e782e6402f1d6b339cc513a8476",
+              "subtreeDigest": "unknown",
+              "stableProperties": {
+                "event_type": "function",
+                "id": "app/helpers/UsersHelper#gravatar_for",
+                "raises_exception": false
+              },
+              "returnValue": {
+                "returnValueType": {
+                  "name": "ActiveSupport::SafeBuffer"
+                },
+                "raisesException": false
+              },
+              "children": [],
+              "elapsed": 0.00007590500001697364,
+              "eventIds": [
+                66
+              ]
+            },
+            {
+              "nodeType": 3,
+              "caller": "package:app/views",
+              "callee": "package:app/views",
+              "name": "render",
+              "static": true,
+              "digest": "8e18aef5ea89591739f74bd4df0cac0e9ff8f82fff7c8d75bda368f44e2b053c",
+              "subtreeDigest": "unknown",
+              "stableProperties": {
+                "event_type": "function",
+                "id": "app/views/app_views_shared__stats_html_erb.render",
+                "raises_exception": false
+              },
+              "returnValue": {
+                "returnValueType": {
+                  "name": "void"
+                },
+                "raisesException": false
+              },
+              "children": [
+                {
+                  "nodeType": 6,
+                  "caller": "package:app/views",
+                  "callee": "database:Database",
+                  "query": "SELECT COUNT(*) FROM \"users\" INNER JOIN \"relationships\" ON \"users\".\"id\" = \"relationships\".\"followed_id\" WHERE \"relationships\".\"follower_id\" = ?",
+                  "digest": "8a345505b3941e0f4906e48e2d219860fa022aaa4d4a4b788602fe6a0ab6a2af",
+                  "subtreeDigest": "unknown",
+                  "children": [],
+                  "elapsed": 0.000294319,
+                  "eventIds": [
+                    73
+                  ]
+                },
+                {
+                  "nodeType": 6,
+                  "caller": "package:app/views",
+                  "callee": "database:Database",
+                  "query": "SELECT COUNT(*) FROM \"users\" INNER JOIN \"relationships\" ON \"users\".\"id\" = \"relationships\".\"follower_id\" WHERE \"relationships\".\"followed_id\" = ?",
+                  "digest": "0b21465b7b46abb916524effe611b800ea8b5642559d3857bec7e1e319200899",
+                  "subtreeDigest": "unknown",
+                  "children": [],
+                  "elapsed": 0.000292219,
+                  "eventIds": [
+                    77
+                  ]
+                }
+              ],
+              "elapsed": 0.002972492999987253,
+              "eventIds": [
+                68
+              ]
+            },
+            {
+              "nodeType": 3,
+              "caller": "package:app/views",
+              "callee": "package:app/helpers",
+              "name": "logged_in?",
+              "static": false,
+              "digest": "77ba104e4ac11aaffbd62768cc00961bc71badb260963485b9897fbad354a39c",
+              "subtreeDigest": "unknown",
+              "stableProperties": {
+                "event_type": "function",
+                "id": "app/helpers/SessionsHelper#logged_in?",
+                "raises_exception": false
+              },
+              "returnValue": {
+                "returnValueType": {
+                  "name": "void"
+                },
+                "raisesException": false
+              },
+              "children": [
+                {
+                  "nodeType": 3,
+                  "caller": "package:app/helpers",
+                  "callee": "package:app/helpers",
+                  "name": "current_user",
+                  "static": false,
+                  "digest": "f2fde231b0994ff4256ad0e5188d0308c1a6148f09070dc9de9afaa808d8cd73",
+                  "subtreeDigest": "unknown",
+                  "stableProperties": {
+                    "event_type": "function",
+                    "id": "app/helpers/SessionsHelper#current_user",
+                    "raises_exception": false
+                  },
+                  "returnValue": {
+                    "returnValueType": {
+                      "name": "void"
+                    },
+                    "raisesException": false
+                  },
+                  "children": [],
+                  "elapsed": 0.00030431900000849055,
+                  "eventIds": [
+                    83
+                  ]
+                }
+              ],
+              "elapsed": 0.00034142199999109835,
+              "eventIds": [
+                82
+              ]
+            },
+            {
+              "nodeType": 6,
+              "caller": "package:app/views",
+              "callee": "database:Database",
+              "query": "SELECT 1 AS one FROM \"microposts\" WHERE \"microposts\".\"user_id\" = ? LIMIT ?",
+              "digest": "8e7658cc55f04124152ee4729500f556a4c625a9206d9454d43da5754d957f28",
+              "subtreeDigest": "unknown",
+              "children": [],
+              "elapsed": 0.000252917,
+              "eventIds": [
+                96
+              ]
+            },
+            {
+              "nodeType": 6,
+              "caller": "package:app/views",
+              "callee": "database:Database",
+              "query": "SELECT COUNT(*) FROM \"microposts\" WHERE \"microposts\".\"user_id\" = ?",
+              "digest": "e1f3459e5ab185d533ff4a74856412ce48b234520639d2544fdf4efd57b62323",
+              "subtreeDigest": "unknown",
+              "children": [],
+              "elapsed": 0.000279418,
+              "eventIds": [
+                100
+              ]
+            },
+            {
+              "nodeType": 6,
+              "caller": "package:app/views",
+              "callee": "database:Database",
+              "query": "SELECT \"microposts\".* FROM \"microposts\" WHERE \"microposts\".\"user_id\" = ? ORDER BY \"microposts\".\"created_at\" DESC LIMIT ? OFFSET ?",
+              "digest": "19bc023ca792487c0257cd408be3a4ddc9c5d42aa35e4e8d6b2af664e5f91809",
+              "subtreeDigest": "unknown",
+              "children": [],
+              "elapsed": 0.000282719,
+              "eventIds": [
+                104
+              ]
+            },
+            {
+              "nodeType": 6,
+              "caller": "package:app/views",
+              "callee": "database:Database",
+              "query": "SELECT \"active_storage_attachments\".* FROM \"active_storage_attachments\" WHERE \"active_storage_attachments\".\"record_type\" = ? AND \"active_storage_attachments\".\"name\" = ? AND \"active_storage_attachments\".\"record_id\" IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+              "digest": "delete:d031fc0625c610d8b9047d7afc547a644adfe51395d06f73e9d19b413384cf48",
+              "subtreeDigest": "unknown",
+              "children": [],
+              "elapsed": 0.000471202,
+              "eventIds": [
+                108
+              ],
+              "diffMode": 2
+            },
+            {
+              "nodeType": 1,
+              "count": 30,
+              "digest": "loop",
+              "subtreeDigest": "unknown",
+              "children": [
+                {
+                  "nodeType": 3,
+                  "caller": "package:app/views",
+                  "callee": "package:app/helpers",
+                  "name": "gravatar_for",
+                  "static": false,
+                  "digest": "5ff1bfc2a21871ef1ea4c8455f3723347e6f7e782e6402f1d6b339cc513a8476",
+                  "subtreeDigest": "unknown",
+                  "stableProperties": {
+                    "event_type": "function",
+                    "id": "app/helpers/UsersHelper#gravatar_for",
+                    "raises_exception": false
+                  },
+                  "returnValue": {
+                    "returnValueType": {
+                      "name": "ActiveSupport::SafeBuffer"
+                    },
+                    "raisesException": false
+                  },
+                  "children": [],
+                  "elapsed": 0.0015968019999945682,
+                  "eventIds": [
+                    108,
+                    122,
+                    136,
+                    150,
+                    164,
+                    178,
+                    192,
+                    206,
+                    220,
+                    234,
+                    248,
+                    262,
+                    276,
+                    290,
+                    304,
+                    318,
+                    332,
+                    346,
+                    360,
+                    374,
+                    388,
+                    402,
+                    416,
+                    430,
+                    444,
+                    458,
+                    472,
+                    486,
+                    500,
+                    514
+                  ]
+                },
+                {
+                  "nodeType": 6,
+                  "caller": "package:app/views",
+                  "callee": "database:Database",
+                  "query": "SELECT \"active_storage_attachments\".* FROM \"active_storage_attachments\" WHERE \"active_storage_attachments\".\"record_id\" = ? AND \"active_storage_attachments\".\"record_type\" = ? AND \"active_storage_attachments\".\"name\" = ? LIMIT ?",
+                  "digest": "dc0970d40da095c45e53e50c788edd77b994cabdd5ca2826131b3afdfbb64fb9",
+                  "subtreeDigest": "unknown",
+                  "children": [],
+                  "elapsed": 0.007971016999999999,
+                  "eventIds": [
+                    112,
+                    126,
+                    140,
+                    154,
+                    168,
+                    182,
+                    196,
+                    210,
+                    224,
+                    238,
+                    252,
+                    266,
+                    280,
+                    294,
+                    308,
+                    322,
+                    336,
+                    350,
+                    364,
+                    378,
+                    392,
+                    406,
+                    420,
+                    434,
+                    448,
+                    462,
+                    476,
+                    490,
+                    504,
+                    518
+                  ],
+                  "diffMode": 1
+                },
+                {
+                  "nodeType": 3,
+                  "caller": "package:app/views",
+                  "callee": "package:app/helpers",
+                  "name": "current_user?",
+                  "static": false,
+                  "digest": "dbef797d2a0a8556f531d01acd2f8591a9ea6fd301fe70a393db0861e4155175",
+                  "subtreeDigest": "unknown",
+                  "stableProperties": {
+                    "event_type": "function",
+                    "id": "app/helpers/SessionsHelper#current_user?",
+                    "raises_exception": false
+                  },
+                  "returnValue": {
+                    "returnValueType": {
+                      "name": "void"
+                    },
+                    "raisesException": false
+                  },
+                  "children": [
+                    {
+                      "nodeType": 3,
+                      "caller": "package:app/helpers",
+                      "callee": "package:app/helpers",
+                      "name": "current_user",
+                      "static": false,
+                      "digest": "f2fde231b0994ff4256ad0e5188d0308c1a6148f09070dc9de9afaa808d8cd73",
+                      "subtreeDigest": "unknown",
+                      "stableProperties": {
+                        "event_type": "function",
+                        "id": "app/helpers/SessionsHelper#current_user",
+                        "raises_exception": false
+                      },
+                      "returnValue": {
+                        "returnValueType": {
+                          "name": "void"
+                        },
+                        "raisesException": false
+                      },
+                      "children": [],
+                      "elapsed": 0.00853625500010935,
+                      "eventIds": [
+                        115,
+                        129,
+                        143,
+                        157,
+                        171,
+                        185,
+                        199,
+                        213,
+                        227,
+                        241,
+                        255,
+                        269,
+                        283,
+                        297,
+                        311,
+                        325,
+                        339,
+                        353,
+                        367,
+                        381,
+                        395,
+                        409,
+                        423,
+                        437,
+                        451,
+                        465,
+                        479,
+                        493,
+                        507,
+                        521
+                      ]
+                    }
+                  ],
+                  "elapsed": 0.01157365000008781,
+                  "eventIds": [
+                    114,
+                    128,
+                    142,
+                    156,
+                    170,
+                    184,
+                    198,
+                    212,
+                    226,
+                    240,
+                    254,
+                    268,
+                    282,
+                    296,
+                    310,
+                    324,
+                    338,
+                    352,
+                    366,
+                    380,
+                    394,
+                    408,
+                    422,
+                    436,
+                    450,
+                    464,
+                    478,
+                    492,
+                    506,
+                    520
+                  ]
+                }
+              ],
+              "elapsed": 0.021141469000082375,
+              "eventIds": []
+            },
+            {
+              "nodeType": 6,
+              "caller": "package:app/views",
+              "callee": "database:Database",
+              "query": "SELECT COUNT(*) FROM \"microposts\" WHERE \"microposts\".\"user_id\" = ?",
+              "digest": "e1f3459e5ab185d533ff4a74856412ce48b234520639d2544fdf4efd57b62323",
+              "subtreeDigest": "unknown",
+              "children": [],
+              "elapsed": 0.00015681,
+              "eventIds": [
+                532
+              ]
+            },
+            {
+              "nodeType": 3,
+              "caller": "package:app/views",
+              "callee": "package:app/helpers",
+              "name": "full_title",
+              "static": false,
+              "digest": "6428a5b259bbf6313835680ae71302835d39681d81cd69e41c710da42e1d99f7",
+              "subtreeDigest": "unknown",
+              "stableProperties": {
+                "event_type": "function",
+                "id": "app/helpers/ApplicationHelper#full_title",
+                "raises_exception": false
+              },
+              "returnValue": {
+                "returnValueType": {
+                  "name": "string"
+                },
+                "raisesException": false
+              },
+              "children": [],
+              "elapsed": 0.0000038999999958377884,
+              "eventIds": [
+                536
+              ]
+            },
+            {
+              "nodeType": 3,
+              "caller": "package:app/views",
+              "callee": "package:app/views",
+              "name": "render",
+              "static": true,
+              "digest": "8b9ec9f22e5fd30edef15949402dd291692d065f0c826216741d476d3afaa5d9",
+              "subtreeDigest": "unknown",
+              "stableProperties": {
+                "event_type": "function",
+                "id": "app/views/app_views_layouts__shim_html_erb.render",
+                "raises_exception": false
+              },
+              "returnValue": {
+                "returnValueType": {
+                  "name": "void"
+                },
+                "raisesException": false
+              },
+              "children": [],
+              "elapsed": 0.0005487360000131503,
+              "eventIds": [
+                538
+              ]
+            },
+            {
+              "nodeType": 3,
+              "caller": "package:app/views",
+              "callee": "package:app/views",
+              "name": "render",
+              "static": true,
+              "digest": "delete:a067a33c75f6a3a7014f32072c87f4c12afb634a4141d6c1d757b8f345269315",
+              "subtreeDigest": "unknown",
+              "stableProperties": {
+                "event_type": "function",
+                "id": "app/views/app_views_layouts__header_html_erb.render",
+                "raises_exception": false
+              },
+              "returnValue": {
+                "returnValueType": {
+                  "name": "void"
+                },
+                "raisesException": false
+              },
+              "children": [
+                {
+                  "nodeType": 3,
+                  "caller": "package:app/views",
+                  "callee": "package:app/helpers",
+                  "name": "logged_in?",
+                  "static": false,
+                  "digest": "delete:77ba104e4ac11aaffbd62768cc00961bc71badb260963485b9897fbad354a39c",
+                  "subtreeDigest": "unknown",
+                  "stableProperties": {
+                    "event_type": "function",
+                    "id": "app/helpers/SessionsHelper#logged_in?",
+                    "raises_exception": false
+                  },
+                  "returnValue": {
+                    "returnValueType": {
+                      "name": "void"
+                    },
+                    "raisesException": false
+                  },
+                  "children": [
+                    {
+                      "nodeType": 3,
+                      "caller": "package:app/helpers",
+                      "callee": "package:app/helpers",
+                      "name": "current_user",
+                      "static": false,
+                      "digest": "delete:f2fde231b0994ff4256ad0e5188d0308c1a6148f09070dc9de9afaa808d8cd73",
+                      "subtreeDigest": "unknown",
+                      "stableProperties": {
+                        "event_type": "function",
+                        "id": "app/helpers/SessionsHelper#current_user",
+                        "raises_exception": false
+                      },
+                      "returnValue": {
+                        "returnValueType": {
+                          "name": "void"
+                        },
+                        "raisesException": false
+                      },
+                      "children": [],
+                      "elapsed": 0.0001012999999971953,
+                      "eventIds": [
+                        432
+                      ],
+                      "diffMode": 2
+                    }
+                  ],
+                  "elapsed": 0.00013940100001264,
+                  "eventIds": [
+                    431
+                  ],
+                  "diffMode": 2
+                }
+              ],
+              "elapsed": 0.0007040039999992587,
+              "eventIds": [
+                428
+              ],
+              "diffMode": 2
+            }
+          ],
+          "elapsed": 0.10010930799998619,
+          "eventIds": [
+            51
+          ]
+        }
+      ],
+      "elapsed": 0.10447039199999608,
+      "eventIds": [
+        25
+      ]
+    }
+  ]
+}

--- a/packages/components/src/stories/data/sequence/appland_api_key_diff.sequence.json
+++ b/packages/components/src/stories/data/sequence/appland_api_key_diff.sequence.json
@@ -483,7 +483,10 @@
       ],
       "diffMode": 3,
       "formerName": "POST /api/api_keys",
-      "formerResult": "201"
+      "formerResult": "201",
+      "eventIds": [
+        1
+      ]
     },
     {
       "nodeType": 4,

--- a/packages/components/tests/e2e/specs/appmap/sequenceDiagramDiff.spec.js
+++ b/packages/components/tests/e2e/specs/appmap/sequenceDiagramDiff.spec.js
@@ -30,4 +30,18 @@ context('Sequence Diagram', () => {
     cy.get('.sequence-diagram [data-event-ids="108"]').should('have.class', 'diff-delete');
     cy.get('.sequence-diagram [data-event-ids="108"]').should('have.class', 'focused');
   });
+
+  it('exanding a package actor is disabled', () => {
+    cy.get('.sequence-actor[data-actor-id="package:app/views"]').should('exist');
+    cy.get('.sequence-actor[data-actor-id="package:app/views"]')
+      .contains('.expand-actor')
+      .should('not.exist');
+  });
+
+  it('hiding an actor is disabled', () => {
+    cy.get('.sequence-actor[data-actor-id="package:app/views"]').should('exist');
+    cy.get('.sequence-actor[data-actor-id="package:app/views"]')
+      .contains('.hide-container')
+      .should('not.exist');
+  });
 });

--- a/packages/components/tests/e2e/specs/appmap/sequenceDiagramDiff.spec.js
+++ b/packages/components/tests/e2e/specs/appmap/sequenceDiagramDiff.spec.js
@@ -15,13 +15,19 @@ context('Sequence Diagram', () => {
   });
 
   it('unchanged calls are collapsed', () => {
-    cy.get('.sequence-diagram [data-event-ids=42]').should('exist');
-    cy.get('.sequence-diagram [data-event-ids=42]').contains('show').should('exist');
+    cy.get('.sequence-diagram [data-event-ids="42"]').should('exist');
+    cy.get('.sequence-diagram [data-event-ids="42"]').contains('show').should('exist');
 
-    cy.get('.sequence-diagram [data-event-ids=42] .collapse-expand').should('exist');
-    cy.get('.sequence-diagram [data-event-ids=42] .collapse-expand').should(
+    cy.get('.sequence-diagram [data-event-ids="42"] .collapse-expand').should('exist');
+    cy.get('.sequence-diagram [data-event-ids="42"] .collapse-expand').should(
       'have.class',
       'collapsed'
     );
+  });
+
+  it('first diff element is selected', () => {
+    cy.get('.sequence-diagram [data-event-ids="108"]').should('exist');
+    cy.get('.sequence-diagram [data-event-ids="108"]').should('have.class', 'diff-delete');
+    cy.get('.sequence-diagram [data-event-ids="108"]').should('have.class', 'focused');
   });
 });

--- a/packages/components/tests/e2e/specs/appmap/sequenceDiagramDiff.spec.js
+++ b/packages/components/tests/e2e/specs/appmap/sequenceDiagramDiff.spec.js
@@ -1,0 +1,27 @@
+context('Sequence Diagram', () => {
+  beforeEach(() => {
+    cy.visit(
+      'http://localhost:6006/iframe.html?id=pages-vs-code--extension-with-sequence-diff&viewMode=story'
+    );
+  });
+
+  it('opens as the initial view', () => {
+    cy.get('.sequence-diagram').should('exist');
+  });
+
+  it('displays a diff deletion', () => {
+    cy.get('.sequence-diagram .diff-delete').should('exist');
+    cy.get('.sequence-diagram .diff-delete .name').contains('render').should('exist');
+  });
+
+  it('unchanged calls are collapsed', () => {
+    cy.get('.sequence-diagram [data-event-ids=42]').should('exist');
+    cy.get('.sequence-diagram [data-event-ids=42]').contains('show').should('exist');
+
+    cy.get('.sequence-diagram [data-event-ids=42] .collapse-expand').should('exist');
+    cy.get('.sequence-diagram [data-event-ids=42] .collapse-expand').should(
+      'have.class',
+      'collapsed'
+    );
+  });
+});

--- a/packages/scanner/package.json
+++ b/packages/scanner/package.json
@@ -83,7 +83,7 @@
     "lru-cache": "^6.0.0",
     "minimatch": "^5.1.2",
     "octokit": "^2.0.19",
-    "openapi-diff": "^0.23.5",
+    "openapi-diff": "^0.23.6",
     "ora": "~5",
     "pretty-format": "^27.4.6",
     "read-pkg-up": "^7.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -451,7 +451,7 @@ __metadata:
     minimatch: ^5.1.2
     nock: ^13.2.2
     octokit: ^2.0.19
-    openapi-diff: ^0.23.5
+    openapi-diff: ^0.23.6
     openapi-types: ^9.3.0
     ora: ~5
     pkg: ^5.5.2
@@ -26500,25 +26500,6 @@ __metadata:
     is-docker: ^2.1.1
     is-wsl: ^2.2.0
   checksum: e9545bec64cdbf30a0c35c1bdc310344adf8428a117f7d8df3c0af0a0a24c513b304916a6d9b11db0190ff7225c2d578885080b761ed46a3d5f6f1eebb98b63c
-  languageName: node
-  linkType: hard
-
-"openapi-diff@npm:^0.23.5":
-  version: 0.23.5
-  resolution: "openapi-diff@npm:0.23.5"
-  dependencies:
-    commander: ^8.2.0
-    js-yaml: ^4.0.0
-    json-schema-diff: ^0.17.1
-    jsonpointer: ^4.1.0
-    lodash: ^4.17.20
-    openapi3-ts: ^2.0.0
-    request: ^2.88.2
-    swagger-parser: ^10.0.2
-    verror: ^1.10.0
-  bin:
-    openapi-diff: bin/openapi-diff
-  checksum: f7289b46006605a9ae1daae6f797012c3fb035fa26b0ac8c9b325dd20dae3a5727adbe970bb98ddda7b80f9a448f308bfe891b229685a011a71caa497c10a16f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes #1096 

Display sequence diagram diff in AppMap view. This feature is designed to be used to display the "diff" diagrams that are generated by AppMap Analysis in CI / GitHub Actions. 

When the AppMap diagram `loadData` method is called with a `sequenceDiagram` argument, that diagram will be used in place of the auto-generated sequence diagram that would otherwise be created. This "precomputed" sequence diagram provided can be a "diff" diagram. In this mode, the AppMap behavior differs from the default behavior in the following ways:

* The Filters functionality is disabled, because there is no way to change the sequence diagram to reflect the filters. 
* Diagram actions that do not contain any "diff" content are collapsed by default.
* The diagram scrolls to show the first "diff" action.

For an interactive example, see http://localhost:6006/?path=/story/pages-vs-code--extension-with-sequence-diff.

We will need to update the AppMap view in getappmap.com to fetch both the head AppMap and the sequence diagram diff, and construct the AppMap in accordance with these instructions. 

Related: https://github.com/getappmap/vscode-appland/pull/794

<img width="1297" alt="Screen Shot 2023-08-31 at 3 39 43 PM" src="https://github.com/getappmap/appmap-js/assets/86395/88e011e8-2afc-4025-8f27-967a020abb4c">
