### PR TITLE
fix: Make API key optional for index watch mode

### DIFF
--- a/packages/cli/src/cmds/index/index.ts
+++ b/packages/cli/src/cmds/index/index.ts
@@ -63,7 +63,7 @@ export const handler = async (argv) => {
   if (port && !watch) warn(`Note: --port option implies --watch`);
 
   if (runServer) {
-    loadConfiguration();
+    loadConfiguration(false);
 
     log(`Running indexer in watch mode`);
     const cmd = new FingerprintWatchCommand(appmapDir);


### PR DESCRIPTION
Otherwise the indexer will not run without an API key, and the API key is not yet reliably provided (not should it be absolutely required, since indexing does not require a key and the local RPC operations don't require one either).