### PR TITLE
Improve appmap performance in components

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -28,8 +28,8 @@
   ],
   "dependencies": {
     "@appland/diagrams": "workspace:^1.7.0",
-    "@appland/models": "workspace:^2.6.3",
-    "@appland/sequence-diagram": "workspace:^1.8.1",
+    "@appland/models": "workspace:^2.7.0",
+    "@appland/sequence-diagram": "workspace:^1.9.0",
     "buffer": "^6.0.3",
     "d3": "^7.8.4",
     "d3-flame-graph": "^4.1.3",

--- a/packages/components/src/components/DetailsPanelListHeader.vue
+++ b/packages/components/src/components/DetailsPanelListHeader.vue
@@ -1,4 +1,4 @@
-<template>
+<template functional>
   <h5 class="details-panel-list-header"><slot /></h5>
 </template>
 

--- a/packages/components/src/components/DiagramSequence.vue
+++ b/packages/components/src/components/DiagramSequence.vue
@@ -23,14 +23,12 @@
               :actionSpec="action"
               :key="actionKey(action)"
               :interactive="interactive"
-              :collapsed-actions="collapsedActionState"
               :appMap="appMap"
             />
           </template>
           <template v-if="action.nodeType === 'return'">
             <VReturnAction
               :actionSpec="action"
-              :collapsed-actions="collapsedActionState"
               :key="actionKey(action)"
               :return-value="returnValue(action)"
             />
@@ -66,7 +64,7 @@ import VReturnAction from '@/components/sequence/ReturnAction.vue';
 import VActor from '@/components/sequence/Actor.vue';
 import DiagramSpec from './sequence/DiagramSpec';
 import { ActionSpec } from './sequence/ActionSpec';
-import { SET_FOCUSED_EVENT } from '../store/vsCode';
+import { SET_FOCUSED_EVENT, SET_COLLAPSED_ACTION_STATE } from '../store/vsCode';
 
 const SCROLL_OPTIONS = { behavior: 'smooth', block: 'center', inline: 'center' };
 export const DEFAULT_SEQ_DIAGRAM_COLLAPSE_DEPTH = 3;
@@ -93,13 +91,16 @@ export default {
     },
   },
 
