### PR TITLE
Update text on the 'Record AppMaps' page

### DIFF
--- a/packages/components/src/components/install-guide/record-instructions/IntelliJ.vue
+++ b/packages/components/src/components/install-guide/record-instructions/IntelliJ.vue
@@ -1,8 +1,11 @@
 <template>
   <section>
     <p>
-      The more AppMaps you record, the more information you will have about your running application. No matter which method you start with, you can add more AppMaps or remove old AppMaps at any time.
-    </p><br/>
+      The more AppMaps you record, the more information you will have about your running
+      application. No matter which method you start with, you can add more AppMaps or remove old
+      AppMaps at any time.
+    </p>
+    <br />
     <p>
       Use the <component :is="runConfigIcon" class="run-config-icon" /> "Start with AppMap" option
       from the "Run" menu to start your run configurations with AppMap enabled.
@@ -24,8 +27,13 @@
           <i class="header-icon"><TestsIcon /></i>Tests recording<span class="recommended-badge"
             >recommended</span
           >
-        </h3><br/>
-        <p>Recording your test run will provide a broad range of AppMaps that trace important behaviors.</p><br/>
+        </h3>
+        <br />
+        <p>
+          Recording your test run will provide a broad range of AppMaps that trace important
+          behaviors.
+        </p>
+        <br />
         <p>
           When you run your JUnit tests with the AppMap <code class="inline">javaagent</code> JVM
           argument, an AppMap will be created for each test.
@@ -34,7 +42,8 @@
           Right-click on any test class or package, and choose
           <component :is="runConfigIcon" class="run-config-icon" /> "Start with AppMap". This will
           add the required JVM argument to enable AppMap recording.
-        </p><br/>
+        </p>
+        <br />
         <p>
           Docs:
           <a
@@ -51,8 +60,13 @@
       <section class="recording-method">
         <h3>
           <i class="header-icon"><RemoteRecordingIcon /></i>Remote recording
-        </h3><br/>
-        <p>Create AppMaps as you interact with your applications UI or API. This is helpful for tracing the backend during specific usage scenarios.</p><br/>
+        </h3>
+        <br />
+        <p>
+          Create AppMaps as you interact with your applications UI or API. This is helpful for
+          tracing the backend during specific usage scenarios.
+        </p>
+        <br />
         <p>
           When your application uses {{ this.webFramework.name }}, and you run your application with
           the AppMap <code class="inline">javaagent</code> JVM argument, remote recording is
@@ -62,11 +76,10 @@
           interface and/or by making API requests using a tool such as Postman. When you are done,
           click the "Record" button again to stop the recording and view the AppMap.
         </p>
-        <p><br/>
+        <p>
+          <br />
           Docs:
-          <a
-            href="https://appmap.io/docs/reference/jetbrains.html#remote-recording"
-            target="_blank"
+          <a href="https://appmap.io/docs/reference/jetbrains.html#remote-recording" target="_blank"
             >Java remote recording</a
           >
         </p>
@@ -76,24 +89,28 @@
       <div class="recording-method recording-method--disabled">
         <h3>
           <i class="header-icon header-icon--disabled"><RemoteRecordingIcon /></i>Remote recording
-        </h3><br/>
+        </h3>
+        <br />
         <p>
-          When you run a Spring app, you can make AppMaps of all the HTTP requests
-          served by your app.</p>
-          <p>Spring was not detected in this project.</p>
+          When you run a Spring app, you can make AppMaps of all the HTTP requests served by your
+          app.
         </p>
+        <p>Spring was not detected in this project.</p>
       </div> </template
     ><br />
     <section class="recording-method">
       <h3>
         <i class="header-icon"><ProcessIcon /></i>Process recording
-      </h3><br/>
-      <p>Record an entire Java process from startup to teardown.</p><br/>
+      </h3>
+      <br />
+      <p>Record an entire Java process from startup to teardown.</p>
+      <br />
       <p>
         To use process recording, run your application using
         <component :is="runConfigIcon" class="run-config-icon" /> "Start with AppMap". When your
         application exits, the AppMap will be saved and opened.
-      </p><br/>
+      </p>
+      <br />
       <p>
         Docs:
         <a
@@ -107,16 +124,21 @@
     <section class="recording-method">
       <h3>
         <i class="header-icon"><CodeBlockIcon /></i>Code Block recording
-      </h3><br/>
+      </h3>
+      <br />
+      <p>With this method, you can control exactly which code spans are recorded.</p>
+      <br />
       <p>
-        With this method, you can control exactly which code spans are recorded.
-      </p><br/>
-      <p>
-        You can use the AppMap Java library directly to record a specific span of code. To
-        use code block recording, add an AppMap code snippet to the section of code you want to
-        record, then run your application using
-        <component :is="runConfigIcon" class="run-config-icon" /> "Start with AppMap". Instructions for adding the AppMap code snippet to a span of code can be
-        <a href="https://appmap.io/docs/reference/appmap-java.html#code-block-recording" target="_blank">found in our documentation</a>.
+        You can use the AppMap Java library directly to record a specific span of code. To use code
+        block recording, add an AppMap code snippet to the section of code you want to record, then
+        run your application using
+        <component :is="runConfigIcon" class="run-config-icon" /> "Start with AppMap". Instructions
+        for adding the AppMap code snippet to a span of code can be
+        <a
+          href="https://appmap.io/docs/reference/appmap-java.html#code-block-recording"
+          target="_blank"
+          >found in our documentation</a
+        >.
       </p>
     </section>
   </section>

