### PR TITLE
Fix and re-enable "View in Sequence" test

### DIFF
--- a/packages/components/src/components/DiagramSequence.vue
+++ b/packages/components/src/components/DiagramSequence.vue
@@ -196,15 +196,42 @@ export default {
         element.scrollIntoView(SCROLL_OPTIONS);
       });
     },
+    scrollElementIntoView(element) {
+      const boundingRect = element.getBoundingClientRect();
+
+      let intervalId;
+      let retries = 0;
+      let lastScrollTop = boundingRect.top;
+      let lastScrollLeft = boundingRect.left;
+
+      // Once scrolling has started or we've retried more than 5 times, stop retrying
+      const tryToScrollIntoView = () => {
+        element.scrollIntoView(SCROLL_OPTIONS);
+        const newBoundingRect = element.getBoundingClientRect();
+
+        if (
+          lastScrollTop !== newBoundingRect.top ||
+          lastScrollLeft !== newBoundingRect.left ||
+          retries > 5
+        ) {
+          clearInterval(intervalId);
+        } else {
+          lastScrollLeft = newBoundingRect.left;
+          lastScrollTop = newBoundingRect.top;
+          retries += 1;
+        }
+      };
+
+      intervalId = setInterval(tryToScrollIntoView, 100);
+    },
     focusHighlighted() {
-      setTimeout(() => {
+      this.$nextTick(() => {
         if (!this.$el || !this.$el.querySelector) return;
 
         const selected = this.$el.querySelector('.selected');
-        if (selected && selected.firstElementChild) {
-          selected.firstElementChild.scrollIntoView(SCROLL_OPTIONS);
-        }
-      }, 16);
+        if (selected && selected.firstElementChild)
+          this.scrollElementIntoView(selected.firstElementChild);
+      });
     },
     returnValue(action: ActionSpec): string {
       if (!action.eventIds || !this.appMap || !this.appMap.eventsById) {

--- a/packages/components/src/pages/VsCodeExtension.vue
+++ b/packages/components/src/pages/VsCodeExtension.vue
@@ -1163,7 +1163,6 @@ export default {
         let result = '50px';
 
         const width = this.$refs.app.offsetWidth;
-        console.log('width: ', width);
         if (width < 600 && this.showDetailsPanel) {
           result = `${width}px`;
         } else if (this.showDetailsPanel) {

--- a/packages/components/tests/e2e/specs/appmap/sequenceDiagram.spec.js
+++ b/packages/components/tests/e2e/specs/appmap/sequenceDiagram.spec.js
@@ -154,12 +154,7 @@ context('AppMap sequence diagram', () => {
       cy.get('button').contains('Show in Sequence').click();
       cy.get('.call.selected > :first').should('be.visible');
     });
-    // TODO: Passes locally, but fails in CI.
-    // ➤ YN0000: [@appland/components]:      AssertionError: Timed out retrying after 4000ms: expected '<div.call-line-segment.single-span>' to be 'visible'
-    // ➤ YN0000: [@appland/components]:
-    // ➤ YN0000: [@appland/components]: This element `<div.call-line-segment.single-span>` is not visible because its content is being clipped by one of its parent elements, which has a CSS property of overflow: `hidden`, `scroll` or `auto`
-    // ➤ YN0000: [@appland/components]:       at Context.eval (http://localhost:6006/__cypress/tests?p=tests/e2e/specs/appmap/sequenceDiagram.spec.js:128:41)
-    xit('pans to the correct location when selecting "View in Sequence"', () => {
+    it('pans to the correct location when selecting "View in Sequence"', () => {
       cy.get('.node.class[data-id="active_support/ActiveSupport::SecurityUtils"]').click();
 
       cy.get('.v-details-panel-list')


### PR DESCRIPTION
This test was failing because calling `scrollIntoView` on the selected element was doing nothing. This PR fixes this problem by re-calling `scrollIntoView` until scrolling starts.