### PR TITLE
Fix control button styling

### DIFF
--- a/packages/components/src/pages/VsCodeExtension.vue
+++ b/packages/components/src/pages/VsCodeExtension.vue
@@ -1644,15 +1644,21 @@ code {
           transition-timing-function: ease-out;
         }
 
-        svg path {
-          stroke: $lightgray2;
-        }
-
         &__stroke {
           width: 16px;
           height: 14px;
           stroke-width: 4;
           fill: none;
+
+          path {
+            stroke: $lightgray2;
+          }
+
+          &:hover {
+            path {
+              stroke: $gray5;
+            }
+          }
         }
 
         &__icon {


### PR DESCRIPTION
* The icons for the export, stats, and refresh control buttons got a bit too thick recently. This PR slims them back down.
* Adds a hover effect to the fullscreen icon.

## Before
![image](https://github.com/getappmap/appmap-js/assets/45714532/06350938-0b50-4eee-8404-14bbc494eec2)


## After
![image](https://github.com/getappmap/appmap-js/assets/45714532/fecda9bc-6bfc-499b-89fe-8c4ceeb7fb03)
