### PR TITLE
Improve appmap performance in sequence diagram

### DIFF
--- a/packages/sequence-diagram/package.json
+++ b/packages/sequence-diagram/package.json
@@ -19,7 +19,7 @@
   "author": "AppLand, Inc.",
   "license": "Commons Clause + MIT",
   "dependencies": {
-    "@appland/models": "workspace:^2.6.3",
+    "@appland/models": "workspace:^2.7.0",
     "@appland/openapi": "workspace:^1.4.3",
     "@datastructures-js/priority-queue": "^6.1.3",
     "crypto-js": "^4.1.1",

--- a/packages/sequence-diagram/package.json
+++ b/packages/sequence-diagram/package.json
@@ -23,7 +23,8 @@
     "@appland/openapi": "workspace:^1.4.3",
     "@datastructures-js/priority-queue": "^6.1.3",
     "crypto-js": "^4.1.1",
-    "diff": "^5.1.0"
+    "diff": "^5.1.0",
+    "lru-cache": "6.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/sequence-diagram/src/buildDiagram.ts
+++ b/packages/sequence-diagram/src/buildDiagram.ts
@@ -22,6 +22,7 @@ import {
 const MAX_WINDOW_SIZE = 5;
 
 const parsedSqlCache = new LRUCache<string, any>({ max: 1000 });
+const sha256Cache = new LRUCache<string, string>({ max: 1000 });
 
 class ActorManager {
   private _actorsByCodeObjectId = new Map<string, Actor>();
@@ -204,7 +205,13 @@ export default function buildDiagram(
 
       hashEntries.push(child.subtreeDigest);
     });
-    node.subtreeDigest = sha256(hashEntries.join('\n')).toString();
+    const hashInput = hashEntries.join('\n');
+    let sha256Digest = sha256Cache.get(hashInput);
+    if (!sha256Digest) {
+      sha256Digest = sha256(hashInput).toString();
+      sha256Cache.set(hashInput, sha256Digest);
+    }
+    node.subtreeDigest = sha256Digest;
   };
 
   const detectLoops = (node: Action): void => {

--- a/packages/sequence-diagram/src/mergeWindow.ts
+++ b/packages/sequence-diagram/src/mergeWindow.ts
@@ -1,8 +1,17 @@
 import sha256 from 'crypto-js/sha256.js';
+import LRUCache from 'lru-cache';
 import { Action, Loop, NodeType } from './types';
 
+const sha256Cache = new LRUCache<string, string>({ max: 3000 });
+
 function buildDigest(actions: Action[]): string {
-  return sha256(actions.map((action) => action.subtreeDigest).join('\n')).toString();
+  const sha256Input = actions.map((action) => action.subtreeDigest).join('\n');
+  let result = sha256Cache.get(sha256Input);
+  if (!result) {
+    result = sha256(sha256Input).toString();
+    sha256Cache.set(sha256Input, result);
+  }
+  return result;
 }
 
 function countDigests(actions: Action[], windowSize: number): Map<string, number> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -365,7 +365,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@appland/models@workspace:*, @appland/models@workspace:^2.2.0, @appland/models@workspace:^2.6.3, @appland/models@workspace:packages/models":
+"@appland/models@workspace:*, @appland/models@workspace:^2.2.0, @appland/models@workspace:^2.6.3, @appland/models@workspace:^2.7.0, @appland/models@workspace:packages/models":
   version: 0.0.0-use.local
   resolution: "@appland/models@workspace:packages/models"
   dependencies:
@@ -481,7 +481,7 @@ __metadata:
   resolution: "@appland/sequence-diagram@workspace:packages/sequence-diagram"
   dependencies:
     "@appland/appmap-agent-js": ^13.9.0
-    "@appland/models": "workspace:^2.6.3"
+    "@appland/models": "workspace:^2.7.0"
     "@appland/openapi": "workspace:^1.4.3"
     "@datastructures-js/priority-queue": ^6.1.3
     "@types/diff": ^5.0.2

--- a/yarn.lock
+++ b/yarn.lock
@@ -495,6 +495,7 @@ __metadata:
     eslint-plugin-node: ^11.1.0
     eslint-plugin-prettier: ^3.4.1
     jest: ^29.5.0
+    lru-cache: 6.0.0
     prettier: ^2.7.1
     ts-jest: ^29.0.5
     typescript: ^4.4.2


### PR DESCRIPTION
- [x] This PR should be merged after #1432 gets merged and released.

This small PR represents a massive performance boost for large AppMaps. It adds three caches to avoid repeating expensive computations:
- A cache for SQL that is parsed into an AST. This requires that [this commit](https://github.com/getappmap/appmap-js/pull/1432/commits/f813f3771e742afe8bffb0645774bb7b98984b8f) is released in `@appland/models`.
- Two caches for `sha256` values that are used when building digests.