### PR TITLE
Finding is selected in appmaps from PR report

### DIFF
--- a/packages/cli/resources/change-report/findings/details.hbs
+++ b/packages/cli/resources/change-report/findings/details.hbs
@@ -29,7 +29,7 @@
 
 ##### View in AppMap
 
-- [Full AppMap &raquo;]({{ appmap_url 'head' appmap }})
+- [Full AppMap &raquo;]({{ appmap_url_with_finding 'head' appmap finding.hash_v2 }})
     {{#if appmap.changed}}
 - [Sequence diagram diff &raquo;]({{ appmap_diff_url appmap }})
     {{/if}}

--- a/packages/cli/src/cmds/compare-report/ReportSection.ts
+++ b/packages/cli/src/cmds/compare-report/ReportSection.ts
@@ -2,12 +2,13 @@ import Handlebars, { SafeString } from 'handlebars';
 import { isAbsolute, join, relative } from 'path';
 
 import { readFile } from 'fs/promises';
-import ChangeReport, { AppMap, FindingDiff } from './ChangeReport';
+import ChangeReport, { AppMap } from './ChangeReport';
 import { existsSync } from 'fs';
 import assert from 'assert';
 import { RevisionName } from '../compare/RevisionName';
 import buildPreprocessor, { filterFindings } from './Preprocessor';
 import helpers from './helpers';
+import { base64UrlEncode } from '@appland/models';
 
 export const TemplateDirectory = [
   '../../../resources/change-report', // As packaged
@@ -195,35 +196,57 @@ export default class ReportSection {
       return tokens.join(' ');
     };
 
-    const appmap_url = (revisionName: RevisionName, appmap: AppMap) => {
+    const buildUrlString = (searchParams: Record<string, string>): string => {
+      const url = new URL(options.appmapURL.toString());
+      Object.keys(searchParams).forEach((key) => url.searchParams.append(key, searchParams[key]));
+      return url.toString();
+    };
+
+    const appmap_url = (revisionName: RevisionName, appmap: AppMap): SafeString => {
       let { id } = appmap;
       const path = [revisionName, `${id}.appmap.json`].join('/');
 
-      if (options.appmapURL) {
-        const url = new URL(options.appmapURL.toString());
-        url.searchParams.append('path', path);
-        return new Handlebars.SafeString(url.toString());
-      } else {
-        return new Handlebars.SafeString(path);
-      }
+      let url = path;
+      if (options.appmapURL) url = buildUrlString({ path });
+      return new SafeString(url);
     };
 
     const appmap_diff_url = (appmap: AppMap): SafeString => {
       const path = ['diff', `${appmap.id}.diff.sequence.json`].join('/');
 
+      let url = path;
+      if (options.appmapURL) url = buildUrlString({ path });
+      return new SafeString(url);
+    };
+
+    const appmap_url_with_finding = (
+      revisionName: RevisionName,
+      appmap: AppMap,
+      findingHash: string
+    ) => {
+      let { id } = appmap;
+      const path = [revisionName, `${id}.appmap.json`].join('/');
+
+      let url = path;
       if (options.appmapURL) {
-        const url = new URL(options.appmapURL.toString());
-        url.searchParams.append('path', path);
-        return new Handlebars.SafeString(url.toString());
-      } else {
-        return new Handlebars.SafeString(path);
+        const searchParams = { path } as Record<string, string>;
+        try {
+          const stateObject = { selectedObject: `analysis-finding:${findingHash}` };
+          const state = base64UrlEncode(JSON.stringify(stateObject));
+          searchParams.state = state;
+        } catch (e) {
+          // do not add state
+        }
+        url = buildUrlString(searchParams);
       }
+      return new SafeString(url);
     };
 
     return {
       appmap_diff_url,
       appmap_title,
       appmap_url,
+      appmap_url_with_finding,
       group_appmaps_by_recorder_name,
       source_url,
       ...helpers,

--- a/packages/cli/tests/unit/compareReport/findings.spec.ts
+++ b/packages/cli/tests/unit/compareReport/findings.spec.ts
@@ -92,7 +92,7 @@ describe('findings', () => {
 
 ##### View in AppMap
 
-- [Full AppMap &raquo;](https://getappmap.com/?path=head%2Fminitest%2FMicroposts_interface_micropost_interface.appmap.json)
+- [Full AppMap &raquo;](https://getappmap.com/?path=head%2Fminitest%2FMicroposts_interface_micropost_interface.appmap.json&state=eyJzZWxlY3RlZE9iamVjdCI6ImFuYWx5c2lzLWZpbmRpbmc6YzdhNDk0OWY1NTNjMTcyYWIxYTFmYjJjNTdiMWE1YjVhNjFjZDk5ODAzOTA5MzM2NTVkNDI3NmE4ZGY0ZTc0MCJ9)
 - [Sequence diagram diff &raquo;](https://getappmap.com/?path=diff%2Fminitest%2FMicroposts_interface_micropost_interface.diff.sequence.json)
 
 

--- a/packages/cli/tests/unit/compareReport/helpers.spec.ts
+++ b/packages/cli/tests/unit/compareReport/helpers.spec.ts
@@ -1,4 +1,9 @@
 import helpers from '../../../src/cmds/compare-report/helpers';
+import assert from 'assert';
+import sinon from 'sinon';
+import ReportSection, { ReportOptions } from '../../../src/cmds/compare-report/ReportSection';
+import { base64UrlEncode } from '@appland/models';
+import { SafeString } from 'handlebars';
 
 describe('pluralize', () => {
   const pluralize = (helpers as any).pluralize;
@@ -17,4 +22,55 @@ describe('pluralize', () => {
     expect(pluralize(0, 'test', {})).toEqual('tests'));
   it(`ignores the 'plural' argument if it's a function`, () =>
     expect(pluralize(0, 'test', () => true)).toEqual('tests'));
+});
+
+describe('ReportSection', () => {
+  describe('appmap_url_with_finding helper', () => {
+    const appmapURL = new URL('https://getappmap.com');
+    const sourceURL = new URL('http://fake.com');
+    const mockHash = 'a0b1c2d3e4f5g6h7i8j9k';
+    const pathToMap = 'path/to/map';
+    const revision = 'head';
+    let sandbox: sinon.SinonSandbox;
+
+    beforeEach(() => (sandbox = sinon.createSandbox()));
+    afterEach(() => sandbox.restore());
+
+    it('creates the expected URL when appmapURL is set', () => {
+      const helpers = ReportSection.helpers({ appmapURL, sourceURL } as ReportOptions);
+      assert(helpers);
+      expect(helpers).toHaveProperty('appmap_url_with_finding');
+      const result = helpers.appmap_url_with_finding(revision, { id: pathToMap }, mockHash);
+      expect(result).toBeInstanceOf(SafeString);
+
+      const expectedPath = `${revision}%2F${pathToMap.replace(/\//g, '%2F')}.appmap.json`;
+      const expectedStateObject = { selectedObject: `analysis-finding:${mockHash}` };
+      const expectedState = base64UrlEncode(JSON.stringify(expectedStateObject));
+      expect(result.string).toBe(
+        `${appmapURL.toString()}?path=${expectedPath}&state=${expectedState}`
+      );
+    });
+
+    it('creates the expected URL when state is not created', () => {
+      sinon.stub(JSON, 'stringify').throws(new Error('mock error'));
+      const helpers = ReportSection.helpers({ appmapURL, sourceURL } as ReportOptions);
+      assert(helpers);
+      expect(helpers).toHaveProperty('appmap_url_with_finding');
+      const result = helpers.appmap_url_with_finding(revision, { id: pathToMap }, mockHash);
+      expect(result).toBeInstanceOf(SafeString);
+
+      const expectedPath = `${revision}%2F${pathToMap.replace(/\//g, '%2F')}.appmap.json`;
+      expect(result.string).toBe(`${appmapURL.toString()}?path=${expectedPath}`);
+    });
+
+    it('creates the expected URL when appmapURL is not set', () => {
+      const helpers = ReportSection.helpers({ sourceURL } as ReportOptions);
+      assert(helpers);
+      expect(helpers).toHaveProperty('appmap_url_with_finding');
+      const result = helpers.appmap_url_with_finding('head', { id: pathToMap }, mockHash);
+      expect(result).toBeInstanceOf(SafeString);
+
+      expect(result.string).toBe(`${revision}/${pathToMap}.appmap.json`);
+    });
+  });
 });


### PR DESCRIPTION
Fixes #1437 

When opening an AppMap from the findings section of a PR report, the relevant finding is selected in the AppMap viewer. This is accomplished by adding a `state` query param that has a base64-url-encoded string as its value.