### PR TITLE
fix: Don't report undefined when the index is already up-to-date

### DIFF
--- a/packages/cli/src/cmds/archive/analyzeTask.ts
+++ b/packages/cli/src/cmds/archive/analyzeTask.ts
@@ -26,6 +26,7 @@ export async function analyzeTask(
     handler.maxFileSizeInBytes = undefined; // This has already been checked
     const indexResult = await handler.fingerprint(task.appmapFile);
     if (indexResult) result = indexResult;
+    else result = { numEvents: 0 };
   } else if (isScanTask(task)) {
     const scanResults = await scan(task.appmapFile, 'appmap-scanner.yml');
     await writeIndexFile(JSON.stringify(scanResults, null, 2), 'appmap-findings.json');

--- a/packages/cli/src/cmds/index/IndexResult.ts
+++ b/packages/cli/src/cmds/index/IndexResult.ts
@@ -2,6 +2,6 @@ import type { Metadata } from '@appland/models';
 
 export type IndexResult = {
   error?: Error;
-  metadata: Metadata;
+  metadata?: Metadata;
   numEvents: number;
 };


### PR DESCRIPTION
The index worker shouldn’t return undefined. 

If it does, the worker crashes and a new one is launched, making indexing very slow.

In CI, this case doesn’t happen because the AppMaps are always unindexed when the analyzer runs. But locally, it’s easy to run the archive command on a repo that’s already indexed (eg by the IDE extension) and then this problem occurs. 