### PR TITLE
fix: Ignore invalid OpenAPI paths

### DIFF
--- a/packages/cli/src/cmds/openapi/DefinitionGenerator.ts
+++ b/packages/cli/src/cmds/openapi/DefinitionGenerator.ts
@@ -37,6 +37,9 @@ export default class DefinitionGenerator {
       for (const [path, pathItem] of Object.entries(openapi)) {
         if (pathItem) paths[path] = pathItem;
       }
+      for (const error of model.errors) {
+        console.warn(`Warning: ${error}`);
+      }
     }
     return {
       paths: Object.keys(paths)


### PR DESCRIPTION
OpenAPI paths must start with `/`. Discard paths that don't match this constraint.