### PR TITLE
Collapsible sidebar

### DIFF
--- a/packages/components/src/assets/hamburger-menu.svg
+++ b/packages/components/src/assets/hamburger-menu.svg
@@ -1,0 +1,6 @@
+<svg viewBox="0 0 58 58" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="29" cy="29" r="28" stroke="#D9D9D9" stroke-width="2"/>
+  <line x1="16" y1="20" x2="43" y2="20" stroke="#D9D9D9" stroke-width="2"/>
+  <line x1="16" y1="38" x2="43" y2="38" stroke="#D9D9D9" stroke-width="2"/>
+  <line x1="16" y1="29" x2="43" y2="29" stroke="#D9D9D9" stroke-width="2"/>
+</svg>

--- a/packages/components/src/components/DetailsPanel.vue
+++ b/packages/components/src/components/DetailsPanel.vue
@@ -2,6 +2,10 @@
   <div class="details-panel">
     <h3 class="details-panel__title">
       <AppMapLogo width="70" />
+      <ChevronDownIcon
+        class="details-panel__hide-panel-icon"
+        @click="() => this.$emit('hideDetailsPanel')"
+      />
     </h3>
 
     <div
@@ -131,6 +135,7 @@ import ExclamationIcon from '@/assets/exclamation-circle.svg';
 import ScissorsIcon from '@/assets/scissors-icon.svg';
 import NavArrow from '@/assets/nav-arrow.svg';
 import ClearIcon from '@/assets/x-icon.svg';
+import ChevronDownIcon from '@/assets/fa-solid_chevron-down.svg';
 import { SELECT_CODE_OBJECT } from '@/store/vsCode';
 
 const MAX_DISPLAY_NAME_LENGTH = 150;
