### PR TITLE
fix: Package all resources in the native binary

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -138,8 +138,7 @@
     ],
     "assets": [
       "package.json",
-      "**/openapi-template.yaml",
-      "**/change-report.hbs",
+      "resources",
       "built/appmap.html"
     ],
     "outputPath": "dist"


### PR DESCRIPTION
Binaries built for `3.97.0` did not include the necessary Handlebars resources used by `compare-report`.

**3.97.0**

```
➜  cli git:(main) ./release/appmap-macos-arm64 archive -d ~/source/land-of-apps/sample_app_6th_ed
pkg/prelude/bootstrap.js:1876
      throw error;
      ^

AssertionError [ERR_ASSERTION]: Report template directory 'change-report' not found
    at Object.<anonymous> (/snapshot/appmap-js/packages/cli/built/cmds/compare-report/ReportSection.js:19:22)
```

**This branch**

```
➜  cli git:(fix/include-all-hbs-in-native-binary) ./release/appmap-macos-arm64 archive -d ~/source/land-of-apps/sample_app_6th_ed
Note: The AppMap archive won't contain the version of @appland/appmap because process.env.npm_package_version is not available.
Building 'auto' archive from tmp/appmap
Building archive of revision 50f25a2b124e40555bf67015c1eb33115c5019df
Analyzing AppMaps using 10 worker threads
Indexing AppMaps...
```
