### PR TITLE
Ensure smooth initial load in vs code & performance updates

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@appland/diagrams": "workspace:^1.7.0",
     "@appland/models": "workspace:^2.6.3",
-    "@appland/sequence-diagram": "workspace:^1.6.1",
+    "@appland/sequence-diagram": "workspace:^1.8.1",
     "buffer": "^6.0.3",
     "d3": "^7.8.4",
     "d3-flame-graph": "^4.1.3",

--- a/packages/components/src/components/DiagramSequence.vue
+++ b/packages/components/src/components/DiagramSequence.vue
@@ -9,7 +9,7 @@
         <template v-for="(actor, index) in visuallyReachableActors">
           <VActor
             :actor="actor"
-            :key="actorKey(actor)"
+            :key="actor.id"
             :row="1"
             :index="index"
             :height="actions.length"
@@ -197,11 +197,8 @@ export default {
     },
   },
   methods: {
-    actorKey(actor: Actor): string {
-      return ['actor', this.diagramSpec.uniqueId, actor.id].join(':');
-    },
     actionKey(action: ActionSpec): string {
-      return ['action', this.diagramSpec.uniqueId, action.index].join(':');
+      return `action:${action.index}:${action.action.digest}`;
     },
     isSelected(action: ActionSpec): boolean {
       return !!this.selectedEvents?.find(({ id }) => action.eventIds.includes(id));

--- a/packages/components/src/components/DiagramSequence.vue
+++ b/packages/components/src/components/DiagramSequence.vue
@@ -61,6 +61,7 @@ import {
   Diagram,
   Specification,
   Action,
+  getActors,
 } from '@appland/sequence-diagram';
 import VLoopAction from '@/components/sequence/LoopAction.vue';
 import VCallAction from '@/components/sequence/CallAction.vue';
@@ -121,11 +122,8 @@ export default {
       let { appMap } = this.$store.state;
       if (!appMap) appMap = this.appMap;
 
-      // TODO: optimize for performance building actor priority separately
       const specification = Specification.build(appMap, { loops: true });
-      const diagram = buildDiagram('<an AppMap file>', appMap, specification);
-
-      return diagram.actors;
+      return getActors(appMap, specification);
     },
     priority() {
       const priority = {};

--- a/packages/components/src/components/DiagramSequence.vue
+++ b/packages/components/src/components/DiagramSequence.vue
@@ -331,6 +331,7 @@ export default {
     this.focusHighlighted();
   },
   updated() {
+    this.$emit('setMaxSeqDiagramCollapseDepth', this.getMaxActionDepth());
     this.focusHighlighted();
   },
   created() {

--- a/packages/components/src/components/DiagramSequence.vue
+++ b/packages/components/src/components/DiagramSequence.vue
@@ -12,13 +12,13 @@
             :key="actorKey(actor)"
             :row="1"
             :index="index"
-            :height="diagramSpec.actions.length"
+            :height="actions.length"
             :interactive="interactive"
             :selected-actor="selectedActor"
             :appMap="appMap"
           />
         </template>
-        <template v-for="action in diagramSpec.actions">
+        <template v-for="action in actions">
           <template v-if="action.nodeType === 'call'">
             <VCallAction
               :actionSpec="action"
@@ -39,7 +39,7 @@
             />
           </template>
         </template>
-        <template v-for="action in diagramSpec.actions">
+        <template v-for="action in actions">
           <template v-if="action.nodeType === 'loop'"
             ><VLoopAction
               :actionSpec="action"
@@ -174,11 +174,14 @@ export default {
 
       return result;
     },
+    actions() {
+      return this.diagramSpec?.actions || [];
+    },
     actors() {
       return this.diagram.actors;
     },
     visuallyReachableActors() {
-      return this.diagramSpec.visuallyReachableActors;
+      return this.diagramSpec?.visuallyReachableActors || [];
     },
     selectedActor() {
       if (!this.$store) return;
@@ -292,7 +295,7 @@ export default {
       rootActionSpecs.forEach((h) => visit(h.action));
     },
     getMaxActionDepth() {
-      return this.diagramSpec?.actions.reduce((maxDepth, action) => {
+      return this.actions.reduce((maxDepth, action) => {
         const depth = action.ancestorIndexes.length;
         if (depth > maxDepth) return depth;
         return maxDepth;
@@ -301,16 +304,14 @@ export default {
   },
   watch: {
     collapseDepth() {
-      const diffMode = this.diagramSpec.actions.some((a) => a.action.diffMode);
-      if (!diffMode)
-        this.collapseActionsForCompactLook(this.diagramSpec.actions, this.collapseDepth);
+      const diffMode = this.actions.some((a) => a.action.diffMode);
+      if (!diffMode) this.collapseActionsForCompactLook(this.actions, this.collapseDepth);
     },
     focusedEvent(newVal) {
       // If there are hidden actions containing this event ensure
       // they are not hidden by expanding collapsed ancestors
       if (newVal) {
-        const actionSpecs = this.diagramSpec.actions;
-        for (const actionSpec of actionSpecs)
+        for (const actionSpec of this.actions)
           if (actionSpec.eventIds.includes(newVal.id)) {
             const collapsedAncestorIndexes = actionSpec.ancestorIndexes.filter(
               (ancestorIndex) => this.collapsedActionState[ancestorIndex]
@@ -363,7 +364,7 @@ export default {
     this.diagram?.rootActions.forEach((root) => markExpandedActions(root));
     expandedActions.delete(undefined);
 
-    this.collapsedActionState = this.diagramSpec.actions.map((action) => !shouldExpand(action));
+    this.collapsedActionState = this.actions.map((action) => !shouldExpand(action));
 
     if (firstDiffAction && this.$store?.state) {
       const eventId = eventIds(firstDiffAction).filter(Boolean)[0];
@@ -373,7 +374,7 @@ export default {
     }
 
     if (!firstDiffAction && this.interactive)
-      this.collapseActionsForCompactLook(this.diagramSpec.actions, this.collapseDepth);
+      this.collapseActionsForCompactLook(this.actions, this.collapseDepth);
   },
 };
 </script>

--- a/yarn.lock
+++ b/yarn.lock
@@ -257,7 +257,7 @@ __metadata:
   dependencies:
     "@appland/diagrams": "workspace:^1.7.0"
     "@appland/models": "workspace:^2.6.3"
-    "@appland/sequence-diagram": "workspace:^1.6.1"
+    "@appland/sequence-diagram": "workspace:^1.8.1"
     "@babel/core": ^7.22.5
     "@babel/node": ^7.22.5
     "@babel/preset-env": ^7.22.5
@@ -475,7 +475,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@appland/sequence-diagram@workspace:^1.6.1, @appland/sequence-diagram@workspace:^1.7.0, @appland/sequence-diagram@workspace:packages/sequence-diagram":
+"@appland/sequence-diagram@workspace:^1.7.0, @appland/sequence-diagram@workspace:^1.8.1, @appland/sequence-diagram@workspace:packages/sequence-diagram":
   version: 0.0.0-use.local
   resolution: "@appland/sequence-diagram@workspace:packages/sequence-diagram"
   dependencies:


### PR DESCRIPTION
When loading an AppMap in VS Code, the Vue components are created and mounted before any data is available. This can lead to errors where we try to access properties on `undefined`. This PR ensures that we don't try to access these properties before there is appropriate data.

Also, because not all of the data is available upon component creation in VS Code, the `maxSeqDiagramCollapseDepth` was getting set to `0` when the sequence diagram was `mounted`, and it wasn't getting updated, causing problems with the auto-collapse feature. This PR fixes that.

Finally, this PR includes a couple of performance updates:

- Simplify action/actor key computation
- Get sequence diagram actors without building an entire sequence diagram (#1416)