### PR TITLE
Ensure that styles are scoped

### DIFF
--- a/packages/components/src/components/Accordion.vue
+++ b/packages/components/src/components/Accordion.vue
@@ -34,7 +34,7 @@ export default {
 };
 </script>
 
-<style lang="scss">
+<style scoped lang="scss">
 .accordion {
   &--open {
     .accordion__header {

--- a/packages/components/src/components/DetailsPanelEvent.vue
+++ b/packages/components/src/components/DetailsPanelEvent.vue
@@ -298,8 +298,6 @@ export default {
     }
   }
 }
-</style>
-<style scoped>
 .details-panel-event >>> .sql-code {
   margin-bottom: 8px;
   padding: 0;

--- a/packages/components/src/components/DetailsPanelListHeader.vue
+++ b/packages/components/src/components/DetailsPanelListHeader.vue
@@ -6,7 +6,7 @@
 export default { name: 'v-details-panel-list-header' };
 </script>
 
-<style lang="scss">
+<style scoped lang="scss">
 h5.details-panel-list-header {
   border-bottom: 1px solid $gray2;
   color: $gray4;

--- a/packages/components/src/components/DetailsPanelStackTrace.vue
+++ b/packages/components/src/components/DetailsPanelStackTrace.vue
@@ -63,7 +63,7 @@ export default {
 };
 </script>
 
-<style lang="scss">
+<style scoped lang="scss">
 .stack-trace {
   &__header {
     h3 {

--- a/packages/components/src/components/DetailsPanelText.vue
+++ b/packages/components/src/components/DetailsPanelText.vue
@@ -15,7 +15,7 @@ export default {
 };
 </script>
 
-<style lang="scss">
+<style scoped lang="scss">
 .details-panel-text {
   p {
     padding: 0 0.5rem;

--- a/packages/components/src/components/DiagramComponent.vue
+++ b/packages/components/src/components/DiagramComponent.vue
@@ -145,7 +145,7 @@ export default {
 };
 </script>
 
-<style lang="scss">
+<style scoped lang="scss">
 @import '~@appland/diagrams/dist/style.css';
 .diagram-component {
   width: 100%;

--- a/packages/components/src/components/Pending.vue
+++ b/packages/components/src/components/Pending.vue
@@ -28,7 +28,7 @@ export default {
 };
 </script>
 
-<style lang="scss">
+<style scoped lang="scss">
 @keyframes spin {
   from {
     transform: rotate(0deg);

--- a/packages/components/src/components/chat/UserMessage.vue
+++ b/packages/components/src/components/chat/UserMessage.vue
@@ -110,9 +110,6 @@ export default {
     margin-left: 1rem;
   }
 }
-</style>
-
-<style lang="scss">
 .message .message-body {
   hr {
     border: none;

--- a/packages/components/src/components/flamegraph/FlamegraphMain.vue
+++ b/packages/components/src/components/flamegraph/FlamegraphMain.vue
@@ -239,7 +239,7 @@ export default {
 };
 </script>
 
-<style lang="scss">
+<style scoped lang="scss">
 .flamegraph-main {
   cursor: grab;
   display: flex;

--- a/packages/components/src/components/quickstart/QuickstartLayout.vue
+++ b/packages/components/src/components/quickstart/QuickstartLayout.vue
@@ -41,7 +41,7 @@ export default {
 };
 </script>
 
-<style lang="scss">
+<style scoped lang="scss">
 html,
 body {
   width: 100%;

--- a/packages/components/src/components/trace/Trace.vue
+++ b/packages/components/src/components/trace/Trace.vue
@@ -65,7 +65,7 @@ export default {
 };
 </script>
 
-<style lang="scss">
+<style scoped lang="scss">
 .trace {
   width: max-content;
   display: inline-block;

--- a/packages/components/src/components/trace/TraceEventBlock.vue
+++ b/packages/components/src/components/trace/TraceEventBlock.vue
@@ -220,7 +220,7 @@ export default {
 };
 </script>
 
-<style lang="scss">
+<style scoped lang="scss">
 .event-block {
   display: flex;
   flex-shrink: 0;

--- a/packages/components/src/components/trace/TraceFilter.vue
+++ b/packages/components/src/components/trace/TraceFilter.vue
@@ -255,7 +255,7 @@ export default {
 };
 </script>
 
-<style lang="scss">
+<style scoped lang="scss">
 .trace-filter {
   padding: 1rem 1.25rem;
   display: flex;

--- a/packages/components/src/components/trace/TraceSummary.vue
+++ b/packages/components/src/components/trace/TraceSummary.vue
@@ -32,7 +32,7 @@ export default {
 };
 </script>
 
-<style lang="scss">
+<style scoped lang="scss">
 .trace-summary {
   user-select: none;
   -moz-user-select: none;

--- a/packages/components/src/pages/install-guide/RecordAppMaps.vue
+++ b/packages/components/src/pages/install-guide/RecordAppMaps.vue
@@ -222,7 +222,7 @@ export default {
 };
 </script>
 
-<style>
+<style scoped lang="scss">
 .status-message {
   border-radius: 0.5rem;
   background-color: #69ad34;


### PR DESCRIPTION
@dustinbyrne mentioned that we have Vue components with non-`scoped` style tags, meaning the styles are not scoped to the Vue element where they are defined. This PR makes it so that nearly every Vue component has `scoped` styles. Unfortunately, the largest element (`VsCodeExtension.vue`) is still un-`scoped` because `scope`-ing it breaks a bunch of stuff. Fixing that will be a larger effort for a different time IMO.