### PR TITLE
Default collapse depth should be within range

### DIFF
--- a/packages/components/src/pages/VsCodeExtension.vue
+++ b/packages/components/src/pages/VsCodeExtension.vue
@@ -1093,7 +1093,10 @@ export default {
     },
 
     resetDiagram() {
-      this.seqDiagramCollapseDepth = DEFAULT_SEQ_DIAGRAM_COLLAPSE_DEPTH;
+      this.seqDiagramCollapseDepth =
+        DEFAULT_SEQ_DIAGRAM_COLLAPSE_DEPTH > this.maxSeqDiagramCollapseDepth
+          ? this.maxSeqDiagramCollapseDepth
+          : DEFAULT_SEQ_DIAGRAM_COLLAPSE_DEPTH;
       this.$store.commit(CLEAR_EXPANDED_PACKAGES);
       this.clearSelection();
       this.$store.commit(RESET_FILTERS);
@@ -1314,6 +1317,7 @@ export default {
     },
 
     setMaxSeqDiagramCollapseDepth(maxDepth) {
+      if (maxDepth < this.seqDiagramCollapseDepth) this.seqDiagramCollapseDepth = maxDepth;
       this.maxSeqDiagramCollapseDepth = maxDepth;
     },
   },

--- a/packages/components/tests/e2e/specs/appmap/sequenceDiagram.spec.js
+++ b/packages/components/tests/e2e/specs/appmap/sequenceDiagram.spec.js
@@ -299,4 +299,22 @@ context('AppMap sequence diagram', () => {
       getCollapseExpandElementOfActionLabel('index').should('have.class', 'expanded');
     });
   });
+
+  context('default collapse depth check', () => {
+    beforeEach(() => {
+      cy.visit(
+        'http://localhost:6006/iframe.html?args=scenario:appland1&id=pages-vs-code--extension-with-default-sequence-view&viewMode=story'
+      );
+    });
+
+    it('depth is within limits', () => {
+      cy.get('div.depth-text').first().contains('1');
+
+      cy.get('button[data-cy="decrease-collapse-depth"]').click({ force: true });
+      cy.get('div.depth-text').first().contains('0');
+
+      cy.get('button[data-cy="increase-collapse-depth"]').click({ force: true });
+      cy.get('div.depth-text').first().contains('1');
+    });
+  });
 });


### PR DESCRIPTION
Fixes: #1426 

feat(VsCodeExtension.vue): prevent seqDiagramCollapseDepth from exceeding max
test(sequenceDiagram.spec.js): add checks for default collapse depth limits