### PR TITLE
Add filtering on analysis findings search.

### DIFF
--- a/packages/components/src/components/DetailsSearch.vue
+++ b/packages/components/src/components/DetailsSearch.vue
@@ -160,9 +160,13 @@ export default {
         }
       });
 
-      items[CodeObjectType.ANALYSIS_FINDING].data = this.findings.map((f) => ({
-        object: toListItem(f),
-      }));
+      this.findings.forEach((f) => {
+        if (this.passesFilter(f)) {
+          items[CodeObjectType.ANALYSIS_FINDING].data.push({
+            object: toListItem(f),
+          });
+        }
+      });
 
       Object.entries(items).forEach(([key, item]) => {
         if (!item.data.length) {
@@ -202,6 +206,13 @@ export default {
     passesFilter(obj) {
       // If it's null, we don't need to apply any filtering. Always return true.
       if (!this.filterRegex) {
+        return true;
+      }
+
+      if (
+        (obj.finding?.message && this.filterRegex.test(obj.finding.message.replace(/\n/g, ' '))) ||
+        (obj.rule?.title && this.filterRegex.test(obj.rule.title))
+      ) {
         return true;
       }
 

--- a/packages/components/tests/e2e/specs/appmap/findings.spec.js
+++ b/packages/components/tests/e2e/specs/appmap/findings.spec.js
@@ -55,6 +55,30 @@ context('AppMap findings', () => {
           'Deserialization of untrusted data'
         );
       });
+
+      it('shows findings when finding title is searched', () => {
+        cy.get('.details-search__input-element').type('Deserialization');
+        cy.get('.details-search__block--analysis-finding')
+          .should('exist')
+          .find('.details-search__block-item')
+          .should('have.length', 1);
+      });
+
+      it('shows findings when finding message is searched', () => {
+        cy.get('.details-search__input-element').type('reset secret');
+        cy.get('.details-search__block--analysis-finding')
+          .should('exist')
+          .find('.details-search__block-item')
+          .should('have.length', 1);
+      });
+
+      it('shows no findings when irrelevant term is searched', () => {
+        cy.get('.details-search__input-element').type('access');
+        cy.get('.details-search__block--analysis-finding').should('not.exist');
+        cy.get('.details-search__block--labels')
+          .find('.details-search__block-item')
+          .should('have.length', 1);
+      });
     });
 
     describe('trace view', () => {
@@ -197,6 +221,27 @@ context('AppMap findings', () => {
         // go back to last selection
         cy.get('.details-btn').contains('Back to previous').click();
         cy.get('.highlighted').should('have.length', 0);
+      });
+
+      it('shows two findings when finding title is searched', () => {
+        cy.get('.details-search__input-element').type('N plus 1 SQL query');
+        cy.get('.details-search__block--analysis-finding')
+          .should('exist')
+          .find('.details-search__block-item')
+          .should('have.length', 2);
+      });
+
+      it('shows one finding when finding message is searched', () => {
+        cy.get('.details-search__input-element').type('active_storage_attachments');
+        cy.get('.details-search__block--analysis-finding')
+          .should('exist')
+          .find('.details-search__block-item')
+          .should('have.length', 1);
+      });
+
+      it('shows no findings when irrelevant term is searched', () => {
+        cy.get('.details-search__input-element').type('I_DONT_EXIST');
+        cy.get('.details-search__block--analysis-finding').should('not.exist');
       });
     });
   });


### PR DESCRIPTION
Fixes: #1375 

feat(DetailsSearch.vue): enhance findings filtering to include message and rule title
test(findings.spec.js): add e2e tests for new filtering functionality