### PR TITLE
fix: Apply button in filter dialog is confusing

### DIFF
--- a/packages/components/src/components/FilterMenu.vue
+++ b/packages/components/src/components/FilterMenu.vue
@@ -130,13 +130,13 @@
                 {{ savedFilter.filterName }}
               </option>
             </select>
+            <button class="filters__button" data-cy="apply-filter-button" @click="applyFilter">
+              Load
+            </button>
           </div>
         </div>
         <div class="filters__block-row">
           <div class="filters__block-row-content">
-            <button class="filters__button" data-cy="apply-filter-button" @click="applyFilter">
-              Apply
-            </button>
             <button :class="deleteButtonClass" data-cy="delete-filter-button" @click="deleteFilter">
               Delete
             </button>
@@ -449,6 +449,7 @@ export default {
     flex: 1;
     padding: 2px;
     margin-left: 7px;
+    margin-right: 10px;
     display: inline-block;
     vertical-align: middle;
     width: 100%;

--- a/packages/components/src/components/FilterMenu.vue
+++ b/packages/components/src/components/FilterMenu.vue
@@ -130,13 +130,13 @@
                 {{ savedFilter.filterName }}
               </option>
             </select>
-            <button class="filters__button" data-cy="apply-filter-button" @click="applyFilter">
-              Load
-            </button>
           </div>
         </div>
         <div class="filters__block-row">
           <div class="filters__block-row-content">
+            <button :class="applyButtonClass" data-cy="apply-filter-button" @click="applyFilter">
+              Load
+            </button>
             <button :class="deleteButtonClass" data-cy="delete-filter-button" @click="deleteFilter">
               Delete
             </button>
@@ -308,6 +308,15 @@ export default {
       );
     },
 
+    applyButtonClass() {
+      const serializedFilter = serializeFilter(this.filters);
+      const state = base64UrlEncode(JSON.stringify({ filters: serializedFilter }));
+
+      const suffix =
+        this.selectedSavedFilter && this.selectedSavedFilter.state === state ? '-disabled' : '';
+      return 'filters__button' + suffix;
+    },
+
     defaultButtonClass() {
       const suffix =
         this.selectedSavedFilter && this.selectedSavedFilter.default ? '-disabled' : '';
@@ -449,7 +458,6 @@ export default {
     flex: 1;
     padding: 2px;
     margin-left: 7px;
-    margin-right: 10px;
     display: inline-block;
     vertical-align: middle;
     width: 100%;

--- a/packages/components/tests/e2e/specs/appmap/viewFilter.spec.js
+++ b/packages/components/tests/e2e/specs/appmap/viewFilter.spec.js
@@ -237,10 +237,10 @@ context('AppMap view filter', () => {
       cy.get('.tabs__controls .popper__button').click();
 
       cy.get('.filters__select').find(':selected').should('contain.text', 'AppMap default');
-      cy.get('.filters__button').eq(1).should('contain.text', 'Apply');
-      cy.get('.filters__button').eq(2).should('contain.text', 'Copy');
-      cy.get('.filters__button-disabled').first().should('contain.text', 'Delete');
-      cy.get('.filters__button-disabled').eq(1).should('contain.text', 'Set as default');
+      cy.get('.filters__button-disabled').first().should('contain.text', 'Load');
+      cy.get('.filters__button').eq(1).should('contain.text', 'Copy');
+      cy.get('.filters__button-disabled').eq(1).should('contain.text', 'Delete');
+      cy.get('.filters__button-disabled').eq(2).should('contain.text', 'Set as default');
     });
 
     it('enables all buttons for a non-default filter', () => {
@@ -250,7 +250,7 @@ context('AppMap view filter', () => {
 
       cy.get('.filters__select').select('filter');
       cy.get('.filters__select').find(':selected').should('contain.text', 'filter');
-      cy.get('.filters__button').eq(1).should('contain.text', 'Apply');
+      cy.get('.filters__button').eq(1).should('contain.text', 'Load');
       cy.get('.filters__button').eq(2).should('contain.text', 'Delete');
       cy.get('.filters__button').eq(3).should('contain.text', 'Set as default');
       cy.get('.filters__button').eq(4).should('contain.text', 'Copy');

--- a/packages/components/tests/e2e/specs/filterMenu.spec.js
+++ b/packages/components/tests/e2e/specs/filterMenu.spec.js
@@ -1,0 +1,19 @@
+context('Filter Menu', () => {
+  beforeEach(() => {
+    cy.visit('http://localhost:6006/iframe.html?id=appland-diagrams-filter-menu--filter-menu&viewMode=story');
+  });
+
+  
+  it('disables the Load button when selected filter matches current filter state', () => {
+    
+    cy.get('.filters__select').find(':selected').should('contain.text', 'AppMap default');
+    // Check "Hide external code"
+    cy.get('.filters__checkbox input[type="checkbox"]').eq(2).click({force: true})
+    cy.get('.filters__button').eq(1).should('contain.text', 'Load');
+    // Uncheck "Hide exteranl code" to match selected filter
+    cy.get('.filters__checkbox input[type="checkbox"]').eq(2).click({force: true})
+    cy.get('.filters__button-disabled').first().should('contain.text', 'Load');
+  });
+
+  
+});


### PR DESCRIPTION
Fixes #1347. 

Changed FilterMenu.vue:
- apply button title renamed from "Apply" to "Load"
- moved the button to the right of the filter select
- spacing between "Load" button and select on the left made consistent with Save Filter button and the input box on its left.

Before (Filter Menu storybook)
<img width="651" alt="Before" src="https://github.com/getappmap/appmap-js/assets/98758224/6d073c71-d401-4c2e-bf1a-1b9ce60d1934">

After (Filter Menu storybook)
<img width="621" alt="After" src="https://github.com/getappmap/appmap-js/assets/98758224/1bc84d6f-39e9-4444-a936-99d533d27539">
