### PR TITLE
Appmap filter works in the browser

### DIFF
--- a/packages/components/tests/e2e/specs/appmap/viewFilter.spec.js
+++ b/packages/components/tests/e2e/specs/appmap/viewFilter.spec.js
@@ -272,6 +272,63 @@ context('AppMap view filter', () => {
     });
   });
 
+  context('when used in a browser', () => {
+    beforeEach(() => {
+      cy.visit(
+        'http://localhost:6006/iframe.html?args=&id=pages-vs-code--extension&viewMode=story'
+      );
+    });
+
+    it('disables the delete and default buttons for AppMap default filter', () => {
+      cy.get('.tabs .tab-btn').contains('Trace View').click();
+      cy.get('.trace .trace-node').should('have.length', 4);
+      cy.get('.tabs__controls .popper__button').click();
+
+      cy.get('.filters__select').find(':selected').should('contain.text', 'AppMap default');
+      cy.get('.filters__button-disabled').first().should('contain.text', 'Load');
+      cy.get('.filters__button').eq(1).should('contain.text', 'Copy');
+      cy.get('.filters__button-disabled').eq(1).should('contain.text', 'Delete');
+      cy.get('.filters__button-disabled').eq(2).should('contain.text', 'Set as default');
+    });
+
+    it('saves a new filter and sets it as default', () => {
+      cy.get('.tabs__controls .popper__button').click();
+      cy.get('.filters__select > option').should('have.length', 1);
+
+      // save new filter
+      cy.get('.filters__checkbox').eq(2).click();
+      cy.get('.filters__input').type('new filter');
+      cy.get('[data-cy="save-filter-button"]').click();
+
+      cy.get('.filters__select').find(':selected').should('contain.text', 'new filter');
+      cy.get('.filters__button-disabled').first().should('contain.text', 'Load');
+      cy.get('.filters__select > option').should('have.length', 2);
+
+      // set as default
+      cy.get('.filters__button').contains('Set as default').click();
+      cy.get('.filters__button-disabled').eq(1).should('contain.text', 'Set as default');
+
+      cy.get('.filters__select').select('AppMap default');
+      cy.get('.filters__button').eq(2).should('contain.text', 'Set as default');
+    });
+
+    it('overwrites an existing filter with the same name', () => {
+      cy.get('.tabs__controls .popper__button').click();
+
+      // save new filter
+      cy.get('.filters__checkbox').eq(2).click();
+      cy.get('.filters__input').type('new filter');
+      cy.get('[data-cy="save-filter-button"]').click();
+
+      // overwrite new filter
+      cy.get('.filters__checkbox').eq(3).click();
+      cy.get('.filters__input').type('new filter');
+      cy.get('[data-cy="save-filter-button"]').click();
+
+      cy.get('.filters__select > option').should('have.length', 2);
+    });
+  });
+
   context('without HTTP events', () => {
     beforeEach(() => {
       cy.visit(


### PR DESCRIPTION
Fixes #1379 

If you want to test this just go [here](https://5fe18baf66f2280021e634d0-gjwlzrufqf.chromatic.com/iframe.html?id=pages-vs-code--extension&viewMode=story) and try it out. Saving, deleting, and setting filters as default didn't used to work in Storybook, but now you can do any of those things and the filters will get saved in the browser's local storage.