### PR TITLE
fix: set appmap_dir for maven, gradle project

### DIFF
--- a/packages/cli/src/cmds/agentInstaller/gradleInstaller.ts
+++ b/packages/cli/src/cmds/agentInstaller/gradleInstaller.ts
@@ -23,7 +23,7 @@ export default class GradleInstaller extends JavaBuildToolInstaller {
   }
 
   get appmap_dir(): string {
-    return 'build/appmap';
+    return 'tmp/appmap';
   }
 
   private get buildGradleFileName(): string {

--- a/packages/cli/src/cmds/agentInstaller/mavenInstaller.ts
+++ b/packages/cli/src/cmds/agentInstaller/mavenInstaller.ts
@@ -22,7 +22,7 @@ export default class MavenInstaller extends JavaBuildToolInstaller {
   }
 
   get appmap_dir(): string {
-    return 'target/appmap';
+    return 'tmp/appmap';
   }
 
   get buildFile(): string {

--- a/packages/cli/tests/unit/agentInstall/installCommand.spec.ts
+++ b/packages/cli/tests/unit/agentInstall/installCommand.spec.ts
@@ -103,14 +103,14 @@ packages:
 packages:
   - path: com.fake.Fake
 language: java
-appmap_dir: target/appmap
+appmap_dir: tmp/appmap
 `;
 
     const expectedGradleConfig = `name: fake-app
 packages:
   - path: com.fake.Fake
 language: java
-appmap_dir: build/appmap
+appmap_dir: tmp/appmap
 `;
 
     const initAgent = (cmdStruct: CommandStruct) => {


### PR DESCRIPTION
Set `appmap_dir` to `tmp/appmap` when creating the default configs for maven and gradle projects.