@@ -160,6 +165,7 @@ export default {
     ScissorsIcon,
     NavArrow,
     ClearIcon,
+    ChevronDownIcon,
   },
   props: {
     subtitle: String,
@@ -271,6 +277,9 @@ export default {
   updated() {
     this.currentSelection = this.selectedObject;
   },
+  mounted() {
+    this.currentSelection = this.selectedObject;
+  },
 };
 </script>
 
@@ -292,10 +301,23 @@ export default {
     font-size: 0;
     display: flex;
     align-items: center;
+    justify-content: space-between;
 
     svg {
       max-width: 20rem;
       width: 100%;
+    }
+  }
+
+  &__hide-panel-icon {
+    fill: $gray6;
+    width: 14px !important;
+    transform: rotate(90deg);
+
+    &:hover {
+      cursor: pointer;
+      fill: $blue;
+      transition: $transition;
     }
   }
 

--- a/packages/components/src/pages/VsCodeExtension.vue
+++ b/packages/components/src/pages/VsCodeExtension.vue
@@ -1080,6 +1080,7 @@ export default {
 
       this.renderKey += 1;
       this.eventFilterText = '';
+      this.resetDetailsPanel();
     },
     toggleShareModal() {
       this.showShareModal = !this.showShareModal;
@@ -1099,6 +1100,11 @@ export default {
     },
     revealDetailsPanel() {
       this.showDetailsPanel = true;
+      this.autoResizeLeftPanel();
+    },
+    resetDetailsPanel() {
+      const width = this.$refs.app.offsetWidth;
+      this.showDetailsPanel = width > 900;
       this.autoResizeLeftPanel();
     },
     uniqueFindings(findings) {
@@ -1153,7 +1159,18 @@ export default {
       this.isPanelResizing = false;
     },
     autoResizeLeftPanel() {
-      this.$refs.mainColumnLeft.style.width = this.showDetailsPanel ? '420px' : '50px';
+      this.$nextTick(() => {
+        let result = '50px';
+
+        const width = this.$refs.app.offsetWidth;
+        console.log('width: ', width);
+        if (width < 600 && this.showDetailsPanel) {
+          result = `${width}px`;
+        } else if (this.showDetailsPanel) {
+          result = '420px';
+        }
+        this.$refs.mainColumnLeft.style.width = result;
+      });
     },
     prevTraceFilter() {
       if (this.eventFilterMatches.length === 0) {
@@ -1335,9 +1352,7 @@ export default {
     this.$root.$on('removeRoot', (fqid) => {
       this.$store.commit(REMOVE_ROOT_OBJECT, this.filters.rootObjects.indexOf(fqid));
     });
-    const width = this.$refs.app.offsetWidth;
-    this.showDetailsPanel = width > 900;
-    this.autoResizeLeftPanel();
+    this.resetDetailsPanel();
   },
   beforeUpdate() {
     if (this.isGiantAppMap) {

--- a/packages/components/src/pages/VsCodeExtension.vue
+++ b/packages/components/src/pages/VsCodeExtension.vue
@@ -413,7 +413,6 @@ import { DEFAULT_SEQ_DIAGRAM_COLLAPSE_DEPTH } from '../components/DiagramSequenc
 
 export default {
   name: 'VSCodeExtension',
-
   components: {
     CloseIcon,
     CopyIcon,
@@ -443,9 +442,7 @@ export default {
     FullscreenEnterIcon,
     FullscreenExitIcon,
   },
-
   store,
-
   data() {
     return {
       renderKey: 0,
@@ -472,7 +469,6 @@ export default {
       isFullscreen: false,
     };
   },
-
   props: {
     defaultView: {
       type: String,
@@ -491,7 +487,6 @@ export default {
       default: false,
     },
   },
-
   watch: {
     '$store.state.currentView': {
       handler(view) {
@@ -569,17 +564,14 @@ export default {
       },
     },
   },
-
   computed: {
     isPrecomputedSequenceDiagram,
     classes() {
       return this.isLoading ? 'app--loading' : '';
     },
-
     isInBrowser() {
       return window.location.protocol.includes('http');
     },
-
     pruneFilter() {
       const { appMap } = this.$store.state;
       const {
@@ -587,11 +579,9 @@ export default {
       } = appMap;
       return pruneFilter || {};
     },
-
     wasAutoPruned() {
       return this.pruneFilter.auto;
     },
-
     findings() {
       const { appMap } = this.$store.state;
       const {
@@ -599,7 +589,6 @@ export default {
       } = appMap;
       return this.uniqueFindings(findings);
     },
-
     stats() {
       const { appMap } = this.$store.state;
       const {
@@ -607,30 +596,25 @@ export default {
       } = appMap;
       return stats;
     },
-
     filters() {
       return this.$store.state.filters;
     },
-
     filteredAppMap() {
       const { appMap } = this.$store.state;
       return this.filters.filter(appMap, this.findings);
     },
-
     rootObjectsSuggestions() {
       const filters = this.filters;
       return this.$store.state.appMap.classMap.codeObjects
         .map((co) => co.fqid)
         .filter((fqid) => !filters.rootObjects.includes(fqid));
     },
-
     hideNamesSuggestions() {
       const filters = this.filters;
       return this.filteredAppMap.classMap.codeObjects
         .map((co) => co.fqid)
         .filter((fqid) => !filters.declutter.hideName.names.includes(fqid));
     },
-
     eventsSuggestions() {
       const highlightedIds = new Set(this.eventFilterMatches.map((e) => e.id));
       const uniqueEventNames = new Set(
@@ -640,14 +624,12 @@ export default {
       );
       return Array.from(uniqueEventNames);
     },
-
     eventsById() {
       return this.filteredAppMap.events.reduce((map, e) => {
         map[e.id] = e.callEvent;
         return map;
       }, {});
     },
-
     eventsByLabel() {
       return this.filteredAppMap.events
         .filter((e) => e.isCall())
@@ -659,7 +641,6 @@ export default {
           return map;
         }, {});
     },
-
     eventFilterMatches() {
       const nodes = new Set();
 
@@ -743,59 +724,45 @@ export default {
 
       return Array.from(nodes).sort((a, b) => a.id - b.id);
     },
-
     eventFilterMatch() {
       return this.eventFilterMatches[this.eventFilterMatchIndex];
     },
-
     selectedObject() {
       return this.$store.getters.selectedObject;
     },
-
     selectionStack() {
       return this.$store.state.selectionStack;
     },
-
     selectedEvent() {
       return this.selectedObject instanceof Event ? [this.selectedObject] : [];
     },
-
     selectedLabel() {
       return this.$store.state.selectedLabel;
     },
-
     currentView() {
       return this.$store.state.currentView;
     },
-
     expandedPackages() {
       return this.$store.state.expandedPackages;
     },
-
     baseActors() {
       return this.$store.state.baseActors;
     },
-
     isViewingComponent() {
       return this.currentView === VIEW_COMPONENT;
     },
-
     isViewingSequence() {
       return this.currentView === VIEW_SEQUENCE;
     },
-
     isViewingFlow() {
       return this.currentView === VIEW_FLOW;
     },
-
     isViewingFlamegraph() {
       return this.currentView === VIEW_FLAMEGRAPH;
     },
-
     showDownload() {
       return this.isViewingSequence;
     },
-
     isEmptyAppMap() {
       const appMap = this.filteredAppMap;
       const hasEvents = Array.isArray(appMap.events) && appMap.events.length;
@@ -804,11 +771,9 @@ export default {
 
       return !this.filtersChanged && !this.eventFilterText && (!hasEvents || !hasClassMap);
     },
-
     isGiantAppMap() {
       return this.isEmptyAppMap && this.hasStats;
     },
-
     filtersChanged() {
       return (
         this.filters.rootObjects.length > 0 ||
@@ -826,21 +791,17 @@ export default {
         })
       );
     },
-
     shareURLmessage() {
       if (this.shareURL) return this.shareURL;
       return 'Retrieving link...';
     },
-
     hasStats() {
       return this.stats && this.stats.functions && this.stats.functions.length > 0;
     },
-
     fullscreenIcon() {
       return this.isFullscreen ? FullscreenExitIcon : FullscreenEnterIcon;
     },
   },
-
   methods: {
     loadData(appMap, sequenceDiagram) {
       if (sequenceDiagram) {
@@ -867,27 +828,22 @@ export default {
 
       this.isLoading = false;
     },
-
     showInstructions() {
       this.$refs.instructions.open();
       this.$root.$emit('showInstructions');
     },
-
     showVersionNotification(version, versionText = '') {
       this.version = version;
       this.versionText = versionText;
     },
-
     onNotificationOpen() {
       this.$root.$emit('notificationOpen');
     },
-
     onNotificationClose() {
       this.version = null;
       this.versionText = '';
       this.$root.$emit('notificationClose');
     },
-
     onChangeTab(tab) {
       // 'tab' can be the tab name or the actual tab.
       let index = Object.values(this.$refs).findIndex((ref) => ref === tab);
@@ -907,20 +863,17 @@ export default {
         clearTimeout(this.seqDiagramTimeoutId);
       }
     },
-
     startSeqDiagramTimer() {
       // prompt for feedback after viewing a sequence diagram for 1 minute
       this.seqDiagramTimeoutId = setTimeout(() => {
         this.$root.$emit('seq-diagram-feedback');
       }, 60 * 1000);
     },
-
     setView(view) {
       if (this.currentView !== view) {
         this.$store.commit(SET_VIEW, view);
       }
     },
-
     codeObjectToIdentifier(codeObject) {
       if (!codeObject) return '';
 
@@ -930,7 +883,6 @@ export default {
         return `analysis-finding:${codeObject.resolvedFinding?.finding?.hash_v2}`;
       }
     },
-
     getState() {
       const state = {};
 
@@ -962,11 +914,9 @@ export default {
 
       return base64UrlEncode(JSON.stringify(state));
     },
-
     openFilterModal() {
       this.$root.$emit('clickFilterButton');
     },
-
     setSelectedObject(fqid) {
       const matchResult = fqid.match(/^([a-z\-]+):(.+)/);
 
@@ -998,7 +948,6 @@ export default {
 
       this.$store.commit(SELECT_CODE_OBJECT, selectedObject);
     },
-
     selectObjectFromState(fqid) {
       const [match, type, object] = fqid.match(/^([a-z\-]+):(.+)/);
       if (!match) return;
@@ -1039,7 +988,6 @@ export default {
 
       if (selectedObject) this.$store.commit(SELECT_CODE_OBJECT, selectedObject);
     },
-
     setState(serializedState) {
       return new Promise((resolve) => {
         if (!serializedState) {
@@ -1091,13 +1039,11 @@ export default {
         });
       });
     },
-
     clearSelection() {
       this.eventFilterMatchIndex = 0;
       this.$store.commit(CLEAR_SELECTION_STACK);
       this.$root.$emit('clearSelection');
     },
-
     resetDiagram() {
       this.$store.commit(SET_COLLAPSED_ACTION_STATE, []);
       this.seqDiagramCollapseDepth =
@@ -1112,22 +1058,18 @@ export default {
       this.renderKey += 1;
       this.eventFilterText = '';
     },
-
     toggleShareModal() {
       this.showShareModal = !this.showShareModal;
       this.$root.$emit('uploadAppmap');
       if (this.showShareModal && this.showStatsPanel) this.showStatsPanel = false;
     },
-
     toggleStatsPanel() {
       this.showStatsPanel = !this.showStatsPanel;
       if (this.showShareModal && this.showStatsPanel) this.showShareModal = false;
     },
-
     closeStatsPanel() {
       this.showStatsPanel = false;
     },
-
     uniqueFindings(findings) {
       if (!findings) return undefined;
 
@@ -1138,19 +1080,15 @@ export default {
         }, {})
       );
     },
-
     closeShareModal() {
       this.showShareModal = false;
     },
-
     setShareURL(url) {
       this.shareURL = url;
     },
-
     copyToClipboard(input) {
       this.$root.$emit('copyToClipboard', input);
     },
-
     onFlamegraphSelect(event) {
       if (event) {
         this.onClickTraceEvent(event);
@@ -1158,18 +1096,15 @@ export default {
         this.clearSelection();
       }
     },
-
     onClickTraceEvent(e) {
       this.$store.commit(SELECT_CODE_OBJECT, e);
     },
-
     startResizing(event) {
       document.body.style.userSelect = 'none';
       this.isPanelResizing = true;
       this.initialPanelWidth = this.$refs.mainColumnLeft.offsetWidth;
       this.initialClientX = event.clientX;
     },
-
     makeResizing(event) {
       if (this.isPanelResizing) {
         const MIN_PANEL_WIDTH = 280;
@@ -1182,12 +1117,10 @@ export default {
         this.$refs.mainColumnLeft.style.width = `${newWidth}px`;
       }
     },
-
     stopResizing() {
       document.body.style.userSelect = '';
       this.isPanelResizing = false;
     },
-
     prevTraceFilter() {
       if (this.eventFilterMatches.length === 0) {
         return;
@@ -1213,7 +1146,6 @@ export default {
         this.eventFilterMatchIndex = this.eventFilterMatches.length - 1;
       }
     },
-
     nextTraceFilter() {
       if (this.eventFilterMatches.length === 0) {
         return;
@@ -1242,13 +1174,11 @@ export default {
         this.eventFilterMatchIndex = 0;
       }
     },
-
     selectCurrentHighlightedEvent() {
       if (this.eventFilterMatch) {
         this.$store.commit(SELECT_CODE_OBJECT, this.eventFilterMatch);
       }
     },
-
     initializeSavedFilters() {
       let savedFilters = this.savedFilters;
 
@@ -1290,11 +1220,9 @@ export default {
         this.setState(defaultFilter.state);
       }
     },
-
     updateFilters(updatedFilters) {
       this.$store.commit(SET_SAVED_FILTERS, updatedFilters);
     },
-
     analysisFindingSelection(findingObject) {
       const finding = findingObject.resolvedFinding && findingObject.resolvedFinding.finding;
       if (!finding) return;
@@ -1313,16 +1241,13 @@ export default {
       const event = this.filteredAppMap.eventsById[eventToFocus.id];
       this.$store.commit(SET_FOCUSED_EVENT, event);
     },
-
     increaseSeqDiagramCollapseDepth() {
       if (this.seqDiagramCollapseDepth < this.maxSeqDiagramCollapseDepth)
         this.seqDiagramCollapseDepth++;
     },
-
     decreaseSeqDiagramCollapseDepth() {
       if (this.seqDiagramCollapseDepth > 0) this.seqDiagramCollapseDepth--;
     },
-
     setMaxSeqDiagramCollapseDepth(maxDepth) {
       if (!maxDepth) return;
       if (maxDepth < this.seqDiagramCollapseDepth) this.seqDiagramCollapseDepth = maxDepth;
@@ -1369,7 +1294,6 @@ export default {
       this.isFullscreen = !this.isFullscreen;
     },
   },
-
   mounted() {
     this.$root.$on('makeRoot', (codeObject) => {
       this.$store.commit(ADD_ROOT_OBJECT, codeObject.fqid);
@@ -1379,7 +1303,6 @@ export default {
       this.$store.commit(REMOVE_ROOT_OBJECT, this.filters.rootObjects.indexOf(fqid));
     });
   },
-
   beforeUpdate() {
     if (this.isGiantAppMap) {
       this.showStatsPanel = true;

--- a/packages/components/tests/e2e/specs/appmap/collapsibleSidebar.spec.js
+++ b/packages/components/tests/e2e/specs/appmap/collapsibleSidebar.spec.js
@@ -1,28 +1,64 @@
 context('Collapsible sidebar', () => {
-  beforeEach(() => {
-    cy.visit(
-      'http://localhost:6006/iframe.html?id=pages-vs-code--extension-with-default-sequence-view&viewMode=story'
-    );
+  context('on a large device', () => {
+    beforeEach(() => {
+      cy.visit(
+        'http://localhost:6006/iframe.html?id=pages-vs-code--extension-with-default-sequence-view&viewMode=story'
+      );
+    });
+
+    it('can be collapsed and expanded', () => {
+      cy.get('.details-panel__hide-panel-icon').click();
+      cy.get('[data-cy="sidebar-menu"]').should('be.visible');
+      cy.get('.details-search').should('not.exist');
+
+      cy.get('.sidebar-menu__hamburger-menu').click();
+      cy.get('.details-search').should('be.visible');
+      cy.get('[data-cy="sidebar-menu"]').should('not.exist');
+    });
+
+    it('opens the sidebar when selecting a code object', () => {
+      cy.get('.details-panel__hide-panel-icon').click();
+      cy.get('span').contains('index').click();
+      cy.get('.details-panel-header__details-name')
+        .contains('Spree::Admin::RootController#index')
+        .should('be.visible');
+      cy.get('.selection-nav-menu')
+        .find('option:selected')
+        .should('contain.text', 'Spree::Admin::RootController#index');
+    });
   });
 
-  it('can be collapsed and expanded', () => {
-    cy.get('.details-panel__hide-panel-icon').click();
-    cy.get('[data-cy="sidebar-menu"]').should('be.visible');
-    cy.get('.details-search').should('not.exist');
+  context('on a medium-sized device', () => {
+    const width = 690;
+    const height = 844;
 
-    cy.get('.sidebar-menu__hamburger-menu').click();
-    cy.get('.details-search').should('be.visible');
-    cy.get('[data-cy="sidebar-menu"]').should('not.exist');
+    beforeEach(() => {
+      cy.viewport(width, height);
+      cy.visit(
+        'http://localhost:6006/iframe.html?id=pages-vs-code--extension-with-default-sequence-view&viewMode=story'
+      );
+    });
+
+    it('correctly resets the diagram', () => {
+      cy.get('.diagram-reload').click();
+      cy.get('.main-column--left').invoke('outerWidth').should('be.lt', 60).and('be.gt', 0);
+    });
   });
 
-  it('opens the sidebar when selecting a code object', () => {
-    cy.get('.details-panel__hide-panel-icon').click();
-    cy.get('span').contains('index').click();
-    cy.get('.details-panel-header__details-name')
-      .contains('Spree::Admin::RootController#index')
-      .should('be.visible');
-    cy.get('.selection-nav-menu')
-      .find('option:selected')
-      .should('contain.text', 'Spree::Admin::RootController#index');
+  context('on a small device', () => {
+    const width = 500;
+    const height = 844;
+
+    beforeEach(() => {
+      cy.viewport(width, height);
+      cy.visit(
+        'http://localhost:6006/iframe.html?id=pages-vs-code--extension-with-default-sequence-view&viewMode=story'
+      );
+    });
+
+    it('makes the sidebar menu full screen', () => {
+      cy.get('.sidebar-menu__hamburger-menu').click();
+      cy.get('.main-column--left').invoke('outerWidth').should('eq', width);
+    });
   });
 });

--- a/packages/components/tests/e2e/specs/appmap/collapsibleSidebar.spec.js
+++ b/packages/components/tests/e2e/specs/appmap/collapsibleSidebar.spec.js
@@ -1,0 +1,28 @@
+context('Collapsible sidebar', () => {
+  beforeEach(() => {
+    cy.visit(
+      'http://localhost:6006/iframe.html?id=pages-vs-code--extension-with-default-sequence-view&viewMode=story'
+    );
+  });
+
+  it('can be collapsed and expanded', () => {
+    cy.get('.details-panel__hide-panel-icon').click();
+    cy.get('[data-cy="sidebar-menu"]').should('be.visible');
+    cy.get('.details-search').should('not.exist');
+
+    cy.get('.sidebar-menu__hamburger-menu').click();
+    cy.get('.details-search').should('be.visible');
+    cy.get('[data-cy="sidebar-menu"]').should('not.exist');
+  });
+
+  it('opens the sidebar when selecting a code object', () => {
+    cy.get('.details-panel__hide-panel-icon').click();
+    cy.get('span').contains('index').click();
+    cy.get('.details-panel-header__details-name')
+      .contains('Spree::Admin::RootController#index')
+      .should('be.visible');
+    cy.get('.selection-nav-menu')
+      .find('option:selected')
+      .should('contain.text', 'Spree::Admin::RootController#index');
+  });
+});

--- a/packages/components/tests/e2e/specs/appmap/smallDevice.spec.js
+++ b/packages/components/tests/e2e/specs/appmap/smallDevice.spec.js
@@ -3,12 +3,12 @@ context('AppMap sidebar', () => {
   const height = 844;
 
   beforeEach(() => {
-    cy.visit('http://localhost:6006/iframe.html?id=pages-vs-code--extension&viewMode=story');
     cy.viewport(width, height);
+    cy.visit('http://localhost:6006/iframe.html?id=pages-vs-code--extension&viewMode=story');
   });
 
   it('should not display the sidebar', () => {
-    cy.get('[data-cy="sidebar"]').should('not.be.visible');
+    cy.get('[data-cy="sidebar-menu"]').should('be.visible');
   });
 
   it('can scroll the tabs', () => {


### PR DESCRIPTION
[Try it out here](https://5fe18baf66f2280021e634d0-yhfbggzizq.chromatic.com/iframe.html?args=&id=pages-vs-code--extension-with-default-sequence-view&viewMode=story)

This PR makes it so that the left-hand side (LHS) panel is collapsible. When the component is rendered, the side panel is shown unless the component width is less than 900px.

This adds a chevron in the top right corner of the LHS panel:

![image](https://github.com/getappmap/appmap-js/assets/45714532/1a321567-b371-4ca0-8284-a001fffd8919)

If you click the chevron, then the panel slides to the left:

![image](https://github.com/getappmap/appmap-js/assets/45714532/13b0cb40-4db1-4082-a0f1-d11bf9523e31)

Clicking the hamburger menu icon makes the LHS panel visible again. 

Also, if you click on a code object in the diagram and the LHS panel is collapsed, then it will expand and become visible.