--- a/packages/components/src/components/install-guide/record-instructions/IntelliJ.vue
+++ b/packages/components/src/components/install-guide/record-instructions/IntelliJ.vue
@@ -1,6 +1,9 @@
 <template>
   <section>
     <p>
+      The more AppMaps you record, the more information you will have about your running application. No matter which method you start with, you can add more AppMaps or remove old AppMaps at any time.
+    </p><br/>
+    <p>
       Use the <component :is="runConfigIcon" class="run-config-icon" /> "Start with AppMap" option
       from the "Run" menu to start your run configurations with AppMap enabled.
     </p>
@@ -21,7 +24,8 @@
           <i class="header-icon"><TestsIcon /></i>Tests recording<span class="recommended-badge"
             >recommended</span
           >
-        </h3>
+        </h3><br/>
+        <p>Recording your test run will provide a broad range of AppMaps that trace important behaviors.</p><br/>
         <p>
           When you run your JUnit tests with the AppMap <code class="inline">javaagent</code> JVM
           argument, an AppMap will be created for each test.
@@ -30,14 +34,14 @@
           Right-click on any test class or package, and choose
           <component :is="runConfigIcon" class="run-config-icon" /> "Start with AppMap". This will
           add the required JVM argument to enable AppMap recording.
-        </p>
+        </p><br/>
         <p>
-          For more information, visit
+          Docs:
           <a
             href="https://appmap.io/docs/reference/jetbrains.html#create-appmaps-from-junit-test-runs"
             target="_blank"
-            >AppMap docs - IntelliJ Tests recording</a
-          >.
+            >IntelliJ tests recording</a
+          >
         </p>
       </section>
       <br />
@@ -47,7 +51,8 @@
       <section class="recording-method">
         <h3>
           <i class="header-icon"><RemoteRecordingIcon /></i>Remote recording
-        </h3>
+        </h3><br/>
+        <p>Create AppMaps as you interact with your applications UI or API. This is helpful for tracing the backend during specific usage scenarios.</p><br/>
         <p>
           When your application uses {{ this.webFramework.name }}, and you run your application with
           the AppMap <code class="inline">javaagent</code> JVM argument, remote recording is
@@ -57,13 +62,13 @@
           interface and/or by making API requests using a tool such as Postman. When you are done,
           click the "Record" button again to stop the recording and view the AppMap.
         </p>
-        <p>
-          For more information, visit
+        <p><br/>
+          Docs:
           <a
-            href="https://appmap.io/docs/reference/jetbrains.html#running-a-java-application-with-appmap"
+            href="https://appmap.io/docs/reference/jetbrains.html#remote-recording"
             target="_blank"
-            >AppMap docs - IntelliJ Remote recording</a
-          >.
+            >Java remote recording</a
+          >
         </p>
       </section>
     </template>
@@ -71,53 +76,47 @@
       <div class="recording-method recording-method--disabled">
         <h3>
           <i class="header-icon header-icon--disabled"><RemoteRecordingIcon /></i>Remote recording
-        </h3>
+        </h3><br/>
         <p>
-          Did you know? When you run a Spring app, you can make AppMaps of all the HTTP requests
-          served by your app. Spring wasn't detected in this project, though.
+          When you run a Spring app, you can make AppMaps of all the HTTP requests
+          served by your app.</p>
+          <p>Spring was not detected in this project.</p>
         </p>
       </div> </template
     ><br />
     <section class="recording-method">
       <h3>
         <i class="header-icon"><ProcessIcon /></i>Process recording
-      </h3>
+      </h3><br/>
+      <p>Record an entire Java process from startup to teardown.</p><br/>
       <p>
-        AppMap can record an entire Java process from start to finish. To use process recording, run
-        your application using
+        To use process recording, run your application using
         <component :is="runConfigIcon" class="run-config-icon" /> "Start with AppMap". When your
         application exits, the AppMap will be saved and opened.
-      </p>
+      </p><br/>
       <p>
-        Visit
+        Docs:
         <a
           href="https://appmap.io/docs/reference/appmap-java.html#process-recording"
           target="_blank"
-          >AppMap Docs - Java Process recording</a
+          >Java process recording</a
         >
-        for more information.
       </p>
     </section>
     <br />
     <section class="recording-method">
       <h3>
-        <i class="header-icon"><PlayIcon /></i>Code Block recording
-      </h3>
+        <i class="header-icon"><CodeBlockIcon /></i>Code Block recording
+      </h3><br/>
       <p>
-        You can use the AppMap Java library directly to record a specific span of code. With this
-        method, you can control exactly what code is recorded, and where the recording is saved. To
+        With this method, you can control exactly which code spans are recorded.
+      </p><br/>
+      <p>
+        You can use the AppMap Java library directly to record a specific span of code. To
         use code block recording, add an AppMap code snippet to the section of code you want to
         record, then run your application using
-        <component :is="runConfigIcon" class="run-config-icon" /> "Start with AppMap".
-      </p>
-      <p>
-        Visit
-        <a
-          href="https://appmap.io/docs/reference/appmap-java.html#code-block-recording"
-          target="_blank"
-          >AppMap Docs - Java Code Block recording</a
-        >
-        for more information.
+        <component :is="runConfigIcon" class="run-config-icon" /> "Start with AppMap". Instructions for adding the AppMap code snippet to a span of code can be
+        <a href="https://appmap.io/docs/reference/appmap-java.html#code-block-recording" target="_blank">found in our documentation</a>.
       </p>
     </section>
   </section>
