### PR TITLE
Improve sequence diagram load time

### DIFF
--- a/packages/components/src/components/DiagramSequence.vue
+++ b/packages/components/src/components/DiagramSequence.vue
@@ -61,6 +61,7 @@ import {
   Diagram,
   Specification,
   Action,
+  getActors,
 } from '@appland/sequence-diagram';
 import VLoopAction from '@/components/sequence/LoopAction.vue';
 import VCallAction from '@/components/sequence/CallAction.vue';
@@ -121,11 +122,8 @@ export default {
       let { appMap } = this.$store.state;
       if (!appMap) appMap = this.appMap;
 
-      // TODO: optimize for performance building actor priority separately
       const specification = Specification.build(appMap, { loops: true });
-      const diagram = buildDiagram('<an AppMap file>', appMap, specification);
-
-      return diagram.actors;
+      return getActors(appMap, specification);
     },
     priority() {
       const priority = {};

--- a/packages/components/src/components/DiagramSequence.vue
+++ b/packages/components/src/components/DiagramSequence.vue
@@ -9,7 +9,7 @@
         <template v-for="(actor, index) in visuallyReachableActors">
           <VActor
             :actor="actor"
-            :key="actorKey(actor)"
+            :key="actor.id"
             :row="1"
             :index="index"
             :height="diagramSpec.actions.length"
@@ -194,11 +194,8 @@ export default {
     },
   },
   methods: {
-    actorKey(actor: Actor): string {
-      return ['actor', this.diagramSpec.uniqueId, actor.id].join(':');
-    },
     actionKey(action: ActionSpec): string {
-      return ['action', this.diagramSpec.uniqueId, action.index].join(':');
+      return `action:${action.index}:${action.action.digest}`;
     },
     isSelected(action: ActionSpec): boolean {
       return !!this.selectedEvents?.find(({ id }) => action.eventIds.includes(id));

--- a/packages/sequence-diagram/src/types.ts
+++ b/packages/sequence-diagram/src/types.ts
@@ -196,12 +196,12 @@ export enum ValidationResult {
   AppMap = 2,
 }
 
-import buildDiagram from './buildDiagram';
+import buildDiagram, { getActors } from './buildDiagram';
 import buildDiffDiagram from './buildDiffDiagram';
 import diff from './diff';
 import unparseDiagram from './unparseDiagram';
 import validateDiagram from './validateDiagram';
-export { buildDiagram, buildDiffDiagram, diff, unparseDiagram, validateDiagram };
+export { buildDiagram, buildDiffDiagram, diff, unparseDiagram, validateDiagram, getActors };
 
 export enum FormatType {
   JSON = 'json',


### PR DESCRIPTION
Fixes #1411 

PRs #1416 and #1418 will need to be merged and released before this one.

- Simplify actor/action key computation (~15 % improvement)
- Avoid calling `buildDiagram` twice when loading sequence diagram (~46% improvement)
- Cache parsed SQL in Event class (~24% improvement)