### PR TITLE
feat: Enable and disable report sections

### DIFF
--- a/packages/cli/resources/change-report.hbs
+++ b/packages/cli/resources/change-report.hbs
@@ -26,9 +26,9 @@ No relevant code changes found.
 {{#with stack }}
 {{#each this }}
 {{#if (source_url this)}}
-* [{{this}}]({{ source_url this }})
+- [{{this}}]({{ source_url this }})
 {{else}}
-* {{ this }}
+- {{ this }}
 {{/if}}
 {{/each}}
 {{/with}}
@@ -62,8 +62,10 @@ No relevant code changes found.
 
 | Summary | Status |
 | --- | --- |
-| [Test failures](#test-failures) | {{#if testFailures.length}}:warning: {{testFailures.length}} failed{{else}}:white_check_mark: All tests passed{{/if}} |
-{{#if (defined apiDiff) }}
+{{#if (enabled 'failed-tests') }}
+| [Failed tests](#failed-tests) | {{#if testFailures.length}}:warning: {{testFailures.length}} failed{{else}}:white_check_mark: All tests passed{{/if}} |
+{{~/if}}
+{{~#if (enabled 'openapi-diff')}}{{~#if (defined apiDiff) }}
 | [API changes](#api-changes) | 
   {{~#unless apiDiff.differenceCount }}
   :white_check_mark: No API changes
@@ -73,8 +75,8 @@ No relevant code changes found.
   {{~#if apiDiff.nonBreakingDifferenceCount }}{{#if apiDiff.breakingDifferenceCount }},&nbsp;{{~/if}}:wrench: {{apiDiff.nonBreakingDifferenceCount}} non-breaking{{~/if}}
   {{~/if}}
   |
-{{/if}}
-{{#if (defined findingDiff) }}
+{{~/if}}{{~/if}}
+{{~#if (enabled 'findings')}}{{~#if (defined findingDiff) }}
 | [Findings](#findings) |
   {{~#with findingDiff}}
   {{~#unless (length new resolved) }}
@@ -88,7 +90,8 @@ No relevant code changes found.
   {{~/if}}
   {{~/with}}
   |
-{{/if}}
+{{~/if}}{{~/if}}
+{{#if (enabled 'new-appmaps')}}
 | [New AppMaps](#new-appmaps) | 
   {{~#unless newAppMaps.length }}
   :white_check_mark: None
@@ -96,16 +99,20 @@ No relevant code changes found.
   :star: {{newAppMaps.length}} new
   {{~/unless}}
   |
-| [Changed code behavior](#changed-code-behavior) |
+{{/if}}
+{{#if (enabled 'changed-appmaps')}}
+| [Changed AppMaps](#changed-appmaps) |
   {{~#unless sequenceDiagramDiffSnippetCount }}
   :white_check_mark: No changes
   {{~else}}
   :twisted_rightwards_arrows: {{sequenceDiagramDiffSnippetCount}} changes
   {{~/unless}}
   |
+{{~/if}}
 
+{{#if (enabled 'failed-tests')}}
 {{#if testFailures.length}}
-## :warning: Test failures
+## :warning: Failed tests
 
 {{#each testFailures}}
 
@@ -159,7 +166,9 @@ No relevant code changes found.
 
 {{/each}}
 {{/if}}
+{{/if}}
 
+{{#if (enabled 'openapi-diff')}}
 {{#if apiDiff.differenceCount }}
 
 ## 🔄 API changes
@@ -168,7 +177,7 @@ No relevant code changes found.
 ### 🚧 Breaking changes
 
 {{#each apiDiff.breakingDifferences}}
-  - {{> api-change }}
+- {{> api-change }}
 {{/each}}
 {{/if}}
 
@@ -176,7 +185,7 @@ No relevant code changes found.
 ### :wrench: Non-breaking changes
 
 {{#each apiDiff.nonBreakingDifferences}}
-  - {{> api-change }}
+- {{> api-change }}
 {{/each}}
 {{/if}}
 
@@ -199,7 +208,9 @@ No relevant code changes found.
 </details>
 
 {{/if}}
+{{/if}}
 
+{{#if (enabled 'findings') }}
 {{#with findingDiff}}
 {{#if (length new resolved)}}
 
@@ -225,7 +236,9 @@ No relevant code changes found.
 
 {{/if}}
 {{/with}}
+{{/if}}
 
+{{#if (enabled 'new-appmaps')}}
 {{#if newAppMaps.length }}
 
 <h2 id="new-appmaps">New AppMaps</h2>
@@ -237,9 +250,11 @@ No relevant code changes found.
 {{/each}}
 
 {{/if}}
+{{/if}}
 
+{{#if (enabled 'changed-appmaps')}}
 {{#if sequenceDiagramDiffSnippetCount }}
-## :twisted_rightwards_arrows: Changed code behavior
+## :twisted_rightwards_arrows: Changed AppMaps
 
 <details>
 
@@ -260,4 +275,5 @@ Review {{ sequenceDiagramDiffSnippetCount }} changes
 {{/each}}
 
 </details>
+{{/if}}
 {{/if}}

--- a/packages/cli/src/cmds/compare-report/MarkdownReport.ts
+++ b/packages/cli/src/cmds/compare-report/MarkdownReport.ts
@@ -25,7 +25,14 @@ function isURL(path: string): boolean {
   }
 }
 
+export const SECTIONS = ['failed-tests', 'openapi-diff', 'findings', 'new-appmaps'];
+
+export const EXPERIMENTAL_SECTIONS = ['changed-appmaps'];
+
 export default class MarkdownReport implements Report {
+  public excludeSections: string[] | undefined;
+  public includeSections: string[] | undefined;
+
   constructor(public appmapURL: URL, public sourceURL: URL) {}
 
   async generateReport(changeReport: ChangeReport, baseDir: string): Promise<string> {
@@ -135,6 +142,15 @@ export default class MarkdownReport implements Report {
     }
 
     const self = this;
+
+    Handlebars.registerHelper('enabled', function (section: string): boolean {
+      if (SECTIONS.includes(section) && !self.excludeSections?.includes(section)) return true;
+
+      if (EXPERIMENTAL_SECTIONS.includes(section) && self.includeSections?.includes(section))
+        return true;
+
+      return false;
+    });
 
     Handlebars.registerHelper('inspect', function (value: any) {
       return new Handlebars.SafeString(JSON.stringify(value, null, 2));

--- a/packages/cli/tests/unit/compareReport/expectedReport-changedAppMaps.md.txt
+++ b/packages/cli/tests/unit/compareReport/expectedReport-changedAppMaps.md.txt
@@ -7,13 +7,13 @@
 
 | Summary | Status |
 | --- | --- |
-| [Test failures](#test-failures) | :warning: 3 failed |
+| [Failed tests](#failed-tests) | :warning: 3 failed |
 | [API changes](#api-changes) |🚧 4 breaking,&nbsp;:wrench: 1 non-breaking  |
 | [Findings](#findings) |  :tada: 4 resolved  |
 | [New AppMaps](#new-appmaps) |  :star: 1 new  |
-| [Changed code behavior](#changed-code-behavior) |  :twisted_rightwards_arrows: 1 changes  |
+| [Changed AppMaps](#changed-appmaps) |  :twisted_rightwards_arrows: 1 changes  |
 
-## :warning: Test failures
+## :warning: Failed tests
 
 
 <details>
@@ -116,14 +116,14 @@ No relevant code changes found.
 
 ### 🚧 Breaking changes
 
-  - Remove path `/microposts/{id}` 
-  - Remove response status code `302 POST /microposts` 
-  - Remove response status code `303 POST /microposts` 
-  - Remove response status code `422 POST /microposts` 
+- Remove path `/microposts/{id}` 
+- Remove response status code `302 POST /microposts` 
+- Remove response status code `303 POST /microposts` 
+- Remove response status code `422 POST /microposts` 
 
 ### :wrench: Non-breaking changes
 
-  - Add response status code  `200 POST /microposts`
+- Add response status code  `200 POST /microposts`
 
 
 <details>
@@ -198,11 +198,11 @@ No relevant code changes found.
 
 ##### Stack trace
 
-* [app/helpers/sessions_helper.rb:19](app/helpers/sessions_helper.rb:19)
-* [app/helpers/sessions_helper.rb:35](app/helpers/sessions_helper.rb:35)
-* [app/views/shared/_feed.html.erb](app/views/shared/_feed.html.erb)
-* [app/views/static_pages/home.html.erb](app/views/static_pages/home.html.erb)
-* /home/ahtrotta/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/actionpack-7.0.4/lib/action_controller/metal/renderers.rb:140
+- [app/helpers/sessions_helper.rb:19](app/helpers/sessions_helper.rb:19)
+- [app/helpers/sessions_helper.rb:35](app/helpers/sessions_helper.rb:35)
+- [app/views/shared/_feed.html.erb](app/views/shared/_feed.html.erb)
+- [app/views/static_pages/home.html.erb](app/views/static_pages/home.html.erb)
+- /home/ahtrotta/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/actionpack-7.0.4/lib/action_controller/metal/renderers.rb:140
 
 
 </details>
@@ -224,12 +224,12 @@ No relevant code changes found.
 
 ##### Stack trace
 
-* [app/helpers/sessions_helper.rb:19](app/helpers/sessions_helper.rb:19)
-* [app/helpers/sessions_helper.rb:35](app/helpers/sessions_helper.rb:35)
-* [app/views/shared/_feed.html.erb](app/views/shared/_feed.html.erb)
-* [app/views/static_pages/home.html.erb](app/views/static_pages/home.html.erb)
-* /home/ahtrotta/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/actionpack-7.0.4/lib/action_controller/metal/renderers.rb:140
-* [app/controllers/microposts_controller.rb:5](app/controllers/microposts_controller.rb:5)
+- [app/helpers/sessions_helper.rb:19](app/helpers/sessions_helper.rb:19)
+- [app/helpers/sessions_helper.rb:35](app/helpers/sessions_helper.rb:35)
+- [app/views/shared/_feed.html.erb](app/views/shared/_feed.html.erb)
+- [app/views/static_pages/home.html.erb](app/views/static_pages/home.html.erb)
+- /home/ahtrotta/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/actionpack-7.0.4/lib/action_controller/metal/renderers.rb:140
+- [app/controllers/microposts_controller.rb:5](app/controllers/microposts_controller.rb:5)
 
 
 </details>
@@ -251,11 +251,11 @@ No relevant code changes found.
 
 ##### Stack trace
 
-* [app/helpers/sessions_helper.rb:19](app/helpers/sessions_helper.rb:19)
-* [app/helpers/sessions_helper.rb:35](app/helpers/sessions_helper.rb:35)
-* [app/views/shared/_feed.html.erb](app/views/shared/_feed.html.erb)
-* [app/views/static_pages/home.html.erb](app/views/static_pages/home.html.erb)
-* /home/ahtrotta/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/actionpack-7.0.4/lib/action_controller/metal/renderers.rb:140
+- [app/helpers/sessions_helper.rb:19](app/helpers/sessions_helper.rb:19)
+- [app/helpers/sessions_helper.rb:35](app/helpers/sessions_helper.rb:35)
+- [app/views/shared/_feed.html.erb](app/views/shared/_feed.html.erb)
+- [app/views/static_pages/home.html.erb](app/views/static_pages/home.html.erb)
+- /home/ahtrotta/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/actionpack-7.0.4/lib/action_controller/metal/renderers.rb:140
 
 
 </details>
@@ -277,10 +277,10 @@ No relevant code changes found.
 
 ##### Stack trace
 
-* [app/helpers/sessions_helper.rb:19](app/helpers/sessions_helper.rb:19)
-* [app/helpers/sessions_helper.rb:40](app/helpers/sessions_helper.rb:40)
-* [app/views/users/show.html.erb](app/views/users/show.html.erb)
-* /home/ahtrotta/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/actionpack-7.0.4/lib/action_controller/metal/renderers.rb:140
+- [app/helpers/sessions_helper.rb:19](app/helpers/sessions_helper.rb:19)
+- [app/helpers/sessions_helper.rb:40](app/helpers/sessions_helper.rb:40)
+- [app/views/users/show.html.erb](app/views/users/show.html.erb)
+- /home/ahtrotta/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/actionpack-7.0.4/lib/action_controller/metal/renderers.rb:140
 
 
 </details>
@@ -293,22 +293,15 @@ No relevant code changes found.
 
 [minitest/Valid_login_redirect_after_login](head/minitest/Valid_login_redirect_after_login.appmap.json)
 
-
-
-## :twisted_rightwards_arrows: Changed code behavior
+## :twisted_rightwards_arrows: Changed AppMaps
 
 <details>
-
 <summary>
 Review 1 changes
 </summary>
 
-
 ```
 removed SQL `PRAGMA foreign_keys = ON`
 ```
-
 - [minitest/Microposts_controller_should_redirect_destroy_for_wrong_micropost](diff/minitest/Microposts_controller_should_redirect_destroy_for_wrong_micropost.diff.sequence.json)
-
-
 </details>

--- a/packages/cli/tests/unit/compareReport/expectedReport-openapiDiff.md.txt
+++ b/packages/cli/tests/unit/compareReport/expectedReport-openapiDiff.md.txt
@@ -1,0 +1,229 @@
+# AppMap
+
+
+
+
+
+
+| Summary | Status |
+| --- | --- |
+| [Failed tests](#failed-tests) | :warning: 3 failed |
+| [Findings](#findings) |  :tada: 4 resolved  |
+| [New AppMaps](#new-appmaps) |  :star: 1 new  |
+
+## :warning: Failed tests
+
+
+<details>
+<summary>
+test/controllers/microposts_controller_test.rb:24
+</summary>
+
+<p/>
+
+[test/controllers/microposts_controller_test.rb:24](test/controllers/microposts_controller_test.rb:24) failed with error:
+
+```
+NoMethodError: undefined method `micropost_path' for #<MicropostsControllerTest:0x00007f311d97a068>
+Did you mean?  microposts
+    test/controllers/microposts_controller_test.rb:28:in `block (2 levels) in <class:MicropostsControllerTest>'
+    test/controllers/microposts_controller_test.rb:27:in `block in <class:MicropostsControllerTest>'
+```
+
+
+
+
+No relevant code changes found.
+
+| Diagram | Link |
+| --- | --- |
+| Sequence diagram diff | [minitest/Microposts_controller_should_redirect_destroy_for_wrong_micropost.diff.sequence.json](diff/minitest/Microposts_controller_should_redirect_destroy_for_wrong_micropost.diff.sequence.json) |
+| AppMap | [minitest/Microposts_controller_should_redirect_destroy_for_wrong_micropost](head/minitest/Microposts_controller_should_redirect_destroy_for_wrong_micropost.appmap.json) |
+
+</details>
+
+
+<details>
+<summary>
+test/integration/microposts_interface_test.rb:9
+</summary>
+
+<p/>
+
+[test/integration/microposts_interface_test.rb:9](test/integration/microposts_interface_test.rb:9) failed with error:
+
+```
+ActionView::Template::Error: undefined method `micropost_path' for #<ActionView::Base:0x00000000028410>
+
+              target.public_send(method, *args)
+                    ^^^^^^^^^^^^
+Did you mean?  microposts_path
+    app/views/microposts/_micropost.html.erb:13
+    app/views/shared/_feed.html.erb:3
+    app/views/static_pages/home.html.erb:16
+    test/integration/microposts_interface_test.rb:11:in `block in <class:MicropostsInterfaceTest>'
+```
+
+
+
+
+No relevant code changes found.
+
+| Diagram | Link |
+| --- | --- |
+| Sequence diagram diff | [minitest/Microposts_interface_micropost_interface.diff.sequence.json](diff/minitest/Microposts_interface_micropost_interface.diff.sequence.json) |
+| AppMap | [minitest/Microposts_interface_micropost_interface](head/minitest/Microposts_interface_micropost_interface.appmap.json) |
+
+</details>
+
+
+<details>
+<summary>
+test/integration/users_login_test.rb:45
+</summary>
+
+<p/>
+
+[test/integration/users_login_test.rb:45](test/integration/users_login_test.rb:45) failed with error:
+
+```
+ActionView::Template::Error: undefined method `micropost_path' for #<ActionView::Base:0x0000000002b3e0>
+
+              target.public_send(method, *args)
+                    ^^^^^^^^^^^^
+Did you mean?  microposts_path
+    app/views/microposts/_micropost.html.erb:13
+    app/views/users/show.html.erb:19
+    test/integration/users_login_test.rb:46:in `block in <class:ValidLoginTest>'
+```
+
+
+
+
+No relevant code changes found.
+
+| Diagram | Link |
+| --- | --- |
+| AppMap | [minitest/Valid_login_redirect_after_login](head/minitest/Valid_login_redirect_after_login.appmap.json) |
+
+</details>
+
+
+<h2 id="findings">Findings</h2>
+
+
+### :tada: Resolved findings (4)
+
+
+### N plus 1 SQL query
+
+<details>
+<summary>
+  Finding details
+</summary>
+
+| Field | Value |
+| --- | --- |
+| Message | app_views_shared__feed_html_erb.render[418] contains 30 occurrences of SQL: SELECT &quot;users&quot;.* FROM &quot;users&quot; WHERE &quot;users&quot;.&quot;id&quot; &#x3D; ? LIMIT ? |
+| AppMap | [minitest/Microposts_interface_micropost_interface.appmap.json](head/minitest/Microposts_interface_micropost_interface.appmap.json) |
+
+##### Related code changes
+No relevant code changes found.
+
+##### Stack trace
+
+- [app/helpers/sessions_helper.rb:19](app/helpers/sessions_helper.rb:19)
+- [app/helpers/sessions_helper.rb:35](app/helpers/sessions_helper.rb:35)
+- [app/views/shared/_feed.html.erb](app/views/shared/_feed.html.erb)
+- [app/views/static_pages/home.html.erb](app/views/static_pages/home.html.erb)
+- /home/ahtrotta/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/actionpack-7.0.4/lib/action_controller/metal/renderers.rb:140
+
+
+</details>
+
+### N plus 1 SQL query
+
+<details>
+<summary>
+  Finding details
+</summary>
+
+| Field | Value |
+| --- | --- |
+| Message | app_views_shared__feed_html_erb.render[2707] contains 30 occurrences of SQL: SELECT &quot;users&quot;.* FROM &quot;users&quot; WHERE &quot;users&quot;.&quot;id&quot; &#x3D; ? LIMIT ? |
+| AppMap | [minitest/Microposts_interface_micropost_interface.appmap.json](head/minitest/Microposts_interface_micropost_interface.appmap.json) |
+
+##### Related code changes
+No relevant code changes found.
+
+##### Stack trace
+
+- [app/helpers/sessions_helper.rb:19](app/helpers/sessions_helper.rb:19)
+- [app/helpers/sessions_helper.rb:35](app/helpers/sessions_helper.rb:35)
+- [app/views/shared/_feed.html.erb](app/views/shared/_feed.html.erb)
+- [app/views/static_pages/home.html.erb](app/views/static_pages/home.html.erb)
+- /home/ahtrotta/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/actionpack-7.0.4/lib/action_controller/metal/renderers.rb:140
+- [app/controllers/microposts_controller.rb:5](app/controllers/microposts_controller.rb:5)
+
+
+</details>
+
+### N plus 1 SQL query
+
+<details>
+<summary>
+  Finding details
+</summary>
+
+| Field | Value |
+| --- | --- |
+| Message | app_views_shared__feed_html_erb.render[3734] contains 30 occurrences of SQL: SELECT &quot;users&quot;.* FROM &quot;users&quot; WHERE &quot;users&quot;.&quot;id&quot; &#x3D; ? LIMIT ? |
+| AppMap | [minitest/Microposts_interface_micropost_interface.appmap.json](head/minitest/Microposts_interface_micropost_interface.appmap.json) |
+
+##### Related code changes
+No relevant code changes found.
+
+##### Stack trace
+
+- [app/helpers/sessions_helper.rb:19](app/helpers/sessions_helper.rb:19)
+- [app/helpers/sessions_helper.rb:35](app/helpers/sessions_helper.rb:35)
+- [app/views/shared/_feed.html.erb](app/views/shared/_feed.html.erb)
+- [app/views/static_pages/home.html.erb](app/views/static_pages/home.html.erb)
+- /home/ahtrotta/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/actionpack-7.0.4/lib/action_controller/metal/renderers.rb:140
+
+
+</details>
+
+### N plus 1 SQL query
+
+<details>
+<summary>
+  Finding details
+</summary>
+
+| Field | Value |
+| --- | --- |
+| Message | app_views_users_show_html_erb.render[4559] contains 6 occurrences of SQL: SELECT &quot;users&quot;.* FROM &quot;users&quot; WHERE &quot;users&quot;.&quot;id&quot; &#x3D; ? LIMIT ? |
+| AppMap | [minitest/Microposts_interface_micropost_interface.appmap.json](head/minitest/Microposts_interface_micropost_interface.appmap.json) |
+
+##### Related code changes
+No relevant code changes found.
+
+##### Stack trace
+
+- [app/helpers/sessions_helper.rb:19](app/helpers/sessions_helper.rb:19)
+- [app/helpers/sessions_helper.rb:40](app/helpers/sessions_helper.rb:40)
+- [app/views/users/show.html.erb](app/views/users/show.html.erb)
+- /home/ahtrotta/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/actionpack-7.0.4/lib/action_controller/metal/renderers.rb:140
+
+
+</details>
+
+
+
+
+<h2 id="new-appmaps">New AppMaps</h2>
+
+
+[minitest/Valid_login_redirect_after_login](head/minitest/Valid_login_redirect_after_login.appmap.json)
+

--- a/packages/cli/tests/unit/compareReport/expectedReport.md.txt
+++ b/packages/cli/tests/unit/compareReport/expectedReport.md.txt
@@ -1,0 +1,294 @@
+# AppMap
+
+
+
+
+
+
+| Summary | Status |
+| --- | --- |
+| [Failed tests](#failed-tests) | :warning: 3 failed |
+| [API changes](#api-changes) |🚧 4 breaking,&nbsp;:wrench: 1 non-breaking  |
+| [Findings](#findings) |  :tada: 4 resolved  |
+| [New AppMaps](#new-appmaps) |  :star: 1 new  |
+
+## :warning: Failed tests
+
+
+<details>
+<summary>
+test/controllers/microposts_controller_test.rb:24
+</summary>
+
+<p/>
+
+[test/controllers/microposts_controller_test.rb:24](test/controllers/microposts_controller_test.rb:24) failed with error:
+
+```
+NoMethodError: undefined method `micropost_path' for #<MicropostsControllerTest:0x00007f311d97a068>
+Did you mean?  microposts
+    test/controllers/microposts_controller_test.rb:28:in `block (2 levels) in <class:MicropostsControllerTest>'
+    test/controllers/microposts_controller_test.rb:27:in `block in <class:MicropostsControllerTest>'
+```
+
+
+
+
+No relevant code changes found.
+
+| Diagram | Link |
+| --- | --- |
+| Sequence diagram diff | [minitest/Microposts_controller_should_redirect_destroy_for_wrong_micropost.diff.sequence.json](diff/minitest/Microposts_controller_should_redirect_destroy_for_wrong_micropost.diff.sequence.json) |
+| AppMap | [minitest/Microposts_controller_should_redirect_destroy_for_wrong_micropost](head/minitest/Microposts_controller_should_redirect_destroy_for_wrong_micropost.appmap.json) |
+
+</details>
+
+
+<details>
+<summary>
+test/integration/microposts_interface_test.rb:9
+</summary>
+
+<p/>
+
+[test/integration/microposts_interface_test.rb:9](test/integration/microposts_interface_test.rb:9) failed with error:
+
+```
+ActionView::Template::Error: undefined method `micropost_path' for #<ActionView::Base:0x00000000028410>
+
+              target.public_send(method, *args)
+                    ^^^^^^^^^^^^
+Did you mean?  microposts_path
+    app/views/microposts/_micropost.html.erb:13
+    app/views/shared/_feed.html.erb:3
+    app/views/static_pages/home.html.erb:16
+    test/integration/microposts_interface_test.rb:11:in `block in <class:MicropostsInterfaceTest>'
+```
+
+
+
+
+No relevant code changes found.
+
+| Diagram | Link |
+| --- | --- |
+| Sequence diagram diff | [minitest/Microposts_interface_micropost_interface.diff.sequence.json](diff/minitest/Microposts_interface_micropost_interface.diff.sequence.json) |
+| AppMap | [minitest/Microposts_interface_micropost_interface](head/minitest/Microposts_interface_micropost_interface.appmap.json) |
+
+</details>
+
+
+<details>
+<summary>
+test/integration/users_login_test.rb:45
+</summary>
+
+<p/>
+
+[test/integration/users_login_test.rb:45](test/integration/users_login_test.rb:45) failed with error:
+
+```
+ActionView::Template::Error: undefined method `micropost_path' for #<ActionView::Base:0x0000000002b3e0>
+
+              target.public_send(method, *args)
+                    ^^^^^^^^^^^^
+Did you mean?  microposts_path
+    app/views/microposts/_micropost.html.erb:13
+    app/views/users/show.html.erb:19
+    test/integration/users_login_test.rb:46:in `block in <class:ValidLoginTest>'
+```
+
+
+
+
+No relevant code changes found.
+
+| Diagram | Link |
+| --- | --- |
+| AppMap | [minitest/Valid_login_redirect_after_login](head/minitest/Valid_login_redirect_after_login.appmap.json) |
+
+</details>
+
+
+
+## 🔄 API changes
+
+### 🚧 Breaking changes
+
+- Remove path `/microposts/{id}` 
+- Remove response status code `302 POST /microposts` 
+- Remove response status code `303 POST /microposts` 
+- Remove response status code `422 POST /microposts` 
+
+### :wrench: Non-breaking changes
+
+- Add response status code  `200 POST /microposts`
+
+
+<details>
+<summary>
+  Detailed OpenAPI diff
+</summary>
+
+```diff
+--- base/openapi.yml	2023-08-17 12:23:50.000000000 -0400
++++ head/openapi.yml	2023-08-17 12:28:49.000000000 -0400
+@@ -100,18 +100,9 @@
+   /microposts:
+     post:
+       responses:
+-        '302':
+-          content:
+-            text/html: {}
+-          description: Found
+-        '303':
+-          content:
+-            text/html: {}
+-          description: See Other
+-        '422':
+-          content:
+-            text/html: {}
+-          description: Unprocessable Entity
++        '200':
++          content: {}
++          description: OK
+       requestBody:
+         content:
+           application/x-www-form-urlencoded:
+@@ -123,13 +114,6 @@
+                   properties:
+                     content:
+                       type: string
+-  /microposts/{id}:
+-    delete:
+-      responses:
+-        '303':
+-          content:
+-            text/html: {}
+-          description: See Other
+   /password_resets:
+     post:
+       responses:
+```
+</details>
+
+
+
+<h2 id="findings">Findings</h2>
+
+
+### :tada: Resolved findings (4)
+
+
+### N plus 1 SQL query
+
+<details>
+<summary>
+  Finding details
+</summary>
+
+| Field | Value |
+| --- | --- |
+| Message | app_views_shared__feed_html_erb.render[418] contains 30 occurrences of SQL: SELECT &quot;users&quot;.* FROM &quot;users&quot; WHERE &quot;users&quot;.&quot;id&quot; &#x3D; ? LIMIT ? |
+| AppMap | [minitest/Microposts_interface_micropost_interface.appmap.json](head/minitest/Microposts_interface_micropost_interface.appmap.json) |
+
+##### Related code changes
+No relevant code changes found.
+
+##### Stack trace
+
+- [app/helpers/sessions_helper.rb:19](app/helpers/sessions_helper.rb:19)
+- [app/helpers/sessions_helper.rb:35](app/helpers/sessions_helper.rb:35)
+- [app/views/shared/_feed.html.erb](app/views/shared/_feed.html.erb)
+- [app/views/static_pages/home.html.erb](app/views/static_pages/home.html.erb)
+- /home/ahtrotta/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/actionpack-7.0.4/lib/action_controller/metal/renderers.rb:140
+
+
+</details>
+
+### N plus 1 SQL query
+
+<details>
+<summary>
+  Finding details
+</summary>
+
+| Field | Value |
+| --- | --- |
+| Message | app_views_shared__feed_html_erb.render[2707] contains 30 occurrences of SQL: SELECT &quot;users&quot;.* FROM &quot;users&quot; WHERE &quot;users&quot;.&quot;id&quot; &#x3D; ? LIMIT ? |
+| AppMap | [minitest/Microposts_interface_micropost_interface.appmap.json](head/minitest/Microposts_interface_micropost_interface.appmap.json) |
+
+##### Related code changes
+No relevant code changes found.
+
+##### Stack trace
+
+- [app/helpers/sessions_helper.rb:19](app/helpers/sessions_helper.rb:19)
+- [app/helpers/sessions_helper.rb:35](app/helpers/sessions_helper.rb:35)
+- [app/views/shared/_feed.html.erb](app/views/shared/_feed.html.erb)
+- [app/views/static_pages/home.html.erb](app/views/static_pages/home.html.erb)
+- /home/ahtrotta/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/actionpack-7.0.4/lib/action_controller/metal/renderers.rb:140
+- [app/controllers/microposts_controller.rb:5](app/controllers/microposts_controller.rb:5)
+
+
+</details>
+
+### N plus 1 SQL query
+
+<details>
+<summary>
+  Finding details
+</summary>
+
+| Field | Value |
+| --- | --- |
+| Message | app_views_shared__feed_html_erb.render[3734] contains 30 occurrences of SQL: SELECT &quot;users&quot;.* FROM &quot;users&quot; WHERE &quot;users&quot;.&quot;id&quot; &#x3D; ? LIMIT ? |
+| AppMap | [minitest/Microposts_interface_micropost_interface.appmap.json](head/minitest/Microposts_interface_micropost_interface.appmap.json) |
+
+##### Related code changes
+No relevant code changes found.
+
+##### Stack trace
+
+- [app/helpers/sessions_helper.rb:19](app/helpers/sessions_helper.rb:19)
+- [app/helpers/sessions_helper.rb:35](app/helpers/sessions_helper.rb:35)
+- [app/views/shared/_feed.html.erb](app/views/shared/_feed.html.erb)
+- [app/views/static_pages/home.html.erb](app/views/static_pages/home.html.erb)
+- /home/ahtrotta/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/actionpack-7.0.4/lib/action_controller/metal/renderers.rb:140
+
+
+</details>
+
+### N plus 1 SQL query
+
+<details>
+<summary>
+  Finding details
+</summary>
+
+| Field | Value |
+| --- | --- |
+| Message | app_views_users_show_html_erb.render[4559] contains 6 occurrences of SQL: SELECT &quot;users&quot;.* FROM &quot;users&quot; WHERE &quot;users&quot;.&quot;id&quot; &#x3D; ? LIMIT ? |
+| AppMap | [minitest/Microposts_interface_micropost_interface.appmap.json](head/minitest/Microposts_interface_micropost_interface.appmap.json) |
+
+##### Related code changes
+No relevant code changes found.
+
+##### Stack trace
+
+- [app/helpers/sessions_helper.rb:19](app/helpers/sessions_helper.rb:19)
+- [app/helpers/sessions_helper.rb:40](app/helpers/sessions_helper.rb:40)
+- [app/views/users/show.html.erb](app/views/users/show.html.erb)
+- /home/ahtrotta/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/actionpack-7.0.4/lib/action_controller/metal/renderers.rb:140
+
+
+</details>
+
+
+
+
+<h2 id="new-appmaps">New AppMaps</h2>
+
+
+[minitest/Valid_login_redirect_after_login](head/minitest/Valid_login_redirect_after_login.appmap.json)
+


### PR DESCRIPTION
Experimental report sections can be enabled with the `--include-section` option. Default report sections can be disabled with the `--exclude-section` option.

`changed-appmaps` is now an experimental section, and therefore off by default.

See https://github.com/getappmap/analyze-action/pull/38