@@ -126,7 +125,7 @@
 import TestsIcon from '@/assets/tests-icon.svg';
 import RemoteRecordingIcon from '@/assets/remote-recording-icon.svg';
 import ProcessIcon from '@/assets/process-icon.svg';
-import PlayIcon from '@/assets/play-icon.svg';
+import CodeBlockIcon from '@/assets/code-block-icon.svg';
 import VRunConfigDark from '@/assets/jetbrains_run_config_execute_dark.svg';
 import VRunConfigLight from '@/assets/jetbrains_run_config_execute.svg';
 import VTestsPrompt from './TestsPrompt.vue';
@@ -144,7 +143,7 @@ export default {
     VRunConfigDark,
     VRunConfigLight,
     VTestsPrompt,
-    PlayIcon,
+    CodeBlockIcon,
     ProcessIcon,
     RemoteRecordingIcon,
     TestsIcon,

--- a/packages/components/src/components/install-guide/record-instructions/Java.vue
+++ b/packages/components/src/components/install-guide/record-instructions/Java.vue
@@ -1,6 +1,9 @@
 <template>
   <section>
     <p>
+      The more AppMaps you record, the more information you will have about your running application.
+      No matter which method you start with, you can add more AppMaps or remove old AppMaps at any time.</p><br/>
+    <p>
       Use the "Run with AppMap" debug configuration to launch your application or run your tests
       through Microsoft's Test Runner for Java extension.
     </p>
@@ -23,7 +26,8 @@
           <i class="header-icon"><TestsIcon /></i>
           Tests recording
           <span class="recommended-badge">recommended</span>
-        </h3>
+        </h3><br/>
+        <p>Recording your test run will provide a broad range of AppMaps that trace important behaviors.</p><br/>
         <p>
           When you run your {{ testFramework.name }} tests with the AppMap
           <code class="inline">javaagent</code> JVM argument, an AppMap will be created for each
@@ -33,14 +37,14 @@
           This will automatically be configured for you by running your tests via the "Testing"
           button available in the sidebar or by pressing F1 and running the
           <code class="inline">Test: Run All Tests</code> command.
-        </p>
+        </p><br/>
         <p>
-          For more information, visit
+          Docs:
           <a
             href="https://appmap.io/docs/reference/vscode.html#create-appmaps-from-junit-test-runs"
             target="_blank"
           >
-            AppMap docs - VSCode Tests recording
+            VSCode Java tests recording
           </a>
         </p>
       </section>
@@ -55,7 +59,8 @@
         <h3>
           <i class="header-icon"><RemoteRecordingIcon /></i>
           Remote recording
-        </h3>
+        </h3><br/>
+        <p>Create AppMaps as you interact with your applications UI or API. This is helpful for tracing the backend during specific usage scenarios.</p><br/>
         <p>
           When your application uses {{ this.webFramework.name }}, and you run your application with
           the AppMap <code class="inline">javaagent</code> JVM argument, remote recording is
@@ -64,13 +69,13 @@
           with your application, through its user interface and/or by making API requests using a
           tool such as Postman. When you are done, click the "Record" button again to save the
           recording and view the AppMap.
-        </p>
+        </p><br/>
         <p>
-          For more information, visit
+          Docs:
           <a
             href="https://appmap.io/docs/reference/vscode.html#running-a-java-application-with-appmap"
             target="_blank"
-            >AppMap docs - VSCode Remote recording</a
+            >VSCode Java remote recording</a
           >
         </p>
       </section>
@@ -91,46 +96,46 @@
     <section class="recording-method">
       <h3>
         <i class="header-icon"><ProcessIcon /></i>Process recording
-      </h3>
+      </h3><br/>
       <p>
         AppMap can record an entire Java process from start to finish. To use process recording,
         modify <code class="inline">.vscode/launch.json</code> to include
         <code class="inline">-Dappmap.recording.auto=true</code> in
         <code class="inline">vmArgs</code>. After running this configuration, an AppMap will be
         saved once your application exits.
-      </p>
+      </p><br/>
       <p>
-        Visit
+        Docs:
         <a
           href="https://appmap.io/docs/reference/appmap-java.html#process-recording"
           target="_blank"
         >
-          AppMap Docs - Java Process recording
+         Java process recording
         </a>
-        for more information.
       </p>
     </section>
     <br />
     <section class="recording-method">
       <h3>
-        <i class="header-icon"><PlayIcon /></i>
+        <i class="header-icon"><CodeBlockIcon /></i>
         Code Block recording
-      </h3>
+      </h3><br/>
       <p>
-        You can use the AppMap Java library directly to record a specific span of code. With this
-        method, you can control exactly what code is recorded, and where the recording is saved. To
-        use code block recording, add an AppMap code snippet to the section of code you want to
-        record, then run your application using the Debug Configuration with AppMap.
-      </p>
+        With this method, you can control exactly which code spans are recorded.
+      </p><br/>
       <p>
-        Visit
+        You can use the AppMap Java library directly to record a specific span of code. To use code block recording, add an
+        AppMap code snippet to the section of code you want to record, then run your application
+        using the Debug Configuration with AppMap.
+      </p><br/>
+      <p>
+        Docs:
         <a
           href="https://appmap.io/docs/reference/appmap-java.html#code-block-recording"
           target="_blank"
         >
-          AppMap Docs - Java Code Block recording
+          Java code block recording
         </a>
-        for more information.
       </p>
     </section>
   </section>
@@ -139,7 +144,7 @@
 import TestsIcon from '@/assets/tests-icon.svg';
 import RemoteRecordingIcon from '@/assets/remote-recording-icon.svg';
 import ProcessIcon from '@/assets/process-icon.svg';
-import PlayIcon from '@/assets/play-icon.svg';
+import CodeBlockIcon from '@/assets/code-block-icon.svg';
 import VTestsPrompt from './TestsPrompt.vue';
 
 export default {
@@ -152,7 +157,7 @@ export default {
 
   components: {
     VTestsPrompt,
-    PlayIcon,
+    CodeBlockIcon,
     ProcessIcon,
     RemoteRecordingIcon,
     TestsIcon,

--- a/packages/components/src/components/install-guide/record-instructions/Java.vue
+++ b/packages/components/src/components/install-guide/record-instructions/Java.vue
@@ -1,8 +1,11 @@
 <template>
   <section>
     <p>
-      The more AppMaps you record, the more information you will have about your running application.
-      No matter which method you start with, you can add more AppMaps or remove old AppMaps at any time.</p><br/>
+      The more AppMaps you record, the more information you will have about your running
+      application. No matter which method you start with, you can add more AppMaps or remove old
+      AppMaps at any time.
+    </p>
+    <br />
     <p>
       Use the "Run with AppMap" debug configuration to launch your application or run your tests
       through Microsoft's Test Runner for Java extension.
@@ -26,8 +29,13 @@
           <i class="header-icon"><TestsIcon /></i>
           Tests recording
           <span class="recommended-badge">recommended</span>
-        </h3><br/>
-        <p>Recording your test run will provide a broad range of AppMaps that trace important behaviors.</p><br/>
+        </h3>
+        <br />
+        <p>
+          Recording your test run will provide a broad range of AppMaps that trace important
+          behaviors.
+        </p>
+        <br />
         <p>
           When you run your {{ testFramework.name }} tests with the AppMap
           <code class="inline">javaagent</code> JVM argument, an AppMap will be created for each
@@ -37,7 +45,8 @@
           This will automatically be configured for you by running your tests via the "Testing"
           button available in the sidebar or by pressing F1 and running the
           <code class="inline">Test: Run All Tests</code> command.
-        </p><br/>
+        </p>
+        <br />
         <p>
           Docs:
           <a
@@ -59,8 +68,13 @@
         <h3>
           <i class="header-icon"><RemoteRecordingIcon /></i>
           Remote recording
-        </h3><br/>
-        <p>Create AppMaps as you interact with your applications UI or API. This is helpful for tracing the backend during specific usage scenarios.</p><br/>
+        </h3>
+        <br />
+        <p>
+          Create AppMaps as you interact with your applications UI or API. This is helpful for
+          tracing the backend during specific usage scenarios.
+        </p>
+        <br />
         <p>
           When your application uses {{ this.webFramework.name }}, and you run your application with
           the AppMap <code class="inline">javaagent</code> JVM argument, remote recording is
@@ -69,7 +83,8 @@
           with your application, through its user interface and/or by making API requests using a
           tool such as Postman. When you are done, click the "Record" button again to save the
           recording and view the AppMap.
-        </p><br/>
+        </p>
+        <br />
         <p>
           Docs:
           <a
@@ -96,21 +111,23 @@
     <section class="recording-method">
       <h3>
         <i class="header-icon"><ProcessIcon /></i>Process recording
-      </h3><br/>
+      </h3>
+      <br />
       <p>
         AppMap can record an entire Java process from start to finish. To use process recording,
         modify <code class="inline">.vscode/launch.json</code> to include
         <code class="inline">-Dappmap.recording.auto=true</code> in
         <code class="inline">vmArgs</code>. After running this configuration, an AppMap will be
         saved once your application exits.
-      </p><br/>
+      </p>
+      <br />
       <p>
         Docs:
         <a
           href="https://appmap.io/docs/reference/appmap-java.html#process-recording"
           target="_blank"
         >
-         Java process recording
+          Java process recording
         </a>
       </p>
     </section>
@@ -119,15 +136,16 @@
       <h3>
         <i class="header-icon"><CodeBlockIcon /></i>
         Code Block recording
-      </h3><br/>
+      </h3>
+      <br />
+      <p>With this method, you can control exactly which code spans are recorded.</p>
+      <br />
       <p>
-        With this method, you can control exactly which code spans are recorded.
-      </p><br/>
-      <p>
-        You can use the AppMap Java library directly to record a specific span of code. To use code block recording, add an
-        AppMap code snippet to the section of code you want to record, then run your application
-        using the Debug Configuration with AppMap.
-      </p><br/>
+        You can use the AppMap Java library directly to record a specific span of code. To use code
+        block recording, add an AppMap code snippet to the section of code you want to record, then
+        run your application using the Debug Configuration with AppMap.
+      </p>
+      <br />
       <p>
         Docs:
         <a

--- a/packages/components/src/components/install-guide/record-instructions/Python.vue
+++ b/packages/components/src/components/install-guide/record-instructions/Python.vue
@@ -1,6 +1,9 @@
 <template>
   <section>
     <p>
+      The more AppMaps you record, the more information you will have about your running application. No matter which method you start with, you can add more AppMaps or remove old AppMaps at any time.
+    </p><br/>
+    <p>
       When you run your Python code with the <code class="inline"> appmap </code> package, AppMap
       will be enabled for recording.
     </p>
@@ -14,7 +17,8 @@
           <i class="header-icon"><TestsIcon /></i>Tests recording<span class="recommended-badge"
             >recommended</span
           >
-        </h3>
+        </h3><br/>
+        <p>Recording your test run will provide a broad range of AppMaps that trace important behaviors.</p><br/>
         <p>
           When you run your {{ testFramework.name }} tests with AppMap enabled, an AppMap will be
           created for each test.
@@ -22,14 +26,14 @@
         <template v-if="testFramework.name.toLowerCase() == 'pytest'">
           Run Pytest tests:
           <v-code-snippet clipboard-text="pytest" :kind="codeSnippetType" />
-        </template>
+        </template><br/>
         <p>
-          For more information, visit
+          Docs:
           <a
             href="https://appmap.io/docs/reference/appmap-python.html#tests-recording"
             target="_blank"
-            >AppMap docs - Python Tests recording</a
-          >.
+            >Python tests recording</a
+          >
         </p>
       </section>
     </template>
@@ -38,7 +42,8 @@
       <section class="recording-method">
         <h3>
           <i class="header-icon"><RequestsIcon /></i>Requests recording
-        </h3>
+        </h3><br/>
+        <p>Create AppMaps as you interact with your applications UI or API. This is helpful for tracing the backend during specific usage scenarios.</p><br/>
         <p>
           When your application uses Django or Flask, and you run your application with AppMap
           enabled, HTTP server requests recording is enabled. To record requests, first run your
@@ -46,26 +51,25 @@
         </p>
         <br />
         <p>
-          Start your Django server:
+          Start your Django server with AppMap enabled:
           <v-code-snippet clipboard-text="python manage.py runserver" :kind="codeSnippetType" />
         </p>
         <p>
-          Start your Flask server:
+          Start your Flask server with AppMap enabled:
           <v-code-snippet clipboard-text="flask run" :kind="codeSnippetType" />
         </p>
-        <br />
         <p>
           Then, interact with your application through its user interface and/or by making API
           requests using a tool such as Postman. An AppMap will be created for each HTTP server
           request that's served by your app.
-        </p>
+        </p><br/>
         <p>
-          For more information, visit
+          Docs:
           <a
             href="https://appmap.io/docs/reference/appmap-python.html#requests-recording"
             target="_blank"
-            >AppMap docs - Python Requests recording</a
-          >.
+            >Python requests recording</a
+          >
         </p>
       </section>
     </template>
@@ -73,18 +77,13 @@
     <section class="recording-method">
       <h3>
         <i class="header-icon"><CodeIcon /></i>Context manager recording
-      </h3>
+      </h3><br/>
       <p>
-        You can use the AppMap Python package directly to record a specific span of code. With this
-        method, you can control exactly what code is recorded, and where the recording is saved. To
+        You can use the AppMap Python package directly to record a specific span of code.</p><br/>
+      <p>With this method, you can control exactly what code is recorded, and where the recording is saved. To
         use Context manager recording, add an AppMap code snippet to the section of code you want to
-        record, then run your application with AppMap enabled. Visit
-        <a
-          href="https://appmap.io/docs/reference/appmap-python.html#context-manager-recording"
-          target="_blank"
-          >AppMap Docs - Python Context manager recording</a
-        >
-        for more information.
+        record, then run your application with AppMap enabled. Instructions for adding the AppMap code snippet to a span of code can be
+        <a href="https://appmap.io/docs/reference/appmap-python.html#context-manager-recording" target="_blank">found in our documentation</a>.
       </p>
     </section>
   </section>

--- a/packages/components/src/components/install-guide/record-instructions/Python.vue
+++ b/packages/components/src/components/install-guide/record-instructions/Python.vue
@@ -1,8 +1,11 @@
 <template>
   <section>
     <p>
-      The more AppMaps you record, the more information you will have about your running application. No matter which method you start with, you can add more AppMaps or remove old AppMaps at any time.
-    </p><br/>
+      The more AppMaps you record, the more information you will have about your running
+      application. No matter which method you start with, you can add more AppMaps or remove old
+      AppMaps at any time.
+    </p>
+    <br />
     <p>
       When you run your Python code with the <code class="inline"> appmap </code> package, AppMap
       will be enabled for recording.
@@ -17,16 +20,21 @@
           <i class="header-icon"><TestsIcon /></i>Tests recording<span class="recommended-badge"
             >recommended</span
           >
-        </h3><br/>
-        <p>Recording your test run will provide a broad range of AppMaps that trace important behaviors.</p><br/>
+        </h3>
+        <br />
+        <p>
+          Recording your test run will provide a broad range of AppMaps that trace important
+          behaviors.
+        </p>
+        <br />
         <p>
           When you run your {{ testFramework.name }} tests with AppMap enabled, an AppMap will be
           created for each test.
         </p>
         <template v-if="testFramework.name.toLowerCase() == 'pytest'">
           Run Pytest tests:
-          <v-code-snippet clipboard-text="pytest" :kind="codeSnippetType" />
-        </template><br/>
+          <v-code-snippet clipboard-text="pytest" :kind="codeSnippetType" /> </template
+        ><br />
         <p>
           Docs:
           <a
@@ -42,8 +50,13 @@
       <section class="recording-method">
         <h3>
           <i class="header-icon"><RequestsIcon /></i>Requests recording
-        </h3><br/>
-        <p>Create AppMaps as you interact with your applications UI or API. This is helpful for tracing the backend during specific usage scenarios.</p><br/>
+        </h3>
+        <br />
+        <p>
+          Create AppMaps as you interact with your applications UI or API. This is helpful for
+          tracing the backend during specific usage scenarios.
+        </p>
+        <br />
         <p>
           When your application uses Django or Flask, and you run your application with AppMap
           enabled, HTTP server requests recording is enabled. To record requests, first run your
@@ -62,7 +75,8 @@
           Then, interact with your application through its user interface and/or by making API
           requests using a tool such as Postman. An AppMap will be created for each HTTP server
           request that's served by your app.
-        </p><br/>
+        </p>
+        <br />
         <p>
           Docs:
           <a
@@ -77,13 +91,20 @@
     <section class="recording-method">
       <h3>
         <i class="header-icon"><CodeIcon /></i>Context manager recording
-      </h3><br/>
+      </h3>
+      <br />
+      <p>You can use the AppMap Python package directly to record a specific span of code.</p>
+      <br />
       <p>
-        You can use the AppMap Python package directly to record a specific span of code.</p><br/>
-      <p>With this method, you can control exactly what code is recorded, and where the recording is saved. To
-        use Context manager recording, add an AppMap code snippet to the section of code you want to
-        record, then run your application with AppMap enabled. Instructions for adding the AppMap code snippet to a span of code can be
-        <a href="https://appmap.io/docs/reference/appmap-python.html#context-manager-recording" target="_blank">found in our documentation</a>.
+        With this method, you can control exactly what code is recorded, and where the recording is
+        saved. To use Context manager recording, add an AppMap code snippet to the section of code
+        you want to record, then run your application with AppMap enabled. Instructions for adding
+        the AppMap code snippet to a span of code can be
+        <a
+          href="https://appmap.io/docs/reference/appmap-python.html#context-manager-recording"
+          target="_blank"
+          >found in our documentation</a
+        >.
       </p>
     </section>
   </section>

--- a/packages/components/src/components/install-guide/record-instructions/Ruby.vue
+++ b/packages/components/src/components/install-guide/record-instructions/Ruby.vue
@@ -1,8 +1,10 @@
 <template>
   <section>
     <p>
-      The more AppMaps you record, the more information you will have about your running application.
-    </p><br/>
+      The more AppMaps you record, the more information you will have about your running
+      application.
+    </p>
+    <br />
     <p>
       When you run your Ruby code with the <code class="inline">appmap</code> gem in your bundle,
       AppMap will be enabled for recording. By default, the <code class="inline">appmap</code> gem
@@ -13,8 +15,13 @@
       Before you run your app with AppMap, stop or disable Spring. You can stop Spring with the
       command <code class="inline">spring stop</code>, or you can run your Ruby program with the
       environment variable <code class="inline">DISABLE_SPRING=true</code>.
-    </p><br/>
-    <p>No matter which method you start with, you can add more AppMaps or remove old AppMaps at any time.</p><br/>
+    </p>
+    <br />
+    <p>
+      No matter which method you start with, you can add more AppMaps or remove old AppMaps at any
+      time.
+    </p>
+    <br />
     <h2>Choose the best recording method for this project</h2>
     <br />
     <template v-if="testFramework">
@@ -23,11 +30,14 @@
           <i class="header-icon"><TestsIcon /></i>Tests recording<span class="recommended-badge"
             >recommended</span
           >
-        </h3><br/>
-          <p>
-            Recording your test run will provide a broad range of AppMaps that trace important behaviors.  
-            When you run your {{ testFramework.name }} tests with AppMap enabled, an AppMap will be created for each test.
-        </p><br/>
+        </h3>
+        <br />
+        <p>
+          Recording your test run will provide a broad range of AppMaps that trace important
+          behaviors. When you run your {{ testFramework.name }} tests with AppMap enabled, an AppMap
+          will be created for each test.
+        </p>
+        <br />
         <p>
           <template v-if="testFramework.name.toLowerCase() == 'minitest'">
             Run Minitest tests with AppMap enabled:
@@ -42,7 +52,7 @@
           </template>
         </p>
         <p>
-        Docs: 
+          Docs:
           <a
             href="https://appmap.io/docs/reference/appmap-ruby.html#tests-recording"
             target="_blank"
@@ -59,10 +69,15 @@
       <section class="recording-method">
         <h3>
           <i class="header-icon"><RequestsIcon /></i>Requests recording
-        </h3><br/>
-        <p>Create AppMaps as you interact with your applications UI or API. This is helpful for tracing the backend during specific usage scenarios.
-          When your application uses {{ this.webFramework.name }}, and you run your application with
-          AppMap enabled, HTTP server request recording will be enabled.</p><br/>
+        </h3>
+        <br />
+        <p>
+          Create AppMaps as you interact with your applications UI or API. This is helpful for
+          tracing the backend during specific usage scenarios. When your application uses
+          {{ this.webFramework.name }}, and you run your application with AppMap enabled, HTTP
+          server request recording will be enabled.
+        </p>
+        <br />
         <p>
           <strong>First</strong>, start your Rails server with AppMap enabled:
           <v-code-snippet
@@ -71,10 +86,11 @@
           />
         </p>
         <p>
-          <strong>Second</strong>, interact with your application, through its user interface and/or by making API requests
-          using a tool such as Postman. An AppMap will be created for each HTTP server request
-          that's served by your app.
-        </p><br/>
+          <strong>Second</strong>, interact with your application, through its user interface and/or
+          by making API requests using a tool such as Postman. An AppMap will be created for each
+          HTTP server request that's served by your app.
+        </p>
+        <br />
         <p>
           Docs:
           <a
@@ -92,15 +108,21 @@
     <section class="recording-method">
       <h3>
         <i class="header-icon"><CodeBlockIcon /></i>Block recording
-      </h3><br/>
+      </h3>
+      <br />
+      <p>With this method, you can control exactly which code spans are recorded.</p>
+      <br />
       <p>
-        With this method, you can control exactly which code spans are recorded.
-      </p><br/>
-      <p>
-        To use Block recording, add an AppMap code snippet to the section of code you want to record,
-        then run your application with AppMap enabled. Instructions for adding the AppMap code snippet to a span of code can be
-        <a href="https://appmap.io/docs/reference/appmap-ruby.html#code-block-recording" target="_blank">found in our documentation</a>.
-      </p><br/>
+        To use Block recording, add an AppMap code snippet to the section of code you want to
+        record, then run your application with AppMap enabled. Instructions for adding the AppMap
+        code snippet to a span of code can be
+        <a
+          href="https://appmap.io/docs/reference/appmap-ruby.html#code-block-recording"
+          target="_blank"
+          >found in our documentation</a
+        >.
+      </p>
+      <br />
     </section>
   </section>
 </template>

--- a/packages/components/src/components/install-guide/record-instructions/Ruby.vue
+++ b/packages/components/src/components/install-guide/record-instructions/Ruby.vue
@@ -1,6 +1,9 @@
 <template>
   <section>
     <p>
+      The more AppMaps you record, the more information you will have about your running application.
+    </p><br/>
+    <p>
       When you run your Ruby code with the <code class="inline">appmap</code> gem in your bundle,
       AppMap will be enabled for recording. By default, the <code class="inline">appmap</code> gem
       is only enabled in the "test" and "development" environments.
@@ -10,8 +13,8 @@
       Before you run your app with AppMap, stop or disable Spring. You can stop Spring with the
       command <code class="inline">spring stop</code>, or you can run your Ruby program with the
       environment variable <code class="inline">DISABLE_SPRING=true</code>.
-    </p>
-    <br />
+    </p><br/>
+    <p>No matter which method you start with, you can add more AppMaps or remove old AppMaps at any time.</p><br/>
     <h2>Choose the best recording method for this project</h2>
     <br />
     <template v-if="testFramework">
@@ -20,31 +23,31 @@
           <i class="header-icon"><TestsIcon /></i>Tests recording<span class="recommended-badge"
             >recommended</span
           >
-        </h3>
-        <p>
-          When you run your {{ testFramework.name }} tests with AppMap enabled, an AppMap will be
-          created for each test.
-        </p>
+        </h3><br/>
+          <p>
+            Recording your test run will provide a broad range of AppMaps that trace important behaviors.  
+            When you run your {{ testFramework.name }} tests with AppMap enabled, an AppMap will be created for each test.
+        </p><br/>
         <p>
           <template v-if="testFramework.name.toLowerCase() == 'minitest'">
-            Run Minitest tests:
+            Run Minitest tests with AppMap enabled:
             <v-code-snippet
               clipboard-text="DISABLE_SPRING=true rails test"
               :kind="codeSnippetType"
             />
           </template>
           <template v-if="testFramework.name.toLowerCase() == 'rspec'">
-            Run Rspec tests:
+            Run Rspec tests with AppMap enabled:
             <v-code-snippet clipboard-text="DISABLE_SPRING=true rspec" :kind="codeSnippetType" />
           </template>
         </p>
         <p>
-          For more information, visit
+        Docs: 
           <a
             href="https://appmap.io/docs/reference/appmap-ruby.html#tests-recording"
             target="_blank"
-            >AppMap docs - Ruby Tests recording</a
-          >.
+            >Ruby tests recording</a
+          >
         </p>
       </section>
     </template>
@@ -56,31 +59,29 @@
       <section class="recording-method">
         <h3>
           <i class="header-icon"><RequestsIcon /></i>Requests recording
-        </h3>
-        <p>
+        </h3><br/>
+        <p>Create AppMaps as you interact with your applications UI or API. This is helpful for tracing the backend during specific usage scenarios.
           When your application uses {{ this.webFramework.name }}, and you run your application with
-          AppMap enabled, HTTP server request recording will be enabled. To record requests, first
-          run your application:
-        </p>
+          AppMap enabled, HTTP server request recording will be enabled.</p><br/>
         <p>
-          Start your Rails server:
+          <strong>First</strong>, start your Rails server with AppMap enabled:
           <v-code-snippet
             clipboard-text="DISABLE_SPRING=true rails server"
             :kind="codeSnippetType"
           />
         </p>
         <p>
-          Interact with your application, through its user interface and/or by making API requests
+          <strong>Second</strong>, interact with your application, through its user interface and/or by making API requests
           using a tool such as Postman. An AppMap will be created for each HTTP server request
           that's served by your app.
-        </p>
+        </p><br/>
         <p>
-          For more information, visit
+          Docs:
           <a
             href="https://appmap.io/docs/reference/appmap-ruby.html#requests-recording"
             target="_blank"
-            >AppMap docs - Ruby Requests recording</a
-          >.
+            >Ruby requests recording</a
+          >
         </p>
       </section>
     </template>
@@ -91,17 +92,15 @@
     <section class="recording-method">
       <h3>
         <i class="header-icon"><CodeBlockIcon /></i>Block recording
-      </h3>
+      </h3><br/>
       <p>
-        You can use the AppMap Ruby gem directly to record a specific span of code. With this
-        method, you can control exactly what code is recorded, and where the recording is saved. To
-        use Block recording, add an AppMap code snippet to the section of code you want to record,
-        then run your application with AppMap enabled. Visit
-        <a href="https://appmap.io/docs/reference/appmap-ruby.html#block-recording" target="_blank"
-          >AppMap Docs - Ruby Block recording</a
-        >
-        for more information.
-      </p>
+        With this method, you can control exactly which code spans are recorded.
+      </p><br/>
+      <p>
+        To use Block recording, add an AppMap code snippet to the section of code you want to record,
+        then run your application with AppMap enabled. Instructions for adding the AppMap code snippet to a span of code can be
+        <a href="https://appmap.io/docs/reference/appmap-ruby.html#code-block-recording" target="_blank">found in our documentation</a>.
+      </p><br/>
     </section>
   </section>
 </template>

--- a/packages/components/src/components/install-guide/record-instructions/TestsPrompt.vue
+++ b/packages/components/src/components/install-guide/record-instructions/TestsPrompt.vue
@@ -2,12 +2,13 @@
   <div class="recording-method recording-method--disabled">
     <h3>
       <i class="header-icon header-icon--disabled"><TestsIcon /></i>Tests recording
-    </h3><br/>
+    </h3>
+    <br />
     <p>
-      If you use a test framework such as {{ framework }}, you can make AppMaps of all
-      your test cases.</p>
-    <p>No tests were detected in this project.</p>
+      If you use a test framework such as {{ framework }}, you can make AppMaps of all your test
+      cases.
     </p>
+    <p>No tests were detected in this project.</p>
   </div>
 </template>
 <script>

--- a/packages/components/src/components/install-guide/record-instructions/TestsPrompt.vue
+++ b/packages/components/src/components/install-guide/record-instructions/TestsPrompt.vue
@@ -2,10 +2,11 @@
   <div class="recording-method recording-method--disabled">
     <h3>
       <i class="header-icon header-icon--disabled"><TestsIcon /></i>Tests recording
-    </h3>
+    </h3><br/>
     <p>
-      Did you know? If you use a test framework such as {{ framework }}, you can make AppMaps of all
-      your test cases. Tests weren't detected in this project, though.
+      If you use a test framework such as {{ framework }}, you can make AppMaps of all
+      your test cases.</p>
+    <p>No tests were detected in this project.</p>
     </p>
   </div>
 </template>

--- a/packages/components/src/components/install-guide/record-instructions/WebFrameworkPrompt.vue
+++ b/packages/components/src/components/install-guide/record-instructions/WebFrameworkPrompt.vue
@@ -2,10 +2,11 @@
   <div class="recording-method recording-method--disabled">
     <h3>
       <i class="header-icon header-icon--disabled"><RequestsIcon /></i>Requests recording
-    </h3>
+    </h3><br/>
     <p>
-      Did you know? When you run a {{ this.frameworks }} app, you can make AppMaps of all the HTTP
-      requests served by your app. {{ this.frameworks }} wasn't detected in this project, though.
+      When you run a {{ this.frameworks }} app, you can make AppMaps of all the HTTP
+      requests served by your app.</p>
+    <p>{{ this.frameworks }} was not detected in this project.
     </p>
   </div>
 </template>

--- a/packages/components/src/components/install-guide/record-instructions/WebFrameworkPrompt.vue
+++ b/packages/components/src/components/install-guide/record-instructions/WebFrameworkPrompt.vue
@@ -2,12 +2,13 @@
   <div class="recording-method recording-method--disabled">
     <h3>
       <i class="header-icon header-icon--disabled"><RequestsIcon /></i>Requests recording
-    </h3><br/>
+    </h3>
+    <br />
     <p>
-      When you run a {{ this.frameworks }} app, you can make AppMaps of all the HTTP
-      requests served by your app.</p>
-    <p>{{ this.frameworks }} was not detected in this project.
+      When you run a {{ this.frameworks }} app, you can make AppMaps of all the HTTP requests served
+      by your app.
     </p>
+    <p>{{ this.frameworks }} was not detected in this project.</p>
   </div>
 </template>
 <script>


### PR DESCRIPTION
Updates the text on the 'Record AppMaps' page to better inform the user as to what data they are creating and how they might want to proceed. It also breaks up the text to make it more scannable.

Examples:

![image](https://github.com/getappmap/appmap-js/assets/1229326/bfd99b5d-29d7-4adc-9a01-e3431970af30)

![image](https://github.com/getappmap/appmap-js/assets/1229326/65329d09-8715-4772-9201-ac2b42980bb7)



