### PR TITLE
Select finding when map opened from findings webview

### DIFF
--- a/packages/components/src/pages/VsCodeExtension.vue
+++ b/packages/components/src/pages/VsCodeExtension.vue
@@ -357,6 +357,7 @@ import VStatsPanel from '../components/StatsPanel.vue';
 import VTabs from '../components/Tabs.vue';
 import VTab from '../components/Tab.vue';
 import VTraceFilter from '../components/trace/TraceFilter.vue';
+import toListItem from '@/lib/finding';
 import {
   store,
   SET_APPMAP_DATA,
@@ -945,7 +946,7 @@ export default {
         if (state.selectedObject) {
           do {
             const fqid = state.selectedObject;
-            const [match, type, object] = fqid.match(/^([a-z]+):(.+)/);
+            const [match, type, object] = fqid.match(/^([a-z\-]+):(.+)/);
 
             if (!match) {
               break;
@@ -979,6 +980,10 @@ export default {
                   });
                 }
               }
+            } else if (type === 'analysis-finding') {
+              const hash_v2 = object;
+              const finding = this.findings.find(({ finding }) => finding.hash_v2 === hash_v2);
+              if (finding) this.$store.commit(SELECT_CODE_OBJECT, toListItem(finding));
             } else {
               selectedObject = classMap.codeObjects.find((obj) => obj.fqid === fqid);
             }

--- a/packages/components/tests/unit/VsCodeExtension.spec.js
+++ b/packages/components/tests/unit/VsCodeExtension.spec.js
@@ -36,6 +36,9 @@ describe('VsCodeExtension.vue', () => {
     wrapper.vm.setState('{"selectedObject":"class:app/models/User"}');
     expect(wrapper.vm.selectedObject.id).toMatch('app/models/User');
 
+    wrapper.vm.setState('{"selectedObject":"analysis-finding:fakeHash"}');
+    expect(wrapper.vm.selectedObject.id).toMatch('fakeHash');
+
     wrapper.vm.clearSelection();
 
     const appState =

--- a/packages/components/tests/unit/fixtures/user_page_scenario.appmap.json
+++ b/packages/components/tests/unit/fixtures/user_page_scenario.appmap.json
@@ -1696,5 +1696,16 @@
         "object_id": 70301279735240
       }
     }
+  ],
+  "findings": [
+    {
+      "finding": {
+        "hash_v2": "fakeHash",
+        "message": "fake finding message"
+      },
+      "rule": {
+        "title": "fakeFindingTitle"
+      }
+    }
   ]
 }


### PR DESCRIPTION
Fixes #1340 

Previously, when opening an AppMap from the findings webview:

![image](https://github.com/getappmap/vscode-appland/assets/45714532/b6974158-38e3-4eab-b787-e41170a0bc54)

It would open to the `Trace View`:

![image](https://github.com/getappmap/vscode-appland/assets/45714532/69579a4b-1412-49a9-b244-70a0f2c23ecb)

This change (along with a followup change in `vscode-appland`) makes it so that it opens the AppMap to the finding:

![image](https://github.com/getappmap/vscode-appland/assets/45714532/e8023edc-de37-40eb-8d4c-32b94db7783c)
