### PR TITLE
Correctly set initial collapse depth in sequence diagram

### DIFF
--- a/packages/components/src/components/DiagramSequence.vue
+++ b/packages/components/src/components/DiagramSequence.vue
@@ -269,6 +269,7 @@ export default {
       rootActionSpecs.forEach((h) => visit(h.action));
     },
     getMaxActionDepth() {
+      if (this.actions.length === 0) return undefined;
       return this.actions.reduce((maxDepth, action) => {
         const depth = action.ancestorIndexes.length;
         if (depth > maxDepth) return depth;

--- a/packages/components/src/pages/VsCodeExtension.vue
+++ b/packages/components/src/pages/VsCodeExtension.vue
@@ -1318,6 +1318,7 @@ export default {
     },
 
     setMaxSeqDiagramCollapseDepth(maxDepth) {
+      if (!maxDepth) return;
       if (maxDepth < this.seqDiagramCollapseDepth) this.seqDiagramCollapseDepth = maxDepth;
       this.maxSeqDiagramCollapseDepth = maxDepth;
     },

--- a/packages/components/src/stories/VsCodeExtension.stories.js
+++ b/packages/components/src/stories/VsCodeExtension.stories.js
@@ -119,3 +119,27 @@ export const extensionWithoutHTTP = (args, { argTypes }) => ({
     this.$refs.vsCode.loadData(diffScenario);
   },
 });
+
+export const extensionWithSlowLoad = (args, { argTypes }) => {
+  return {
+    props: Object.keys(argTypes),
+    components: { VVsCodeExtension },
+    template: '<v-vs-code-extension v-bind="$props" ref="vsCode" />',
+    mounted() {
+      const scenario = scenarioData[args.scenario];
+      const sequenceDiagram = sequenceDiagramData[args.scenario];
+      if (scenario) {
+        // The delay mimics the time it takes to load an appmap in the VS Code extension
+        setTimeout(() => {
+          this.$refs.vsCode.loadData(scenario, sequenceDiagram);
+        }, 1000);
+      }
+
+      bindResolvePath(this);
+    },
+  };
+};
+
+extensionWithSlowLoad.args = {
+  defaultView: VIEW_SEQUENCE,
+};

--- a/packages/components/tests/e2e/specs/appmap/slowLoad.spec.js
+++ b/packages/components/tests/e2e/specs/appmap/slowLoad.spec.js
@@ -1,0 +1,11 @@
+context('AppMap sequence diagram with slow load', () => {
+  beforeEach(() => {
+    cy.visit(
+      'http://localhost:6006/iframe.html?args=&id=pages-vs-code--extension-with-slow-load&viewMode=story'
+    );
+  });
+
+  it('correctly sets the initial collapse depth', () => {
+    cy.get('.depth-text').should('contain.text', '3');
+  });
+});


### PR DESCRIPTION
Fixes #1471 

In the VS Code extension, the collapse depth was initially being set to `0` whenever a map was opened. This behavior only happens in VS Code and it does not happen in Storybook.

## Before

![Image](https://github.com/getappmap/appmap-js/assets/45714532/5f3bdc31-bb97-4193-bca1-9e92e5c78554)


## After

![image](https://github.com/getappmap/appmap-js/assets/45714532/0e1723b3-09fd-43ef-b42a-a7a6ee7b6c37)
