### PR TITLE
Pan to selected event in sequence diagram

### DIFF
--- a/packages/components/src/components/DiagramSequence.vue
+++ b/packages/components/src/components/DiagramSequence.vue
@@ -310,6 +310,14 @@ export default {
         }
       },
     },
+    '$store.getters.selectedObject': {
+      handler(newVal) {
+        if (newVal) {
+          this.expandCollapsedAncestors(newVal.id);
+          this.focusHighlighted();
+        }
+      },
+    },
     '$store.state.currentView': {
       handler(newVal) {
         if (newVal === 'viewSequence') {

--- a/packages/components/tests/e2e/specs/appmap/sequenceDiagram.spec.js
+++ b/packages/components/tests/e2e/specs/appmap/sequenceDiagram.spec.js
@@ -321,6 +321,14 @@ context('AppMap sequence diagram', () => {
       cy.get('div.depth-text').first().contains('1');
       cy.get('div[data-event-ids="64"]').should('have.class', 'selected');
     });
+
+    it('shows the selected event even if it is collapsed', () => {
+      cy.get('button[data-cy="decrease-collapse-depth"]').click().click().click();
+      cy.get('div.depth-text').first().contains('0');
+      cy.get('.details-search__block-item').contains('OpenSSL::Cipher#final').click();
+      cy.get('li.list-item').first().click();
+      cy.get('div.selected').contains('final').should('be.visible');
+    });
   });
 
   context('default collapse depth check', () => {


### PR DESCRIPTION
Fixes #1473 

This fixes the problem where selecting an event from the sidebar did not pan to the event in the sequence diagram.