### PR TITLE
fix: Commands involving HTTP serving work again

### DIFF
--- a/packages/cli/src/lib/serveAndOpen.ts
+++ b/packages/cli/src/lib/serveAndOpen.ts
@@ -41,15 +41,13 @@ export default async function serveAndOpen(
 
       if (!contentType) contentType = mimeTypeOfName(fileName);
 
-      res.writeHead(200, 'OK', { 'Content-Type': contentType });
-
       const fileStream = createReadStream(path);
       fileStream.pipe(res);
       fileStream.on('open', function () {
         if (verbose()) {
           console.log(`${path}: 200`);
         }
-        res.writeHead(200);
+        res.writeHead(200, 'OK', { 'Content-Type': contentType });
       });
       fileStream.on('error', function (e) {
         if (verbose()) {


### PR DESCRIPTION
The code tried to send an HTTP response twice in some cases, breaking eg. the 'sequence-diagram' command with the error `Error [ERR_HTTP_HEADERS_SENT]: Cannot write headers after they are sent to the client`.