### PR TITLE
Full screen fixes

### DIFF
--- a/packages/components/src/pages/VsCodeExtension.vue
+++ b/packages/components/src/pages/VsCodeExtension.vue
@@ -1308,15 +1308,14 @@ export default {
       this.seqDiagramCollapseDepth = newDepth;
     },
     async enterFullscreen() {
-      const body = document.body;
       const requestMethod =
-        body.requestFullScreen ||
-        body.webkitRequestFullScreen ||
-        body.mozRequestFullScreen ||
-        body.msRequestFullScreen;
+        this.$el.requestFullScreen ||
+        this.$el.webkitRequestFullScreen ||
+        this.$el.mozRequestFullScreen ||
+        this.$el.msRequestFullScreen;
       if (requestMethod) {
         try {
-          await requestMethod.call(body);
+          await requestMethod.call(this.$el);
         } catch (e) {
           console.warn(e);
         }

--- a/packages/components/tests/e2e/specs/appmap/fullscreen.spec.js
+++ b/packages/components/tests/e2e/specs/appmap/fullscreen.spec.js
@@ -3,8 +3,47 @@ context('Fullscreen toggle', () => {
     cy.visit('http://localhost:6006/iframe.html?id=pages-vs-code--extension&viewMode=story');
   });
 
-  it('toggles on and off', () => {
-    cy.get('[data-cy="fullscreen-button"]:not([data-enabled])').click();
-    cy.get('[data-cy="fullscreen-button"][data-enabled]').click();
+  it('toggles on and off via click', async () => {
+    const requestFullScreen = cy.stub();
+    const exitFullscreen = cy.stub();
+
+    let appElement = null;
+    cy.get('[data-cy="app"]').then(([el]) => {
+      appElement = el;
+      appElement.requestFullScreen = requestFullScreen;
+    });
+
+    cy.get('[data-cy="fullscreen-button"]')
+      .click()
+      .then(() => {
+        expect(requestFullScreen).to.be.called;
+      });
+
+    // Manually set the fullscreenElement property on the document
+    // to simulate the browser entering fullscreen mode.
+    cy.document().then((doc) => {
+      cy.stub(doc, 'fullscreenElement', appElement);
+      cy.stub(doc, 'exitFullscreen', exitFullscreen);
+    });
+
+    // Similarly, manually trigger the fullscreenchange event
+    // The browser won't let an automated test trigger fullscreen without user interaction
+    cy.get('[data-cy="app"]').trigger('fullscreenchange');
+
+    cy.get('[data-cy="fullscreen-button"][data-enabled]')
+      .click()
+      .then(() => {
+        expect(exitFullscreen).to.be.called;
+      });
+
+    // Manually clear the fullscreenElement
+    cy.document().then((doc) => {
+      cy.stub(doc, 'fullscreenElement', undefined);
+    });
+
+    // Fire the fullscreenchange event again so the frontend can be notified
+    cy.get('[data-cy="app"]').trigger('fullscreenchange');
+
+    cy.get('[data-cy="fullscreen-button"]:not([data-enabled])').should('exist');
   });
 });


### PR DESCRIPTION
- The state no longer de-syncs after pressing Esc
- Full screen now only targets the AppMap viewer element, not the entire document
  - This will be useful for dropping the element into other contexts 