### PR TITLE
Long function call labels on top of lifelines

### DIFF
--- a/packages/components/src/components/sequence/CallAction.vue
+++ b/packages/components/src/components/sequence/CallAction.vue
@@ -441,6 +441,10 @@ export default {
   fill: $sequence-call-line-color;
 }
 
+.connecting-span {
+  position: relative;
+}
+
 .call-right {
   .single-span {
     left: calc(((var(--caller-lifecycle-depth)) * $sequence-activation-gutter-width));
@@ -470,6 +474,7 @@ export default {
   .connecting-span {
     border-radius: 0;
     border-top: 4px solid $black;
+    position: relative;
   }
 
   .arrow {
@@ -487,6 +492,7 @@ export default {
   .connecting-span {
     border-radius: 0;
     border-top: 4px solid $black;
+    position: relative;
   }
 
   .arrow-head {

--- a/packages/components/src/components/sequence/CallLabel.vue
+++ b/packages/components/src/components/sequence/CallLabel.vue
@@ -168,6 +168,7 @@ $bg-fade: rgba(0, 0, 0, 0.8);
 
   .name {
     border-radius: 3px;
+    background-color: rgba(0, 0, 0, 0.7);
     color: lighten($gray4, 20);
     display: inline-block;
     padding: 2px 4px;

--- a/packages/components/tests/e2e/specs/appmap/sequenceDiagram.spec.js
+++ b/packages/components/tests/e2e/specs/appmap/sequenceDiagram.spec.js
@@ -45,6 +45,13 @@ context('AppMap sequence diagram', () => {
       cy.get('.sequence-actor[data-actor-id="class:openssl/Digest::Instance"]').should('exist');
       cy.get('.sequence-actor[data-actor-id="class:openssl/OpenSSL::Cipher"]').should('exist');
     });
+
+    it('check if all .call-line-segment.connecting-span elements have position as relative', () => {
+      // Check each .connecting-span for position: relative
+      cy.get('.call-line-segment.connecting-span').each(($el) => {
+        expect($el.css('position')).to.eq('relative');
+      });
+    });
   });
 
   context('with no data provided', () => {


### PR DESCRIPTION
Fixes: #1051 
style(CallAction.vue): add position:relative to .connecting-span for better alignment
test(sequenceDiagram.spec.js): verify .call-line-segment.connecting-span has position relative