### PR TITLE
fix: Resolve some cases where AppMaps failed to be located

### DIFF
--- a/packages/cli/src/appMapCatalog.js
+++ b/packages/cli/src/appMapCatalog.js
@@ -9,7 +9,7 @@ const { baseName, findFiles } = require('./utils');
  */
 async function appMapCatalog(directory) {
   const appMapsByName = {};
-  const appMapFiles = await findFiles(directory, '*.appmap.json');
+  const appMapFiles = await findFiles(directory, '.appmap.json');
 
   await Promise.all(
     // eslint-disable-next-line prefer-arrow-callback

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -15,7 +15,7 @@ const { join } = require('path');
 import { setSQLErrorHandler } from '@appland/models';
 
 const { verbose } = require('./utils');
-const FingerprintDirectoryCommand = require('./fingerprint/fingerprintDirectoryCommand');
+const FingerprintDirectoryCommand = require('./fingerprint/fingerprintDirectoryCommand').default;
 const FingerprintWatchCommand = require('./fingerprint/fingerprintWatchCommand').default;
 const Depends = require('./depends');
 import InstallCommand from './cmds/agentInstaller/install-agent';

--- a/packages/cli/src/fingerprint/fingerprintDirectoryCommand.ts
+++ b/packages/cli/src/fingerprint/fingerprintDirectoryCommand.ts
@@ -35,7 +35,7 @@ class FingerprintDirectoryCommand {
   }
 
   async files(fn) {
-    return findFiles(this.directory, '*.appmap.json', fn);
+    return findFiles(this.directory, '.appmap.json', fn);
   }
 }
 

--- a/packages/cli/src/fingerprint/fingerprintDirectoryCommand.ts
+++ b/packages/cli/src/fingerprint/fingerprintDirectoryCommand.ts
@@ -39,4 +39,4 @@ class FingerprintDirectoryCommand {
   }
 }
 
-module.exports = FingerprintDirectoryCommand;
+export default FingerprintDirectoryCommand;

--- a/packages/cli/src/inventoryCommand.js
+++ b/packages/cli/src/inventoryCommand.js
@@ -48,7 +48,7 @@ class InventoryCommand {
   }
 
   async files(fn) {
-    return findFiles(this.directory, '*.appmap.json', fn);
+    return findFiles(this.directory, '.appmap.json', fn);
   }
 }
 

--- a/packages/cli/tests/unit/fingerprint/fingerprintDirectoryCommand.spec.ts
+++ b/packages/cli/tests/unit/fingerprint/fingerprintDirectoryCommand.spec.ts
@@ -1,0 +1,25 @@
+import { dir } from 'tmp';
+import FingerprintDirectoryCommand from '../../../src/fingerprint/fingerprintDirectoryCommand';
+import { promisify } from 'util';
+import { writeFile, rm } from 'node:fs/promises';
+import { join } from 'path';
+
+const mkTmpDir = promisify(dir);
+
+describe('index command', () => {
+  let appMapDir: string;
+  let appMapPath: string;
+
+  beforeEach(async () => {
+    appMapDir = await mkTmpDir();
+    appMapPath = join(appMapDir, 'example.appmap.json');
+    await writeFile(appMapPath, '{}');
+  });
+
+  afterEach(() => rm(appMapDir, { recursive: true, force: true }));
+
+  it('identifies AppMaps for indexing', () => {
+    const subject = new FingerprintDirectoryCommand(appMapDir);
+    return expect(subject.files(() => {})).resolves.toEqual([appMapPath]);
+  });
+});


### PR DESCRIPTION
The `findFiles` utility function doesn't accept glob patterns, so these would never resolve to anything.