### PR TITLE
feat: Recognize certain labeled functions as roots

### DIFF
--- a/packages/models/tests/unit/appMapFilter.spec.js
+++ b/packages/models/tests/unit/appMapFilter.spec.js
@@ -136,11 +136,23 @@ describe('appMapFilter', () => {
       }
     });
 
-    it('is a nop if there are no HTTP server requests in the AppMap', () => {
+    it('recognizes ROOT_EVENT_LABELS', () => {
+      const augmentedModelData = { ...modelData };
+      const validateFunction = augmentedModelData.classMap[0].children[0].children[0].children[1];
+      expect(validateFunction.name).toEqual('validate');
+      validateFunction.labels = ['job.perform'];
+      const augmentedModelAppMap = buildAppMap().source(augmentedModelData).build();
+      filter.declutter.limitRootEvents.on = true;
+      const filteredAppMap = filter.filter(augmentedModelAppMap);
+      expect(filteredAppMap.events.length).toEqual(8);
+    });
+
+    it('is a nop if there are no "commands" in the AppMap', () => {
       const eventCount = modelAppMap.events.length;
+      expect(eventCount).toEqual(10);
       filter.declutter.limitRootEvents.on = true;
       const filteredAppMap = filter.filter(modelAppMap);
-      expect(filteredAppMap.events.length).toEqual(eventCount);
+      expect(filteredAppMap.events.length).toEqual(10);
     });
   });
 });


### PR DESCRIPTION
The following labels are recognized as being "roots" (aka commands):

* `cli.command`
* `job.perform`
* `message.handle`

These labels extend the existing definition of a "root", which is currently only HTTP server requests.

A follow-on to this will change "Limit root events to HTTP" to something like "Limit root events to commands":

<img width="370" alt="Screen Shot 2023-11-10 at 5 33 35 PM" src="https://github.com/getappmap/appmap-js/assets/86395/f6fe225e-e245-483f-88a9-f7c680ffde6a">

PS "Hide unlabeled" seems kind of useless, maybe we should drop it.