### PR TITLE
feat: Diff once

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -115,6 +115,7 @@
     "open": "^8.2.1",
     "openapi-diff": "^0.23.6",
     "ora": "^5.4.1",
+    "parse-diff": "^0.11.1",
     "pkg": "^5.8.0",
     "port-pid": "^0.0.7",
     "pretty-bytes": "^5.6.0",

--- a/packages/cli/src/cmds/compare/ChangeReporter.ts
+++ b/packages/cli/src/cmds/compare/ChangeReporter.ts
@@ -90,7 +90,7 @@ class SourceDiff {
       if (!codeObject.location) return;
 
       const path = codeObject.location.split(':')[0];
-      if (path.indexOf('.') && !path.startsWith('<') && !isAbsolute(path)) {
+      if (path.indexOf('.') && !path.startsWith('<') && !path.includes('#') && !isAbsolute(path)) {
         sourcePaths.add(path);
         const pathTokens = path.split('/');
         if (pathTokens.length > 0) sourcePathRoots.add(pathTokens[0]);
@@ -98,6 +98,13 @@ class SourceDiff {
     });
 
     await this.diffLoader.update(sourcePathRoots);
+
+    const result = [...sourcePaths]
+      .sort()
+      .map((path) => this.diffLoader.lookupDiff(path))
+      .join('');
+    // warn(`${[...sourcePaths].sort()}: ${result}`);
+    return result;
   }
 }
 

--- a/packages/cli/src/cmds/compare/ChangeReporter.ts
+++ b/packages/cli/src/cmds/compare/ChangeReporter.ts
@@ -22,10 +22,11 @@ import { AppMapLink, AppMapName, ChangeReport, ChangedAppMap, TestFailure } from
 import { exists, verbose } from '../../utils';
 import mapToRecord from './mapToRecord';
 import { mutedStyle, prominentStyle } from './ui';
-import { executeCommand } from '../../lib/executeCommand';
 import loadFindings from './loadFindings';
 import { loadSequenceDiagram } from './loadSequenceDiagram';
 import { warn } from 'console';
+import DiffLoader from './DiffLoader';
+import { report } from 'process';
 
 export type BaseOrHead = RevisionName.Base | RevisionName.Head;
 
