### PR TITLE
feat: Organize findings by category

### DIFF
--- a/packages/cli/resources/change-report/changed-appmaps/details.hbs
+++ b/packages/cli/resources/change-report/changed-appmaps/details.hbs
@@ -19,7 +19,7 @@ Review changes
   {{/each}}
 
   {{#if pruned}}
-Because there are so many changed AppMaps, some of them are not listed in this report.
+Because there are many changed AppMaps, some of them are not listed in this report.
   {{/if}}
 </details>
 {{/if}}

--- a/packages/cli/resources/change-report/changed-appmaps/heading.hbs
+++ b/packages/cli/resources/change-report/changed-appmaps/heading.hbs
@@ -1,6 +1,6 @@
 | [Changed AppMaps](#changed-appmaps) |
   {{~#unless (length changedAppMaps) }}
-  :white_check_mark: No changes
+  :zero: No changes
   {{~else}}
   :twisted_rightwards_arrows: {{length changedAppMaps}} changes
   {{~/unless}}

--- a/packages/cli/resources/change-report/failed-tests/details.hbs
+++ b/packages/cli/resources/change-report/failed-tests/details.hbs
@@ -52,6 +52,6 @@ The error occurred at [{{failureLocation}}]({{ source_url failureLocation }}):
 
   {{/each}}
   {{#if pruned}}
-Because there are so many failed tests, some of them are not listed in this report.
+Because there are many failed tests, some of them are not listed in this report.
   {{/if}}
 {{/if}}

--- a/packages/cli/resources/change-report/findings/details.hbs
+++ b/packages/cli/resources/change-report/findings/details.hbs
@@ -51,30 +51,26 @@
 
 </details>
 {{/inline}}
-{{#with findingDiff}}
-  {{#if (length newFindings resolvedFindings)}}
-<h2 id="findings">Findings</h2>
-
-    {{#with newFindings}}
-### :beetle: New findings ({{ length this}})
-
-      {{#each this}}
+{{#if (length findingDiff.newFindings findingDiff.resolvedFindings)}}
+<h2 id="{{ metadata.anchor }}">{{ metadata.title }}</h2>
+  {{#if (length findingDiff.newFindings) }}
+### {{metadata.emoji}} New problems detected ({{ length findingDiff.newFindings }})
+      {{#each findingDiff.newFindings}}
 {{> finding}}
       {{/each}}
 
-    {{/with}}
-
-    {{#with resolvedFindings}}
-### :tada: Resolved findings ({{ length this}})
-
-      {{#each this}}
-{{> finding}}
-      {{/each}}
-
-    {{/with}}
-
-    {{#if pruned}}
-Because there are so many new and resolved findings, some of them are not listed in this report.
-    {{/if}}
   {{/if}}
-{{/with}}
+
+  {{#if (length findingDiff.resolvedFindings) }}
+### :tada: Problems resolved ({{ length findingDiff.resolvedFindings}})
+
+      {{#each findingDiff.resolvedFindings}}
+{{> finding}}
+      {{/each}}
+
+  {{/if}}
+
+  {{#if findingDiff.pruned}}
+Because there are so many new and resolved {{ metadata.name }}, some of them are not listed in this report.
+  {{/if}}
+{{/if}}

--- a/packages/cli/resources/change-report/findings/details.hbs
+++ b/packages/cli/resources/change-report/findings/details.hbs
@@ -54,23 +54,23 @@
 {{#if (length findingDiff.newFindings findingDiff.resolvedFindings)}}
 <h2 id="{{ metadata.anchor }}">{{ metadata.title }}</h2>
   {{#if (length findingDiff.newFindings) }}
+
 ### {{metadata.emoji}} New problems detected ({{ length findingDiff.newFindings }})
-      {{#each findingDiff.newFindings}}
+
+    {{#each findingDiff.newFindings}}
 {{> finding}}
-      {{/each}}
-
+    {{/each}}
   {{/if}}
-
   {{#if (length findingDiff.resolvedFindings) }}
+
 ### :tada: Problems resolved ({{ length findingDiff.resolvedFindings}})
 
-      {{#each findingDiff.resolvedFindings}}
+    {{#each findingDiff.resolvedFindings}}
 {{> finding}}
-      {{/each}}
-
+    {{/each}}
   {{/if}}
-
   {{#if findingDiff.pruned}}
-Because there are so many new and resolved {{ metadata.name }}, some of them are not listed in this report.
+
+Because there are many new and resolved {{ metadata.name }}, some of them are not listed in this report.
   {{/if}}
 {{/if}}

--- a/packages/cli/resources/change-report/findings/heading.hbs
+++ b/packages/cli/resources/change-report/findings/heading.hbs
@@ -1,13 +1,11 @@
-| [Findings](#findings) |
-  {{~#with findingDiff}}
-  {{~#unless (length newFindings resolvedFindings) }}
-  :white_check_mark: None
+| [{{ metadata.title }}](#{{ metadata.anchor }}) |
+  {{~#unless (length findingDiff.newFindings findingDiff.resolvedFindings) }}
+  :white_check_mark: None detected
   {{~/unless}}
-  {{~#if (length newFindings) }}
-  :beetle: {{length newFindings}} new
+  {{~#if (length findingDiff.newFindings) }}
+  {{ metadata.emoji }} {{length findingDiff.newFindings}} new
   {{~/if}}
-  {{~#if (length resolvedFindings) }}
-  :tada: {{length resolvedFindings}} resolved
+  {{~#if (length findingDiff.resolvedFindings) }}
+  :tada: {{length findingDiff.resolvedFindings}} resolved
   {{~/if}}
-  {{~/with}}
   |

--- a/packages/cli/resources/change-report/new-appmaps/details.hbs
+++ b/packages/cli/resources/change-report/new-appmaps/details.hbs
@@ -6,6 +6,6 @@
 
   {{/each}}
   {{#if pruned}}
-Because there are so many new AppMaps, some of them are not listed in this report.
+Because there are many new AppMaps, some of them are not listed in this report.
   {{/if}}
 {{/if}}

--- a/packages/cli/resources/change-report/new-appmaps/heading.hbs
+++ b/packages/cli/resources/change-report/new-appmaps/heading.hbs
@@ -1,3 +1,3 @@
 | [New AppMaps](#new-appmaps) |
-  {{~#with (group_appmaps_by_recorder_name newAppMaps) }} :star: {{#each @this}}{{#unless @first }}, {{/unless}}{{ count }} new {{ recorderName }}{{#if isTest}} {{ pluralize count 'test' }}{{/if}}{{/each}} {{else}} :white_check_mark: None {{/with~}}
+  {{~#with (group_appmaps_by_recorder_name newAppMaps) }} :star: {{#each @this}}{{#unless @first }}, {{/unless}}{{ count }} new {{ recorderName }}{{#if isTest}} {{ pluralize count 'test' }}{{/if}}{{/each}} {{else}} :zero: No new AppMaps {{/with~}}
 |

--- a/packages/cli/resources/change-report/new-appmaps/heading.hbs
+++ b/packages/cli/resources/change-report/new-appmaps/heading.hbs
@@ -1,3 +1,3 @@
 | [New AppMaps](#new-appmaps) |
-  {{~#unless newAppMaps.length }} :white_check_mark: None {{else}} :star: {{newAppMaps.length}} new {{/unless~}}
-  |
+  {{~#with (group_appmaps_by_recorder_name newAppMaps) }} :star: {{#each @this}}{{#unless @first }}, {{/unless}}{{ count }} new {{ recorderName }}{{#if isTest}} {{ pluralize count 'test' }}{{/if}}{{/each}} {{else}} :white_check_mark: None {{/with~}}
+|

--- a/packages/cli/resources/change-report/openapi-diff/details.hbs
+++ b/packages/cli/resources/change-report/openapi-diff/details.hbs
@@ -37,7 +37,7 @@
     {{/if}}
 
     {{#if pruned}}
-Because there are so many OpenAPI changes, some of them are not listed in this report,
+Because there are many OpenAPI changes, some of them are not listed in this report,
 and the full diff has not been printed either.
     {{else}}
 <details>

--- a/packages/cli/resources/change-report/openapi-diff/heading.hbs
+++ b/packages/cli/resources/change-report/openapi-diff/heading.hbs
@@ -3,6 +3,6 @@
   {{~#if differenceCount }}
     {{~#if breakingDifferenceCount }} 🚧 {{breakingDifferenceCount}} breaking{{~/if}}
     {{~#if nonBreakingDifferenceCount }}{{#if breakingDifferenceCount }},{{~/if}} :wrench: {{nonBreakingDifferenceCount}} non-breaking{{/if~}}
-  {{~else}} :white_check_mark: No API changes
+  {{~else}} :zero: No API changes
   {{~/if}} |
 {{~/with}}

--- a/packages/cli/resources/change-report/removed-appmaps/details.hbs
+++ b/packages/cli/resources/change-report/removed-appmaps/details.hbs
@@ -6,6 +6,6 @@
 
   {{/each}}
   {{#if pruned}}
-Because there are so many removed AppMaps, some of them are not listed in this report.
+Because there are many removed AppMaps, some of them are not listed in this report.
   {{/if}}
 {{/if}}

--- a/packages/cli/resources/change-report/removed-appmaps/heading.hbs
+++ b/packages/cli/resources/change-report/removed-appmaps/heading.hbs
@@ -1,3 +1,5 @@
 {{#if removedAppMaps.length ~}}
-| [Removed AppMaps](#removed-appmaps) | :heavy_multiplication_x: {{removedAppMaps.length}} removed |
+| [Removed AppMaps](#removed-appmaps) | 
+  {{~#with (group_appmaps_by_recorder_name removedAppMaps) }} :heavy_multiplication_x: {{#each @this}}{{#unless @first }}, {{/unless}}{{ count }} removed {{ recorderName }}{{#if isTest}} {{ pluralize count 'test' }}{{/if}}{{/each}} {{/with~}}
+  |
 {{~/if}}

--- a/packages/cli/src/cmds/compare-report/ChangeReport.ts
+++ b/packages/cli/src/cmds/compare-report/ChangeReport.ts
@@ -28,6 +28,10 @@ export class AppMap {
     return this.metadata.name || this.sourceLocation || '<anonymous AppMap>';
   }
 
+  get isTest(): boolean {
+    return this.metadata.recorder.type === 'tests' || this.metadata.test_status !== undefined;
+  }
+
   get recorderName(): string | undefined {
     return this.metadata.recorder.name;
   }

--- a/packages/cli/src/cmds/compare-report/MarkdownReport.ts
+++ b/packages/cli/src/cmds/compare-report/MarkdownReport.ts
@@ -2,13 +2,14 @@ import Report from './Report';
 import { ChangeReport as ChangeReportData } from '../compare/ChangeReport';
 import ChangeReport from './ChangeReport';
 import ReportSection, { ExperimentalSection, ReportOptions, Section } from './ReportSection';
-import { log } from 'console';
 
 // TODO: Get this from the type?
 export const SECTIONS: Section[] = [
   Section.FailedTests,
   Section.OpenAPIDiff,
-  Section.Findings,
+  Section.SecurityFlaws,
+  Section.PerformanceProblems,
+  Section.CodeAntiPatterns,
   Section.NewAppMaps,
   Section.RemovedAppMaps,
 ];

--- a/packages/cli/src/cmds/compare-report/ReportSection.ts
+++ b/packages/cli/src/cmds/compare-report/ReportSection.ts
@@ -2,11 +2,12 @@ import Handlebars, { SafeString } from 'handlebars';
 import { isAbsolute, join, relative } from 'path';
 
 import { readFile } from 'fs/promises';
-import ChangeReport, { AppMap } from './ChangeReport';
+import ChangeReport, { AppMap, FindingDiff } from './ChangeReport';
 import { existsSync } from 'fs';
 import assert from 'assert';
 import { RevisionName } from '../compare/RevisionName';
-import buildPreprocessor from './Preprocessor';
+import buildPreprocessor, { filterFindings } from './Preprocessor';
+import { ImpactDomain } from '@appland/scanner';
 
 export const TemplateDirectory = [
   '../../../resources/change-report', // As packaged
@@ -21,20 +22,65 @@ export const DEFAULT_MAX_ELEMENTS = 10;
 export enum Section {
   FailedTests = 'failed-tests',
   OpenAPIDiff = 'openapi-diff',
-  Findings = 'findings',
+  SecurityFlaws = 'security-flaws',
+  PerformanceProblems = 'performance-problems',
+  CodeAntiPatterns = 'code-antipatterns',
   NewAppMaps = 'new-appmaps',
   RemovedAppMaps = 'removed-appmaps',
 }
 
+export const FindingsSections: (Section | ExperimentalSection)[] = [
+  Section.SecurityFlaws,
+  Section.PerformanceProblems,
+  Section.CodeAntiPatterns,
+];
+
 export enum ExperimentalSection {
   ChangedAppMaps = 'changed-appmaps',
 }
+
+export type SectionMetadata = {
+  name: string;
+  title: string;
+  anchor: string;
+  emoji: string;
+};
+
+type ReportContext = ChangeReport & { metadata?: SectionMetadata };
+
+const SECTION_DIRECTORY: Record<Section & ExperimentalSection, string> = {
+  'performance-problems': 'findings',
+  'security-flaws': 'findings',
+  'code-antipatterns': 'findings',
+};
+
+const SECTION_METADATA: Record<Section & ExperimentalSection, SectionMetadata> = {
+  'performance-problems': {
+    name: 'performance problems',
+    title: 'Performance problems',
+    anchor: 'performance-problems',
+    emoji: '🐌',
+  },
+  'security-flaws': {
+    name: 'security flaws',
+    title: 'Security flaws',
+    anchor: 'security-flaws',
+    emoji: '🔒',
+  },
+  'code-antipatterns': {
+    name: 'code anti-patterns',
+    title: 'Code anti-patterns',
+    anchor: 'code-antipatterns',
+    emoji: '🚨',
+  },
+};
 
 export type ReportOptions = {
   sourceURL: URL;
   appmapURL: URL;
   maxElements?: number;
   baseDir?: string;
+  metadata?: SectionMetadata;
 };
 
 export default class ReportSection {
@@ -45,7 +91,7 @@ export default class ReportSection {
   ) {}
 
   generateHeading(changeReport: ChangeReport, options: ReportOptions) {
-    return this.headingTemplate(changeReport, {
+    return this.headingTemplate(this.buildContext(changeReport), {
       helpers: ReportSection.helpers(options),
     });
   }
@@ -66,10 +112,27 @@ export default class ReportSection {
       }
     }
 
-    return this.detailsTemplate(report, {
+    return this.detailsTemplate(this.buildContext(report), {
       helpers: ReportSection.helpers(options),
       allowProtoPropertiesByDefault: true,
     });
+  }
+
+  buildContext(changeReport: ChangeReport): ReportContext {
+    const context = { ...changeReport } as any;
+    const metadata = SECTION_METADATA[this.section];
+    if (metadata) context.metadata = metadata;
+
+    if (FindingsSections.includes(this.section)) {
+      const newFindings = filterFindings(changeReport.findingDiff.newFindings, this.section);
+      const resolvedFindings = filterFindings(
+        changeReport.findingDiff.resolvedFindings,
+        this.section
+      );
+      context.findingDiff = { newFindings, resolvedFindings };
+    }
+
+    return context;
   }
 
   static helpers(options: ReportOptions): { [name: string]: Function } | undefined {
@@ -176,10 +239,13 @@ export default class ReportSection {
     templateDir = TemplateDirectory
   ): Promise<ReportSection> {
     assert(templateDir);
-    const headingTemplateFile = join(templateDir, section, 'heading.hbs');
+
+    const sectionDir = SECTION_DIRECTORY[section] || section;
+
+    const headingTemplateFile = join(templateDir, sectionDir, 'heading.hbs');
     const headingTemplate = Handlebars.compile(await readFile(headingTemplateFile, 'utf8'));
 
-    const detailsTemplateFile = join(templateDir, section, 'details.hbs');
+    const detailsTemplateFile = join(templateDir, sectionDir, 'details.hbs');
     const detailsTemplate = Handlebars.compile(await readFile(detailsTemplateFile, 'utf8'));
 
     return new ReportSection(section, headingTemplate, detailsTemplate);

--- a/packages/cli/src/cmds/compare-report/ReportSection.ts
+++ b/packages/cli/src/cmds/compare-report/ReportSection.ts
@@ -191,6 +191,27 @@ export default class ReportSection {
       }
     };
 
+    type RecorderGroup = {
+      recorderName: string;
+      count: number;
+      isTest: boolean;
+    };
+
+    const group_appmaps_by_recorder_name = (appmaps: AppMap[]): RecorderGroup[] => {
+      const recorderGroups = appmaps.reduce((acc, appmap) => {
+        const recorderName = appmap.recorderName || 'unknown';
+        if (!acc.has(recorderName))
+          acc.set(recorderName, {
+            recorderName: recorderName,
+            isTest: appmap.isTest,
+            count: 1,
+          });
+        else acc.get(recorderName)!.count += 1;
+        return acc;
+      }, new Map<string, RecorderGroup>());
+      return [...recorderGroups.values()].sort((a, b) => b.count - a.count);
+    };
+
     const appmap_title = (appmap: AppMap): string => {
       const tokens: string[] = [];
       if (appmap.recorderName) tokens.push(['[', appmap.recorderName, ']'].join(''));
@@ -223,13 +244,19 @@ export default class ReportSection {
       }
     };
 
+    const pluralize = (count: number, singular: string, plural?: string): string => {
+      return count === 1 ? singular : plural || singular + 's';
+    };
+
     return {
-      inspect,
-      length,
-      coalesce,
+      appmap_diff_url,
       appmap_title,
       appmap_url,
-      appmap_diff_url,
+      coalesce,
+      group_appmaps_by_recorder_name,
+      inspect,
+      length,
+      pluralize,
       source_url,
     };
   }

--- a/packages/cli/src/cmds/compare/loadFindings.ts
+++ b/packages/cli/src/cmds/compare/loadFindings.ts
@@ -1,12 +1,8 @@
-import assert from 'assert';
-import { SemVer } from 'semver';
 import { readFile } from 'fs/promises';
 import { Finding } from '@appland/scanner';
 
-import { ArchiveMetadata } from '../archive/ArchiveMetadata';
 import { Paths } from './Paths';
 import { RevisionName } from './RevisionName';
-import { executeCommand } from '../../lib/executeCommand';
 import { processNamedFiles } from '../../utils';
 
 export default async function loadFindings(
@@ -14,10 +10,6 @@ export default async function loadFindings(
   revisionName: RevisionName,
   appMapDir: string
 ): Promise<Finding[]> {
-  const manifest: ArchiveMetadata = JSON.parse(
-    await readFile(paths.manifestPath(revisionName), 'utf-8')
-  );
-
   const findings = new Array<Finding>();
 
   const collectFindings = (findings: Finding[]): ((findingsFile: string) => Promise<void>) => {
@@ -27,27 +19,11 @@ export default async function loadFindings(
     };
   };
 
-  let archiveVersion = manifest.versions.archive;
-  assert(archiveVersion);
-  if (archiveVersion.split('.').length === 2) archiveVersion += '.0';
-  if (new SemVer(archiveVersion).compare('1.3.0') < 0) {
-    const workingDir = paths.revisionPath(revisionName);
-    console.info(
-      `Scanning ${revisionName} revision for findings (archive version: ${archiveVersion}).`
-    );
-    let command = `npx @appland/scanner@latest scan -d ${workingDir} --all`;
-    await executeCommand(command);
-
-    // Pre-1.3.0 archive. Scan and load findings the old way.
-    const scanResults = JSON.parse(await readFile(paths.findingsPath(revisionName), 'utf-8'));
-    findings.push(...(scanResults.findings || []));
-  } else {
-    await processNamedFiles(
-      paths.revisionPath(revisionName),
-      'appmap-findings.json',
-      collectFindings(findings)
-    );
-  }
+  await processNamedFiles(
+    paths.revisionPath(revisionName),
+    'appmap-findings.json',
+    collectFindings(findings)
+  );
 
   console.info(`Found ${findings.length} findings for ${revisionName} revision`);
 

--- a/packages/cli/tests/unit/compareReport/changedAppMaps.spec.ts
+++ b/packages/cli/tests/unit/compareReport/changedAppMaps.spec.ts
@@ -22,9 +22,7 @@ describe('changedAppMaps', () => {
           } as unknown as ChangeReport,
           reportOptions
         );
-        expect(report).toEqual(
-          '| [Changed AppMaps](#changed-appmaps) |  :white_check_mark: No changes  |'
-        );
+        expect(report).toEqual('| [Changed AppMaps](#changed-appmaps) |  :zero: No changes  |');
       });
     });
     describe('details', () => {

--- a/packages/cli/tests/unit/compareReport/changedAppMaps.spec.ts
+++ b/packages/cli/tests/unit/compareReport/changedAppMaps.spec.ts
@@ -158,7 +158,7 @@ changed 3
 
 - [Users controller test](https://getappmap.com/?path=diff%2Fminitest%2Fusers_controller_test.diff.sequence.json)
 
-Because there are so many changed AppMaps, some of them are not listed in this report.
+Because there are many changed AppMaps, some of them are not listed in this report.
 </details>
 `);
       });

--- a/packages/cli/tests/unit/compareReport/compareReport.spec.ts
+++ b/packages/cli/tests/unit/compareReport/compareReport.spec.ts
@@ -4,7 +4,6 @@ import path from 'path';
 
 import { handler } from '../../../src/cmds/compare-report/compareReport';
 import { cleanProject, fixtureDir } from '../util';
-import { writeFile } from 'fs/promises';
 
 function removeTimeStampLines(report: string): string {
   return report.replace(/[-+]{3}.*openapi\.yml.*\n/g, '');

--- a/packages/cli/tests/unit/compareReport/expectedReport.md.txt
+++ b/packages/cli/tests/unit/compareReport/expectedReport.md.txt
@@ -4,7 +4,9 @@
 | --- | --- |
 | [Failed tests](#failed-tests) | :white_check_mark: All tests passed |
 | [API changes](#openapi-changes) | :wrench: 1 non-breaking |
-| [Findings](#findings) |  :beetle: 1 new  :tada: 2 resolved  |
+| [Security flaws](#security-flaws) |  🔒 1 new  :tada: 2 resolved  |
+| [Performance problems](#performance-problems) |  :white_check_mark: None detected  |
+| [Code anti-patterns](#code-antipatterns) |  :white_check_mark: None detected  |
 | [New AppMaps](#new-appmaps) | :star: 1 new |
 | [Removed AppMaps](#removed-appmaps) | :heavy_multiplication_x: 1 removed |
 
@@ -41,9 +43,9 @@ Detailed OpenAPI diff
 ```
 </details>
 
-<h2 id="findings">Findings</h2>
+<h2 id="security-flaws">Security flaws</h2>
 
-### :beetle: New findings (1)
+### 🔒 New problems detected (1)
 
 
 <details>
@@ -77,7 +79,7 @@ Detailed OpenAPI diff
 </details>
 
 
-### :tada: Resolved findings (2)
+### :tada: Problems resolved (2)
 
 
 <details>

--- a/packages/cli/tests/unit/compareReport/expectedReport.md.txt
+++ b/packages/cli/tests/unit/compareReport/expectedReport.md.txt
@@ -7,8 +7,8 @@
 | [Security flaws](#security-flaws) |  🔒 1 new  :tada: 2 resolved  |
 | [Performance problems](#performance-problems) |  :white_check_mark: None detected  |
 | [Code anti-patterns](#code-antipatterns) |  :white_check_mark: None detected  |
-| [New AppMaps](#new-appmaps) | :star: 1 new |
-| [Removed AppMaps](#removed-appmaps) | :heavy_multiplication_x: 1 removed |
+| [New AppMaps](#new-appmaps) | :star: 1 new minitest test |
+| [Removed AppMaps](#removed-appmaps) | :heavy_multiplication_x: 1 removed minitest test |
 
 
 <h2 id="openapi-changes">🔄 API changes</h2>

--- a/packages/cli/tests/unit/compareReport/findings.spec.ts
+++ b/packages/cli/tests/unit/compareReport/findings.spec.ts
@@ -12,7 +12,7 @@ let resolvedFinding: FindingChange;
 describe('findings', () => {
   let section: ReportSection;
 
-  beforeAll(async () => (section = await ReportSection.build(Section.Findings)));
+  beforeAll(async () => (section = await ReportSection.build(Section.PerformanceProblems)));
 
   describe('when there are no changes', () => {
     const findingDiff = new FindingDiff([], []);
@@ -25,7 +25,9 @@ describe('findings', () => {
           } as unknown as ChangeReport,
           reportOptions
         );
-        expect(report).toEqual('| [Findings](#findings) |  :white_check_mark: None  |');
+        expect(report).toEqual(
+          '| [Performance problems](#performance-problems) |  :white_check_mark: None detected  |'
+        );
       });
     });
     describe('details', () => {
@@ -55,7 +57,9 @@ describe('findings', () => {
           } as unknown as ChangeReport,
           reportOptions
         );
-        expect(report).toEqual('| [Findings](#findings) |  :tada: 1 resolved  |');
+        expect(report).toEqual(
+          '| [Performance problems](#performance-problems) |  :tada: 1 resolved  |'
+        );
       });
     });
     describe('details', () => {
@@ -66,10 +70,9 @@ describe('findings', () => {
           } as unknown as ChangeReport,
           reportOptions
         );
-        expect(report).toEqual(`<h2 id=\"findings\">Findings</h2>
+        expect(report).toEqual(`<h2 id=\"performance-problems\">Performance problems</h2>
 
-
-### :tada: Resolved findings (1)
+### :tada: Problems resolved (1)
 
 
 <details>

--- a/packages/cli/tests/unit/compareReport/findings.spec.ts
+++ b/packages/cli/tests/unit/compareReport/findings.spec.ts
@@ -115,8 +115,6 @@ describe('findings', () => {
 
 
 </details>
-
-
 `);
       });
     });

--- a/packages/cli/tests/unit/compareReport/newAppMaps.spec.ts
+++ b/packages/cli/tests/unit/compareReport/newAppMaps.spec.ts
@@ -19,7 +19,7 @@ describe('newAppMaps', () => {
           } as unknown as ChangeReport,
           reportOptions
         );
-        expect(report).toEqual('| [New AppMaps](#new-appmaps) | :white_check_mark: None |');
+        expect(report).toEqual('| [New AppMaps](#new-appmaps) | :zero: No new AppMaps |');
       });
     });
     describe('details', () => {

--- a/packages/cli/tests/unit/compareReport/newAppMaps.spec.ts
+++ b/packages/cli/tests/unit/compareReport/newAppMaps.spec.ts
@@ -118,7 +118,7 @@ describe('newAppMaps', () => {
 
 - [[rspec] Users controller test](https://getappmap.com/?path=head%2Fminitest%2Fusers_controller_test.appmap.json)
 
-Because there are so many new AppMaps, some of them are not listed in this report.
+Because there are many new AppMaps, some of them are not listed in this report.
 `);
       });
     });

--- a/packages/cli/tests/unit/compareReport/newAppMaps.spec.ts
+++ b/packages/cli/tests/unit/compareReport/newAppMaps.spec.ts
@@ -39,7 +39,7 @@ describe('newAppMaps', () => {
     const metadata: Metadata = {
       name: 'Users controller test',
       client: {} as any,
-      recorder: { name: 'rspec' } as any,
+      recorder: { name: 'rspec', type: 'tests' } as any,
       source_location: 'spec/controllers/users_controller_test.rb:10',
     };
     const appmap = new AppMap('minitest/users_controller_test', metadata, false, undefined);
@@ -53,7 +53,7 @@ describe('newAppMaps', () => {
           } as unknown as ChangeReport,
           reportOptions
         );
-        expect(report).toEqual('| [New AppMaps](#new-appmaps) | :star: 1 new |');
+        expect(report).toEqual('| [New AppMaps](#new-appmaps) | :star: 1 new rspec test |');
       });
     });
     describe('details', () => {
@@ -72,15 +72,23 @@ describe('newAppMaps', () => {
       });
     });
   });
-  describe('when there are many new AppMaps', () => {
-    const metadata: Metadata = {
+  describe('when there are multiple new AppMaps', () => {
+    const metadata1: Metadata = {
       name: 'Users controller test',
       client: {} as any,
       recorder: { name: 'rspec' } as any,
       source_location: 'spec/controllers/users_controller_test.rb:10',
     };
-    const appmap = new AppMap('minitest/users_controller_test', metadata, false, undefined);
-    const newAppMaps = [appmap, appmap, appmap, appmap, appmap];
+    const metadata2: Metadata = {
+      name: 'Sessions controller test',
+      client: {} as any,
+      recorder: { name: 'minitest' } as any,
+      source_location: 'spec/controllers/users_controller_test.rb:10',
+    };
+    const appmap1 = new AppMap('minitest/users_controller_test', metadata1, false, undefined);
+    const appmap2 = new AppMap('minitest/users_controller_test', metadata1, false, undefined);
+    const appmap3 = new AppMap('minitest/users_controller_test', metadata2, false, undefined);
+    const newAppMaps = [appmap1, appmap2, appmap3];
 
     describe('header', () => {
       it('reports the changes', async () => {
@@ -90,7 +98,9 @@ describe('newAppMaps', () => {
           } as unknown as ChangeReport,
           reportOptions
         );
-        expect(report).toEqual('| [New AppMaps](#new-appmaps) | :star: 5 new |');
+        expect(report).toEqual(
+          '| [New AppMaps](#new-appmaps) | :star: 2 new rspec, 1 new minitest |'
+        );
       });
     });
     describe('details', () => {
@@ -99,12 +109,9 @@ describe('newAppMaps', () => {
           {
             newAppMaps,
           } as unknown as ChangeReport,
-          { ...reportOptions, ...{ maxElements: 3 } }
+          { ...reportOptions, ...{ maxElements: 2 } }
         );
         expect(report).toEqual(`<h2 id=\"new-appmaps\">⭐ New AppMaps</h2>
-
-- [[rspec] Users controller test](https://getappmap.com/?path=head%2Fminitest%2Fusers_controller_test.appmap.json)
-
 
 - [[rspec] Users controller test](https://getappmap.com/?path=head%2Fminitest%2Fusers_controller_test.appmap.json)
 

--- a/packages/cli/tests/unit/compareReport/openapiDiff.spec.ts
+++ b/packages/cli/tests/unit/compareReport/openapiDiff.spec.ts
@@ -18,9 +18,7 @@ describe('openapiDiff', () => {
           } as unknown as ChangeReport,
           reportOptions
         );
-        expect(report).toEqual(
-          '| [API changes](#openapi-changes) | :white_check_mark: No API changes |'
-          );
+        expect(report).toEqual('| [API changes](#openapi-changes) | :zero: No API changes |');
       });
     });
     describe('details', () => {

--- a/packages/cli/tests/unit/compareReport/removedAppMaps.spec.ts
+++ b/packages/cli/tests/unit/compareReport/removedAppMaps.spec.ts
@@ -121,7 +121,7 @@ describe('removedAppMaps', () => {
 
 - [[rspec] Users controller test](https://getappmap.com/?path=base%2Fminitest%2Fusers_controller_test.appmap.json)
 
-Because there are so many removed AppMaps, some of them are not listed in this report.
+Because there are many removed AppMaps, some of them are not listed in this report.
 `);
       });
     });

--- a/packages/cli/tests/unit/compareReport/removedAppMaps.spec.ts
+++ b/packages/cli/tests/unit/compareReport/removedAppMaps.spec.ts
@@ -3,7 +3,7 @@ import ChangeReport, { AppMap } from '../../../src/cmds/compare-report/ChangeRep
 import ReportSection, { Section } from '../../../src/cmds/compare-report/ReportSection';
 import { reportOptions } from './testHelper';
 
-describe('newAppMaps', () => {
+describe('removedAppMaps', () => {
   let section: ReportSection;
 
   beforeAll(async () => (section = await ReportSection.build(Section.RemovedAppMaps)));
@@ -36,11 +36,11 @@ describe('newAppMaps', () => {
       });
     });
   });
-  describe('when there is a new AppMap', () => {
+  describe('when there is a removed AppMap', () => {
     const metadata: Metadata = {
       name: 'Users controller test',
       client: {} as any,
-      recorder: { name: 'rspec' } as any,
+      recorder: { name: 'rspec', type: 'tests' } as any,
       source_location: 'spec/controllers/users_controller_test.rb:10',
     };
     const appmap = new AppMap('minitest/users_controller_test', metadata, false, undefined);
@@ -55,7 +55,7 @@ describe('newAppMaps', () => {
           reportOptions
         );
         expect(report).toEqual(
-          '| [Removed AppMaps](#removed-appmaps) | :heavy_multiplication_x: 1 removed |'
+          '| [Removed AppMaps](#removed-appmaps) | :heavy_multiplication_x: 1 removed rspec test |'
         );
       });
     });
@@ -76,14 +76,22 @@ describe('newAppMaps', () => {
     });
   });
   describe('when there are many removed AppMaps', () => {
-    const metadata: Metadata = {
+    const metadata1: Metadata = {
       name: 'Users controller test',
       client: {} as any,
       recorder: { name: 'rspec' } as any,
       source_location: 'spec/controllers/users_controller_test.rb:10',
     };
-    const appmap = new AppMap('minitest/users_controller_test', metadata, false, undefined);
-    const removedAppMaps = [appmap, appmap, appmap, appmap, appmap];
+    const metadata2: Metadata = {
+      name: 'Sessions controller test',
+      client: {} as any,
+      recorder: { name: 'minitest' } as any,
+      source_location: 'spec/controllers/users_controller_test.rb:10',
+    };
+    const appmap1 = new AppMap('minitest/users_controller_test', metadata1, false, undefined);
+    const appmap2 = new AppMap('minitest/users_controller_test', metadata1, false, undefined);
+    const appmap3 = new AppMap('minitest/users_controller_test', metadata2, false, undefined);
+    const removedAppMaps = [appmap1, appmap2, appmap3];
 
     describe('header', () => {
       it('reports the changes', async () => {
@@ -94,7 +102,7 @@ describe('newAppMaps', () => {
           reportOptions
         );
         expect(report).toEqual(
-          '| [Removed AppMaps](#removed-appmaps) | :heavy_multiplication_x: 5 removed |'
+          '| [Removed AppMaps](#removed-appmaps) | :heavy_multiplication_x: 2 removed rspec, 1 removed minitest |'
         );
       });
     });
@@ -104,12 +112,9 @@ describe('newAppMaps', () => {
           {
             removedAppMaps,
           } as unknown as ChangeReport,
-          { ...reportOptions, ...{ maxElements: 3 } }
+          { ...reportOptions, ...{ maxElements: 2 } }
         );
         expect(report).toEqual(`<h2 id=\"removed-appmaps\">✖️ Removed AppMaps</h2>
-
-- [[rspec] Users controller test](https://getappmap.com/?path=base%2Fminitest%2Fusers_controller_test.appmap.json)
-
 
 - [[rspec] Users controller test](https://getappmap.com/?path=base%2Fminitest%2Fusers_controller_test.appmap.json)
 


### PR DESCRIPTION
Organize findings by category, rather than presenting them as one list.

List the "type" of new AppMaps, e.g. `1 new test`.

- [x] Fix headings of finding details

*Avoid*
 ```
<h2 id="security-flaws">Security flaws</h2>
### 🔒 New problems detected (2)

```

*Use*
```
<h2 id="security-flaws">Security flaws</h2>
  <-- New line here
### 🔒 New problems detected (2)

```

## Example

Security flaws, Performance problems, and Code anti-patterns now each get their own section.

| Summary | Status |
| --- | --- |
| [Failed tests](#failed-tests) | :white_check_mark: All tests passed |
| [API changes](#openapi-changes) | :wrench: 1 non-breaking |
| [Security flaws](#security-flaws) |  🔒 1 new  :tada: 2 resolved  |
| [Performance problems](#performance-problems) |  :white_check_mark: None detected  |
| [Code anti-patterns](#code-antipatterns) |  :white_check_mark: None detected  |
| [New AppMaps](#new-appmaps) | :star: 1 new minitest test |
| [Removed AppMaps](#removed-appmaps) | :heavy_multiplication_x: 1 removed minitest test |
