### PR TITLE
feat: Emit run stats after index

### DIFF
--- a/packages/cli/src/cmds/index/IndexResult.ts
+++ b/packages/cli/src/cmds/index/IndexResult.ts
@@ -1,3 +1,7 @@
+import type { Metadata } from '@appland/models';
+
 export type IndexResult = {
   error?: Error;
+  metadata: Metadata;
+  numEvents: number;
 };

--- a/packages/cli/src/lib/emitUsage.ts
+++ b/packages/cli/src/lib/emitUsage.ts
@@ -3,7 +3,8 @@ import { Metadata } from '@appland/models';
 import { Git } from '../telemetry';
 import type { UsageUpdateDto } from '@appland/client';
 import sanitizeURL from './repositoryInfo';
-import { verbose } from '../utils';
+import { mkdir, stat, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
 
 async function buildMetadata(appmapDir: string, metadata?: Metadata): Promise<string> {
   const repository = await Git.repository(appmapDir);
@@ -29,25 +30,27 @@ export default async function emitUsage(
   numEvents: number,
   numAppMaps: number,
   sampleMetadata?: Metadata
-): Promise<UsageUpdateDto> {
-  const contributors = await Git.contributors(90);
+): Promise<string | undefined> {
   const dto: UsageUpdateDto = {
     events: numEvents,
     appmaps: numAppMaps,
-    contributors: contributors.length,
     metadata: await buildMetadata(appmapDir, sampleMetadata),
     ci: process.env.CI !== undefined,
   };
 
-  Usage.update(dto).catch((e) => {
-    // If this fails, it's not a big deal.
-    // In the future, we may want to cache and aggregate numEvents on
-    // disk and try again at a later date. The client will retry on its
-    // own, so we don't need to do it here.
-    if (verbose()) {
-      console.warn('Failed to update usage', e);
-    }
-  });
+  try {
+    const stats = await stat('.appmap');
+    if (stats.isDirectory()) {
+      const runStatsDirectory = join('.appmap', 'run-stats');
+      await mkdir(runStatsDirectory, { recursive: true });
 
-  return dto;
+      const statsFilePath = join(runStatsDirectory, `${Date.now().toString()}.json`);
+      await writeFile(statsFilePath, JSON.stringify(dto));
+      return statsFilePath;
+    }
+  } catch (e) {
+    if (e instanceof Error && 'code' in e && e.code !== 'ENOENT') {
+      console.warn(`Unable to write run stats: ${e}`);
+    }
+  }
 }

--- a/packages/cli/tests/unit/fingerprint/fingerprintWatchCommand.spec.ts
+++ b/packages/cli/tests/unit/fingerprint/fingerprintWatchCommand.spec.ts
@@ -203,14 +203,5 @@ describe(FingerprintWatchCommand, () => {
       ).toBe(false);
       mockWarn.mockRestore();
     });
-
-    describe('usage', () => {
-      const reportUsage = FingerprintWatchCommand.prototype['reportUsage'];
-
-      it('sends usage data', async () => {
-        await reportUsage.call({ directory: '/home/joe/work' }, []);
-        expect(Usage.update).toHaveBeenCalled();
-      });
-    });
   });
 });

--- a/packages/cli/tests/unit/lib/emitUsage.spec.ts
+++ b/packages/cli/tests/unit/lib/emitUsage.spec.ts
@@ -1,39 +1,72 @@
-import * as client from '@appland/client';
-import Sinon from 'sinon';
 import emitUsage from '../../../src/lib/emitUsage';
+import { dir } from 'tmp';
+import { promisify } from 'node:util';
+import { mkdir as mkdirCb, readFile as readFileCb, rm as rmCb } from 'graceful-fs';
+import { chdir } from 'node:process';
+import { UsageUpdateDto } from '@appland/client';
+import { Git } from '../../../src/telemetry';
 
-jest.mock('@appland/client');
-const Usage = jest.mocked(client.Usage);
+// Using graceful-fs should eliminate any risk of EBUSY errors on Windows.
+const mkdir = promisify(mkdirCb);
+const readFile = promisify(readFileCb);
+const rm = promisify(rmCb);
 
 describe('emitUsage', () => {
-  afterEach(Sinon.restore);
+  let rootDirectory: string;
+  const cwd = process.cwd();
 
-  beforeEach(() => {
-    Usage.update.mockResolvedValue();
+  beforeEach(async () => {
+    rootDirectory = await promisify(dir)();
+    chdir(rootDirectory);
   });
 
-  it('emits the expected usage information', async () => {
-    const numEvents = 1;
-    const numAppMaps = 2;
-    const metadata = { app: 'test', foo: 'bar' };
+  afterEach(async () => {
+    chdir(cwd);
+    await rm(rootDirectory, { recursive: true, force: true });
+    jest.clearAllMocks();
+  });
 
-    await emitUsage(process.cwd(), numEvents, numAppMaps, metadata as any);
-
-    expect(Usage.update).toHaveBeenCalled();
-    const [dto] = Usage.update.mock.calls[0];
-    expect(dto).toMatchObject({
-      events: numEvents,
-      appmaps: numAppMaps,
-      contributors: expect.any(Number),
-      ci: Boolean(process.env.CI),
+  describe('when the .appmap directory does not exist', () => {
+    it('does not emit any run stats information', async () => {
+      const resultPath = await emitUsage(process.cwd(), 1, 2);
+      expect(resultPath).toBeUndefined();
     });
-    expect(JSON.parse(dto.metadata ?? '{}')).toMatchObject({
-      app: metadata.app,
-      git: {
-        repository: expect.any(String),
-        branch: expect.any(String),
-        commit: expect.any(String),
-      },
+  });
+
+  describe('when the .appmap directory exists', () => {
+    const repository = 'my-repository';
+    const branch = 'my-branch';
+    const commit = 'my-commit';
+
+    beforeEach(async () => {
+      await mkdir('.appmap');
+      jest.spyOn(Git, 'repository').mockResolvedValue(repository);
+      jest.spyOn(Git, 'branch').mockResolvedValue(branch);
+      jest.spyOn(Git, 'commit').mockResolvedValue(commit);
+    });
+
+    it('emits the expected run stats information', async () => {
+      const numEvents = 1;
+      const numAppMaps = 2;
+      const metadata = { app: 'test', foo: 'bar' };
+
+      const resultPath = await emitUsage(process.cwd(), numEvents, numAppMaps, metadata as any);
+      expect(resultPath).toBeDefined();
+
+      const dto = JSON.parse(await readFile(resultPath as string, 'utf-8')) as UsageUpdateDto;
+      expect(dto).toMatchObject({
+        events: numEvents,
+        appmaps: numAppMaps,
+        ci: Boolean(process.env.CI),
+      });
+      expect(JSON.parse(dto.metadata ?? '{}')).toMatchObject({
+        app: metadata.app,
+        git: {
+          repository,
+          branch,
+          commit,
+        },
+      });
     });
   });
 });


### PR DESCRIPTION
Following indexing, a JSON file is output to `./appmap/run-stats` (assuming `.appmap` exists). This file contains a sample AppMap metadata blob, the number of events and AppMaps processed and indicates whether the index occurred in CI.

Currently, this is not enabled in `--watch` mode, only during one shot indexing of a specific directory or via the `analyze` command.