### PR TITLE
Return value tooltip on hover

### DIFF
--- a/packages/components/src/components/DiagramSequence.vue
+++ b/packages/components/src/components/DiagramSequence.vue
@@ -35,6 +35,7 @@
               :actionSpec="action"
               :collapsed-actions="collapsedActions"
               :key="actionKey(action)"
+              :return-value="returnValue(action)"
             />
           </template>
         </template>
@@ -198,6 +199,26 @@ export default {
           selected.firstElementChild.scrollIntoView(SCROLL_OPTIONS);
         }
       }, 16);
+    },
+    returnValue(action: ActionSpec): string {
+      if (!action.eventIds || !this.appMap || !this.appMap.eventsById) {
+        return '';
+      }
+      const eventId = action.eventIds[0];
+      const event = this.appMap.eventsById[eventId];
+
+      if (!event) return '';
+
+      if (event.returnValue?.value) {
+        return event.returnValue.value;
+      }
+
+      if (event.exceptions?.length) {
+        const exception = event.exceptions[0];
+        return `${exception.class} ${exception.message}`;
+      }
+
+      return '';
     },
   },
 

--- a/packages/components/src/components/sequence/ReturnAction.vue
+++ b/packages/components/src/components/sequence/ReturnAction.vue
@@ -19,7 +19,7 @@
           },
         }"
       >
-        <VReturnLabel :action-spec="actionSpec" />
+        <VReturnLabel :action-spec="actionSpec" :return-value="returnValue" />
       </div>
     </template>
     <template v-else-if="actionSpec.callArrowDirection === 'right'">
@@ -35,7 +35,7 @@
             },
           }"
         >
-          <VReturnLabel :action-spec="actionSpec" />
+          <VReturnLabel :action-spec="actionSpec" :return-value="returnValue" />
           <Arrow class="arrow" />
         </div>
       </template>
@@ -51,7 +51,7 @@
             },
           }"
         >
-          <VReturnLabel :action-spec="actionSpec" />
+          <VReturnLabel :action-spec="actionSpec" :return-value="returnValue" />
           <Arrow class="arrow" />
         </div>
         <template v-if="actionSpec.calleeActionIndex - actionSpec.callerActionIndex > 2">
@@ -93,7 +93,7 @@
             },
           }"
         >
-          <VReturnLabel :action-spec="actionSpec" />
+          <VReturnLabel :action-spec="actionSpec" :return-value="returnValue" />
           <Arrow class="arrow" />
         </div>
       </template>
@@ -133,7 +133,7 @@
             },
           }"
         >
-          <VReturnLabel :action-spec="actionSpec" />
+          <VReturnLabel :action-spec="actionSpec" :return-value="returnValue" />
           <Arrow class="arrow" />
         </div>
       </template>
@@ -162,6 +162,11 @@ export default {
     collapsedActions: {
       type: Array,
       required: true,
+    },
+    returnValue: {
+      type: String,
+      required: true,
+      readonly: true,
     },
   },
 

--- a/packages/components/src/components/sequence/ReturnLabel.vue
+++ b/packages/components/src/components/sequence/ReturnLabel.vue
@@ -1,6 +1,7 @@
 <template>
-  <div class="label">
+  <div class="label" @mouseover="hover = true" @mouseout="hover = false">
     <span class="name">{{ label }}</span>
+    <span v-if="hover && returnValue" class="tooltip">{{ returnValue }}</span>
   </div>
 </template>
 
@@ -10,11 +11,20 @@ import { ActionSpec } from './ActionSpec';
 export default {
   name: 'v-sequence-return-label',
 
-  components: {},
+  data() {
+    return {
+      hover: false,
+    };
+  },
 
   props: {
     actionSpec: {
       type: ActionSpec,
+      required: true,
+      readonly: true,
+    },
+    returnValue: {
+      type: String,
       required: true,
       readonly: true,
     },
@@ -42,5 +52,15 @@ export default {
   text-overflow: ellipsis;
   font-style: italic;
   color: lighten($gray4, 20);
+}
+
+.tooltip {
+  position: absolute;
+  background-color: #fff;
+  color: #000;
+  border: 1px solid #ccc;
+  padding: 5px;
+  z-index: 1;
+  opacity: 0.9;
 }
 </style>

--- a/packages/components/tests/e2e/specs/appmap/sequenceDiagram.spec.js
+++ b/packages/components/tests/e2e/specs/appmap/sequenceDiagram.spec.js
@@ -45,6 +45,14 @@ context('AppMap sequence diagram', () => {
       cy.get('.sequence-actor[data-actor-id="class:openssl/Digest::Instance"]').should('exist');
       cy.get('.sequence-actor[data-actor-id="class:openssl/OpenSSL::Cipher"]').should('exist');
     });
+
+    it.only('should display the tooltip on hover', () => {
+      // Hover over the .label
+      cy.get('.return:nth-child(14) .name').trigger('mouseover');
+      cy.get('.return:nth-child(14) span.tooltip').should('exist');
+      cy.get('.return:nth-child(14) .name').trigger('mouseout');
+      cy.get('.return:nth-child(14) span.tooltip').should('not.exist');
+    });
   });
 
   context('with no data provided', () => {


### PR DESCRIPTION
Fixes: #1353 

feat(components/DiagramSequence.vue): add appMap prop to DiagramSequence
feat(sequence/ReturnAction.vue): integrate appMap prop to VReturnLabel instances
feat(sequence/ReturnLabel.vue): add tooltip to display return values or exceptions on hover
feat(sequenceDiagram.spec.js): add e2e test to verify tooltip visibility on hover