### PR TITLE
fix: The OpenAPI links have been replaced in the sign in page

### DIFF
--- a/packages/components/src/components/SignIn.vue
+++ b/packages/components/src/components/SignIn.vue
@@ -26,8 +26,14 @@
             >Dependency maps</a
           >
         </li>
-        <li @click="clickSignInLink('open-api')">
-          <a href="https://appmap.io/docs/openapi">OpenAPI definitions</a>
+        <li @click="clickSignInLink('flame-graphs')">
+          <a href="https://appmap.io/docs/diagrams/flamegraph.html">Flame graphs</a>
+        </li>
+        <li @click="clickSignInLink('runtime-analysis')">
+          <a href="https://appmap.io/docs/analysis/in-your-code-editor.html">Runtime analysis</a>
+        </li>
+        <li @click="clickSignInLink('appmap-ci')">
+          <a href="https://appmap.io/docs/analysis/in-ci.html">AppMap in CI</a>
         </li>
       </ul>
       <div class="signin-buttons">


### PR DESCRIPTION
Before:
![image](https://github.com/getappmap/appmap-js/assets/8737782/230b936c-2fcf-4f2e-bfad-8037a73d9791)


After:
![image](https://github.com/getappmap/appmap-js/assets/8737782/29d77f89-b0c3-4a20-8d1d-c84a89e21f4a)


Resolves #1385