### PR TITLE
feat: Suppress report sections

### DIFF
--- a/packages/cli/resources/change-report/changed-appmaps/heading.hbs
+++ b/packages/cli/resources/change-report/changed-appmaps/heading.hbs
@@ -1,4 +1,4 @@
-| [Changed AppMaps](#changed-appmaps) |
+| {{ section_link 'Changed AppMaps' 'changed-appmaps' (length changedAppMaps) }} |
   {{~#unless (length changedAppMaps) }}
   :zero: No changes
   {{~else}}

--- a/packages/cli/resources/change-report/failed-tests/heading.hbs
+++ b/packages/cli/resources/change-report/failed-tests/heading.hbs
@@ -1,1 +1,1 @@
-| [Failed tests](#failed-tests) | {{#if testFailures.length}}:warning: {{testFailures.length}} failed{{else}}:white_check_mark: All tests passed{{/if}} |
+| {{ section_link 'Failed tests' 'failed-tests' (length testFailures) }} | {{#if testFailures.length}}:warning: {{testFailures.length}} failed{{else}}:white_check_mark: All tests passed{{/if}} |

--- a/packages/cli/resources/change-report/findings/details.hbs
+++ b/packages/cli/resources/change-report/findings/details.hbs
@@ -51,7 +51,7 @@
 
 </details>
 {{/inline}}
-{{#if (length findingDiff.newFindings findingDiff.resolvedFindings)}}
+{{#if (every findingDiff (length findingDiff.newFindings findingDiff.resolvedFindings)) }}
 <h2 id="{{ metadata.anchor }}">{{ metadata.title }}</h2>
   {{#if (length findingDiff.newFindings) }}
 

--- a/packages/cli/resources/change-report/findings/heading.hbs
+++ b/packages/cli/resources/change-report/findings/heading.hbs
@@ -1,3 +1,4 @@
+{{#if findingDiff }}
 | [{{ metadata.title }}](#{{ metadata.anchor }}) |
   {{~#unless (length findingDiff.newFindings findingDiff.resolvedFindings) }}
   :white_check_mark: None detected
@@ -9,3 +10,4 @@
   :tada: {{length findingDiff.resolvedFindings}} resolved
   {{~/if}}
   |
+{{~/if}}

--- a/packages/cli/resources/change-report/findings/heading.hbs
+++ b/packages/cli/resources/change-report/findings/heading.hbs
@@ -1,5 +1,5 @@
 {{#if findingDiff }}
-| [{{ metadata.title }}](#{{ metadata.anchor }}) |
+| {{ section_link metadata.title metadata.anchor (length findingDiff.newFindings findingDiff.resolvedFindings) }} |
   {{~#unless (length findingDiff.newFindings findingDiff.resolvedFindings) }}
   :white_check_mark: None detected
   {{~/unless}}

--- a/packages/cli/resources/change-report/new-appmaps/heading.hbs
+++ b/packages/cli/resources/change-report/new-appmaps/heading.hbs
@@ -1,3 +1,3 @@
-| [New AppMaps](#new-appmaps) |
+| {{ section_link 'New AppMaps' 'new-appmaps' (length newAppMaps) }} |
   {{~#with (group_appmaps_by_recorder_name newAppMaps) }} :star: {{#each @this}}{{#unless @first }}, {{/unless}}{{ count }} new {{ recorderName }}{{#if isTest}} {{ pluralize count 'test' }}{{/if}}{{/each}} {{else}} :zero: No new AppMaps {{/with~}}
 |

--- a/packages/cli/resources/change-report/openapi-diff/heading.hbs
+++ b/packages/cli/resources/change-report/openapi-diff/heading.hbs
@@ -1,5 +1,5 @@
 {{#with openapiDiff }}
-| [API changes](#openapi-changes) | 
+| {{ section_link 'API changes' 'openapi-changes' differenceCount }} | 
   {{~#if differenceCount }}
     {{~#if breakingDifferenceCount }} 🚧 {{breakingDifferenceCount}} breaking{{~/if}}
     {{~#if nonBreakingDifferenceCount }}{{#if breakingDifferenceCount }},{{~/if}} :wrench: {{nonBreakingDifferenceCount}} non-breaking{{/if~}}

--- a/packages/cli/resources/change-report/removed-appmaps/heading.hbs
+++ b/packages/cli/resources/change-report/removed-appmaps/heading.hbs
@@ -1,5 +1,5 @@
 {{#if removedAppMaps.length ~}}
-| [Removed AppMaps](#removed-appmaps) | 
+| {{ section_link 'Removed AppMaps' 'removed-appmaps' (length removedAppMaps) }} | 
   {{~#with (group_appmaps_by_recorder_name removedAppMaps) }} :heavy_multiplication_x: {{#each @this}}{{#unless @first }}, {{/unless}}{{ count }} removed {{ recorderName }}{{#if isTest}} {{ pluralize count 'test' }}{{/if}}{{/each}} {{/with~}}
   |
 {{~/if}}

--- a/packages/cli/src/cmds/compare-report/ChangeReport.ts
+++ b/packages/cli/src/cmds/compare-report/ChangeReport.ts
@@ -6,7 +6,6 @@ import { RevisionName } from '../compare/RevisionName';
 import assert from 'assert';
 import { executeCommand } from '../../lib/executeCommand';
 import { verbose } from '../../utils';
-import { warn } from 'console';
 import normalizeAppMapId from './normalizeAppMapId';
 
 export class AppMap {
@@ -143,11 +142,11 @@ export class FindingDiff {
 export default class ChangeReport {
   constructor(
     public readonly testFailures: TestFailure[],
-    public readonly openapiDiff: OpenAPIDiff,
-    public readonly findingDiff: FindingDiff,
     public readonly newAppMaps: AppMap[],
     public readonly removedAppMaps: AppMap[],
     public readonly changedAppMaps: Record<string, AppMap[]>,
+    public readonly openapiDiff?: OpenAPIDiff,
+    public readonly findingDiff?: FindingDiff,
     public pruned = false
   ) {}
 
@@ -215,8 +214,6 @@ export default class ChangeReport {
       }
 
       apiDiff = new OpenAPIDiff(differenceCount, changeReportData.apiDiff, sourceDiff);
-    } else {
-      apiDiff = new OpenAPIDiff(0, {}, undefined);
     }
 
     let findingDiff: FindingDiff | undefined;
@@ -243,8 +240,6 @@ export default class ChangeReport {
       const resolvedFindings = buildFindings('resolved', RevisionName.Base);
 
       findingDiff = new FindingDiff(newFindings, resolvedFindings);
-    } else {
-      findingDiff = new FindingDiff([], []);
     }
 
     const newAppMaps = changeReportData.newAppMaps.map((appmapId) =>
@@ -267,11 +262,11 @@ export default class ChangeReport {
 
     return new ChangeReport(
       testFailures,
-      apiDiff,
-      findingDiff,
       newAppMaps,
       removedAppMaps,
-      changedAppMaps
+      changedAppMaps,
+      apiDiff,
+      findingDiff
     );
   }
 }

--- a/packages/cli/src/cmds/compare-report/MarkdownReport.ts
+++ b/packages/cli/src/cmds/compare-report/MarkdownReport.ts
@@ -53,6 +53,18 @@ export default class MarkdownReport implements Report {
       ...headings,
       '',
     ].join('\n');
-    return [heading, ...details].join('\n');
+
+    const comments: string[] = [];
+    if (changeReport.testFailures.length > 0) {
+      comments.push('');
+      comments.push(
+        `:warning: **Note** Because ${changeReport.testFailures.length} test${
+          changeReport.testFailures.length > 1 ? 's' : ''
+        } failed, AppMap is showing an abbreviated analysis to help you get them working. Once all tests are passing, all report sections will be available.`
+      );
+      comments.push('');
+    }
+
+    return [heading, ...comments, ...details].join('\n');
   }
 }

--- a/packages/cli/src/cmds/compare-report/ReportSection.ts
+++ b/packages/cli/src/cmds/compare-report/ReportSection.ts
@@ -220,11 +220,15 @@ export default class ReportSection {
       }
     };
 
+    const section_link = (sectionName: string, anchor: string, itemCount: number): SafeString =>
+      new SafeString(itemCount === 0 ? sectionName : `[${sectionName}](#${anchor})`);
+
     return {
       appmap_diff_url,
       appmap_title,
       appmap_url,
       group_appmaps_by_recorder_name,
+      section_link,
       source_url,
       ...helpers,
     };

--- a/packages/cli/src/cmds/compare-report/ReportSection.ts
+++ b/packages/cli/src/cmds/compare-report/ReportSection.ts
@@ -123,7 +123,7 @@ export default class ReportSection {
     const metadata = SECTION_METADATA[this.section];
     if (metadata) context.metadata = metadata;
 
-    if (FindingsSections.includes(this.section)) {
+    if (changeReport.findingDiff && FindingsSections.includes(this.section)) {
       const newFindings = filterFindings(changeReport.findingDiff.newFindings, this.section);
       const resolvedFindings = filterFindings(
         changeReport.findingDiff.resolvedFindings,

--- a/packages/cli/src/cmds/compare-report/helpers.ts
+++ b/packages/cli/src/cmds/compare-report/helpers.ts
@@ -9,7 +9,9 @@ const length = (...list: any[]): number => {
   const _fn = list.pop();
   let result = 0;
   for (const item of list) {
-    if (Array.isArray(item)) {
+    if (item === undefined || item === null) {
+      // pass
+    } else if (Array.isArray(item)) {
       result += item.length;
     } else if (item.constructor === Map) {
       result += item.size;
@@ -22,10 +24,16 @@ const length = (...list: any[]): number => {
 
 const coalesce = (...list: any[]): number => {
   const _fn = list.pop();
-  return list.find((item) => item !== undefined && item !== '');
+  return list.find((item) => item !== undefined && item !== null && item !== '');
 };
 
 const extractArrayValue = (args: any[]): any[] => (Array.isArray(args[0]) ? args[0] : args);
+
+const every = (...args: any[]): boolean => {
+  args = [...args];
+  const _fn = args.pop();
+  return args.every((value) => !!value);
+};
 
 const eq = (...args: any[]): boolean => {
   args = [...args];
@@ -97,6 +105,7 @@ export default {
   lang_package_alias,
   length,
   coalesce,
+  every,
   eq,
   pluralize,
   subtract,

--- a/packages/cli/tests/unit/compareReport/changedAppMaps.spec.ts
+++ b/packages/cli/tests/unit/compareReport/changedAppMaps.spec.ts
@@ -22,7 +22,7 @@ describe('changedAppMaps', () => {
           } as unknown as ChangeReport,
           reportOptions
         );
-        expect(report).toEqual('| [Changed AppMaps](#changed-appmaps) |  :zero: No changes  |');
+        expect(report).toEqual('| Changed AppMaps |  :zero: No changes  |');
       });
     });
     describe('details', () => {

--- a/packages/cli/tests/unit/compareReport/expectedReport.md.txt
+++ b/packages/cli/tests/unit/compareReport/expectedReport.md.txt
@@ -2,11 +2,11 @@
 
 | Summary | Status |
 | --- | --- |
-| [Failed tests](#failed-tests) | :white_check_mark: All tests passed |
+| Failed tests | :white_check_mark: All tests passed |
 | [API changes](#openapi-changes) | :wrench: 1 non-breaking |
 | [Security flaws](#security-flaws) |  🔒 1 new  :tada: 2 resolved  |
-| [Performance problems](#performance-problems) |  :white_check_mark: None detected  |
-| [Code anti-patterns](#code-antipatterns) |  :white_check_mark: None detected  |
+| Performance problems |  :white_check_mark: None detected  |
+| Code anti-patterns |  :white_check_mark: None detected  |
 | [New AppMaps](#new-appmaps) | :star: 1 new minitest test |
 | [Removed AppMaps](#removed-appmaps) | :heavy_multiplication_x: 1 removed minitest test |
 

--- a/packages/cli/tests/unit/compareReport/failedTests.spec.ts
+++ b/packages/cli/tests/unit/compareReport/failedTests.spec.ts
@@ -18,7 +18,7 @@ describe('failedTests', () => {
           reportOptions
         );
         expect(report).toEqual(
-          '| [Failed tests](#failed-tests) | :white_check_mark: All tests passed |'
+          '| Failed tests | :white_check_mark: All tests passed |'
         );
       });
     });

--- a/packages/cli/tests/unit/compareReport/findings.spec.ts
+++ b/packages/cli/tests/unit/compareReport/findings.spec.ts
@@ -26,7 +26,7 @@ describe('findings', () => {
           reportOptions
         );
         expect(report).toEqual(
-          '| [Performance problems](#performance-problems) |  :white_check_mark: None detected  |'
+          '| Performance problems |  :white_check_mark: None detected  |'
         );
       });
     });

--- a/packages/cli/tests/unit/compareReport/findings.spec.ts
+++ b/packages/cli/tests/unit/compareReport/findings.spec.ts
@@ -44,6 +44,22 @@ describe('findings', () => {
     });
   });
 
+  describe('when the findingDiff is not present', () => {
+    describe('header', () => {
+      it('is blank', async () => {
+        const report = section.generateHeading({} as unknown as ChangeReport, reportOptions);
+        expect(report).toEqual('');
+      });
+    });
+    describe('details', () => {
+      it('are blank', () => {
+        const report = section.generateDetails({} as unknown as ChangeReport, reportOptions);
+
+        expect(report).toEqual(``);
+      });
+    });
+  });
+
   describe('when there is a resolved finding', () => {
     let findingDiff: FindingDiff;
 

--- a/packages/cli/tests/unit/compareReport/newAppMaps.spec.ts
+++ b/packages/cli/tests/unit/compareReport/newAppMaps.spec.ts
@@ -19,7 +19,7 @@ describe('newAppMaps', () => {
           } as unknown as ChangeReport,
           reportOptions
         );
-        expect(report).toEqual('| [New AppMaps](#new-appmaps) | :zero: No new AppMaps |');
+        expect(report).toEqual('| New AppMaps | :zero: No new AppMaps |');
       });
     });
     describe('details', () => {

--- a/packages/cli/tests/unit/compareReport/openapiDiff.spec.ts
+++ b/packages/cli/tests/unit/compareReport/openapiDiff.spec.ts
@@ -18,7 +18,7 @@ describe('openapiDiff', () => {
           } as unknown as ChangeReport,
           reportOptions
         );
-        expect(report).toEqual('| [API changes](#openapi-changes) | :zero: No API changes |');
+        expect(report).toEqual('| API changes | :zero: No API changes |');
       });
     });
     describe('details', () => {

--- a/packages/cli/tests/unit/compareReport/openapiDiff.spec.ts
+++ b/packages/cli/tests/unit/compareReport/openapiDiff.spec.ts
@@ -35,6 +35,22 @@ describe('openapiDiff', () => {
     });
   });
 
+  describe('when the openapiDiff is not present', () => {
+    describe('header', () => {
+      it('is blank', async () => {
+        const report = section.generateHeading({} as unknown as ChangeReport, reportOptions);
+        expect(report).toEqual('');
+      });
+    });
+    describe('details', () => {
+      it('are blank', () => {
+        const report = section.generateDetails({} as unknown as ChangeReport, reportOptions);
+
+        expect(report).toEqual(``);
+      });
+    });
+  });
+
   describe('when there are changes', () => {
     const sourceDiff = `--- base/openapi.yml    2023-08-31 13:25:30.000000000 -0400
     +++ head/openapi.yml    2023-08-31 13:25:30.000000000 -0400


### PR DESCRIPTION
## Links suppressed

| Summary | Status |
| --- | --- |
| Failed tests | :white_check_mark: All tests passed |
| [API changes](#openapi-changes) | :wrench: 1 non-breaking |
| [Security flaws](#security-flaws) |  🔒 1 new  :tada: 2 resolved  |
| Performance problems |  :white_check_mark: None detected  |
| Code anti-patterns |  :white_check_mark: None detected  |
| [New AppMaps](#new-appmaps) | :star: 1 new minitest test |
| [Removed AppMaps](#removed-appmaps) | :heavy_multiplication_x: 1 removed minitest test |

## Abbreviated report for failed tests

| Summary | Status |
| --- | --- |
| [Failed tests](#failed-tests) | :warning: 1 failed |
| [New AppMaps](#new-appmaps) | :star: 1 new minitest test |
| [Removed AppMaps](#removed-appmaps) | :heavy_multiplication_x: 1 removed minitest test |

:warning: **Note** Because 2 tests failed, AppMap is showing an abbreviated analysis to help you get them working. Once all tests are passing, all report sections will be available.
