### PR TITLE
fix: Authenticate Chat/ChatSearch frontend clients

### DIFF
--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,5 +1,5 @@
 export { default as Configuration } from './configuration';
-export { default as loadConfiguration, setConfiguration } from './loadConfiguration';
+export { default as loadConfiguration, setConfiguration, DefaultApiURL } from './loadConfiguration';
 export { default as get } from './get';
 export { default as handleError } from './handleError';
 export { default as retryOn503 } from './retryOn503';

--- a/packages/components/src/components/mixins/authenticatedClient.js
+++ b/packages/components/src/components/mixins/authenticatedClient.js
@@ -1,0 +1,27 @@
+import { setConfiguration, DefaultApiURL } from '@appland/client';
+
+export default {
+  props: {
+    apiKey: {
+      type: String,
+      required: false,
+    },
+    apiUrl: {
+      type: String,
+      required: false,
+    },
+  },
+  watch: {
+    apiKey: {
+      handler() {
+        this.updateClientConfiguration();
+      },
+      immediate: true,
+    },
+  },
+  methods: {
+    updateClientConfiguration() {
+      setConfiguration({ apiKey: this.apiKey, apiURL: this.apiUrl || DefaultApiURL });
+    },
+  },
+};

--- a/packages/components/src/pages/Chat.vue
+++ b/packages/components/src/pages/Chat.vue
@@ -7,8 +7,8 @@
 <script lang="ts">
 //@ts-nocheck
 import VChat from '@/components/chat/Chat.vue';
-import { AIClient } from '@appland/client';
-import { AI, setConfiguration, DefaultApiURL } from '@appland/client';
+import { AI, AIClient } from '@appland/client';
+import authenticatedClient from '@/components/mixins/authenticatedClient';
 
 export default {
   name: 'v-chat-page',
@@ -16,13 +16,6 @@ export default {
     VChat,
   },
   props: {
-    apiKey: {
-      type: String,
-    },
-    apiUrl: {
-      type: String,
-      default: DefaultApiURL,
-    },
     suggestions: {
       type: Array,
       required: false,
@@ -31,17 +24,8 @@ export default {
       type: Function,
     },
   },
-  watch: {
-    apiKey() {
-      this.updateConfiguration();
-    },
-  },
+  mixins: [authenticatedClient],
   computed: {
-    clientConfiguration() {
-      return {
-        apiKey: this.apiKey,
-      };
-    },
     vchat() {
       return this.$refs.vchat as VChat;
     },
@@ -66,12 +50,6 @@ export default {
     async aiClient(callbacks: Callbacks): Promise<AIClient> {
       return this.aiClientFn ? this.aiClientFn(callbacks) : AI.connect(callbacks);
     },
-    updateConfiguration() {
-      setConfiguration({ apiKey: this.apiKey, apiURL: this.apiUrl });
-    },
-  },
-  mounted() {
-    this.updateConfiguration();
   },
 };
 </script>

--- a/packages/components/src/pages/ChatSearch.vue
+++ b/packages/components/src/pages/ChatSearch.vue
@@ -95,6 +95,7 @@ import VChat from '@/components/chat/Chat.vue';
 import VAccordion from '@/components/Accordion.vue';
 import VAppMap from './VsCodeExtension.vue';
 import AppMapRPC from '@/lib/AppMapRPC';
+import authenticatedClient from '@/components/mixins/authenticatedClient';
 
 export default {
   name: 'v-chat-search',
@@ -103,6 +104,7 @@ export default {
     VAppMap,
     VAccordion,
   },
+  mixins: [authenticatedClient],
   props: {
     question: {
       type: String,

--- a/packages/components/tests/unit/chat/authentication.spec.js
+++ b/packages/components/tests/unit/chat/authentication.spec.js
@@ -1,0 +1,36 @@
+import VChat from '@/pages/Chat.vue';
+import VChatSearch from '@/pages/ChatSearch.vue';
+import { mount } from '@vue/test-utils';
+import { setConfiguration, loadConfiguration } from '@appland/client';
+
+describe('Authentication', () => {
+  const apiKey = 'apiKey';
+  const apiUrl = 'apiUrl';
+
+  beforeEach(() => {
+    setConfiguration({
+      apiKey: undefined,
+      apiURL: undefined,
+    });
+  });
+
+  it('authenticates Chat', async () => {
+    const wrapper = mount(VChat, { propsData: { apiKey, apiUrl } });
+    await wrapper.vm.$nextTick();
+    expect(loadConfiguration()).toStrictEqual({
+      apiKey,
+      apiURL: apiUrl,
+      baseURL: expect.any(String),
+    });
+  });
+
+  it('authenticates ChatSearch', async () => {
+    const wrapper = mount(VChatSearch, { propsData: { apiKey, apiUrl } });
+    await wrapper.vm.$nextTick();
+    expect(loadConfiguration()).toStrictEqual({
+      apiKey,
+      apiURL: apiUrl,
+      baseURL: expect.any(String),
+    });
+  });
+});


### PR DESCRIPTION
This change allows authenticated API requests from Chat/ChatSearch. This is still used for things like providing message feedback.