### PR TITLE
Cache parsed SQL in `buildDiagram` Function

### DIFF
--- a/packages/models/package.json
+++ b/packages/models/package.json
@@ -38,6 +38,7 @@
     "eslint-plugin-import": "^2.22.1",
     "jest": "^27.4.7",
     "lint-staged": "^10.5.4",
+    "lru-cache": "6.0.0",
     "prettier": "^2.7.1",
     "ts-jest": "^27.1.4",
     "tsup": "^6.5.0",

--- a/packages/models/src/event.js
+++ b/packages/models/src/event.js
@@ -362,14 +362,14 @@ export default class Event {
 
   get identityHash() {
     if (!this.$hidden.identityHash) {
-      this.$hidden.identityHash = this.buildIdentityHash(this).digest();
+      this.$hidden.identityHash = this.buildIdentityHash().digest();
     }
     return this.$hidden.identityHash;
   }
 
   get hash() {
     if (!this.$hidden.hash) {
-      this.$hidden.hash = this.buildStableHash(this).digest();
+      this.$hidden.hash = this.buildStableHash().digest();
     }
     return this.$hidden.hash;
   }
@@ -379,6 +379,13 @@ export default class Event {
       this.$hidden.stableProperties = this.gatherStableProperties();
     }
     return this.$hidden.stableProperties;
+  }
+
+  getHashWithSqlCache(parsedSqlCache) {
+    if (!this.$hidden.hash) {
+      this.$hidden.hash = this.buildStableHash(parsedSqlCache).digest();
+    }
+    return this.$hidden.hash;
   }
 
   callStack() {
@@ -501,7 +508,7 @@ export default class Event {
 
   // Collects properties of an event which are not dependent on the specifics
   // of invocation.
-  gatherStableProperties() {
+  gatherStableProperties(parsedSqlCache) {
     const { sqlQuery } = this;
 
     // Convert null and undefined values to empty strings
@@ -526,10 +533,17 @@ export default class Event {
 
     let properties;
     if (sqlQuery) {
-      const sqlNormalized = abstractSqlAstJSON(sqlQuery, this.sql.database_type)
-        // Collapse repeated variable literals and parameter tokens (e.g. '?, ?' in an IN clause)
-        .split(/{"type":"variable"}(?:,{"type":"variable"})*/g)
-        .join(`{"type":"variable"}`);
+      let sqlNormalized;
+      const cacheKey = `${this.sql.database_type}:${sqlQuery}`;
+      if (parsedSqlCache) sqlNormalized = parsedSqlCache.get(cacheKey);
+      if (!sqlNormalized) {
+        sqlNormalized = abstractSqlAstJSON(sqlQuery, this.sql.database_type)
+          // Collapse repeated variable literals and parameter tokens (e.g. '?, ?' in an IN clause)
+          .split(/{"type":"variable"}(?:,{"type":"variable"})*/g)
+          .join(`{"type":"variable"}`);
+        parsedSqlCache.set(cacheKey, sqlNormalized);
+      }
+
       properties = {
         event_type: 'sql',
         sql_normalized: sqlNormalized,
@@ -554,7 +568,10 @@ export default class Event {
     return HashBuilder.buildHash('event-identity-v2', this.gatherIdentityProperties());
   }
 
-  buildStableHash() {
-    return HashBuilder.buildHash('event-stable-properties-v2', this.gatherStableProperties());
+  buildStableHash(parsedSqlCache) {
+    return HashBuilder.buildHash(
+      'event-stable-properties-v2',
+      this.gatherStableProperties(parsedSqlCache)
+    );
   }
 }

--- a/packages/models/types/index.d.ts
+++ b/packages/models/types/index.d.ts
@@ -1,4 +1,5 @@
 import type { SqliteParser } from './sqlite-parser';
+import type LRUCache from 'lru-cache';
 
 declare module '@appland/models' {
   export type CodeObjectType =
@@ -214,6 +215,7 @@ declare module '@appland/models' {
     dataObjects(): Array<ParameterObject | ReturnValueObject>;
     toString(): string;
     toJSON(): any;
+    getHashWithSqlCache(parsedSqlCache: LRUCache<string, any>): string;
   }
 
   export class EventNavigator {

--- a/packages/sequence-diagram/src/buildDiagram.ts
+++ b/packages/sequence-diagram/src/buildDiagram.ts
@@ -1,6 +1,7 @@
 import { AppMap, Event } from '@appland/models';
 import { classNameToOpenAPIType } from '@appland/openapi';
 import sha256 from 'crypto-js/sha256.js';
+import LRUCache from 'lru-cache';
 import { merge } from './mergeWindow';
 import { selectEvents } from './selectEvents';
 import Specification from './specification';
@@ -19,6 +20,7 @@ import {
 } from './types';
 
 const MAX_WINDOW_SIZE = 5;
+const parsedSqlCache = new LRUCache<string, any>({ max: 1000 });
 
 class ActorManager {
   private _actorsByCodeObjectId = new Map<string, Actor>();
@@ -68,7 +70,7 @@ export default function buildDiagram(
         callee: actorManager.findOrCreateActor(callee),
         route: callee.route,
         status: response.status || response.status_code,
-        digest: callee.hash,
+        digest: callee.getHashWithSqlCache(parsedSqlCache),
         subtreeDigest: 'undefined',
         children: [],
         elapsed: callee.elapsedTime,
@@ -83,7 +85,7 @@ export default function buildDiagram(
         callee: actorManager.findOrCreateActor(callee),
         route: callee.route,
         status: response.status || response.status_code,
-        digest: callee.hash,
+        digest: callee.getHashWithSqlCache(parsedSqlCache),
         subtreeDigest: 'undefined',
         children: [],
         elapsed: callee.elapsedTime,
@@ -96,7 +98,7 @@ export default function buildDiagram(
         caller: caller ? actorManager.findOrCreateActor(caller) : undefined,
         callee: actorManager.findOrCreateActor(callee),
         query: callee.sqlQuery,
-        digest: truncatedQuery ? 'truncatedQuery' : callee.hash,
+        digest: truncatedQuery ? 'truncatedQuery' : callee.getHashWithSqlCache(parsedSqlCache),
         subtreeDigest: 'undefined',
         children: [],
         elapsed: callee.elapsedTime,
@@ -109,7 +111,7 @@ export default function buildDiagram(
         callee: actorManager.findOrCreateActor(callee),
         name: callee.codeObject.name,
         static: callee.codeObject.static,
-        digest: callee.hash,
+        digest: callee.getHashWithSqlCache(parsedSqlCache),
         subtreeDigest: 'undefined',
         stableProperties: { ...callee.stableProperties },
         returnValue: buildReturnValue(callee),

--- a/yarn.lock
+++ b/yarn.lock
@@ -380,6 +380,7 @@ __metadata:
     eslint-plugin-import: ^2.22.1
     jest: ^27.4.7
     lint-staged: ^10.5.4
+    lru-cache: 6.0.0
     prettier: ^2.7.1
     ts-jest: ^27.1.4
     tsup: ^6.5.0
@@ -24788,6 +24789,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lru-cache@npm:6.0.0, lru-cache@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "lru-cache@npm:6.0.0"
+  dependencies:
+    yallist: ^4.0.0
+  checksum: f97f499f898f23e4585742138a22f22526254fdba6d75d41a1c2526b3b6cc5747ef59c5612ba7375f42aca4f8461950e925ba08c991ead0651b4918b7c978297
+  languageName: node
+  linkType: hard
+
 "lru-cache@npm:^4.0.1, lru-cache@npm:^4.1.2, lru-cache@npm:^4.1.5":
   version: 4.1.5
   resolution: "lru-cache@npm:4.1.5"
@@ -24804,15 +24814,6 @@ __metadata:
   dependencies:
     yallist: ^3.0.2
   checksum: c154ae1cbb0c2206d1501a0e94df349653c92c8cbb25236d7e85190bcaf4567a03ac6eb43166fabfa36fd35623694da7233e88d9601fbf411a9a481d85dbd2cb
-  languageName: node
-  linkType: hard
-
-"lru-cache@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "lru-cache@npm:6.0.0"
-  dependencies:
-    yallist: ^4.0.0
-  checksum: f97f499f898f23e4585742138a22f22526254fdba6d75d41a1c2526b3b6cc5747ef59c5612ba7375f42aca4f8461950e925ba08c991ead0651b4918b7c978297
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes #1417 

When loading a sequence diagram, the `buildDiagram` function is one of the most expensive function calls. When it uses the [`hash` getter](https://github.com/getappmap/appmap-js/blob/main/packages/sequence-diagram/src/buildDiagram.ts#L62) on an instance of `Event`, the [`buildStableHash` function](https://github.com/getappmap/appmap-js/blob/main/packages/models/src/event.js#L370) is called, which ultimately ends up parsing SQL if the event has any. It turns out that parsing SQL is a relatively expensive operation, so this can add up to a lot of computation if there are a lot of events with SQL in the sequence diagram. In this flame graph you can see that `peg$parseRule` accounts for 41% of `buildDiagram`:

![image](https://github.com/getappmap/appmap-js/assets/45714532/1e4185de-3e2d-4e05-a84a-1373f6c89d59)

This PR creates an LRU cache in the `buildDiagram` method, and then passes it into the `getHashWithSqlCache` method on the `Event` class so that we don't repeat the computation needlessly. 

This will need to be split up into two PRs so that we can release a version of `@appland/models` that will get used in `@appland/sequence-diagram`.