### PR TITLE
Changing installer to add our gem with double quotes

### DIFF
--- a/packages/cli/src/cmds/agentInstaller/rubyAgentInstaller.ts
+++ b/packages/cli/src/cmds/agentInstaller/rubyAgentInstaller.ts
@@ -16,7 +16,7 @@ import InstallerUI from './installerUI';
 const REGEX_GEM_DECLARATION = /^(?:gem|group|require)\s/m;
 
 const REGEX_GEM_DEPENDENCY = /^\s*gem\s+['|"]appmap['|"].*$/m;
-const GEM_DEPENDENCY = "gem 'appmap', :groups => [:development, :test]";
+const GEM_DEPENDENCY = "gem \"appmap\", :groups => [:development, :test]";
 
 export class BundleInstaller extends AgentInstaller {
   static identifier = 'Bundler';


### PR DESCRIPTION
Done to satisfy standardrb linters that require double quoted strings.