@@ -50,8 +51,11 @@ class ReferencedAppMaps {
 class SourceDiff {
   private diffs = new Map<AppMapName, string>();
   private classMaps = new Map<AppMapName, ClassMap>();
+  private diffLoader: DiffLoader;
 
-  constructor(private reporter: ChangeReporter) {}
+  constructor(private reporter: ChangeReporter) {
+    this.diffLoader = new DiffLoader(reporter.baseRevision, reporter.headRevision);
+  }
 
   async get(appmap: AppMapName): Promise<string | undefined> {
     [RevisionName.Base, RevisionName.Head].forEach((revisionName) =>
@@ -81,25 +85,19 @@ class SourceDiff {
 
     const classMap = this.classMaps.get(appmap) || (await loadClassMap());
     const sourcePaths = new Set<string>();
+    const sourcePathRoots = new Set<string>();
     classMap.visit((codeObject) => {
       if (!codeObject.location) return;
 
       const path = codeObject.location.split(':')[0];
-      if (path.indexOf('.') && !path.startsWith('<') && !isAbsolute(path)) sourcePaths.add(path);
+      if (path.indexOf('.') && !path.startsWith('<') && !isAbsolute(path)) {
+        sourcePaths.add(path);
+        const pathTokens = path.split('/');
+        if (pathTokens.length > 0) sourcePathRoots.add(pathTokens[0]);
+      }
     });
 
-    let diff = '';
-    if (sourcePaths.size > 0) {
-      const paths = [...sourcePaths]
-        .sort()
-        .map((p) => [this.reporter.srcDir, p].join('/'))
-        .join(' ');
-      diff = await executeCommand(
-        `git diff ${this.reporter.baseRevision}..${this.reporter.headRevision} -- ${paths}`
-      );
-    }
-
-    return diff;
+    await this.diffLoader.update(sourcePathRoots);
   }
 }
 

--- a/packages/cli/src/cmds/compare/DiffLoader.ts
+++ b/packages/cli/src/cmds/compare/DiffLoader.ts
@@ -2,6 +2,7 @@ import parseDiff from 'parse-diff';
 import { executeCommand } from '../../lib/executeCommand';
 import { warn } from 'console';
 import assert from 'assert';
+import { exists } from '../../utils';
 
 export const MAX_DIFF_LENGTH = 1000 * 1000;
 
@@ -12,9 +13,30 @@ export default class DiffLoader {
 
   constructor(public baseRevision: string, public headRevision: string) {}
 
+  lookupDiff(path: string): string | undefined {
+    assert(this.diffByFile);
+
+    const diffFiles = this.diffByFile.get(path);
+    if (!diffFiles) return;
+
+    return diffFiles
+      .map((diffFile) =>
+        diffFile.chunks
+          .map((chunk) =>
+            [chunk.content, chunk.changes.map((change) => change.content).join('\n')].join('\n')
+          )
+          .join('\n')
+      )
+      .join('\n');
+  }
+
   async update(sourcePathRoots: Set<string>) {
     let reloadDiff = false;
     for (const root of sourcePathRoots) {
+      if (['vendor', 'node_modules'].includes(root)) continue;
+
+      if (!(await exists(root))) continue;
+
       if (!this.sourcePathRoots.has(root)) {
         this.sourcePathRoots.add(root);
         reloadDiff = true;
@@ -29,12 +51,19 @@ export default class DiffLoader {
   }
 
   private async reloadDiff() {
+    const diffCommands = new Set<string>();
+
     while (this.reloadQueue.length > 0) {
       const sourcePathRoots = this.reloadQueue.shift()!.sort();
+      const diffCommand = `git diff ${this.baseRevision}..${
+        this.headRevision
+      } -- ${sourcePathRoots.join(' ')}`;
+      if (diffCommands.has(diffCommand)) continue;
+
+      diffCommands.add(diffCommand);
+
       try {
-        const diffStr = await executeCommand(
-          `git diff ${this.baseRevision}..${this.headRevision} -- ${sourcePathRoots.join(' ')}}`
-        );
+        const diffStr = await executeCommand(diffCommand, true);
         if (diffStr.length > MAX_DIFF_LENGTH) {
           warn(`Diff is too large to parse. Skipping...`);
           continue;
@@ -42,11 +71,14 @@ export default class DiffLoader {
 
         const diffFiles = parseDiff(diffStr);
         this.diffByFile = diffFiles.reduce((memo, diffFile) => {
-          [diffFile.to, diffFile.from].filter(Boolean).forEach((path) => {
-            assert(path);
-            if (!memo.has(path)) memo.set(path, []);
-            memo.get(path)?.push(diffFile);
-          });
+          [...new Set([diffFile.to, diffFile.from])]
+            .filter(Boolean)
+            .sort()
+            .forEach((path) => {
+              assert(path);
+              if (!memo.has(path)) memo.set(path, []);
+              memo.get(path)?.push(diffFile);
+            });
           return memo;
         }, new Map<string, parseDiff.File[]>());
       } catch (err) {

--- a/packages/cli/src/cmds/compare/DiffLoader.ts
+++ b/packages/cli/src/cmds/compare/DiffLoader.ts
@@ -1,89 +1,125 @@
 import parseDiff from 'parse-diff';
-import { executeCommand } from '../../lib/executeCommand';
 import { warn } from 'console';
 import assert from 'assert';
-import { exists } from '../../utils';
+
+import { executeCommand } from '../../lib/executeCommand';
+import { QueueObject, queue } from 'async';
+import { existsSync } from 'fs';
 
 export const MAX_DIFF_LENGTH = 1000 * 1000;
 
+export type Diff = {
+  command: string;
+  files: parseDiff.File[];
+};
+
+export class DiffLoaderQueue {
+  private diffQueue: QueueObject<string>;
+  private diffByRoots = new Map<string, Diff>();
+
+  constructor(public baseRevision: string, public headRevision: string) {
+    this.diffQueue = queue(this.executeDiffCommand.bind(this), 1);
+  }
+
+  async diff(sourcePathRoots: Set<string>): Promise<Diff | undefined> {
+    // Process only one diff at a time.
+
+    if (this.diffQueue.length()) await this.diffQueue.drain();
+
+    const roots = [...sourcePathRoots].sort().join(' ');
+
+    this.diffQueue.push(roots);
+    await this.diffQueue.drain();
+
+    return this.diffByRoots.get(roots);
+  }
+
+  private async executeDiffCommand(roots: string) {
+    if (roots === '') return;
+
+    if (this.diffByRoots.get(roots)) return;
+
+    const command = `git diff ${this.baseRevision}..${this.headRevision} -- ${roots}`;
+    let diff: Diff = { command, files: [] };
+    try {
+      const diffStr = await executeCommand(command, true);
+      if (diffStr.length > MAX_DIFF_LENGTH) {
+        warn(`Diff is too large to parse. Skipping...`);
+      } else {
+        const files = parseDiff(diffStr);
+        diff = { command, files };
+      }
+    } catch (err) {
+      // There's no point in trying this command again.
+      warn(err);
+    } finally {
+      this.diffByRoots.set(roots, diff);
+    }
+  }
+}
+
 export default class DiffLoader {
   private sourcePathRoots = new Set<string>();
-  private diffByFile: Map<string, parseDiff.File[]> | undefined;
-  private reloadQueue: Array<string[]> = [];
+  private diffByFile: Map<string, Diff> | undefined;
+  private diffLoaderQueue: DiffLoaderQueue;
 
-  constructor(public baseRevision: string, public headRevision: string) {}
+  constructor(public baseRevision: string, public headRevision: string) {
+    this.diffLoaderQueue = new DiffLoaderQueue(baseRevision, headRevision);
+  }
 
   lookupDiff(path: string): string | undefined {
-    assert(this.diffByFile);
+    if (!this.diffByFile) return;
 
-    const diffFiles = this.diffByFile.get(path);
-    if (!diffFiles) return;
+    const diff = this.diffByFile.get(path);
+    if (!diff) return;
 
-    return diffFiles
-      .map((diffFile) =>
-        diffFile.chunks
+    const { files: diffFiles } = diff;
+    const content = diffFiles
+      .map((diffFile) => {
+        const fromLine = ['---', diffFile.from].join(' ');
+        const toLine = ['+++', diffFile.to].join(' ');
+        const content = diffFile.chunks
           .map((chunk) =>
             [chunk.content, chunk.changes.map((change) => change.content).join('\n')].join('\n')
           )
-          .join('\n')
-      )
+          .join('\n');
+        return [fromLine, toLine, content, ''].join('\n');
+      })
       .join('\n');
+    return [content].join('\n');
   }
 
   async update(sourcePathRoots: Set<string>) {
-    let reloadDiff = false;
+    const diffRoots = new Set<string>();
     for (const root of sourcePathRoots) {
-      if (['vendor', 'node_modules'].includes(root)) continue;
-
-      if (!(await exists(root))) continue;
-
       if (!this.sourcePathRoots.has(root)) {
         this.sourcePathRoots.add(root);
-        reloadDiff = true;
+        if (DiffLoader.isEligibleFile(root)) diffRoots.add(root);
       }
     }
 
-    if (this.diffByFile && !reloadDiff) return;
-
-    this.reloadQueue.push([...this.sourcePathRoots]);
-
-    await this.reloadDiff();
+    const diff = await this.diffLoaderQueue.diff(diffRoots);
+    if (diff) this.parseDiffStr(diff);
   }
 
-  private async reloadDiff() {
-    const diffCommands = new Set<string>();
+  static isEligibleFile(root: string): boolean {
+    return !['vendor', 'node_modules'].includes(root) && existsSync(root);
+  }
 
-    while (this.reloadQueue.length > 0) {
-      const sourcePathRoots = this.reloadQueue.shift()!.sort();
-      const diffCommand = `git diff ${this.baseRevision}..${
-        this.headRevision
-      } -- ${sourcePathRoots.join(' ')}`;
-      if (diffCommands.has(diffCommand)) continue;
+  private parseDiffStr(diff: Diff) {
+    if (!this.diffByFile) this.diffByFile = new Map<string, Diff>();
 
-      diffCommands.add(diffCommand);
+    diff.files.reduce((memo, diffFile) => {
+      [...new Set([diffFile.to, diffFile.from])]
+        .filter(Boolean)
+        .sort()
+        .forEach((path) => {
+          assert(path);
+          if (!memo.has(path)) memo.set(path, { command: diff.command, files: [] });
 
-      try {
-        const diffStr = await executeCommand(diffCommand, true);
-        if (diffStr.length > MAX_DIFF_LENGTH) {
-          warn(`Diff is too large to parse. Skipping...`);
-          continue;
-        }
-
-        const diffFiles = parseDiff(diffStr);
-        this.diffByFile = diffFiles.reduce((memo, diffFile) => {
-          [...new Set([diffFile.to, diffFile.from])]
-            .filter(Boolean)
-            .sort()
-            .forEach((path) => {
-              assert(path);
-              if (!memo.has(path)) memo.set(path, []);
-              memo.get(path)?.push(diffFile);
-            });
-          return memo;
-        }, new Map<string, parseDiff.File[]>());
-      } catch (err) {
-        warn(err);
-      }
-    }
+          memo.get(path)!.files.push(diffFile);
+        });
+      return memo;
+    }, this.diffByFile);
   }
 }

--- a/packages/cli/src/cmds/compare/DiffLoader.ts
+++ b/packages/cli/src/cmds/compare/DiffLoader.ts
@@ -1,0 +1,57 @@
+import parseDiff from 'parse-diff';
+import { executeCommand } from '../../lib/executeCommand';
+import { warn } from 'console';
+import assert from 'assert';
+
+export const MAX_DIFF_LENGTH = 1000 * 1000;
+
+export default class DiffLoader {
+  private sourcePathRoots = new Set<string>();
+  private diffByFile: Map<string, parseDiff.File[]> | undefined;
+  private reloadQueue: Array<string[]> = [];
+
+  constructor(public baseRevision: string, public headRevision: string) {}
+
+  async update(sourcePathRoots: Set<string>) {
+    let reloadDiff = false;
+    for (const root of sourcePathRoots) {
+      if (!this.sourcePathRoots.has(root)) {
+        this.sourcePathRoots.add(root);
+        reloadDiff = true;
+      }
+    }
+
+    if (this.diffByFile && !reloadDiff) return;
+
+    this.reloadQueue.push([...this.sourcePathRoots]);
+
+    await this.reloadDiff();
+  }
+
+  private async reloadDiff() {
+    while (this.reloadQueue.length > 0) {
+      const sourcePathRoots = this.reloadQueue.shift()!.sort();
+      try {
+        const diffStr = await executeCommand(
+          `git diff ${this.baseRevision}..${this.headRevision} -- ${sourcePathRoots.join(' ')}}`
+        );
+        if (diffStr.length > MAX_DIFF_LENGTH) {
+          warn(`Diff is too large to parse. Skipping...`);
+          continue;
+        }
+
+        const diffFiles = parseDiff(diffStr);
+        this.diffByFile = diffFiles.reduce((memo, diffFile) => {
+          [diffFile.to, diffFile.from].filter(Boolean).forEach((path) => {
+            assert(path);
+            if (!memo.has(path)) memo.set(path, []);
+            memo.get(path)?.push(diffFile);
+          });
+          return memo;
+        }, new Map<string, parseDiff.File[]>());
+      } catch (err) {
+        warn(err);
+      }
+    }
+  }
+}

--- a/packages/cli/src/lib/executeCommand.ts
+++ b/packages/cli/src/lib/executeCommand.ts
@@ -13,7 +13,7 @@ export function executeCommand(
   printStderr = verbose(),
   okCodes = [0]
 ): Promise<string> {
-  if (printCommand) console.log(commandStyle(cmd));
+  if (printCommand) console.warn(commandStyle(cmd));
   const command = exec(cmd);
   const result: string[] = [];
   const stderr: string[] = [];
@@ -31,11 +31,11 @@ export function executeCommand(
     command.addListener('exit', (code, signal) => {
       if (signal || (code !== null && okCodes.includes(code))) {
         if (signal) {
-          console.log(`Command "${cmd}" killed by signal ${signal}, exited with code ${code}`);
+          console.warn(`Command "${cmd}" killed by signal ${signal}, exited with code ${code}`);
         }
         resolve(result.join(''));
       } else {
-        if (!printCommand) console.log(commandStyle(cmd));
+        if (!printCommand) console.warn(commandStyle(cmd));
         console.warn(stderr.join(''));
         reject(new Error(`Command failed with code ${code}`));
       }

--- a/packages/cli/tests/unit/compare/DiffLoader.spec.ts
+++ b/packages/cli/tests/unit/compare/DiffLoader.spec.ts
@@ -1,0 +1,154 @@
+import { join } from 'path';
+import { readFileSync } from 'fs';
+import DiffLoader, { Diff, DiffLoaderQueue } from '../../../src/cmds/compare/DiffLoader';
+import * as executeCommand from '../../../src/lib/executeCommand';
+
+import parsedUnifiedDiff from './fixtureData/parsedUnifiedDiff.json';
+import { warn } from 'console';
+const exampleDiff = readFileSync(join(__dirname, 'fixtureData', 'exampleDiff.txt'), 'utf-8');
+const addDeleteChangeRemoveDiff = readFileSync(
+  join(__dirname, 'fixtureData', 'addDeleteChangeRemoveDiff.txt'),
+  'utf-8'
+);
+const expectedDiff = readFileSync(join(__dirname, 'fixtureData', 'expectedDiff.txt'), 'utf-8');
+
+describe('DiffLoader', () => {
+  const baseRevision = 'the-base';
+  const headRevision = 'the-head';
+
+  afterEach(() => jest.restoreAllMocks());
+
+  describe('lookupDiff', () => {
+    let diffLoader: DiffLoader;
+
+    beforeEach(() => (diffLoader = new DiffLoader(baseRevision, headRevision)));
+
+    it('organizes the diff by file', async () => {
+      jest.spyOn(DiffLoader, 'isEligibleFile').mockReturnValue(true);
+      jest.spyOn(executeCommand, 'executeCommand').mockResolvedValue(exampleDiff);
+
+      await diffLoader.update(new Set(['app']));
+
+      expect(diffLoader.lookupDiff('app/controllers/users_controller.rb')).toEqual(expectedDiff);
+      expect(diffLoader.lookupDiff('app/models/user.rb')).toBeUndefined();
+    });
+
+    it('ignores ineligible files', async () => {
+      await diffLoader.update(new Set(['vendor', 'node_modules', 'file_not_exist']));
+
+      expect(diffLoader.lookupDiff('app/models/user.rb')).toBeUndefined();
+    });
+
+    it('updates the diff information incrementally', async () => {
+      jest.spyOn(DiffLoader, 'isEligibleFile').mockReturnValue(true);
+      const executeCommandSpy = jest.spyOn(executeCommand, 'executeCommand');
+      executeCommandSpy.mockResolvedValueOnce('');
+      executeCommandSpy.mockResolvedValueOnce(exampleDiff);
+
+      await diffLoader.update(new Set(['lib']));
+      expect(executeCommandSpy).toHaveBeenCalledWith('git diff the-base..the-head -- lib', true);
+      expect(diffLoader.lookupDiff('app/controllers/users_controller.rb')).toBeUndefined();
+
+      await diffLoader.update(new Set(['app']));
+      expect(executeCommandSpy).toHaveBeenCalledWith('git diff the-base..the-head -- app', true);
+      expect(diffLoader.lookupDiff('app/controllers/users_controller.rb')).toEqual(expectedDiff);
+
+      // This one should be a nop
+      await diffLoader.update(new Set(['app']));
+      expect(diffLoader.lookupDiff('app/controllers/users_controller.rb')).toEqual(expectedDiff);
+
+      expect(executeCommandSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('reports on a variety of diff information', async () => {
+      jest.spyOn(DiffLoader, 'isEligibleFile').mockReturnValue(true);
+      const executeCommandSpy = jest.spyOn(executeCommand, 'executeCommand');
+      executeCommandSpy.mockResolvedValueOnce(addDeleteChangeRemoveDiff);
+
+      await diffLoader.update(new Set(['just-cant-be-empty']));
+
+      expect(diffLoader.lookupDiff('.nvmrc')).toEqual(`--- .nvmrc
++++ .nvmrc.bak
+
+`);
+      expect(diffLoader.lookupDiff('.nvmrc.bak')).toEqual(`--- .nvmrc
++++ .nvmrc.bak
+
+`);
+      expect(diffLoader.lookupDiff('.ruby-version')).toEqual(`--- .ruby-version
++++ /dev/null
+@@ -1 +0,0 @@
+-ruby-3.0.2
+`);
+      expect(diffLoader.lookupDiff('.ruby-version-2')).toEqual(`--- /dev/null
++++ .ruby-version-2
+@@ -0,0 +1 @@
++ruby-3.0.3
+\\ No newline at end of file
+`);
+      expect(diffLoader.lookupDiff('app/controllers/users_controller.rb'))
+        .toEqual(`--- app/controllers/users_controller.rb
++++ app/controllers/users_controller.rb
+@@ -1,5 +1,5 @@
+ class UsersController < ApplicationController
+-  before_action :logged_in_user, only: [:index, :edit, :update, :destroy,
++  before_action :logged_in_user, only: [:index, :show, :edit, :update, :destroy,
+                                         :following, :followers]
+   before_action :correct_user,   only: [:edit, :update]
+   before_action :admin_user,     only: :destroy
+`);
+    });
+  });
+
+  describe('Queue', () => {
+    let q: DiffLoaderQueue;
+
+    beforeEach(() => (q = new DiffLoaderQueue(baseRevision, headRevision)));
+
+    it('processes a single diff request', async () => {
+      const executeCommandSpy = jest.spyOn(executeCommand, 'executeCommand').mockResolvedValue('');
+
+      const sourcePathRoots = new Set(['root-a']);
+      const diff = await q.diff(sourcePathRoots);
+
+      expect(JSON.stringify(diff)).toEqual(
+        JSON.stringify({ command: 'git diff the-base..the-head -- root-a', files: [] })
+      );
+      expect(executeCommandSpy).toHaveBeenCalledTimes(1);
+      expect(executeCommandSpy).toHaveBeenCalledWith('git diff the-base..the-head -- root-a', true);
+    });
+
+    it('returns an empty diff for empty roots', async () => {
+      const diff = await q.diff(new Set<string>());
+      expect(diff).toBeUndefined();
+    });
+
+    it('parses unified diff', async () => {
+      jest.spyOn(executeCommand, 'executeCommand').mockResolvedValue(exampleDiff);
+
+      const sourcePathRoots = new Set(['root-a']);
+      const diff = await q.diff(sourcePathRoots);
+      expect(JSON.stringify(diff?.files, null, 2)).toEqual(
+        JSON.stringify(parsedUnifiedDiff, null, 2)
+      );
+    });
+
+    it('serializes diff requests', async () => {
+      jest.spyOn(executeCommand, 'executeCommand').mockImplementation(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 1));
+        return '';
+      });
+
+      const iterationCount = 10;
+      const promises = new Array<Promise<Diff | undefined>>();
+      const startTime = new Date().getTime();
+      for (let count = 0; count < iterationCount; count++) {
+        const root = `root-${count}`;
+        promises.push(q.diff(new Set([root])));
+      }
+      await Promise.all(promises);
+      const endTime = new Date().getTime();
+      expect(endTime - startTime).toBeGreaterThanOrEqual(iterationCount);
+    });
+  });
+});

--- a/packages/cli/tests/unit/compare/fixtureData/addDeleteChangeRemoveDiff.txt
+++ b/packages/cli/tests/unit/compare/fixtureData/addDeleteChangeRemoveDiff.txt
@@ -1,0 +1,64 @@
+diff --git a/.nvmrc b/.nvmrc.bak
+similarity index 100%
+rename from .nvmrc
+rename to .nvmrc.bak
+diff --git a/.ruby-version b/.ruby-version
+deleted file mode 100644
+index 4efbd8f..0000000
+--- a/.ruby-version
++++ /dev/null
+@@ -1 +0,0 @@
+-ruby-3.0.2
+diff --git a/.ruby-version-2 b/.ruby-version-2
+new file mode 100644
+index 0000000..c939cb5
+--- /dev/null
++++ b/.ruby-version-2
+@@ -0,0 +1 @@
++ruby-3.0.3
+\ No newline at end of file
+diff --git a/app/controllers/users_controller.rb b/app/controllers/users_controller.rb
+index 99a5623..e5754c8 100644
+--- a/app/controllers/users_controller.rb
++++ b/app/controllers/users_controller.rb
+@@ -1,5 +1,5 @@
+ class UsersController < ApplicationController
+-  before_action :logged_in_user, only: [:index, :edit, :update, :destroy,
++  before_action :logged_in_user, only: [:index, :show, :edit, :update, :destroy,
+                                         :following, :followers]
+   before_action :correct_user,   only: [:edit, :update]
+   before_action :admin_user,     only: :destroy
+diff --git a/test/integration/users_profile_test.rb b/test/integration/users_profile_test.rb
+index 6240ce0..695ce90 100644
+--- a/test/integration/users_profile_test.rb
++++ b/test/integration/users_profile_test.rb
+@@ -17,11 +17,10 @@ class UsersProfileTest < ActionDispatch::IntegrationTest
+ 
+   test "profile display while anonyomus" do
+     get user_path(@user)
+-    assert_equal 200, response.status
+-    # assert_match URI.parse(response.location).path, "/login"
++    assert_equal 302, response.status
++    assert_match URI.parse(response.location).path, "/login"
+   end
+ 
+-  <<~LOGGED_IN_USER
+   test "profile display while logged in as the user" do
+     login_as @user
+ 
+@@ -37,15 +36,4 @@ class UsersProfileTest < ActionDispatch::IntegrationTest
+       assert_match micropost.content, response.body
+     end
+   end
+-  LOGGED_IN_USER
+-
+-  <<~OTHER_USER
+-  test "profile display while logged in as someone else" do
+-    login_as @other_user
+-
+-    get user_path(@user)
+-    assert_equal 302, response.status
+-    assert_match URI.parse(response.location).path, "/login"
+-  end
+-  OTHER_USER
+ end

--- a/packages/cli/tests/unit/compare/fixtureData/exampleDiff.txt
+++ b/packages/cli/tests/unit/compare/fixtureData/exampleDiff.txt
@@ -1,0 +1,13 @@
+diff --git a/app/controllers/users_controller.rb b/app/controllers/users_controller.rb
+index 99a5623..0456da2 100644
+--- a/app/controllers/users_controller.rb
++++ b/app/controllers/users_controller.rb
+@@ -86,7 +86,7 @@ class UsersController < ApplicationController
+    # Confirms the correct user.
+    def correct_user
+      @user = User.find(params[:id])
+-    redirect_to(root_url) unless current_user?(@user)
++    redirect_to(root_url) unless current_user?(@user) && !@user.admin?
+    end
+  
+    # Confirms an admin user.

--- a/packages/cli/tests/unit/compare/fixtureData/expectedDiff.txt
+++ b/packages/cli/tests/unit/compare/fixtureData/expectedDiff.txt
@@ -1,0 +1,11 @@
+--- app/controllers/users_controller.rb
++++ app/controllers/users_controller.rb
+@@ -86,7 +86,7 @@ class UsersController < ApplicationController
+    # Confirms the correct user.
+    def correct_user
+      @user = User.find(params[:id])
+-    redirect_to(root_url) unless current_user?(@user)
++    redirect_to(root_url) unless current_user?(@user) && !@user.admin?
+    end
+  
+    # Confirms an admin user.

--- a/packages/cli/tests/unit/compare/fixtureData/parsedUnifiedDiff.json
+++ b/packages/cli/tests/unit/compare/fixtureData/parsedUnifiedDiff.json
@@ -1,0 +1,76 @@
+[
+  {
+    "chunks": [
+      {
+        "content": "@@ -86,7 +86,7 @@ class UsersController < ApplicationController",
+        "changes": [
+          {
+            "type": "normal",
+            "normal": true,
+            "ln1": 86,
+            "ln2": 86,
+            "content": "    # Confirms the correct user."
+          },
+          {
+            "type": "normal",
+            "normal": true,
+            "ln1": 87,
+            "ln2": 87,
+            "content": "    def correct_user"
+          },
+          {
+            "type": "normal",
+            "normal": true,
+            "ln1": 88,
+            "ln2": 88,
+            "content": "      @user = User.find(params[:id])"
+          },
+          {
+            "type": "del",
+            "del": true,
+            "ln": 89,
+            "content": "-    redirect_to(root_url) unless current_user?(@user)"
+          },
+          {
+            "type": "add",
+            "add": true,
+            "ln": 89,
+            "content": "+    redirect_to(root_url) unless current_user?(@user) && !@user.admin?"
+          },
+          {
+            "type": "normal",
+            "normal": true,
+            "ln1": 90,
+            "ln2": 90,
+            "content": "    end"
+          },
+          {
+            "type": "normal",
+            "normal": true,
+            "ln1": 91,
+            "ln2": 91,
+            "content": "  "
+          },
+          {
+            "type": "normal",
+            "normal": true,
+            "ln1": 92,
+            "ln2": 92,
+            "content": "    # Confirms an admin user."
+          }
+        ],
+        "oldStart": 86,
+        "oldLines": 7,
+        "newStart": 86,
+        "newLines": 7
+      }
+    ],
+    "deletions": 1,
+    "additions": 1,
+    "from": "app/controllers/users_controller.rb",
+    "to": "app/controllers/users_controller.rb",
+    "index": ["99a5623..0456da2", "100644"],
+    "newMode": "100644",
+    "oldMode": "100644"
+  }
+]

--- a/yarn.lock
+++ b/yarn.lock
@@ -186,6 +186,7 @@ __metadata:
     openapi-diff: ^0.23.6
     openapi-types: ^12.1.0
     ora: ^5.4.1
+    parse-diff: ^0.11.1
     pkg: ^5.8.0
     port-pid: ^0.0.7
     prettier: ^2.7.1
@@ -27131,6 +27132,13 @@ __metadata:
     just-diff: ^5.0.1
     just-diff-apply: ^5.2.0
   checksum: 076f65c958696586daefb153f59d575dfb59648be43116a21b74d5ff69ec63dd56f585a27cc2da56d8e64ca5abf0373d6619b8330c035131f8d1e990c8406378
+  languageName: node
+  linkType: hard
+
+"parse-diff@npm:^0.11.1":
+  version: 0.11.1
+  resolution: "parse-diff@npm:0.11.1"
+  checksum: d904b37596c6957ac4c9709b79cd383eeb6188beeaf2032ed4d4a3ca76e05ac9315030d0d88999dde9d032347bbc4fbd58c4e85169ce34ddf31e701fc8ea1329
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Don't run `git diff` for every appmap - run it only when a new set of root files is encountered in the classMap.

Parse the diff output to figure out what the diff is for each file.

## Reviewer's guide 🎉 

**How it used to work**

For every AppMap, if that AppMap contained source paths (most do...), [`git diff` was executed](https://github.com/getappmap/appmap-js/pull/1400/files#diff-c437d6ceecd503d4d812155930024411ffbdeba29439ec53f4efc2c9f26d88ecL97) to find the source diff for that AppMap.

When a PR contained a lot of changed AppMaps, this was a lot of work to perform.

**How it works now**

* For each AppMap [find the root source paths](https://github.com/getappmap/appmap-js/pull/1400/files#diff-c437d6ceecd503d4d812155930024411ffbdeba29439ec53f4efc2c9f26d88ecR95) (filename, if the path is not in a directory, or the top-level directory)
* Determine [if there are any new root paths](https://github.com/getappmap/appmap-js/pull/1400/files#diff-209a5b7d3452f008f594d316e58f77edc72a36f3624a4f9bfbea84e189848b9dR93) in the AppMap.
* If so, [load the diff for the new root paths](https://github.com/getappmap/appmap-js/pull/1400/files#diff-209a5b7d3452f008f594d316e58f77edc72a36f3624a4f9bfbea84e189848b9dR101).
* Parse the diff and [store the diff for each source file path](https://github.com/getappmap/appmap-js/pull/1400/files#diff-209a5b7d3452f008f594d316e58f77edc72a36f3624a4f9bfbea84e189848b9dR110).


Other notes:

* Only [one `diff` command is performed at a time](https://github.com/getappmap/appmap-js/pull/1400/files#diff-209a5b7d3452f008f594d316e58f77edc72a36f3624a4f9bfbea84e189848b9dR25). This just makes it easier to avoid race conditions as AppMaps load in parallel.
* The output is the [unified diff format](https://github.com/getappmap/appmap-js/pull/1400/files#diff-209a5b7d3452f008f594d316e58f77edc72a36f3624a4f9bfbea84e189848b9dR77); some of the information output by `git diff` is discarded; but I don't see how this will matter in practice.



