### PR TITLE
Fix: Do not add nodes with no label

### DIFF
--- a/packages/diagrams/src/componentDiagram/graph/index.js
+++ b/packages/diagrams/src/componentDiagram/graph/index.js
@@ -43,6 +43,7 @@ export default class Graph {
 
   setNodeFromCodeObject(codeObject, parentId = null) {
     let label = codeObject.prettyName;
+    if (!label) return;
 
     if (codeObject.type === CodeObjectType.PACKAGE || codeObject.type === CodeObjectType.HTTP) {
       const numChildren = codeObject.childLeafs().length;


### PR DESCRIPTION
Fixes #1407 

This fixes the rendering issue but it does not get to the root of the problem. The root of the problem is that there is a code object that has a value of `null` for it's `name` property in [New_Group.appmap.json.zip](https://github.com/getappmap/appmap-js/files/13506307/New_Group.appmap.json.zip). I assume that this a bug with the Java agent.