### PR TITLE
feat: Expand inventory

### DIFF
--- a/packages/cli/src/cmds/archive/index.ts
+++ b/packages/cli/src/cmds/archive/index.ts
@@ -38,9 +38,7 @@ export async function index(
     }
   );
 
-  if (sampleMetadata) {
-    await emitUsage(appMapDir, totalEvents, result.numProcessed, sampleMetadata);
-  }
+  await emitUsage(appMapDir, totalEvents, result.numProcessed, sampleMetadata);
 
   const elapsed = new Date().getTime() - startTime;
   console.log(`Indexed ${result.numProcessed} AppMaps in ${elapsed}ms`);

--- a/packages/cli/src/cmds/inventory/Report.ts
+++ b/packages/cli/src/cmds/inventory/Report.ts
@@ -10,6 +10,12 @@ export type FindingExample = {
   impactDomain?: string;
 };
 
+export type FunctionInfo = {
+  count: number;
+  size: number;
+  location: string;
+};
+
 export type Report = {
   appmapCountByRecorderName: Record<string, number>;
   appmapCountByHTTPServerRequestCount: Record<number, number>;
@@ -22,4 +28,6 @@ export type Report = {
   packages: string[];
   packageDependencies: Dependency[];
   findings: FindingExample[];
+  largeAppMaps: Record<string, number>;
+  frequentFunctions: Record<string, FunctionInfo>;
 };

--- a/packages/cli/src/cmds/inventory/analyzers/collectAppMapSize.ts
+++ b/packages/cli/src/cmds/inventory/analyzers/collectAppMapSize.ts
@@ -1,0 +1,17 @@
+import { warn } from 'console';
+import { Stats } from 'fs';
+import { stat } from 'fs/promises';
+
+export default function collectAppMapSize(appmapSizeInBytes: Record<string, number>) {
+  return async (appmap: string) => {
+    let stats: Stats;
+    try {
+      stats = await stat(appmap);
+    } catch (e) {
+      warn(`Error reading stats for ${appmap}: ${e}`);
+      return;
+    }
+
+    appmapSizeInBytes[appmap] = stats.size;
+  };
+}

--- a/packages/cli/src/cmds/inventory/analyzers/collectFindings.ts
+++ b/packages/cli/src/cmds/inventory/analyzers/collectFindings.ts
@@ -14,7 +14,7 @@ export default function collectFindings(findings: FindingExample[]) {
       const mDate = modifiedDate(finding);
       if (mDate)
         findings.push({
-          appmap,
+          appmap: appmap.slice(0, -'.appmap.json'.length),
           impactDomain: finding.impactDomain,
           modifiedDate: new Date(mDate),
           hash_v2: finding.hash_v2,

--- a/packages/cli/src/cmds/inventory/analyzers/collectFunctionOccurances.ts
+++ b/packages/cli/src/cmds/inventory/analyzers/collectFunctionOccurances.ts
@@ -1,0 +1,16 @@
+import { EventInfo, accumulateEvents } from '../../stats/accumulateEvents';
+
+export default function collectFunctionOccurances(functionOccurrances: Record<string, EventInfo>) {
+  return async (appmap: string) => {
+    const eventInfos = await accumulateEvents(appmap);
+    for (const eventInfo of eventInfos) {
+      if (!functionOccurrances[eventInfo.function]) {
+        functionOccurrances[eventInfo.function] = eventInfo;
+      } else {
+        const existing = functionOccurrances[eventInfo.function];
+        existing.count += eventInfo.count;
+        existing.size += eventInfo.size;
+      }
+    }
+  };
+}

--- a/packages/cli/src/cmds/inventory/analyzers/collectMetadata.ts
+++ b/packages/cli/src/cmds/inventory/analyzers/collectMetadata.ts
@@ -3,9 +3,8 @@ import readIndexFile from '../readIndexFile';
 
 export default function collectMetadata(appmapCountByRecorderName: Record<string, number>) {
   return async (appmap: string) => {
+    // Existance of metadata.json is assured by buildReport
     const metadata: Metadata = await readIndexFile(appmap, 'metadata.json');
-    if (!metadata) return;
-
     const recorderName = metadata.recorder?.name || 'unknown';
     if (!appmapCountByRecorderName[recorderName]) appmapCountByRecorderName[recorderName] = 1;
     else appmapCountByRecorderName[recorderName] = appmapCountByRecorderName[recorderName] + 1;

--- a/packages/cli/src/cmds/inventory/inventory.ts
+++ b/packages/cli/src/cmds/inventory/inventory.ts
@@ -36,13 +36,37 @@ export const builder = (args: yargs.Argv) => {
     default: 2,
   });
 
+  args.option('resource-tokens', {
+    describe: `number of path tokens to include in the 'by resource' output`,
+    type: 'number',
+    default: 2,
+  });
+
+  args.option('large-appmaps', {
+    describe: `number of largest AppMaps to report`,
+    type: 'number',
+    default: 20,
+  });
+
+  args.option('frequent-functions', {
+    describe: `number of most frequently occurring functions to report (this is an estimate based on inspecting the large AppMaps)`,
+    type: 'number',
+    default: 50,
+  });
+
   return args.strict();
 };
 
 export const handler = async (argv: any) => {
   verbose(argv.verbose);
 
-  const { outputFile, directory, resourceTokens, findingLimit } = argv;
+  const {
+    outputFile,
+    directory,
+    resourceTokens,
+    frequentFunctions: frequentFunctionLimit,
+    largeAppmaps: largeAppMapLimit,
+  } = argv;
   assert(resourceTokens);
   assert(typeof resourceTokens === 'number');
   assert(resourceTokens > 0);
@@ -68,11 +92,12 @@ export const handler = async (argv: any) => {
 
   warn(`Building inventory data from ${appmaps.length} AppMaps in ${appmapDir}`);
 
-  const report = await buildReport(
-    appmapDir,
-    appmaps,
-    resourceTokens + 1 /* The url '/' is actually 2 tokens, so add 1 to the user input */
-  );
+  const report = await buildReport(appmapDir, appmaps, {
+    resourceTokens:
+      resourceTokens + 1 /* The url '/' is actually 2 tokens, so add 1 to the user input */,
+    frequentFunctionLimit,
+    largeAppMapLimit,
+  });
 
   const reportJSONStr = JSON.stringify(report, null, 2);
   if (outputFile) {

--- a/packages/cli/src/cmds/stats/accumulateEvents.ts
+++ b/packages/cli/src/cmds/stats/accumulateEvents.ts
@@ -2,39 +2,14 @@ import * as fs from 'fs';
 import { ClassMap, Event } from '@appland/models';
 import JSONStream from 'JSONStream';
 
+const sizeof = (obj: any): number => JSON.stringify(obj).length;
+
 export type EventInfo = {
   function: string;
   count: number;
   size: number;
   location: string;
 };
-
-const KILOBYTE = 1000;
-const MEGABYTE = KILOBYTE * 1000;
-const GIGABYTE = MEGABYTE * 1000;
-
-const sizeof = (obj: any): number => JSON.stringify(obj).length;
-
-function displaySize(size: number): string {
-  let divisor: number;
-  let suffix: string;
-
-  if (size > GIGABYTE) {
-    divisor = GIGABYTE;
-    suffix = 'GB';
-  } else if (size > MEGABYTE) {
-    divisor = MEGABYTE;
-    suffix = 'MB';
-  } else if (size > KILOBYTE) {
-    divisor = KILOBYTE;
-    suffix = 'KB';
-  } else {
-    divisor = 1;
-    suffix = 'bytes';
-  }
-
-  return `${(size / divisor).toFixed(1)} ${suffix}`;
-}
 
 async function parseClassMap(mapPath: string): Promise<ClassMap> {
   let classMap: ClassMap;
@@ -55,7 +30,7 @@ async function parseClassMap(mapPath: string): Promise<ClassMap> {
   });
 }
 
-async function accumulateEvents(mapPath: string): Promise<Array<EventInfo>> {
+export async function accumulateEvents(mapPath: string): Promise<Array<EventInfo>> {
   const classMap = await parseClassMap(mapPath);
   const events = {};
 
@@ -100,27 +75,4 @@ async function accumulateEvents(mapPath: string): Promise<Array<EventInfo>> {
         })
     );
   });
-}
-
-export async function statsForMap(
-  format: string,
-  limit: number,
-  mapPath: string
-): Promise<Array<EventInfo>> {
-  const eventsStats = (await accumulateEvents(mapPath)).slice(0, limit);
-
-  if (format === 'json') {
-    console.log(JSON.stringify(eventsStats, null, 2));
-  } else {
-    eventsStats.forEach((callData, index) => {
-      const { function: fn, count, size } = callData;
-      console.log(
-        [`${index + 1}. ${fn}`, `count: ${count}`, `estimated size: ${displaySize(size)}`, ''].join(
-          '\n      '
-        )
-      );
-    });
-  }
-
-  return eventsStats;
 }

--- a/packages/cli/src/cmds/stats/stats.ts
+++ b/packages/cli/src/cmds/stats/stats.ts
@@ -1,16 +1,15 @@
 import { existsSync } from 'fs';
 import path from 'path';
-import glob from 'glob';
 import chalk from 'chalk';
 import yargs from 'yargs';
-import { statsForDirectory } from './directory/statsForDirectory';
-import { EventInfo, statsForMap } from './directory/statsForMap';
+import { statsForDirectory } from './statsForDirectory';
+import { statsForMap } from './statsForMap';
 import { SortedAppMapSize } from './types/appMapSize';
 import { SlowestExecutionTime } from './types/functionExecutionTime';
 import { locateAppMapDir } from '../../lib/locateAppMapDir';
-import UI from '../userInteraction';
 import { verbose } from '../../utils';
 import { handleWorkingDirectory } from '../../lib/handleWorkingDirectory';
+import { EventInfo } from './accumulateEvents';
 
 export const command = 'stats [directory]';
 export const describe =

--- a/packages/cli/src/cmds/stats/statsForDirectory.ts
+++ b/packages/cli/src/cmds/stats/statsForDirectory.ts
@@ -1,10 +1,10 @@
 import * as fs from 'fs';
-import UI from '../../userInteraction';
-import Telemetry from '../../../telemetry';
-import { findFiles, verbose } from '../../../utils';
+import UI from '../userInteraction';
+import Telemetry from '../../telemetry';
+import { findFiles, verbose } from '../../utils';
 import { Event, buildAppMap } from '@appland/models';
-import { AppMapSizeTable, SortedAppMapSize } from '../types/appMapSize';
-import { FunctionExecutionTime, SlowestExecutionTime } from '../types/functionExecutionTime';
+import { AppMapSizeTable, SortedAppMapSize } from './types/appMapSize';
+import { FunctionExecutionTime, SlowestExecutionTime } from './types/functionExecutionTime';
 import chalk from 'chalk';
 import { relative } from 'path';
 

--- a/packages/cli/src/cmds/stats/statsForMap.ts
+++ b/packages/cli/src/cmds/stats/statsForMap.ts
@@ -1,0 +1,49 @@
+import { EventInfo, accumulateEvents } from './accumulateEvents';
+
+const KILOBYTE = 1000;
+const MEGABYTE = KILOBYTE * 1000;
+const GIGABYTE = MEGABYTE * 1000;
+
+function displaySize(size: number): string {
+  let divisor: number;
+  let suffix: string;
+
+  if (size > GIGABYTE) {
+    divisor = GIGABYTE;
+    suffix = 'GB';
+  } else if (size > MEGABYTE) {
+    divisor = MEGABYTE;
+    suffix = 'MB';
+  } else if (size > KILOBYTE) {
+    divisor = KILOBYTE;
+    suffix = 'KB';
+  } else {
+    divisor = 1;
+    suffix = 'bytes';
+  }
+
+  return `${(size / divisor).toFixed(1)} ${suffix}`;
+}
+
+export async function statsForMap(
+  format: string,
+  limit: number,
+  mapPath: string
+): Promise<Array<EventInfo>> {
+  const eventsStats = (await accumulateEvents(mapPath)).slice(0, limit);
+
+  if (format === 'json') {
+    console.log(JSON.stringify(eventsStats, null, 2));
+  } else {
+    eventsStats.forEach((callData, index) => {
+      const { function: fn, count, size } = callData;
+      console.log(
+        [`${index + 1}. ${fn}`, `count: ${count}`, `estimated size: ${displaySize(size)}`, ''].join(
+          '\n      '
+        )
+      );
+    });
+  }
+
+  return eventsStats;
+}

--- a/packages/cli/tests/unit/inventory/inventory.spec.ts
+++ b/packages/cli/tests/unit/inventory/inventory.spec.ts
@@ -20,7 +20,8 @@ describe('inventory command', () => {
       appmapDir: '.',
       outputFile: 'inventory.json',
       resourceTokens: 2,
-      findingLimit: 3,
+      largeAppmaps: 10,
+      frequentFunctions: 10,
     });
     assert(existsSync(outputFile));
     const actualReport: Report = JSON.parse(readFileSync(outputFile, 'utf-8'));
@@ -34,5 +35,9 @@ describe('inventory command', () => {
     });
     expect(Object.keys(actualReport.routeCountByResource)).toContain('/account_activations/{id}');
     expect(actualReport.sqlTables).toContain('microposts');
+    expect(Object.keys(actualReport.largeAppMaps)).toContain(
+      'minitest/Microposts_interface_micropost_interface.appmap.json'
+    );
+    expect(Object.keys(actualReport.frequentFunctions)).toContain('function:ruby/Array#pack');
   });
 });

