### PR TITLE
feat: Disable diagram tabs in 'diff' mode

### DIFF
--- a/packages/components/src/components/DetailsButton.vue
+++ b/packages/components/src/components/DetailsButton.vue
@@ -43,7 +43,7 @@ export default {
   align-items: center;
   transition: $transition;
 
-  &:hover {
+  &:hover:not(&--disabled) {
     background-color: $gray4;
     border-color: $gray4;
     color: $gray1;
@@ -53,6 +53,19 @@ export default {
       }
       &--back:before {
         color: $gray1;
+      }
+    }
+  }
+
+  &--disabled {
+    cursor: not-allowed;
+    background-color: transparent;
+    border-color: $gray3;
+    color: $gray3;
+    .icon {
+      &--clear:before,
+      &--back:before {
+        color: $gray3;
       }
     }
   }

--- a/packages/components/src/components/DetailsPanelEvent.vue
+++ b/packages/components/src/components/DetailsPanelEvent.vue
@@ -7,15 +7,27 @@
       :object-id="object.id.toString()"
     >
       <template v-slot:links>
-        <v-details-button v-if="shouldDisplayViewInSequence" @click.native="viewEventInSequence">
+        <v-details-button
+          v-if="shouldDisplayViewInSequence"
+          @click.native="viewEventInSequence"
+          :class="classes"
+          :disabled="isDisabled"
+        >
           Show in Sequence
         </v-details-button>
-        <v-details-button v-if="shouldDisplayViewInTrace" @click.native="viewEventInTrace">
+        <v-details-button
+          v-if="shouldDisplayViewInTrace"
+          @click.native="viewEventInTrace"
+          :class="classes"
+          :disabled="isDisabled"
+        >
           Show in Trace
         </v-details-button>
         <v-details-button
           v-if="shouldDisplayViewInFlamegraph"
           @click.native="viewEventInFlamegraph"
+          :class="classes"
+          :disabled="isDisabled"
         >
           Show in Flame Graph
         </v-details-button>
@@ -214,6 +226,15 @@ export default {
 
     findings() {
       return (this.object.findings || []).map(toListItem);
+    },
+    isDisabled() {
+      if (!this.$store) return false;
+      return !!this.$store.state.precomputedSequenceDiagram;
+    },
+    classes() {
+      return {
+        'details-btn--disabled': this.isDisabled,
+      };
     },
   },
 

--- a/packages/components/src/components/TabButton.vue
+++ b/packages/components/src/components/TabButton.vue
@@ -1,5 +1,5 @@
 <template>
-  <button :class="classes" @click="clickTab">
+  <button :class="classes" :disabled="isDisabled" @click="clickTab">
     {{ label }}
   </button>
 </template>
@@ -14,6 +14,11 @@ export default {
         'tab-btn': true,
         'tab-btn--active': this.isActive,
       };
+    },
+    isDisabled() {
+      if (!this.$store) return false;
+
+      return !!this.$store.state.precomputedSequenceDiagram;
     },
   },
 
@@ -43,7 +48,6 @@ export default {
   border: 1px solid $gray2;
   border-radius: 0.25rem 0.25rem 0 0;
   background-color: transparent;
-  cursor: pointer;
   color: $lightgray2;
   font-size: 0.75rem;
   font-family: $appland-text-font-family;
@@ -52,26 +56,6 @@ export default {
   transition: $transition;
   white-space: nowrap;
 
-  &:hover,
-  &:active {
-    color: $base03;
-  }
-
-  &:focus {
-    outline: none;
-  }
-
-  &--active {
-    border-bottom-color: $black;
-    cursor: default;
-    color: $base03;
-
-    &:hover,
-    &:active {
-      color: $base03;
-    }
-  }
-
   .tab-badge {
     background-color: $hotpink;
     font-size: 11px;
@@ -79,6 +63,24 @@ export default {
     margin-left: 0.4rem;
     padding: 2px 4px;
     color: white;
+  }
+
+  &--active {
+    border-bottom-color: $black;
+    cursor: default;
+    color: $base03;
+  }
+
+  &:enabled {
+    cursor: pointer;
+
+    &:hover {
+      color: $base03;
+    }
+
+    &:focus {
+      outline: none;
+    }
   }
 }
 </style>

--- a/packages/components/src/components/TabButton.vue
+++ b/packages/components/src/components/TabButton.vue
@@ -13,6 +13,7 @@ export default {
       return {
         'tab-btn': true,
         'tab-btn--active': this.isActive,
+        'tab-btn--disabled': !this.isActive && this.isDisabled,
       };
     },
     isDisabled() {
@@ -69,6 +70,10 @@ export default {
     border-bottom-color: $black;
     cursor: default;
     color: $base03;
+  }
+
+  &--disabled {
+    cursor: not-allowed;
   }
 
   &:enabled {

--- a/packages/components/tests/e2e/specs/appmap/sequenceDiagramDiff.spec.js
+++ b/packages/components/tests/e2e/specs/appmap/sequenceDiagramDiff.spec.js
@@ -5,6 +5,13 @@ context('Sequence Diagram', () => {
     );
   });
 
+  it('view tabs are disabled', () => {
+    cy.get('.tabs .tab-btn').contains('Dependency Map').should('be.disabled');
+    cy.get('.tabs .tab-btn').contains('Sequence Diagram').should('be.disabled');
+    cy.get('.tabs .tab-btn').contains('Trace View').should('be.disabled');
+    cy.get('.tabs .tab-btn').contains('Flame Graph').should('be.disabled');
+  });
+
   it('opens as the initial view', () => {
     cy.get('.sequence-diagram').should('exist');
   });

--- a/packages/components/tests/e2e/specs/appmap/sequenceDiagramDiff.spec.js
+++ b/packages/components/tests/e2e/specs/appmap/sequenceDiagramDiff.spec.js
@@ -12,6 +12,14 @@ context('Sequence Diagram', () => {
     cy.get('.tabs .tab-btn').contains('Flame Graph').should('be.disabled');
   });
 
+  it.only('sidebar buttons are disabled', () => {
+    cy.get('div:nth-child(40) > div.call-line-segment.label-span.arrow-base').click();
+    cy.get('.details-panel-header__ghost-link .details-btn').each(($btn) => {
+      // For each button, check if it has the attribute 'disabled'
+      cy.wrap($btn).should('have.attr', 'disabled');
+    });
+  });
+
   it('opens as the initial view', () => {
     cy.get('.sequence-diagram').should('exist');
   });


### PR DESCRIPTION
When showing a precomputed sequence diagram, disable the other tabs since they don't indicate any "diff". Also, disable the options to `Show in Trace`, `Show in Sequence`, `Show in Flame Graph`. This whole section of the LHS panel can be disabled.

In the future, it would be great to bring "diff" to the dependency map as well.

# Progress

When using a precomputed AppMap:

- [x] Tabs to switch between views are disabled
- [x] `Show in X` in the LHS panel is disabled
