### PR TITLE
Include all packages in search

### DIFF
--- a/packages/components/src/components/DetailsSearch.vue
+++ b/packages/components/src/components/DetailsSearch.vue
@@ -121,7 +121,7 @@ export default {
 
         switch (codeObject.type) {
           case CodeObjectType.PACKAGE:
-            if (codeObject.childLeafs().length > 1) {
+            if (codeObject.childLeafs().length) {
               items[codeObject.type].data.push(item);
             }
             break;

--- a/packages/components/tests/e2e/specs/appmap/findings.spec.js
+++ b/packages/components/tests/e2e/specs/appmap/findings.spec.js
@@ -79,6 +79,14 @@ context('AppMap findings', () => {
           .find('.details-search__block-item')
           .should('have.length', 1);
       });
+
+      it('shows actionview package when term is searched', () => {
+        cy.get('.details-search__input-element').type('actionview');
+        cy.get('.details-search__block--package')
+          .should('exist')
+          .find('.details-search__block-item')
+          .should('have.length', 1);
+      });
     });
 
     describe('trace view', () => {

--- a/packages/components/tests/e2e/specs/appmap/sequenceDiagramDiff.spec.js
+++ b/packages/components/tests/e2e/specs/appmap/sequenceDiagramDiff.spec.js
@@ -12,7 +12,7 @@ context('Sequence Diagram', () => {
     cy.get('.tabs .tab-btn').contains('Flame Graph').should('be.disabled');
   });
 
-  it.only('sidebar buttons are disabled', () => {
+  it('sidebar buttons are disabled', () => {
     cy.get('div:nth-child(40) > div.call-line-segment.label-span.arrow-base').click();
     cy.get('.details-panel-header__ghost-link .details-btn').each(($btn) => {
       // For each button, check if it has the attribute 'disabled'

--- a/packages/components/tests/e2e/specs/appmap/viewFilter.spec.js
+++ b/packages/components/tests/e2e/specs/appmap/viewFilter.spec.js
@@ -128,7 +128,7 @@ context('AppMap view filter', () => {
     it('hides unlabeled code', () => {
       cy.get('.details-search__block--package .details-search__block-item').should(
         'have.length',
-        4
+        6
       );
       cy.get('.details-search__block--class .details-search__block-item').should('have.length', 11);
 
@@ -137,7 +137,7 @@ context('AppMap view filter', () => {
 
       cy.get('.details-search__block--package .details-search__block-item').should(
         'have.length',
-        2
+        3
       );
       cy.get('.details-search__block--class .details-search__block-item').should('have.length', 5);
     });


### PR DESCRIPTION
Fixes: #1056 

fix(DetailsSearch.vue): modify condition to push item based on childLeafs length
fix(findings.spec.js): add e2e test for actionview package search in AppMap