--- a/packages/cli/tests/unit/lib/emitUsage.spec.ts
+++ b/packages/cli/tests/unit/lib/emitUsage.spec.ts
@@ -59,7 +59,7 @@ describe('emitUsage', () => {
         appmaps: numAppMaps,
         ci: Boolean(process.env.CI),
       });
-      expect(JSON.parse(dto.metadata ?? '{}')).toMatchObject({
+      expect(dto.metadata).toMatchObject({
         app: metadata.app,
         git: {
           repository,

--- a/packages/cli/tests/unit/stats/stats.spec.ts
+++ b/packages/cli/tests/unit/stats/stats.spec.ts
@@ -1,7 +1,7 @@
 import path from 'path';
-import { EventInfo } from '../../../src/cmds/stats/directory/statsForMap';
 import StatsCommand from '../../../src/cmds/stats/stats';
 import { withStubbedTelemetry } from '../../helper';
+import { EventInfo } from '../../../src/cmds/stats/accumulateEvents';
 
 const fixtureDir = path.join(__dirname, '../', 'fixtures', 'stats');
 const mapPath = path.join('Microposts_interface_micropost_interface.appmap.json');

--- a/packages/client/src/usage.ts
+++ b/packages/client/src/usage.ts
@@ -1,3 +1,4 @@
+import { Metadata } from '@appland/models';
 import { ServiceEndpoint } from './configuration';
 import makeRequest from './makeRequest';
 
@@ -23,7 +24,7 @@ export interface UsageUpdateDto {
   readonly events?: number;
   readonly appmaps?: number;
   readonly contributors?: number;
-  readonly metadata?: string;
+  readonly metadata?: Metadata;
   readonly ci?: boolean;
 }
 


### PR DESCRIPTION
## Configuration report

Configuration  report is expanded to provide:

* largeAppMaps
* frequentFunctions

To help the user streamline and prune their config.

**Example**

https://gist.github.com/kgilpin/1bd0783c330743ae2440522ce0f00e97

```json
"largeAppMaps": {
    "tmp/appmap/minitest/Password_resets_password_resets.appmap.json": 2150673,
    "tmp/appmap/minitest/Microposts_interface_micropost_interface.appmap.json": 2039187,
    "tmp/appmap/minitest/Users_login_login_with_valid_information_followed_by_logout.appmap.json": 982768
}
```

```json
"frequentFunctions": {
    "function:ruby/Array#pack": {
      "function": "function:ruby/Array#pack",
      "count": 3410,
      "size": 1428513,
      "location": "<internal:pack>:133"
    },
    "function:logger/Logger::LogDevice#write": {
      "function": "function:logger/Logger::LogDevice#write",
      "count": 1200,
      "size": 620728,
      "location": "/Users/kgilpin/.rbenv/versions/3.0.2/lib/ruby/3.0.0/logger/log_device.rb:31"
    }
}
```

## Project summary report

Project summary report shows number of rule matches rather than number of distinct findings.

**Example**

https://gist.github.com/kgilpin/5b455bdde3c5e0f7ad396a6585b46391

```md
### Overview of problems and flaws

AppMap detected 4 types of problems and flaws in the runtime code review of your project. 
Here's a list of the types of problems that have been found:

| Rule | Impact Domain |
| --- | --- |
| [exec-of-untrusted-command](https://appmap.io/docs/reference/rules/exec-of-untrusted-command) | Security |
| [n-plus-one-query](https://appmap.io/docs/reference/rules/n-plus-one-query) | Performance |
| [secret-in-log](https://appmap.io/docs/reference/rules/secret-in-log) | Security |
| [update-in-get-request](https://appmap.io/docs/reference/rules/update-in-get-request) | Maintainability |
```