-  data() {
-    return {
-      collapsedActionState: [],
-    };
-  },
-
   computed: {
+    collapsedActionState: {
+      get() {
+        return this.$store?.state?.collapsedActionState || [];
+      },
+      set(value) {
+        if (this.$store?.state?.collapsedActionState)
+          this.$store.commit(SET_COLLAPSED_ACTION_STATE, value);
+      },
+    },
     selectedEvents() {
       const selectedObject = this.$store?.getters?.selectedObject;
       return selectedObject && selectedObject instanceof Event ? [selectedObject] : [];
@@ -257,8 +258,7 @@ export default {
             actionSpec?.ancestorIndexes.length >= collapseDepth &&
             !descendantPreventingCollapseFound;
           if (this.collapsedActionState[actionSpec?.index] != shouldCollapse)
-            // TODO
-            this.$set(this.collapsedActionState, actionSpec?.index, shouldCollapse);
+            this.$set(this.$store.state.collapsedActionState, actionSpec?.index, shouldCollapse);
         }
 
         return descendantPreventingCollapseFound;

--- a/packages/components/src/components/DiagramSequence.vue
+++ b/packages/components/src/components/DiagramSequence.vue
@@ -43,7 +43,7 @@
           <template v-if="action.nodeType === 'loop'"
             ><VLoopAction
               :actionSpec="action"
-              :collapsed-actions="collapsedActionState"
+              :isCollapsed="isCollapsed(action)"
               :key="actionKey(action)"
           /></template>
         </template>
@@ -295,6 +295,9 @@ export default {
         if (depth > maxDepth) return depth;
         return maxDepth;
       }, 0);
+    },
+    isCollapsed(action: ActionSpec) {
+      return action.isCollapsed(this.collapsedActionState);
     },
   },
   watch: {

--- a/packages/components/src/components/DiagramTrace.vue
+++ b/packages/components/src/components/DiagramTrace.vue
@@ -2,8 +2,7 @@
   <v-container @click.native="clearSelection" :zoomControls="zoomControls" ref="container">
     <v-trace
       :events="events"
-      :selected-events="selectedEvents"
-      :focused-event="focusedEvent"
+      :selected-events-for-diff="selectedEventsForDiff"
       :event-filter-matches="eventFilterMatches"
       :event-filter-match="eventFilterMatch"
       :event-filter-match-index="eventFilterMatchIndex"
@@ -36,17 +35,13 @@ export default {
     events: {
       type: Array,
     },
-    selectedEvents: {
+    selectedEventsForDiff: {
       type: Array,
       default: () => [],
     },
-    focusedEvent: {
-      type: Object,
-      default: null,
-    },
     eventFilterMatches: {
       type: Set,
-      default: new Set(),
+      default: () => new Set(),
     },
     eventFilterMatch: {
       type: Event,

--- a/packages/components/src/components/flamegraph/FlamegraphBranch.vue
+++ b/packages/components/src/components/flamegraph/FlamegraphBranch.vue
@@ -15,7 +15,6 @@
 </template>
 
 <script>
-import { Event } from '@appland/models';
 import { isEventDurationValid, getEventDuration, add } from '../../lib/flamegraph';
 export default {
   name: 'v-flamegraph-branch',
@@ -31,23 +30,18 @@ export default {
     factor: {
       type: Number,
       required: true,
-      validator: (value) => value >= 0 && value <= 1,
     },
     focus: {
       type: Object,
       default: null,
-      validator: (value) =>
-        value === null || (value.target instanceof Event && value.ancestors instanceof Set),
     },
     baseBudget: {
       type: Number,
       required: true,
-      validator: (value) => value >= 0,
     },
     zoomBudget: {
       type: Number,
       required: true,
-      validator: (value) => value >= 0,
     },
   },
   computed: {

--- a/packages/components/src/components/flamegraph/FlamegraphHover.vue
+++ b/packages/components/src/components/flamegraph/FlamegraphHover.vue
@@ -5,14 +5,13 @@
 </template>
 <script>
 import { formatDuration, getEventDuration, isEventDurationValid } from '@/lib/flamegraph';
-import { Event } from '@appland/models';
+
 export default {
   name: 'v-flamegraph-hover',
   props: {
     event: {
       type: Object,
       default: null,
-      validator: (value) => value === null || value instanceof Event,
     },
   },
   computed: {

--- a/packages/components/src/components/flamegraph/FlamegraphItem.vue
+++ b/packages/components/src/components/flamegraph/FlamegraphItem.vue
@@ -13,10 +13,10 @@
 
 <script>
 import { formatDurationMillisecond, getEventDuration } from '../../lib/flamegraph';
-import { Event } from '@appland/models';
+
 const MIN_BORDER_WIDTH = 2;
 const MIN_TEXT_WIDTH = 50;
-const statuses = new Set(['trunk', 'crown', 'branch', 'pruned']);
+
 export default {
   name: 'v-flamegraph-item',
   emits: ['select', 'hover'],
@@ -24,27 +24,22 @@ export default {
     event: {
       type: Object,
       required: true,
-      validator: (value) => value instanceof Event,
     },
     factor: {
       type: Number,
       required: true,
-      validator: (value) => value >= 0 && value <= 1,
     },
     status: {
       type: String,
       default: null,
-      validator: (value) => statuses.has(value),
     },
     baseBudget: {
       type: Number,
       required: true,
-      validator: (value) => value >= 0,
     },
     zoomBudget: {
       type: Number,
       required: true,
-      validator: (value) => value >= 0,
     },
   },
   data() {

--- a/packages/components/src/components/flamegraph/FlamegraphMain.vue
+++ b/packages/components/src/components/flamegraph/FlamegraphMain.vue
@@ -46,6 +46,7 @@ export default {
       interval: null,
       focusing: 0,
       inertia: null,
+      grabbing: false,
     };
   },
   props: {
@@ -111,6 +112,7 @@ export default {
       return {
         'flamegraph-main': true,
         'flamegraph-main-focusing': this.focusing > 0,
+        mousedown: this.grabbing,
       };
     },
   },
@@ -147,9 +149,11 @@ export default {
   methods: {
     handleMouseDown() {
       this.inertia = null;
+      this.grabbing = true;
     },
     handleMouseUp() {
       this.up = true;
+      this.grabbing = false;
     },
     startFocusing() {
       this.focusing += 1;
@@ -244,6 +248,10 @@ export default {
   flex-grow: 1;
   flex-shrink: 1;
   overflow: scroll;
+}
+
+.mousedown {
+  cursor: grabbing;
 }
 
 .flamegraph-main-focusing {

--- a/packages/components/src/components/flamegraph/FlamegraphMain.vue
+++ b/packages/components/src/components/flamegraph/FlamegraphMain.vue
@@ -57,7 +57,6 @@ export default {
     zoom: {
       type: Number,
       required: true,
-      validator: (value) => value >= 0 && value <= 1,
     },
     title: {
       type: String,

--- a/packages/components/src/components/flamegraph/FlamegraphNode.vue
+++ b/packages/components/src/components/flamegraph/FlamegraphNode.vue
@@ -23,10 +23,10 @@
 </template>
 
 <script>
-import { Event } from '@appland/models';
 import VFlamegraphBranch from './FlamegraphBranch.vue';
 import VFlamegraphItem from './FlamegraphItem.vue';
 import { add, getEventDuration, isEventDurationValid } from '../../lib/flamegraph';
+
 export default {
   name: 'v-flamegraph-node',
   emits: ['select', 'hover'],
@@ -38,28 +38,22 @@ export default {
     event: {
       type: Object,
       required: true,
-      validator: (value) => value instanceof Event,
     },
     factor: {
       type: Number,
       required: true,
-      validator: (value) => value >= 0 && value <= 1,
     },
     focus: {
       type: Object,
       default: null,
-      validator: (value) =>
-        value === null || (value.target instanceof Event && value.ancestors instanceof Set),
     },
     baseBudget: {
       type: Number,
       required: true,
-      validator: (value) => value >= 0,
     },
     zoomBudget: {
       type: Number,
       required: true,
-      validator: (value) => value >= 0,
     },
   },
   methods: {

--- a/packages/components/src/components/sequence/Actor.vue
+++ b/packages/components/src/components/sequence/Actor.vue
@@ -73,9 +73,6 @@ export default {
       required: true,
       readonly: true,
     },
-    selectedActor: {
-      type: Object,
-    },
     row: {
       type: Number,
       required: true,
@@ -104,6 +101,13 @@ export default {
       type: Object,
     },
   },
+
+  data() {
+    return {
+      isSelectedActor: null,
+    };
+  },
+
   computed: {
     isPrecomputedSequenceDiagram,
     inlineStyle(): { [key: string]: string } {
@@ -114,7 +118,7 @@ export default {
     labelClasses(): { [key: string]: string } {
       return {
         'label-container': true,
-        'label-container--selected': this.actor === this.selectedActor,
+        'label-container--selected': this.isSelectedActor,
         interactive: this.interactive,
       };
     },
@@ -170,6 +174,17 @@ export default {
       const codeObj = this.codeObjectFromActor();
       if (codeObj) this.$store.commit(REMOVE_EXPANDED_PACKAGE, codeObj);
     },
+    updateSelectedActor(selectedObject) {
+      if (!selectedObject || !(selectedObject instanceof CodeObject)) {
+        if (this.isSelectedActor) this.isSelectedActor = false;
+        return;
+      }
+      const ancestorIds = [
+        selectedObject.fqid,
+        ...(selectedObject as any).ancestors().map((ancestor: CodeObject) => ancestor.fqid),
+      ];
+      this.isSelectedActor = ancestorIds.indexOf(this.actor.id) !== -1;
+    },
   },
   watch: {
     '$store.getters.selectedObject': {
@@ -182,6 +197,7 @@ export default {
             this.$refs.label_container.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
           }
         }
+        this.updateSelectedActor(selectedObject);
       },
     },
   },

--- a/packages/components/src/components/sequence/CallAction.vue
+++ b/packages/components/src/components/sequence/CallAction.vue
@@ -213,6 +213,7 @@
 
 <script lang="ts">
 // @ts-nocheck
+import { Event } from '@appland/models';
 import Arrow from '@/assets/sequence-action-arrow.svg';
 import { ActionSpec } from './ActionSpec';
 import VCallLabel from './CallLabel.vue';
@@ -234,17 +235,10 @@ export default {
       type: Array,
       required: true,
     },
-    focusedEvent: {
-      type: Object,
-      default: null,
-    },
     interactive: {
       type: Boolean,
       required: true,
       readonly: true,
-    },
-    selected: {
-      type: Boolean,
     },
     appMap: {
       type: Object,
@@ -258,6 +252,16 @@ export default {
   },
 
   computed: {
+    selected() {
+      return (
+        this.$store.getters.selectedObject &&
+        this.$store.getters.selectedObject instanceof Event &&
+        this.actionSpec.eventIds.includes(this.$store.getters.selectedObject.id)
+      );
+    },
+    focusedEvent() {
+      return this.$store.state.focusedEvent;
+    },
     containerClasses(): string[] {
       const result = [
         'call',

--- a/packages/components/src/components/sequence/CallAction.vue
+++ b/packages/components/src/components/sequence/CallAction.vue
@@ -23,8 +23,8 @@
       >
         <VCallLabel
           :action-spec="actionSpec"
-          :collapsed-actions="collapsedActionState"
           :appMap="appMap"
+          :is-collapsed="isLabelCollapsed"
           :interactive="interactive"
         />
         <VSelfCallArrow :action-spec="actionSpec" />
@@ -45,8 +45,8 @@
         >
           <VCallLabel
             :action-spec="actionSpec"
-            :collapsed-actions="collapsedActionState"
             :appMap="appMap"
+            :is-collapsed="isLabelCollapsed"
             :interactive="interactive"
           />
           <Arrow class="arrow" />
@@ -66,8 +66,8 @@
         >
           <VCallLabel
             :action-spec="actionSpec"
-            :collapsed-actions="collapsedActionState"
             :appMap="appMap"
+            :is-collapsed="isLabelCollapsed"
             :interactive="interactive"
           />
         </div>
@@ -117,8 +117,8 @@
         >
           <VCallLabel
             :action-spec="actionSpec"
-            :collapsed-actions="collapsedActionState"
             :appMap="appMap"
+            :is-collapsed="isLabelCollapsed"
             :interactive="interactive"
           />
           <Arrow class="arrow" />
@@ -138,8 +138,8 @@
         >
           <VCallLabel
             :action-spec="actionSpec"
-            :collapsed-actions="collapsedActionState"
             :appMap="appMap"
+            :is-collapsed="isLabelCollapsed"
             :interactive="interactive"
           />
           <Arrow class="arrow" />
@@ -231,10 +231,6 @@ export default {
       required: true,
       readonly: true,
     },
-    collapsedActions: {
-      type: Array,
-      required: true,
-    },
     interactive: {
       type: Boolean,
       required: true,
@@ -243,12 +239,6 @@ export default {
     appMap: {
       type: Object,
     },
-  },
-
-  data() {
-    return {
-      collapsedActionState: this.collapsedActions,
-    };
   },
 
   computed: {
@@ -262,6 +252,12 @@ export default {
     focusedEvent() {
       return this.$store.state.focusedEvent;
     },
+    isCollapsed() {
+      return this.actionSpec.isCollapsed(this.$store.state.collapsedActionState);
+    },
+    isLabelCollapsed() {
+      return this.$store.state.collapsedActionState[this.actionSpec.index];
+    },
     containerClasses(): string[] {
       const result = [
         'call',
@@ -269,7 +265,7 @@ export default {
         ...this.actionSpec.diffClasses,
       ];
 
-      if (this.actionSpec.isCollapsed(this.collapsedActionState)) result.push('call-collapsed');
+      if (this.isCollapsed) result.push('call-collapsed');
 
       if (this.actionSpec.index === 0) result.push('first-action');
 

--- a/packages/components/src/components/sequence/CallLabel.vue
+++ b/packages/components/src/components/sequence/CallLabel.vue
@@ -13,7 +13,7 @@
     <div :class="nameClasses">
       <template v-for="text in name">
         <div
-          :key="text.text"
+          :key="actionSpec.index + text.text"
           :style="{
             overflow: 'hidden',
             // Text baseline changes when overflow: hidden, so we need next two properties
@@ -35,7 +35,7 @@
           <span
             @click="selectEvent"
             :class="text.class"
-            :key="text.text"
+            :key="actionSpec.index + text.text"
             :title="sqlize"
             @mouseover="startHover"
             @mouseout="stopHover"

--- a/packages/components/src/components/sequence/CallLabel.vue
+++ b/packages/components/src/components/sequence/CallLabel.vue
@@ -30,7 +30,7 @@
           }"
         >
           <span v-if="hoverExpandCollapse" class="tooltip">
-            {{ collapsed ? 'Expand' : 'Collapse' }}
+            {{ isCollapsed ? 'Expand' : 'Collapse' }}
           </span>
           <span
             @click="selectEvent"
@@ -86,9 +86,9 @@ export default {
       required: true,
       readonly: true,
     },
-    collapsedActions: {
-      type: Array,
-      required: true,
+    isCollapsed: {
+      type: Boolean,
+      default: false,
     },
     interactive: {
       type: Boolean,
@@ -102,7 +102,6 @@ export default {
 
   data() {
     return {
-      collapsedActionState: this.collapsedActions,
       hover: false,
       hoverExpandCollapse: false,
     };
@@ -122,15 +121,12 @@ export default {
 
       return true;
     },
-    collapsed(): boolean {
-      return this.collapsedActionState[this.actionSpec.index];
-    },
     collapseExpandIndicator(): string {
-      return this.collapsed ? '[+]' : '[-]';
+      return this.isCollapsed ? '[+]' : '[-]';
     },
     collapseClasses(): string[] {
       const result = ['collapse-expand'];
-      result.push(this.collapsed ? 'collapsed' : 'expanded');
+      result.push(this.isCollapsed ? 'collapsed' : 'expanded');
       return result;
     },
     nameClasses(): string[] {
@@ -202,7 +198,7 @@ export default {
   },
   methods: {
     collapseOrExpand() {
-      this.$set(this.collapsedActionState, this.actionSpec.index, !this.collapsed);
+      this.$set(this.$store.state.collapsedActionState, this.actionSpec.index, !this.isCollapsed);
     },
     selectEvent() {
       if (this.appMap) {

--- a/packages/components/src/components/sequence/LoopAction.vue
+++ b/packages/components/src/components/sequence/LoopAction.vue
@@ -1,17 +1,17 @@
-<template>
+<template functional>
   <div
-    :class="loopClasses"
+    :class="$options.loopClasses(props.isCollapsed)"
     :style="{
-      'grid-column': gridColumns,
-      'grid-row': gridRows,
+      'grid-column': $options.gridColumns(props.actionSpec),
+      'grid-row': $options.gridRows(props.actionSpec),
     }"
   >
     <div class="label-container">
       <div class="label">Loop</div>
       <div class="description">
         [
-        <div class="count">{{ actionSpec.action.count }} times</div>
-        <div class="elapsed">{{ actionSpec.elapsedTimeMs }}ms</div>
+        <div class="count">{{ props.actionSpec.action.count }} times</div>
+        <div class="elapsed">{{ props.actionSpec.elapsedTimeMs }}ms</div>
         ]
       </div>
     </div>
@@ -24,42 +24,29 @@ import { ActionSpec } from './ActionSpec';
 
 export default {
   name: 'v-sequence-loop',
-
   props: {
     actionSpec: {
       type: ActionSpec,
       required: true,
       readonly: true,
     },
-    collapsedActions: {
-      type: Array,
+    isCollapsed: {
+      type: Boolean,
       required: true,
+      readonly: true,
     },
   },
-
-  data() {
-    return {
-      collapsedActionState: this.collapsedActions,
-      columnIndexSpan: this.actionSpec.descendantsActorIndexSpan,
-    };
+  loopClasses(isCollapsed: boolean): string[] {
+    const result = ['loop'];
+    if (isCollapsed) result.push('loop-collapsed');
+    return result;
   },
-
-  computed: {
-    loopClasses(): string[] {
-      const result = ['loop'];
-
-      if (this.actionSpec.isCollapsed(this.collapsedActionState)) result.push('loop-collapsed');
-
-      return result;
-    },
-
-    gridRows(): string {
-      return [this.actionSpec.index + 2, this.actionSpec.returnIndex! + 2].join(' / ');
-    },
-    gridColumns(): string {
-      const [min, max] = this.columnIndexSpan;
-      return [min + 2, max + 2].join(' / ');
-    },
+  gridRows(actionSpec: ActionSpec): string {
+    return [actionSpec.index + 2, actionSpec.returnIndex! + 2].join(' / ');
+  },
+  gridColumns(actionSpec: ActionSpec): string {
+    const [min, max] = actionSpec.descendantsActorIndexSpan;
+    return [min + 2, max + 2].join(' / ');
   },
 };
 </script>

--- a/packages/components/src/components/sequence/ReturnAction.vue
+++ b/packages/components/src/components/sequence/ReturnAction.vue
@@ -19,7 +19,7 @@
           },
         }"
       >
-        <VReturnLabel :action-spec="actionSpec" :return-value="returnValue" />
+        <VReturnLabel :action-spec="actionSpec" :return-value="returnValue" :label="label" />
       </div>
     </template>
     <template v-else-if="actionSpec.callArrowDirection === 'right'">
@@ -35,7 +35,7 @@
             },
           }"
         >
-          <VReturnLabel :action-spec="actionSpec" :return-value="returnValue" />
+          <VReturnLabel :action-spec="actionSpec" :return-value="returnValue" :label="label" />
           <Arrow class="arrow" />
         </div>
       </template>
@@ -51,7 +51,7 @@
             },
           }"
         >
-          <VReturnLabel :action-spec="actionSpec" :return-value="returnValue" />
+          <VReturnLabel :action-spec="actionSpec" :return-value="returnValue" :label="label" />
           <Arrow class="arrow" />
         </div>
         <template v-if="actionSpec.calleeActionIndex - actionSpec.callerActionIndex > 2">
@@ -93,7 +93,7 @@
             },
           }"
         >
-          <VReturnLabel :action-spec="actionSpec" :return-value="returnValue" />
+          <VReturnLabel :action-spec="actionSpec" :return-value="returnValue" :label="label" />
           <Arrow class="arrow" />
         </div>
       </template>
@@ -133,7 +133,7 @@
             },
           }"
         >
-          <VReturnLabel :action-spec="actionSpec" :return-value="returnValue" />
+          <VReturnLabel :action-spec="actionSpec" :return-value="returnValue" :label="label" />
           <Arrow class="arrow" />
         </div>
       </template>
@@ -193,6 +193,15 @@ export default {
     },
     gridRows(): string {
       return [this.actionSpec.index + 2, this.actionSpec.index + 2].join(' / ');
+    },
+    label() {
+      function extractSimpleName(fullName) {
+        const segments = fullName.split('.');
+        return segments[segments.length - 1];
+      }
+
+      const { nodeResult } = this.actionSpec;
+      return !nodeResult || nodeResult === 'void' ? '' : extractSimpleName(nodeResult);
     },
   },
 };

--- a/packages/components/src/components/sequence/ReturnAction.vue
+++ b/packages/components/src/components/sequence/ReturnAction.vue
@@ -159,21 +159,11 @@ export default {
       required: true,
       readonly: true,
     },
-    collapsedActions: {
-      type: Array,
-      required: true,
-    },
     returnValue: {
       type: String,
       required: true,
       readonly: true,
     },
-  },
-
-  data() {
-    return {
-      collapsedActionState: this.collapsedActions,
-    };
   },
 
   computed: {
@@ -185,7 +175,8 @@ export default {
       ];
 
       const caller: ActionSpec = this.actionSpec.diagramSpec.actions[this.actionSpec.callIndex];
-      if (caller.isCollapsed(this.collapsedActionState)) result.push('return-collapsed');
+      if (caller.isCollapsed(this.$store.state.collapsedActionState))
+        result.push('return-collapsed');
 
       if (this.actionSpec.index === 0) result.push('first-action');
 

--- a/packages/components/src/components/sequence/ReturnLabel.vue
+++ b/packages/components/src/components/sequence/ReturnLabel.vue
@@ -1,7 +1,7 @@
-<template>
-  <div class="label" @mouseover="startHover" @mouseout="stopHover">
-    <span class="name">{{ label }}</span>
-    <span v-if="hover && returnValue" class="tooltip">{{ returnValue }}</span>
+<template functional>
+  <div class="label">
+    <span class="name">{{ props.label }}</span>
+    <span :class="[props.returnValue ? 'tooltip' : 'hidden']">{{ props.returnValue }}</span>
   </div>
 </template>
 
@@ -10,21 +10,6 @@ import { ActionSpec } from './ActionSpec';
 
 export default {
   name: 'v-sequence-return-label',
-
-  data() {
-    return {
-      hover: false,
-    };
-  },
-
-  methods: {
-    startHover() {
-      this.hover = true;
-    },
-    stopHover() {
-      this.hover = false;
-    },
-  },
 
   props: {
     actionSpec: {
@@ -37,17 +22,9 @@ export default {
       required: true,
       readonly: true,
     },
-  },
-
-  computed: {
-    label() {
-      function extractSimpleName(fullName) {
-        const segments = fullName.split('.');
-        return segments[segments.length - 1];
-      }
-
-      const { nodeResult } = this.actionSpec;
-      return !nodeResult || nodeResult === 'void' ? '' : extractSimpleName(nodeResult);
+    label: {
+      type: String,
+      readonly: true,
     },
   },
 };
@@ -76,5 +53,14 @@ export default {
   padding: 5px;
   z-index: 1;
   opacity: 0.9;
+  display: none;
+}
+
+.label:hover .tooltip {
+  display: inline-block;
+}
+
+.hidden {
+  display: none;
 }
 </style>

--- a/packages/components/src/components/trace/Trace.vue
+++ b/packages/components/src/components/trace/Trace.vue
@@ -4,8 +4,7 @@
       v-for="(event, i) in events"
       :key="event.id"
       :event="event"
-      :selected-events="selectedEvents"
-      :focused-event="focusedEvent"
+      :selected-events-for-diff="selectedEventsForDiff"
       :event-filter-matches="eventFilterMatches"
       :event-filter-match="eventFilterMatch"
       :event-filter-match-index="eventFilterMatchIndex"
@@ -38,13 +37,9 @@ export default {
       type: Array,
       required: true,
     },
-    selectedEvents: {
+    selectedEventsForDiff: {
       type: Array,
       default: () => [],
-    },
-    focusedEvent: {
-      type: Object,
-      default: null,
     },
     eventFilterMatches: {
       type: Set,

--- a/packages/components/src/components/trace/TraceEventBlock.vue
+++ b/packages/components/src/components/trace/TraceEventBlock.vue
@@ -21,8 +21,7 @@
     <v-trace
       v-if="isExpanded"
       :events="event.children"
-      :selected-events="selectedEvents"
-      :focused-event="focusedEvent"
+      :selected-events-for-diff="selectedEventsForDiff"
       :event-filter-matches="eventFilterMatches"
       :event-filter-match="eventFilterMatch"
       :event-filter-match-index="eventFilterMatchIndex"
@@ -63,13 +62,9 @@ export default {
       type: Event,
       required: true,
     },
-    selectedEvents: {
+    selectedEventsForDiff: {
       type: Array,
       default: () => [],
-    },
-    focusedEvent: {
-      type: Object,
-      default: null,
     },
     eventFilterMatches: {
       type: Set,
@@ -136,6 +131,17 @@ export default {
     },
   },
   computed: {
+    focusedEvent() {
+      return this.$store?.state?.focusedEvent;
+    },
+    selectedEvents() {
+      if (this.selectedEventsForDiff.length > 0) {
+        return this.selectedEventsForDiff;
+      } else {
+        const selectedObject = this.$store?.getters?.selectedObject;
+        return selectedObject && selectedObject instanceof Event ? [selectedObject] : [];
+      }
+    },
     isExpanded() {
       return (
         this.expanded ||

--- a/packages/components/src/components/trace/TraceNode.vue
+++ b/packages/components/src/components/trace/TraceNode.vue
@@ -14,8 +14,14 @@
         @click.stop="$emit('expandChildren')"
       />
       <component :is="`v-trace-node-body-${eventType}`" :event="event" />
-      <v-trace-node-elapsed v-if="event.returnEvent.elapsed" :time="event.returnEvent.elapsed" />
-      <v-trace-node-labels v-if="event.labels.size" :labels="Array.from(event.labels)" />
+      <v-trace-node-elapsed v-if="event.returnEvent.elapsed" :time="event.returnEvent.elapsed">
+        <Clock class="trace-node__elapsed-icon" />
+      </v-trace-node-elapsed>
+      <v-trace-node-labels
+        v-if="event.labels.size"
+        :labels="Array.from(event.labels)"
+        @selectLabel="selectLabel"
+      />
     </div>
   </div>
 </template>
@@ -29,6 +35,8 @@ import VTraceNodeBodyHttpClient from './TraceNodeBodyHttpClient.vue';
 import VTraceNodeBodySql from './TraceNodeBodySql.vue';
 import VTraceNodeElapsed from './TraceNodeElapsed.vue';
 import VTraceNodeLabels from './TraceNodeLabels.vue';
+import Clock from '@/assets/clock.svg';
+import { SELECT_LABEL } from '../../store/vsCode';
 
 export default {
   name: 'v-trace-node',
@@ -40,6 +48,7 @@ export default {
     VTraceNodeBodySql,
     VTraceNodeElapsed,
     VTraceNodeLabels,
+    Clock,
   },
   props: {
     event: {
@@ -115,6 +124,11 @@ export default {
         'connection-icon--right': true,
         'connection-icon--connected': this.event.children.length > 0,
       };
+    },
+  },
+  methods: {
+    selectLabel(label) {
+      this.$store.commit(SELECT_LABEL, label);
     },
   },
 };
@@ -213,6 +227,13 @@ $bg-color: $gray2;
   &--connected {
     fill: lighten($bg-color, 35);
   }
+}
+
+.trace-node__elapsed-icon {
+  margin-right: 0.3rem;
+  width: 1em;
+  height: 1em;
+  fill: currentColor;
 }
 
 @keyframes node-focused {

--- a/packages/components/src/components/trace/TraceNodeColumns.vue
+++ b/packages/components/src/components/trace/TraceNodeColumns.vue
@@ -1,4 +1,4 @@
-<template>
+<template functional>
   <div class="columns">
     <div class="columns__column columns__column--left">
       <slot name="left" />

--- a/packages/components/src/components/trace/TraceNodeElapsed.vue
+++ b/packages/components/src/components/trace/TraceNodeElapsed.vue
@@ -1,29 +1,19 @@
-<template>
+<template functional>
   <div class="trace-node__elapsed">
     <span class="trace-node__elapsed-time">
-      <Clock class="trace-node__elapsed-icon" />
-      {{ elapsedTime }}
+      <slot />
+      {{ String((props.time * 1000).toFixed(0)) + 'ms' }}
     </span>
   </div>
 </template>
 
 <script>
-import Clock from '@/assets/clock.svg';
-
 export default {
   name: 'v-trace-node-elapsed',
-  components: {
-    Clock,
-  },
   props: {
     time: {
       type: Number,
       required: true,
-    },
-  },
-  computed: {
-    elapsedTime() {
-      return `${(this.time * 1000).toFixed(0)}ms`;
     },
   },
 };
@@ -42,12 +32,5 @@ export default {
   color: #eaeaea;
   background-color: #3e4864;
   white-space: nowrap;
-}
-
-.trace-node__elapsed-icon {
-  margin-right: 0.3rem;
-  width: 1em;
-  height: 1em;
-  fill: currentColor;
 }
 </style>

--- a/packages/components/src/components/trace/TraceNodeLabels.vue
+++ b/packages/components/src/components/trace/TraceNodeLabels.vue
@@ -1,10 +1,10 @@
-<template>
+<template functional>
   <ul class="trace-node__labels">
     <li
       class="trace-node__label"
-      v-for="label in labels"
+      v-for="label in props.labels"
       :key="label"
-      @click.stop="selectLabel(label)"
+      @click.stop="listeners['selectLabel'](label)"
     >
       {{ label }}
     </li>
@@ -12,19 +12,12 @@
 </template>
 
 <script>
-import { SELECT_LABEL } from '../../store/vsCode';
-
 export default {
   name: 'v-trace-node-labels',
   props: {
     labels: {
       type: Array,
       required: true,
-    },
-  },
-  methods: {
-    selectLabel(label) {
-      this.$store.commit(SELECT_LABEL, label);
     },
   },
 };

--- a/packages/components/src/components/trace/TraceSummary.vue
+++ b/packages/components/src/components/trace/TraceSummary.vue
@@ -1,10 +1,5 @@
 <template>
-  <div
-    class="trace-summary"
-    @click="$emit('click')"
-    @mouseover="hover = true"
-    @mouseleave="hover = false"
-  >
+  <div class="trace-summary" @click="$emit('click')">
     <div ref="text" class="trace-summary__content">
       {{ text }}
     </div>
@@ -16,17 +11,11 @@ import { Event } from '@appland/models';
 
 export default {
   name: 'v-trace-summary',
-  components: {},
   props: {
     event: {
       type: Event,
       required: true,
     },
-  },
-  data() {
-    return {
-      hover: false,
-    };
   },
   computed: {
     text() {

--- a/packages/components/src/pages/Diff.vue
+++ b/packages/components/src/pages/Diff.vue
@@ -4,7 +4,7 @@
       <v-diagram-trace
         ref="base"
         :events="eventsBase"
-        :selectedEvents="selectedEventsBase"
+        :selectedEventsForDiff="selectedEventsBase"
         :highlightColor="highlightConfig.color"
         :highlightStyle="highlightConfig.style"
         :zoomControls="false"
@@ -46,7 +46,7 @@
       <v-diagram-trace
         ref="working"
         :events="eventsWorking"
-        :selectedEvents="selectedEventsWorking"
+        :selectedEventsForDiff="selectedEventsWorking"
         :highlightColor="highlightConfig.color"
         :highlightStyle="highlightConfig.style"
         :zoomControls="false"

--- a/packages/components/src/pages/VsCodeExtension.vue
+++ b/packages/components/src/pages/VsCodeExtension.vue
@@ -100,8 +100,6 @@
             <v-diagram-trace
               ref="viewFlow_diagram"
               :events="filteredAppMap.rootEvents()"
-              :selected-events="selectedEvent"
-              :focused-event="focusedEvent"
               :event-filter-matches="new Set(eventFilterMatches)"
               :event-filter-match="eventFilterMatch"
               :event-filter-match-index="eventFilterMatchIndex + 1"
@@ -755,10 +753,6 @@ export default {
 
     selectedLabel() {
       return this.$store.state.selectedLabel;
-    },
-
-    focusedEvent() {
-      return this.$store.state.focusedEvent;
     },
 
     currentView() {

--- a/packages/components/src/pages/VsCodeExtension.vue
+++ b/packages/components/src/pages/VsCodeExtension.vue
@@ -76,8 +76,6 @@
           <v-diagram-sequence
             ref="viewSequence_diagram"
             :app-map="filteredAppMap"
-            :focused-event="focusedEvent"
-            :selected-events="selectedEvent"
             :collapse-depth="seqDiagramCollapseDepth"
             @setMaxSeqDiagramCollapseDepth="setMaxSeqDiagramCollapseDepth"
           />

--- a/packages/components/src/pages/VsCodeExtension.vue
+++ b/packages/components/src/pages/VsCodeExtension.vue
@@ -617,15 +617,17 @@ export default {
     },
 
     rootObjectsSuggestions() {
+      const filters = this.filters;
       return this.$store.state.appMap.classMap.codeObjects
         .map((co) => co.fqid)
-        .filter((fqid) => !this.filters.rootObjects.includes(fqid));
+        .filter((fqid) => !filters.rootObjects.includes(fqid));
     },
 
     hideNamesSuggestions() {
+      const filters = this.filters;
       return this.filteredAppMap.classMap.codeObjects
         .map((co) => co.fqid)
-        .filter((fqid) => !this.filters.declutter.hideName.names.includes(fqid));
+        .filter((fqid) => !filters.declutter.hideName.names.includes(fqid));
     },
 
     eventsSuggestions() {
@@ -995,6 +997,8 @@ export default {
           return;
         }
 
+        const filteredMap = this.filteredAppMap;
+
         const state = filterStringToFilterState(serializedState);
         if (state.selectedObject) {
           do {
@@ -1010,7 +1014,7 @@ export default {
               break;
             }
 
-            const { classMap, events } = this.filteredAppMap;
+            const { classMap, events } = filteredMap;
             let selectedObject = null;
 
             if (type === 'event') {
@@ -1060,7 +1064,7 @@ export default {
 
         if (expandedPackages) {
           const codeObjects = expandedPackages.map((expandedPackageId) =>
-            this.filteredAppMap.classMap.codeObjectFromId(expandedPackageId)
+            filteredMap.classMap.codeObjectFromId(expandedPackageId)
           );
           this.$store.commit(SET_EXPANDED_PACKAGES, codeObjects);
         }

--- a/packages/components/src/store/vsCode.js
+++ b/packages/components/src/store/vsCode.js
@@ -39,6 +39,7 @@ export const SET_SELECTED_SAVED_FILTER = 'setselectedSavedFilter';
 export const SET_HIGHLIGHTED_EVENTS = 'setHighlightedEvents';
 export const DEFAULT_VIEW = VIEW_COMPONENT;
 export const DEFAULT_FILTER_NAME = 'AppMap default';
+export const SET_COLLAPSED_ACTION_STATE = 'setCollapsedActionState';
 
 // Always have the AppMap default filter as the top option
 function savedFiltersSorter(a, b) {
@@ -68,6 +69,7 @@ export function buildStore() {
       selectedSavedFilter: null,
       defaultFilter: null,
       highlightedEvents: [],
+      collapsedActionState: [],
     },
 
     getters: {
@@ -231,6 +233,10 @@ export function buildStore() {
 
       [SET_HIGHLIGHTED_EVENTS](state, highlightedEvents) {
         state.highlightedEvents = highlightedEvents;
+      },
+
+      [SET_COLLAPSED_ACTION_STATE](state, collapsedActionState) {
+        state.collapsedActionState = collapsedActionState;
       },
     },
   });

--- a/packages/components/src/stories/DiagramSequence.stories.js
+++ b/packages/components/src/stories/DiagramSequence.stories.js
@@ -5,6 +5,16 @@ import list_users from '@/stories/data/sequence/list_users.sequence.json';
 import list_users_prefetch from '@/stories/data/sequence/list_users_prefetch.sequence.json';
 import show_user from '@/stories/data/sequence/show_user.sequence.json';
 import user_not_found from '@/stories/data/sequence/user_not_found.sequence.json';
+import { buildStore, SELECT_CODE_OBJECT } from '@/store/vsCode';
+import { Event } from '@appland/models';
+
+const store = buildStore();
+
+// Build a mock Event that will trick the instanceof operator
+const mockEvent = Object.create(Event.prototype);
+Object.assign(mockEvent, { id: 536 });
+
+store.commit(SELECT_CODE_OBJECT, mockEvent);
 
 export default {
   title: 'AppLand/Diagrams/Sequence',
@@ -20,7 +30,6 @@ const Template = (args, { argTypes }) => ({
 export const MicropostUserProfileDiff = Template.bind({});
 MicropostUserProfileDiff.args = {
   serializedDiagram: micropost_diff,
-  selectedEvents: [{ id: 536 }],
 };
 export const Empty = Template.bind({});
 

--- a/packages/components/src/stories/DiagramSequence.stories.js
+++ b/packages/components/src/stories/DiagramSequence.stories.js
@@ -25,6 +25,7 @@ const Template = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
   components: { VDiagramSequence },
   template: '<v-diagram-sequence v-bind="$props"/>',
+  store,
 });
 
 export const MicropostUserProfileDiff = Template.bind({});

--- a/packages/components/src/stories/Trace.stories.js
+++ b/packages/components/src/stories/Trace.stories.js
@@ -28,20 +28,6 @@ export default {
 export const trace = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
   components: { VDiagramTrace },
-  template:
-    '<v-diagram-trace v-bind="$props" :selected-events="eventArray" @clickEvent="(e) => selectedEvent = e" />',
-  data() {
-    return {
-      selectedEvent: null,
-    };
-  },
-  computed: {
-    eventArray() {
-      if (this.selectedEvent) {
-        return [this.selectedEvent];
-      }
-      return [];
-    },
-  },
+  template: `<v-diagram-trace v-bind="$props" @clickEvent="(e) => $store.commit('selectCodeObject', e)" />`,
   store,
 });

--- a/packages/components/tests/e2e/specs/appmap/sequenceDiagram.spec.js
+++ b/packages/components/tests/e2e/specs/appmap/sequenceDiagram.spec.js
@@ -51,7 +51,7 @@ context('AppMap sequence diagram', () => {
       cy.get('.return:nth-child(14) .name').trigger('mouseover');
       cy.get('.return:nth-child(14) span.tooltip').should('exist');
       cy.get('.return:nth-child(14) .name').trigger('mouseout');
-      cy.get('.return:nth-child(14) span.tooltip').should('not.exist');
+      cy.get('.return:nth-child(14) span.tooltip').should('not.be.visible');
     });
 
     it('should display the tooltip on hover on call label', () => {

--- a/packages/components/tests/e2e/specs/appmap/sequenceDiagram.spec.js
+++ b/packages/components/tests/e2e/specs/appmap/sequenceDiagram.spec.js
@@ -174,6 +174,23 @@ context('AppMap sequence diagram', () => {
       cy.get('.call.selected > :first').should('be.visible');
       cy.get('.call.selected').should('have.attr', 'data-event-ids', '183 185');
     });
+    it('highlights the proper action when selecting "View in Sequence" and does not collapse the selected event', () => {
+      cy.get('.node.class[data-id="active_support/ActiveSupport::SecurityUtils"]').click();
+
+      cy.get('.v-details-panel-list')
+        .contains('Outbound connections')
+        .parent()
+        .within(() => {
+          cy.get('.list-item').contains('Digest::Instance#digest').click();
+        });
+
+      cy.get('.list-item:nth-child(2)').click();
+      cy.get('button').contains('Show in Sequence').click();
+      cy.get('.call.selected > :first').should('be.visible');
+
+      cy.get('.depth-button__decrease').click();
+      cy.get('.call.selected > :first').should('be.visible');
+    });
   });
 
   context('unused actors', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -256,8 +256,8 @@ __metadata:
   resolution: "@appland/components@workspace:packages/components"
   dependencies:
     "@appland/diagrams": "workspace:^1.7.0"
-    "@appland/models": "workspace:^2.6.3"
-    "@appland/sequence-diagram": "workspace:^1.8.1"
+    "@appland/models": "workspace:^2.7.0"
+    "@appland/sequence-diagram": "workspace:^1.9.0"
     "@babel/core": ^7.22.5
     "@babel/node": ^7.22.5
     "@babel/preset-env": ^7.22.5
@@ -476,7 +476,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@appland/sequence-diagram@workspace:^1.7.0, @appland/sequence-diagram@workspace:^1.8.1, @appland/sequence-diagram@workspace:packages/sequence-diagram":
+"@appland/sequence-diagram@workspace:^1.7.0, @appland/sequence-diagram@workspace:^1.9.0, @appland/sequence-diagram@workspace:packages/sequence-diagram":
   version: 0.0.0-use.local
   resolution: "@appland/sequence-diagram@workspace:packages/sequence-diagram"
   dependencies:


### PR DESCRIPTION
This is the third and largest PR in a series of PRs that improve AppMap viewer performance.

There are several categories of changes in this PR.
- **Functional components**: They have improved performance over standard components because they have less overhead.
- **Stabilize props**: Whenever a prop changes the component and all children re-render. We were passing `selectedEvent` and `focusedEvent` as props down through many levels of components. These values change often and were causing unnecessary re-renders. They were already in the Vuex store, so I removed them as props and changed it so that components that actually use them have computed properties that pull them from the store.
- **Decrease repeated access to computed properties**: There is a small amount of overhead from Vue when accessing computed properties, so it's more efficient to store the computed property as a local variable than repeatedly accessing it directly (i.e. when it is accessed in a `forEach` loop).
- **Remove unnecessary prop validators**: The prop validators in the flame graph were computationally expensive for large AppMaps.

This PR also simplifies the zooming function in the flame graph so that it doesn't have a "smooth" zoom effect. The "smooth" zoom was causing several re-renders, which was problematic for medium-sized or large AppMaps.