### PR TITLE
Analysis tab should opens findings overview

### DIFF
--- a/packages/components/src/pages/install-guide/InvestigateFindings.vue
+++ b/packages/components/src/pages/install-guide/InvestigateFindings.vue
@@ -51,9 +51,10 @@
             <br />
             <p>
               <v-button
+                v-if="enableAnalysisReport"
                 data-cy="investigate-findings-button"
-                label="Open the PROBLEMS tab"
-                @click.native="viewProblems"
+                label="View analysis report"
+                @click.native="viewFindings"
               />
             </p>
           </article>
@@ -162,8 +163,8 @@ export default {
   },
 
   methods: {
-    viewProblems() {
-      this.$root.$emit('view-problems', this.projectPath);
+    viewFindings() {
+      this.$root.$emit('open-findings-overview');
     },
   },
 
@@ -171,6 +172,9 @@ export default {
     enableButtonLabel() {
       if (!this.userAuthenticated) return 'Sign in to enable AppMap Runtime Analysis';
       return 'Enable AppMap Runtime Analysis';
+    },
+    enableAnalysisReport() {
+      return Object.values(this.findingsDomainCounts).some((count) => count > 0);
     },
   },
 };

--- a/packages/components/tests/e2e/specs/investigateFindings.spec.js
+++ b/packages/components/tests/e2e/specs/investigateFindings.spec.js
@@ -17,7 +17,9 @@ context('Investigate Findings (10 findings)', () => {
   });
 
   it('should display a button to investigate findings', () => {
-    cy.get('[data-cy="investigate-findings-button"]').should('be.visible');
+    cy.get('[data-cy="investigate-findings-button"]')
+      .should('be.visible')
+      .should('contain.text', 'View analysis report');
   });
 
   it('shows next button', () => {


### PR DESCRIPTION
Fixes:  https://github.com/getappmap/vscode-appland/issues/819

feat(InvestigateFindings.vue): add conditionally displayed 'View anal…ysis report' button
fix(InvestigateFindings.vue): rename viewProblems to viewFindings
test(investigateFindings.spec.js): update test to reflect new button label