### PR TITLE
Get actors without building a complete diagram

### DIFF
--- a/packages/sequence-diagram/src/types.ts
+++ b/packages/sequence-diagram/src/types.ts
@@ -196,12 +196,12 @@ export enum ValidationResult {
   AppMap = 2,
 }
 
-import buildDiagram from './buildDiagram';
+import buildDiagram, { getActors } from './buildDiagram';
 import buildDiffDiagram from './buildDiffDiagram';
 import diff from './diff';
 import unparseDiagram from './unparseDiagram';
 import validateDiagram from './validateDiagram';
-export { buildDiagram, buildDiffDiagram, diff, unparseDiagram, validateDiagram };
+export { buildDiagram, buildDiffDiagram, diff, unparseDiagram, validateDiagram, getActors };
 
 export enum FormatType {
   JSON = 'json',

--- a/packages/sequence-diagram/tests/unit/sequenceDiagram.spec.ts
+++ b/packages/sequence-diagram/tests/unit/sequenceDiagram.spec.ts
@@ -2,6 +2,7 @@ import assert from 'assert';
 import { isFunction, isLoop } from '../../src/types';
 import {
   findActionById,
+  getActorsFromMap,
   LIST_USERS_APPMAP,
   loadDiagram,
   SHOW_USER_APPMAP,
@@ -37,6 +38,11 @@ describe('Sequence diagram', () => {
           { id: 'package:lib/database', order: 10000 },
         ]
       );
+    });
+    it('is the same when using getActors', () => {
+      const diagram = loadDiagram(SHOW_USER_APPMAP);
+      const actors = getActorsFromMap(SHOW_USER_APPMAP);
+      assert.deepStrictEqual(actors, diagram.actors);
     });
   });
 

--- a/packages/sequence-diagram/tests/util.ts
+++ b/packages/sequence-diagram/tests/util.ts
@@ -2,7 +2,7 @@ import { AppMap, buildAppMap } from '@appland/models';
 import assert from 'assert';
 import { readFileSync } from 'fs';
 import path, { join } from 'path';
-import buildDiagram from '../src/buildDiagram';
+import buildDiagram, { getActors } from '../src/buildDiagram';
 import Specification from '../src/specification';
 import { Action, Actor, Diagram, isFunction } from '../src/types';
 import { SequenceDiagramOptions } from '../src/specification';
@@ -91,6 +91,11 @@ export function loadDiagram(
 ): Diagram {
   const specification = Specification.build(appmap, options);
   return buildDiagram(SHOW_USER_APPMAP_FILE, appmap, specification);
+}
+
+export function getActorsFromMap(appmap: AppMap): Actor[] {
+  const specification = Specification.build(appmap, { loops: true });
+  return getActors(appmap, specification);
 }
 
 export function findActor(diagram: Diagram, id: string): Actor {


### PR DESCRIPTION
Fixes #1413 

When loading the sequence diagram, we first need to [determine the Actors](https://github.com/getappmap/appmap-js/blob/main/packages/components/src/components/DiagramSequence.vue#L128). Previously, we were building an entire diagram using `buildDiagram` for this purpose, but that is unnecessary and computationally expensive. See this flame graph:

![image](https://github.com/getappmap/appmap-js/assets/45714532/58168db2-1e61-44e3-ba92-780ed4eb9da0)

This PR creates a new function `getActors` that creates the actors without building an entire sequence diagram.

This is a separate PR so that we release a version of `@appland/sequence-diagram` that can be subsequently used in `@appland/components`.