### PR TITLE
fix: Reduce max memory usage of OpenAPI gen

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -20,7 +20,7 @@ const FingerprintWatchCommand = require('./fingerprint/fingerprintWatchCommand')
 const Depends = require('./depends');
 import InstallCommand from './cmds/agentInstaller/install-agent';
 import StatusCommand from './cmds/agentInstaller/status';
-import { default as OpenAPICommand } from './cmds/openapi';
+import { default as OpenAPICommand } from './cmds/openapi/openapi';
 import PruneCommand from './cmds/prune/prune';
 import RecordCommand from './cmds/record/record';
 import { handleWorkingDirectory } from './lib/handleWorkingDirectory';

--- a/packages/cli/src/cmds/archive/generateOpenAPI.ts
+++ b/packages/cli/src/cmds/archive/generateOpenAPI.ts
@@ -1,5 +1,5 @@
 import { join } from 'path';
-import openapi from '../openapi';
+import openapi from '../openapi/openapi';
 
 export default async function generateOpenAPI(appMapDir: string, maxAppMapSizeInBytes: number) {
   const startTime = new Date().getTime();

--- a/packages/cli/src/cmds/compare/ArchiveAnalyzer.ts
+++ b/packages/cli/src/cmds/compare/ArchiveAnalyzer.ts
@@ -1,5 +1,5 @@
 import { executeCommand } from '../../lib/executeCommand';
-import { default as openAPICmd } from '../openapi';
+import { default as openAPICmd } from '../openapi/openapi';
 import { DefaultMaxAppMapSizeInMB } from '../../lib/fileSizeFilter';
 import { join } from 'path';
 import { tmpdir } from 'os';

--- a/packages/cli/src/cmds/openapi/DataStore.ts
+++ b/packages/cli/src/cmds/openapi/DataStore.ts
@@ -1,0 +1,109 @@
+import { Event } from '@appland/models';
+import { parseHTTPServerRequests, rpcRequestForEvent } from '@appland/openapi';
+import { RPCRequest } from '@appland/openapi/dist/rpcRequest';
+import assert from 'assert';
+import { log } from 'console';
+import { closeSync, openSync, write, writeSync } from 'fs';
+import { mkdtemp, readFile, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { promisify } from 'util';
+import { verbose } from '../../utils';
+
+class RequestDataFile {
+  bytesWritten = 0;
+
+  constructor(private fd: number, public fileName: string) {
+    const prefix = '[\n';
+    this.bytesWritten = prefix.length;
+    writeSync(fd, prefix);
+  }
+
+  async writeRequest(request: RPCRequest) {
+    const json = JSON.stringify({
+      status: request.status,
+      parameters: request.parameters,
+      returnValue: request.returnValue,
+      requestHeaders: request.requestHeaders,
+      responseHeaders: request.responseHeaders,
+      requestContentType: request.requestContentType,
+      responseContentType: request.responseContentType,
+      requestMethod: request.requestMethod,
+      requestPath: request.requestPath,
+    });
+    const indent = '  ';
+    const lineEnding = ',\n';
+    const line = [indent, json, lineEnding].join('');
+
+    const { bytesWritten } = await promisify(write)(this.fd, line);
+    this.bytesWritten += bytesWritten;
+  }
+
+  async close() {
+    const fileEnding = `\n]\n`;
+    writeSync(this.fd, fileEnding, this.bytesWritten - 2);
+    closeSync(this.fd);
+  }
+}
+
+export default class DataStore {
+  private readonly requestFiles = new Map<string, RequestDataFile>();
+  private workDir: string | undefined;
+
+  async initialize() {
+    if (this.workDir) throw new Error('OpenAPI DataStore already initialized');
+
+    this.workDir = await mkdtemp(join(tmpdir(), 'appmap-openapi-'));
+  }
+
+  get requestFileNames(): string[] {
+    return [...this.requestFiles.values()].map((requestFile) => requestFile.fileName);
+  }
+
+  async storeAppMap(appMapFile: string) {
+    if (!this.workDir) throw new Error('OpenAPI DataStore not initialized');
+
+    const data = await readFile(appMapFile, 'utf-8');
+    const requests = new Array<Event>();
+    parseHTTPServerRequests(JSON.parse(data), (e: Event) => requests.push(e));
+
+    // This function is not async, so that the request files are opened atomically.
+    const openRequestFile = (requestId: string): RequestDataFile => {
+      let requestFile: RequestDataFile | undefined = this.requestFiles.get(requestId);
+      if (!requestFile) {
+        const workFile = Buffer.from(requestId).toString('base64');
+        assert(this.workDir);
+        const requestFileName = join(this.workDir, workFile);
+        if (verbose()) log(`Opening ${requestFileName} for ${requestId}`);
+        const fd = openSync(requestFileName, 'w');
+        requestFile = new RequestDataFile(fd, requestFileName);
+        assert(!this.requestFiles.has(requestId));
+        this.requestFiles.set(requestId, requestFile);
+      }
+      return requestFile;
+    };
+
+    for (const e of requests) {
+      const request = rpcRequestForEvent(e);
+      if (request) {
+        const requestId = request.requestPath;
+        const requestFile = openRequestFile(requestId);
+        await requestFile.writeRequest(request);
+      }
+    }
+  }
+
+  async closeAll() {
+    for (const [_, requestFile] of this.requestFiles) {
+      await requestFile.close();
+    }
+  }
+
+  async cleanup() {
+    const { workDir } = this;
+    if (!workDir) return;
+
+    this.workDir = undefined;
+    await rm(workDir, { recursive: true });
+  }
+}

--- a/packages/cli/src/cmds/openapi/DefinitionGenerator.ts
+++ b/packages/cli/src/cmds/openapi/DefinitionGenerator.ts
@@ -1,0 +1,48 @@
+import { Model, SecuritySchemes } from '@appland/openapi';
+import { OpenAPIV3 } from 'openapi-types';
+import DataStore from './DataStore';
+import { readFile } from 'fs/promises';
+import assert from 'assert';
+import { headerValue } from '@appland/openapi/dist/rpcRequest';
+
+export default class DefinitionGenerator {
+  constructor(public dataStore: DataStore) {}
+
+  async generate(): Promise<{
+    paths: OpenAPIV3.PathsObject;
+    securitySchemes: Record<string, OpenAPIV3.SecuritySchemeObject>;
+  }> {
+    const securitySchemes = new SecuritySchemes();
+    const paths: Record<string, OpenAPIV3.PathItemObject> = {};
+
+    for (const requestFileName of this.dataStore.requestFileNames) {
+      let requestData: any[];
+      try {
+        requestData = JSON.parse(await readFile(requestFileName, 'utf-8'));
+      } catch (e) {
+        console.warn(`Warning: unable to parse AppMap ${requestFileName}: ${e}`);
+        continue;
+      }
+      assert(requestData);
+      const model = new Model();
+      for (const request of requestData) {
+        model.addRpcRequest(request);
+        if (request.requestHeaders) {
+          const authorizationHeader = headerValue(request.requestHeaders, 'Authorization');
+          if (authorizationHeader) securitySchemes.addAuthorizationHeader(authorizationHeader);
+        }
+      }
+
+      const openapi = model.openapi();
+      for (const [path, pathItem] of Object.entries(openapi)) {
+        if (pathItem) paths[path] = pathItem;
+      }
+    }
+    return {
+      paths: Object.keys(paths)
+        .sort()
+        .reduce((memo, path) => ((memo[path] = paths[path]), memo), {}),
+      securitySchemes: securitySchemes.openapi(),
+    };
+  }
+}

--- a/packages/cli/src/lib/fileSizeFilter.ts
+++ b/packages/cli/src/lib/fileSizeFilter.ts
@@ -1,6 +1,6 @@
 import { Stats } from 'fs';
 import { stat } from 'fs/promises';
-import { FilterFunction } from '../cmds/openapi';
+import { FilterFunction } from '../cmds/openapi/openapi';
 
 export const DefaultMaxAppMapSizeInMB = 50;
 

--- a/packages/cli/tests/unit/openapi.spec.ts
+++ b/packages/cli/tests/unit/openapi.spec.ts
@@ -1,5 +1,5 @@
 import { verbose } from '../../src/utils';
-import { default as openapi } from '../../src/cmds/openapi';
+import { default as openapi } from '../../src/cmds/openapi/openapi';
 import assert from 'assert';
 import path from 'path';
 import { fileSizeFilter } from '../../src/lib/fileSizeFilter';

--- a/packages/openapi/src/index.ts
+++ b/packages/openapi/src/index.ts
@@ -1,9 +1,8 @@
 import Model from './model';
 import SecuritySchemes from './securitySchemes';
-import { rpcRequestForEvent } from './rpcRequest';
+import { headerValue, rpcRequestForEvent } from './rpcRequest';
 import { Event } from '@appland/models';
 import { OpenAPIV3 } from 'openapi-types';
-import { URL } from 'url';
 export { default as parseHTTPServerRequests } from './parseHTTPServerRequests';
 export { classNameToOpenAPIType, verbose } from './util';
 
@@ -20,7 +19,10 @@ const forClientRequest = (event: Event): OpenAPIV3Fragment | undefined => {
 
   const securitySchemes = new SecuritySchemes();
   const model = new Model();
-  securitySchemes.addRpcRequest(rpcRequest);
+  if (rpcRequest.requestHeaders) {
+    const authorizationHeader = headerValue(rpcRequest.requestHeaders, 'authorization');
+    if (authorizationHeader) securitySchemes.addAuthorizationHeader(authorizationHeader);
+  }
   model.addRpcRequest(rpcRequest);
 
   return { paths: model.openapi(), securitySchemes: securitySchemes.openapi() };

--- a/packages/openapi/src/method.ts
+++ b/packages/openapi/src/method.ts
@@ -1,4 +1,4 @@
-import { Event, ParameterObject } from '@appland/models';
+import { ParameterObject } from '@appland/models';
 import { OpenAPIV3, OpenAPIV3_1 } from 'openapi-types';
 import Response from './response';
 import { headerValue, RPCRequest } from './rpcRequest';

--- a/packages/openapi/src/securitySchemes.ts
+++ b/packages/openapi/src/securitySchemes.ts
@@ -1,30 +1,24 @@
 import { OpenAPIV3 } from 'openapi-types';
-import { RPCRequest } from './rpcRequest';
 import { parseScheme } from './util';
 
 export default class SecuritySchemes {
-  rpcRequests: RPCRequest[] = [];
+  authorizationHeaders: string[] = [];
 
   /**
    * Adds an event to the security schemes, and assigns a security scheme id.
    * If the event has no detectable security scheme, this function returns null.
-   *
-   * @returns the security scheme id for the event, or null.
    */
-  addRpcRequest(rpcRequest: RPCRequest): void {
-    this.rpcRequests.push(rpcRequest);
+  addAuthorizationHeader(header: string) {
+    this.authorizationHeaders.push(header);
   }
 
   openapi(): Record<string, OpenAPIV3.SecuritySchemeObject> {
-    return this.rpcRequests
-      .map((rpcRequest) => rpcRequest.requestHeaders['Authorization'])
-      .filter((authorization) => authorization)
-      .reduce((memo, authorization) => {
-        const scheme = parseScheme(authorization);
-        if (!memo[scheme.schemeId]) {
-          memo[scheme.schemeId] = scheme.scheme;
-        }
-        return memo;
-      }, {} as Record<string, OpenAPIV3.SecuritySchemeObject>);
+    return this.authorizationHeaders.reduce((memo, authorization) => {
+      const scheme = parseScheme(authorization);
+      if (!memo[scheme.schemeId]) {
+        memo[scheme.schemeId] = scheme.scheme;
+      }
+      return memo;
+    }, {} as Record<string, OpenAPIV3.SecuritySchemeObject>);
   }
 }

--- a/packages/openapi/test/propertiesParser.spec.ts
+++ b/packages/openapi/test/propertiesParser.spec.ts
@@ -32,7 +32,6 @@ describe('PropertiesParser', () => {
     it('parses AppMaps adhering to v1.9.0 spec', async () => {
       const examples = await getExamples('appmap-v1.9.0.yml');
       expect(PropertiesParserV2.canParse(examples[0])).toBe(false);
-      console.log(parse(examples[0]));
       expect(parse(examples[0])).toStrictEqual({
         type: 'array',
         items: {

--- a/packages/openapi/test/securitySchemes.spec.ts
+++ b/packages/openapi/test/securitySchemes.spec.ts
@@ -1,4 +1,4 @@
-import { rpcRequestForEvent } from '../src/rpcRequest';
+import { headerValue, rpcRequestForEvent } from '../src/rpcRequest';
 import SecuritySchemes from '../src/securitySchemes';
 import { httpClientRequests, httpServerRequests } from './util';
 
@@ -10,7 +10,7 @@ describe('openapi.securitySchemes', () => {
     );
 
     const schemes = new SecuritySchemes();
-    schemes.addRpcRequest(request);
+    schemes.addAuthorizationHeader(headerValue(request.requestHeaders, 'authorization')!);
     expect(schemes.openapi()).toEqual({
       bearer: { scheme: 'bearer', type: 'http' },
     });
@@ -22,7 +22,7 @@ describe('openapi.securitySchemes', () => {
     );
 
     const schemes = new SecuritySchemes();
-    schemes.addRpcRequest(request);
+    schemes.addAuthorizationHeader(headerValue(request.requestHeaders, 'authorization')!);
     expect(schemes.openapi()).toEqual({
       bearer: { scheme: 'bearer', type: 'http' },
     });


### PR DESCRIPTION
For OpenAPI generation, stage requests data into files organized by request path, then process one path at a time. This approach will greatly reduce the max memory usage.

Fixes https://github.com/getappmap/appmap-js/issues/1342

* [x] Create pre-release build of the CLI
* [x] Test pre-release on an existing build job that generates OpenAPI. Ensure that the diff report is the same.

Tested in https://github.com/land-of-apps/rails_tutorial_sample_app_7th_ed/pull/19/files#diff-a28198b36e9b27792ef763b3349cc505969aaff75e15e4bd5f43c3ced91117c3R37

