### PR TITLE
Open an AppMap with multiple selected objects

### DIFF
--- a/packages/components/src/pages/VsCodeExtension.vue
+++ b/packages/components/src/pages/VsCodeExtension.vue
@@ -752,6 +752,10 @@ export default {
       return this.$store.getters.selectedObject;
     },
 
+    selectionStack() {
+      return this.$store.state.selectionStack;
+    },
+
     selectedEvent() {
       return this.selectedObject instanceof Event ? [this.selectedObject] : [];
     },
@@ -917,6 +921,16 @@ export default {
       }
     },
 
+    codeObjectToIdentifier(codeObject) {
+      if (!codeObject) return '';
+
+      if (codeObject.fqid) {
+        return codeObject.fqid;
+      } else if (codeObject.type === 'analysis-finding') {
+        return `analysis-finding:${codeObject.resolvedFinding?.finding?.hash_v2}`;
+      }
+    },
+
     getState() {
       const state = {};
 
@@ -924,8 +938,10 @@ export default {
       if (this.expandedPackages.length > 0)
         state.expandedPackages = this.expandedPackages.map((expandedPackage) => expandedPackage.id);
 
-      if (this.selectedObject && this.selectedObject.fqid) {
-        state.selectedObject = this.selectedObject.fqid;
+      if (this.selectionStack.length > 1) {
+        state.selectedObjects = this.selectionStack.map(this.codeObjectToIdentifier.bind(this));
+      } else if (this.selectionStack.length === 1) {
+        state.selectedObject = this.codeObjectToIdentifier(this.selectedObject);
       } else if (this.selectedLabel) {
         state.selectedObject = `label:${this.selectedLabel}`;
       }
@@ -983,6 +999,47 @@ export default {
       this.$store.commit(SELECT_CODE_OBJECT, selectedObject);
     },
 
+    selectObjectFromState(fqid) {
+      const [match, type, object] = fqid.match(/^([a-z\-]+):(.+)/);
+      if (!match) return;
+
+      if (type === 'label') {
+        this.$store.commit(SELECT_LABEL, object);
+        return;
+      }
+
+      const { classMap, events } = this.filteredAppMap;
+      let selectedObject = null;
+
+      if (type === 'event') {
+        const eventId = parseInt(object, 10);
+
+        if (Number.isNaN(eventId)) return;
+
+        selectedObject = events.find((e) => e.id === eventId);
+
+        // It's possible that we're trying to select an object that does not exist in the filtered
+        // set. If we're unable to find an object, we'll look for it in the unfiltered set.
+        if (!selectedObject) {
+          selectedObject = this.$store.state.appMap.events.find((e) => e.id === eventId);
+
+          if (selectedObject) {
+            Object.keys(this.filters.declutter).forEach((declutterProperty) => {
+              this.$store.commit(SET_DECLUTTER_ON, { declutterProperty, value: false });
+            });
+          }
+        }
+      } else if (type === 'analysis-finding') {
+        const hash_v2 = object;
+        const finding = this.findings.find(({ finding }) => finding.hash_v2 === hash_v2);
+        if (finding) this.$store.commit(SELECT_CODE_OBJECT, toListItem(finding));
+      } else {
+        selectedObject = classMap.codeObjects.find((obj) => obj.fqid === fqid);
+      }
+
+      if (selectedObject) this.$store.commit(SELECT_CODE_OBJECT, selectedObject);
+    },
+
     setState(serializedState) {
       return new Promise((resolve) => {
         if (!serializedState) {
@@ -990,59 +1047,11 @@ export default {
           return;
         }
 
-        const filteredMap = this.filteredAppMap;
-
         const state = filterStringToFilterState(serializedState);
-        if (state.selectedObject) {
-          do {
-            const fqid = state.selectedObject;
-            const [match, type, object] = fqid.match(/^([a-z\-]+):(.+)/);
+        if (state.selectedObject) this.selectObjectFromState(state.selectedObject);
 
-            if (!match) {
-              break;
-            }
-
-            if (type === 'label') {
-              this.$store.commit(SELECT_LABEL, object);
-              break;
-            }
-
-            const { classMap, events } = filteredMap;
-            let selectedObject = null;
-
-            if (type === 'event') {
-              const eventId = parseInt(object, 10);
-
-              if (Number.isNaN(eventId)) {
-                break;
-              }
-
-              selectedObject = events.find((e) => e.id === eventId);
-
-              // It's possible that we're trying to select an object that does not exist in the filtered
-              // set. If we're unable to find an object, we'll look for it in the unfiltered set.
-              if (!selectedObject) {
-                selectedObject = this.$store.state.appMap.events.find((e) => e.id === eventId);
-
-                if (selectedObject) {
-                  Object.keys(this.filters.declutter).forEach((declutterProperty) => {
-                    this.$store.commit(SET_DECLUTTER_ON, { declutterProperty, value: false });
-                  });
-                }
-              }
-            } else if (type === 'analysis-finding') {
-              const hash_v2 = object;
-              const finding = this.findings.find(({ finding }) => finding.hash_v2 === hash_v2);
-              if (finding) this.$store.commit(SELECT_CODE_OBJECT, toListItem(finding));
-            } else {
-              selectedObject = classMap.codeObjects.find((obj) => obj.fqid === fqid);
-            }
-
-            if (selectedObject) {
-              this.$store.commit(SELECT_CODE_OBJECT, selectedObject);
-            }
-          } while (false);
-        }
+        if (state.selectedObjects)
+          state.selectedObjects.forEach((obj) => this.selectObjectFromState(obj));
 
         const { filters, expandedPackages } = state;
         if (filters) this.$store.commit(SET_FILTER, deserializeFilter(filters));
@@ -1057,7 +1066,7 @@ export default {
 
         if (expandedPackages) {
           const codeObjects = expandedPackages.map((expandedPackageId) =>
-            filteredMap.classMap.codeObjectFromId(expandedPackageId)
+            this.filteredAppMap.classMap.codeObjectFromId(expandedPackageId)
           );
           this.$store.commit(SET_EXPANDED_PACKAGES, codeObjects);
         }

--- a/packages/components/tests/unit/VsCodeExtension.spec.js
+++ b/packages/components/tests/unit/VsCodeExtension.spec.js
@@ -29,15 +29,31 @@ describe('VsCodeExtension.vue', () => {
   it('sets the selected object by FQID', () => {
     wrapper.vm.setState('{"selectedObject":"label:json"}');
     expect(wrapper.vm.selectedLabel).toMatch('json');
+    expect(wrapper.vm.getState()).toEqual(
+      base64UrlEncode('{"currentView":"viewComponent","selectedObject":"label:json"}')
+    );
 
     wrapper.vm.setState('{"selectedObject":"event:44"}');
     expect(wrapper.vm.selectedObject.toString()).toMatch('User.find_by_id!');
+    expect(wrapper.vm.getState()).toEqual(
+      base64UrlEncode('{"currentView":"viewComponent","selectedObject":"event:44"}')
+    );
 
     wrapper.vm.setState('{"selectedObject":"class:app/models/User"}');
     expect(wrapper.vm.selectedObject.id).toMatch('app/models/User');
+    expect(wrapper.vm.getState()).toEqual(
+      base64UrlEncode(
+        '{"currentView":"viewComponent","selectedObjects":["event:44","class:app/models/User"]}'
+      )
+    );
 
     wrapper.vm.setState('{"selectedObject":"analysis-finding:fakeHash"}');
     expect(wrapper.vm.selectedObject.id).toMatch('fakeHash');
+    expect(wrapper.vm.getState()).toEqual(
+      base64UrlEncode(
+        '{"currentView":"viewComponent","selectedObjects":["event:44","class:app/models/User","analysis-finding:fakeHash"]}'
+      )
+    );
 
     wrapper.vm.clearSelection();
 
@@ -182,5 +198,35 @@ describe('VsCodeExtension.vue', () => {
     const actual = rootWrapper.emitted().saveFilter;
     expect(actual).toBeArrayOfSize(1);
     expect(actual[0][0]).toEqual(expectedFilterObject);
+  });
+
+  it('sets a single selected object by fqid when passed as an array', () => {
+    wrapper.vm.setState('{"selectedObjects":["label:json"]}');
+    expect(wrapper.vm.selectedLabel).toMatch('json');
+
+    wrapper.vm.setState('{"selectedObjects":["event:44"]}');
+    expect(wrapper.vm.selectedObject.toString()).toMatch('User.find_by_id!');
+
+    wrapper.vm.setState('{"selectedObjects":["class:app/models/User"]}');
+    expect(wrapper.vm.selectedObject.id).toMatch('app/models/User');
+
+    wrapper.vm.setState('{"selectedObjects":["analysis-finding:fakeHash"]}');
+    expect(wrapper.vm.selectedObject.id).toMatch('fakeHash');
+
+    wrapper.vm.clearSelection();
+  });
+
+  it('sets multiple objects as selected when passed an array', () => {
+    const objectsToSelect = ['event:44', 'class:app/models/User', 'analysis-finding:fakeHash'];
+    const objectsToSelectString = JSON.stringify({ selectedObjects: objectsToSelect });
+    wrapper.vm.setState(objectsToSelectString);
+
+    const actualSelectedObjects = wrapper.vm.selectionStack.map(wrapper.vm.codeObjectToIdentifier);
+    const actualSelectedObjectsString = JSON.stringify({ selectedObjects: actualSelectedObjects });
+    expect(actualSelectedObjectsString).toMatch(objectsToSelectString);
+
+    expect(wrapper.vm.selectedObject.id).toMatch('fakeHash');
+
+    wrapper.vm.clearSelection();
   });
 });


### PR DESCRIPTION
Currently, it is possible to open an AppMap by including the state as the `fragment` in the URI like this:
```
{ fragment: eyJjdXJyZW50VmlldyI6InZpZXdDb21wb25lbnQiLCJzZWxlY3RlZE9iamVjdCI6ImV2ZW50OjQ0In0 }
```
The state is a base-64-encoded string. The above string `eyJj...` decodes to:
```
'{"currentView":"viewComponent","selectedObject":"event:44"}'
```

With this PR, the state can include the `selectedObjects` field:
```
'{"selectedObjects":["event:44","package:app/controllers"]}'
```
So, opening an AppMap with the above state will have both code objects selected, and they will be navigable using the menu introduced in #1480.