### PR TITLE
feat: Add a page to notify of invalid license

### DIFF
--- a/packages/components/build/svg.d.ts
+++ b/packages/components/build/svg.d.ts
@@ -1,0 +1,4 @@
+declare module '*.svg' {
+  const content: string;
+  export default content;
+}

--- a/packages/components/src/components/mixins/emitLink.ts
+++ b/packages/components/src/components/mixins/emitLink.ts
@@ -1,0 +1,92 @@
+import Vue from 'vue';
+
+type Data = {
+  ownedElements: Set<HTMLAnchorElement>;
+  clickHandler: (e: MouseEvent) => void;
+};
+
+// This is a global set of elements that we've already added a click handler to.
+const listeningElements = new Set<HTMLAnchorElement>();
+
+// This mixin emits a 'click-link' event when a link is clicked. The event
+// contains the href of the link.
+//
+// This mixin is safe to use within nested components. It guarantees that only
+// one click handler is registered per link.
+export default Vue.extend({
+  data(): Data {
+    return {
+      // This is the collection of elements that we've added a click handler to.
+      // We're responsible for removing the click handler when the element is
+      // updated or destroyed.
+      ownedElements: new Set<HTMLAnchorElement>(),
+
+      // A single stable function reference that we can use to add and remove
+      // click handlers. This is initialized in `mounted`.
+      clickHandler: () => {
+        throw new Error('clickHandler not initialized');
+      },
+    };
+  },
+
+  methods: {
+    onLinkClicked(e: MouseEvent) {
+      const link = e.target;
+      if (!(link instanceof HTMLAnchorElement)) return;
+
+      // Ignore links that are internal to the page.
+      const href = link.getAttribute('href');
+      if (!href || href.startsWith('#')) return;
+
+      // Ignore links that aren't valid URLs.
+      try {
+        new URL(href);
+      } catch (e) {
+        return;
+      }
+
+      this.$root.$emit('click-link', href);
+    },
+
+    // If we own the element, remove the click handler and drop references.
+    dropOwnership(el: HTMLAnchorElement) {
+      if (!this.ownedElements.has(el)) return;
+
+      this.ownedElements.delete(el);
+      listeningElements.delete(el);
+      el.removeEventListener('click', this.clickHandler);
+    },
+
+    // Attempt to take ownership of the element via adding the reference to
+    // the global set. If it's already owned, this method returns false.
+    // If the element is not already owned, add the click handler and return
+    // true.
+    takeOwnership(el: HTMLAnchorElement): boolean {
+      if (listeningElements.has(el)) return false;
+
+      this.ownedElements.add(el);
+      listeningElements.add(el);
+      el.addEventListener('click', this.clickHandler);
+
+      return true;
+    },
+
+    // Drop all ownership and rebind click handlers to all elements.
+    // Consider the case where a component is updated and the DOM is
+    // re-rendered. We need to rebind the click handlers to the new
+    // elements.
+    rebindClickHandlers() {
+      this.ownedElements.forEach((el) => this.dropOwnership(el));
+      this.$el.querySelectorAll('a').forEach((el) => this.takeOwnership(el));
+    },
+  },
+
+  mounted() {
+    this.clickHandler = this.onLinkClicked.bind(this);
+    this.rebindClickHandlers();
+  },
+
+  updated() {
+    this.rebindClickHandlers();
+  },
+});

--- a/packages/components/src/components/notices/ConfigurationRequiredNotice.vue
+++ b/packages/components/src/components/notices/ConfigurationRequiredNotice.vue
@@ -1,15 +1,13 @@
 <template>
-  <div class="unlicensed-notice" data-cy="notice-unlicensed">
+  <div class="configuration-required-notice" data-cy="notice-configuration">
     <div class="notice">
       <v-appmap-logo />
-      <p class="unlicensed-notice__title">License expired</p>
+      <p class="configuration-required-notice__title">Additional configuration required</p>
+      <p>To finish setting up this view, edit this macro and select an AppMap from the dropdown.</p>
       <p>
-        To continue enjoying all the great features of this software, an active license is required.
-        Your support is crucial in helping us enhance and develop new features for our community.
+        If you don't yet have an AppMap, drag one into this page in edit mode. Once uploaded, the
+        file can be removed from the page.
       </p>
-      <a :href="purchaseUrl" class="cta" data-cy="purchase" v-if="purchaseUrl" target="_blank">
-        <v-button class="cta" data-cy="purchase"> Purchase AppMap </v-button>
-      </a>
       <p>
         Need assistance or have questions? Join the
         <a href="https://appmap.io/slack" target="_blank" rel="noopener noreferrer">
@@ -20,40 +18,27 @@
         >. For more direct assistance, our support team is just an
         <a href="mailto:support@appmap.io">email</a> away.
       </p>
-      <p>Thank you for being a vital part of our community, we hope to see you again soon!</p>
     </div>
   </div>
 </template>
 
 <script lang="ts">
-//@ts-nocheck
+import Vue from 'vue';
+
 import VAppmapLogo from '@/assets/appmap-full-logo.svg';
-import VButton from '@/components/Button.vue';
 import EmitLinkMixin from '@/components/mixins/emitLink';
 
-export default {
+export default Vue.extend({
+  name: 'v-configuration-required-notice',
   components: {
     VAppmapLogo,
-    VButton,
   },
-  props: {
-    purchaseUrl: {
-      type: String,
-      required: false,
-    },
-  },
-  mixins: [
-    // This should also be included via the parent page (VsCodeExtension).
-    // However, we want to validate that the behavior provided by the mixin
-    // is applied, so it's included here as well. The Mixin is built to allow
-    // this.
-    EmitLinkMixin,
-  ],
-};
+  mixins: [EmitLinkMixin],
+});
 </script>
 
 <style lang="scss" scoped>
-.unlicensed-notice {
+.configuration-required-notice {
   display: flex;
   position: absolute;
   flex-direction: column;
@@ -85,16 +70,6 @@ export default {
     -webkit-text-fill-color: transparent;
   }
 
-  .cta {
-    width: fit-content;
-    align-self: center;
-  }
-
-  p {
-    margin-block-start: 1em;
-    margin-block-end: 1em;
-  }
-
   a {
     color: $brightblue;
     text-decoration: none;
@@ -105,8 +80,9 @@ export default {
     }
   }
 
-  .empty-state-diagram {
-    margin-top: 4rem;
+  p {
+    margin-block-start: 1em;
+    margin-block-end: 1em;
   }
 }
 </style>

--- a/packages/components/src/components/notices/NoDataNotice.vue
+++ b/packages/components/src/components/notices/NoDataNotice.vue
@@ -1,0 +1,95 @@
+<template>
+  <div class="no-data-notice" data-cy="notice-no-data">
+    <div class="notice">
+      <p class="no-data-notice__title">Sorry, but there's no data to display :(</p>
+      <ul class="why-me">
+        <strong>Top 3 reasons why this appmap is empty:</strong>
+        <li>appmap.yml did not list packages/modules/folders of your application logic</li>
+        <li>
+          If this AppMap was recorded from a test, the test did not provide sufficient coverage for
+          good data
+        </li>
+        <li>
+          If other manual method was used to record this AppMap, the instrumented code objects were
+          not executed during the recording.
+        </li>
+      </ul>
+      <p>
+        Need assistance or have questions? Check our
+        <a href="https://appmap.io/docs" target="_blank" rel="noopener noreferrer"> documentation</a
+        >, or ask for help in
+        <a href="https://appmap.io/slack" target="_blank" rel="noopener noreferrer"> Slack</a>.
+      </p>
+    </div>
+    <v-diagram-gray class="empty-state-diagram" />
+  </div>
+</template>
+
+<script lang="ts">
+//@ts-nocheck
+import VDiagramGray from '@/assets/diagram-empty.svg';
+
+export default {
+  components: {
+    VDiagramGray,
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.no-data-notice {
+  display: flex;
+  position: absolute;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  font-family: $appland-text-font-family;
+  line-height: 1.5;
+  color: $base03;
+  background-color: $black;
+  z-index: 2147483647;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+
+  .notice {
+    display: flex;
+    flex-direction: column;
+    max-width: 60%;
+    min-width: 16rem;
+  }
+
+  &__title {
+    margin-bottom: 1rem;
+    font-size: 2rem;
+    font-weight: 700;
+    background: linear-gradient(to right, $royal, $hotpink);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+  }
+
+  a {
+    color: $brightblue;
+    text-decoration: none;
+
+    &:hover,
+    &:active {
+      color: $brightblue;
+    }
+  }
+
+  .empty-state-diagram {
+    margin-top: 4rem;
+  }
+
+  .why-me {
+    padding: 1rem;
+    strong {
+      margin-left: -1rem;
+      color: $royal;
+      margin-bottom: 0.5rem;
+    }
+  }
+}
+</style>

--- a/packages/components/src/components/notices/UnlicensedNotice.vue
+++ b/packages/components/src/components/notices/UnlicensedNotice.vue
@@ -29,6 +29,7 @@
 //@ts-nocheck
 import VAppmapLogo from '@/assets/appmap-full-logo.svg';
 import VButton from '@/components/Button.vue';
+import EmitLinkMixin from '@/components/mixins/emitLink';
 
 export default {
   components: {
@@ -41,6 +42,13 @@ export default {
       required: false,
     },
   },
+  mixins: [
+    // This should also be included via the parent page (VsCodeExtension).
+    // However, we want to validate that the behavior provided by the mixin
+    // is applied, so it's included here as well. The Mixin is built to allow
+    // this.
+    EmitLinkMixin,
+  ],
 };
 </script>
 

--- a/packages/components/src/components/notices/UnlicensedNotice.vue
+++ b/packages/components/src/components/notices/UnlicensedNotice.vue
@@ -1,0 +1,104 @@
+<template>
+  <div class="unlicensed-notice">
+    <div class="notice">
+      <v-appmap-logo />
+      <h1 class="unlicensed-notice__title">License expired</h1>
+      <p>
+        To continue enjoying all the great features of this software, an active license is required.
+        Your support is crucial in helping us enhance and develop new features for our community.
+      </p>
+      <a :href="purchaseUrl" class="cta" data-cy="purchase" v-if="purchaseUrl" target="_blank">
+        <v-button class="cta" data-cy="purchase"> Purchase AppMap </v-button>
+      </a>
+      <p>
+        Need assistance or have questions? Join the
+        <a href="https://appmap.io/slack" target="_blank" rel="noopener noreferrer">
+          AppMap Community Slack
+        </a>
+        for interactive support or check out our
+        <a href="https://appmap.io/docs" target="_blank" rel="noopener noreferrer"> documentation</a
+        >. For more direct assistance, our support team is just an
+        <a href="mailto:support@appmap.io">email</a> away.
+      </p>
+      <p>Thank you for being a vital part of our community, we hope to see you again soon!</p>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+//@ts-nocheck
+import VAppmapLogo from '@/assets/appmap-full-logo.svg';
+import VButton from '@/components/Button.vue';
+
+export default {
+  components: {
+    VAppmapLogo,
+    VButton,
+  },
+  props: {
+    purchaseUrl: {
+      type: String,
+      required: false,
+    },
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.unlicensed-notice {
+  display: flex;
+  position: absolute;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  font-family: $appland-text-font-family;
+  line-height: 1.5;
+  color: $base03;
+  background-color: $black;
+  z-index: 2147483647;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+
+  .notice {
+    display: flex;
+    flex-direction: column;
+    max-width: 50%;
+    min-width: 16rem;
+  }
+
+  &__title {
+    margin-bottom: 1rem;
+    font-size: 2rem;
+    font-weight: 700;
+    background: linear-gradient(to right, $royal, $hotpink);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+  }
+
+  .cta {
+    width: fit-content;
+    align-self: center;
+  }
+
+  p {
+    margin-block-start: 1em;
+    margin-block-end: 1em;
+  }
+
+  a {
+    color: $brightblue;
+    text-decoration: none;
+
+    &:hover,
+    &:active {
+      color: $brightblue;
+    }
+  }
+
+  .empty-state-diagram {
+    margin-top: 4rem;
+  }
+}
+</style>

--- a/packages/components/src/pages/VsCodeExtension.vue
+++ b/packages/components/src/pages/VsCodeExtension.vue
@@ -330,32 +330,7 @@
       </div>
     </div>
 
-    <div class="no-data-notice" v-if="isEmptyAppMap && !isLoading && !hasStats">
-      <div class="notice">
-        <p class="no-data-notice__title">Sorry, but there's no data to display :(</p>
-        <ul class="why-me">
-          <strong>Top 3 reasons why this appmap is empty:</strong>
-          <li>appmap.yml did not list packages/modules/folders of your application logic</li>
-          <li>
-            If this AppMap was recorded from a test, the test did not provide sufficient coverage
-            for good data
-          </li>
-          <li>
-            If other manual method was used to record this AppMap, the instrumented code objects
-            were not executed during the recording.
-          </li>
-        </ul>
-        <p class="no-data-notice__text">
-          Check our
-          <a href="https://appmap.io/docs" target="_blank" rel="noopener noreferrer">
-            documentation</a
-          >,<br />
-          or ask for help in
-          <a href="https://appmap.io/slack" target="_blank" rel="noopener noreferrer"> Slack</a>.
-        </p>
-      </div>
-      <DiagramGray class="empty-state-diagram" />
-    </div>
+    <v-no-data-notice v-if="isEmptyAppMap && !isLoading && !hasStats" />
   </div>
 </template>
 
@@ -399,6 +374,7 @@ import VStatsPanel from '../components/StatsPanel.vue';
 import VTabs from '../components/Tabs.vue';
 import VTab from '../components/Tab.vue';
 import VTraceFilter from '../components/trace/TraceFilter.vue';
+import VNoDataNotice from '../components/notices/NoDataNotice.vue';
 import toListItem from '@/lib/finding';
 import {
   store,
@@ -462,6 +438,7 @@ export default {
     ScissorsIcon,
     FullscreenEnterIcon,
     FullscreenExitIcon,
+    VNoDataNotice,
   },
   store,
   data() {
@@ -1819,62 +1796,6 @@ code {
     flex-direction: column;
     width: 100%;
     height: 100%;
-  }
-
-  .no-data-notice {
-    display: flex;
-    position: absolute;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    font-family: $appland-text-font-family;
-    line-height: 1.5;
-    color: $base03;
-    background-color: $vs-code-gray1;
-    z-index: 2147483647;
-    top: 0;
-    left: 0;
-    bottom: 0;
-    right: 0;
-
-    &__title,
-    &__text {
-      margin: 0;
-    }
-
-    &__title {
-      margin-bottom: 1rem;
-      font-size: 2rem;
-      font-weight: 700;
-      background: linear-gradient(to right, $royal, $hotpink);
-      -webkit-background-clip: text;
-      -webkit-text-fill-color: transparent;
-    }
-
-    &__text {
-      a {
-        color: $blue;
-        text-decoration: none;
-
-        &:hover,
-        &:active {
-          color: $lightblue;
-        }
-      }
-    }
-
-    .empty-state-diagram {
-      margin-top: 4rem;
-    }
-
-    .why-me {
-      padding: 1rem;
-      strong {
-        margin-left: -1rem;
-        color: $royal;
-        margin-bottom: 0.5rem;
-      }
-    }
   }
 }
 

--- a/packages/components/src/pages/VsCodeExtension.vue
+++ b/packages/components/src/pages/VsCodeExtension.vue
@@ -377,6 +377,7 @@ import VTab from '../components/Tab.vue';
 import VTraceFilter from '../components/trace/TraceFilter.vue';
 import VNoDataNotice from '../components/notices/NoDataNotice.vue';
 import VUnlicensedNotice from '../components/notices/UnlicensedNotice.vue';
+import EmitLinkMixin from '@/components/mixins/emitLink';
 import toListItem from '@/lib/finding';
 import {
   store,
@@ -471,6 +472,7 @@ export default {
       showDetailsPanel: false,
     };
   },
+  mixins: [EmitLinkMixin],
   props: {
     defaultView: {
       type: String,

--- a/packages/components/src/pages/VsCodeExtension.vue
+++ b/packages/components/src/pages/VsCodeExtension.vue
@@ -173,14 +173,19 @@
             </button>
           </v-popper>
           <v-popper
-            v-if="showDownload && !isGiantAppMap"
+            v-if="showDownload"
             class="hover-text-popper"
             text="Export in SVG format"
             placement="left"
             text-align="left"
           >
             <v-download-sequence-diagram ref="export">
-              <button class="control-button" @click="$refs.export.download()" title="">
+              <button
+                class="control-button"
+                @click="$refs.export.download()"
+                data-cy="export"
+                title=""
+              >
                 <ExportIcon class="control-button__icon" />
               </button>
             </v-download-sequence-diagram>
@@ -505,6 +510,10 @@ export default {
       type: Boolean,
       default: true,
     },
+    allowExport: {
+      type: Boolean,
+      default: true,
+    },
   },
   watch: {
     '$store.state.currentView': {
@@ -793,7 +802,7 @@ export default {
       return this.currentView === VIEW_FLAMEGRAPH;
     },
     showDownload() {
-      return this.isViewingSequence;
+      return this.isViewingSequence && !this.isGiantAppMap && this.allowExport;
     },
     isEmptyAppMap() {
       const appMap = this.filteredAppMap;

--- a/packages/components/src/pages/VsCodeExtension.vue
+++ b/packages/components/src/pages/VsCodeExtension.vue
@@ -331,6 +331,7 @@
     </div>
 
     <v-no-data-notice v-if="isEmptyAppMap && !isLoading && !hasStats && isLicensed" />
+    <v-configuration-required v-if="!isConfigured" />
     <v-unlicensed-notice v-if="!isLicensed" :purchase-url="purchaseUrl" />
   </div>
 </template>
@@ -377,6 +378,7 @@ import VTab from '../components/Tab.vue';
 import VTraceFilter from '../components/trace/TraceFilter.vue';
 import VNoDataNotice from '../components/notices/NoDataNotice.vue';
 import VUnlicensedNotice from '../components/notices/UnlicensedNotice.vue';
+import VConfigurationRequired from '../components/notices/ConfigurationRequiredNotice.vue';
 import EmitLinkMixin from '@/components/mixins/emitLink';
 import toListItem from '@/lib/finding';
 import {
@@ -443,6 +445,7 @@ export default {
     FullscreenExitIcon,
     VNoDataNotice,
     VUnlicensedNotice,
+    VConfigurationRequired,
   },
   store,
   data() {
@@ -497,6 +500,10 @@ export default {
     purchaseUrl: {
       type: String,
       required: false,
+    },
+    isConfigured: {
+      type: Boolean,
+      default: true,
     },
   },
   watch: {

--- a/packages/components/src/pages/VsCodeExtension.vue
+++ b/packages/components/src/pages/VsCodeExtension.vue
@@ -330,7 +330,8 @@
       </div>
     </div>
 
-    <v-no-data-notice v-if="isEmptyAppMap && !isLoading && !hasStats" />
+    <v-no-data-notice v-if="isEmptyAppMap && !isLoading && !hasStats && isLicensed" />
+    <v-unlicensed-notice v-if="!isLicensed" :purchase-url="purchaseUrl" />
   </div>
 </template>
 
@@ -375,6 +376,7 @@ import VTabs from '../components/Tabs.vue';
 import VTab from '../components/Tab.vue';
 import VTraceFilter from '../components/trace/TraceFilter.vue';
 import VNoDataNotice from '../components/notices/NoDataNotice.vue';
+import VUnlicensedNotice from '../components/notices/UnlicensedNotice.vue';
 import toListItem from '@/lib/finding';
 import {
   store,
@@ -439,6 +441,7 @@ export default {
     FullscreenEnterIcon,
     FullscreenExitIcon,
     VNoDataNotice,
+    VUnlicensedNotice,
   },
   store,
   data() {
@@ -484,6 +487,14 @@ export default {
     allowFullscreen: {
       type: Boolean,
       default: false,
+    },
+    isLicensed: {
+      type: Boolean,
+      default: true,
+    },
+    purchaseUrl: {
+      type: String,
+      required: false,
     },
   },
   watch: {

--- a/packages/components/src/stories/Notices.stories.js
+++ b/packages/components/src/stories/Notices.stories.js
@@ -1,5 +1,6 @@
 import VNoDataNotice from '@/components/notices/NoDataNotice.vue';
 import VUnlicensedNotice from '@/components/notices/UnlicensedNotice.vue';
+import VConfigurationRequiredNotice from '@/components/notices/ConfigurationRequiredNotice.vue';
 
 export default {
   title: 'AppLand/Notices',
@@ -20,3 +21,9 @@ export const Unlicensed = (args, { argTypes }) => ({
 Unlicensed.args = {
   purchaseUrl: 'https://appmap.io/pricing',
 };
+
+export const ConfigurationRequired = (args, { argTypes }) => ({
+  props: Object.keys(argTypes),
+  components: { VConfigurationRequiredNotice },
+  template: `<v-configuration-required-notice v-bind="$props" />`,
+});

--- a/packages/components/src/stories/Notices.stories.js
+++ b/packages/components/src/stories/Notices.stories.js
@@ -1,0 +1,22 @@
+import VNoDataNotice from '@/components/notices/NoDataNotice.vue';
+import VUnlicensedNotice from '@/components/notices/UnlicensedNotice.vue';
+
+export default {
+  title: 'AppLand/Notices',
+  argTypes: {},
+};
+
+export const NoData = (args, { argTypes }) => ({
+  props: Object.keys(argTypes),
+  components: { VNoDataNotice },
+  template: `<v-no-data-notice v-bind="$props" />`,
+});
+
+export const Unlicensed = (args, { argTypes }) => ({
+  props: Object.keys(argTypes),
+  components: { VUnlicensedNotice },
+  template: `<v-unlicensed-notice v-bind="$props" />`,
+});
+Unlicensed.args = {
+  purchaseUrl: 'https://appmap.io/pricing',
+};

--- a/packages/components/src/stories/VsCodeExtensionUnlicensed.stories.js
+++ b/packages/components/src/stories/VsCodeExtensionUnlicensed.stories.js
@@ -7,11 +7,12 @@ export default {
 
 // Controls cannot be set in the URL params until Storybook 6.2 (next release).
 // Until then, use this story for testing Java appmaps.
-export const ExtensionEmpty = (args, { argTypes }) => ({
+export const ExtensionUnlicensed = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
   components: { VExtension },
   template: '<v-extension v-bind="$props" ref="vsCode" />',
-  mounted() {
-    this.$refs.vsCode.loadData('{}');
-  },
 });
+ExtensionUnlicensed.args = {
+  isLicensed: false,
+  purchaseUrl: 'https://appmap.io/pricing',
+};

--- a/packages/components/tests/e2e/specs/appmap/empty.spec.js
+++ b/packages/components/tests/e2e/specs/appmap/empty.spec.js
@@ -1,11 +1,9 @@
 context('Empty AppMap', () => {
   beforeEach(() => {
-    cy.visit(
-      'http://localhost:6006/iframe.html?id=pages-vs-code-extension-empty--extension-empty&viewMode=story'
-    );
+    cy.visit('http://localhost:6006/iframe.html?id=pages-vs-code--extension-empty&viewMode=story');
   });
 
   it("shows 'empty' notice", () => {
-    cy.get('.no-data-notice').should('exist');
+    cy.get('[data-cy="notice-no-data"]').should('exist');
   });
 });

--- a/packages/components/tests/unit/VsCodeExtension.spec.js
+++ b/packages/components/tests/unit/VsCodeExtension.spec.js
@@ -239,4 +239,19 @@ describe('VsCodeExtension.vue', () => {
     await wrapper.setProps({ isConfigured: false });
     expect(wrapper.find('[data-cy="notice-configuration"]').exists()).toBe(true);
   });
+
+  it('provides a button to export the sequence diagram by default', async () => {
+    const state = { currentView: 'viewSequence' };
+    await wrapper.vm.setState(JSON.stringify(state));
+
+    expect(wrapper.find('[data-cy="export"]').exists()).toBe(true);
+  });
+
+  it('hides the export button when `allowExport` is false', async () => {
+    const state = { currentView: 'viewSequence' };
+    await wrapper.vm.setState(JSON.stringify(state));
+    await wrapper.setProps({ allowExport: false });
+
+    expect(wrapper.find('[data-cy="export"]').exists()).toBe(false);
+  });
 });

--- a/packages/components/tests/unit/VsCodeExtension.spec.js
+++ b/packages/components/tests/unit/VsCodeExtension.spec.js
@@ -229,4 +229,14 @@ describe('VsCodeExtension.vue', () => {
 
     wrapper.vm.clearSelection();
   });
+
+  it('renders the `unlicensed` notice when the user is unlicensed', async () => {
+    await wrapper.setProps({ isLicensed: false });
+    expect(wrapper.find('[data-cy="notice-unlicensed"]').exists()).toBe(true);
+  });
+
+  it('renders the `configuration required` notice when the user is unlicensed', async () => {
+    await wrapper.setProps({ isConfigured: false });
+    expect(wrapper.find('[data-cy="notice-configuration"]').exists()).toBe(true);
+  });
 });

--- a/packages/components/tests/unit/mixins/emitLink.spec.js
+++ b/packages/components/tests/unit/mixins/emitLink.spec.js
@@ -1,0 +1,20 @@
+import VVsCodeExtension from '@/pages/VsCodeExtension.vue';
+import { createWrapper, mount } from '@vue/test-utils';
+
+describe('UnlicensedNotice.vue', () => {
+  it('only binds click handlers once', () => {
+    // The VsCodeExtension component includes this Mixin, and so does
+    // the unlicensed notice. Meaning, the click handlers should attempt
+    // to bind twice, and we should only bind once.
+    const wrapper = mount(VVsCodeExtension, { propsData: { isLicensed: false } });
+    const rootWrapper = createWrapper(wrapper.vm.$root);
+
+    const allLinks = wrapper.findAll('a[href]');
+    allLinks.trigger('click');
+
+    const events = rootWrapper.emitted('click-link');
+
+    // If they'd been bound twice, we'd have twice as many events.
+    expect(events).toBeArrayOfSize(allLinks.length);
+  });
+});

--- a/packages/components/tests/unit/notices/ConfigurationRequiredNotice.spec.js
+++ b/packages/components/tests/unit/notices/ConfigurationRequiredNotice.spec.js
@@ -1,0 +1,22 @@
+import VConfigurationRequiredNotice from '@/components/notices/ConfigurationRequiredNotice.vue';
+import { createWrapper, mount } from '@vue/test-utils';
+
+describe('ConfigurationRequiredNotice.vue', () => {
+  it('emits a `clink-link` event when the user clicks any link', () => {
+    const wrapper = mount(VConfigurationRequiredNotice);
+    const rootWrapper = createWrapper(wrapper.vm.$root);
+
+    const allLinks = wrapper.findAll('a[href]');
+    allLinks.trigger('click');
+
+    const events = rootWrapper.emitted('click-link');
+    expect(events).toBeArrayOfSize(allLinks.length);
+
+    const links = events.map(([href]) => href);
+    expect(links).toEqual([
+      'https://appmap.io/slack',
+      'https://appmap.io/docs',
+      'mailto:support@appmap.io',
+    ]);
+  });
+});

--- a/packages/components/tests/unit/notices/UnlicensedNotice.spec.js
+++ b/packages/components/tests/unit/notices/UnlicensedNotice.spec.js
@@ -1,0 +1,9 @@
+import VUnlicensedNotice from '@/components/notices/UnlicensedNotice.vue';
+import { createWrapper, mount } from '@vue/test-utils';
+
+describe('UnlicensedNotice.vue', () => {
+  it('does not render a purchase button if the purchase URL is not provided', () => {
+    const wrapper = mount(VUnlicensedNotice);
+    expect(wrapper.find('[data-cy="purchase"]').exists()).toBe(false);
+  });
+});

--- a/packages/components/tests/unit/notices/UnlicensedNotice.spec.js
+++ b/packages/components/tests/unit/notices/UnlicensedNotice.spec.js
@@ -2,8 +2,38 @@ import VUnlicensedNotice from '@/components/notices/UnlicensedNotice.vue';
 import { createWrapper, mount } from '@vue/test-utils';
 
 describe('UnlicensedNotice.vue', () => {
+  it('emits a `clink-link` event when the user clicks the CTA', () => {
+    const purchaseUrl = 'https://example.com/purchase';
+    const wrapper = mount(VUnlicensedNotice, { propsData: { purchaseUrl } });
+    const rootWrapper = createWrapper(wrapper.vm.$root);
+
+    wrapper.find('[data-cy="purchase"]').trigger('click');
+
+    const events = rootWrapper.emitted('click-link');
+    expect(events).toBeArrayOfSize(1);
+    expect(events[0][0]).toBe(purchaseUrl);
+  });
+
   it('does not render a purchase button if the purchase URL is not provided', () => {
     const wrapper = mount(VUnlicensedNotice);
     expect(wrapper.find('[data-cy="purchase"]').exists()).toBe(false);
+  });
+
+  it('emits a `clink-link` event when the user clicks any link', () => {
+    const wrapper = mount(VUnlicensedNotice);
+    const rootWrapper = createWrapper(wrapper.vm.$root);
+
+    const allLinks = wrapper.findAll('a[href]');
+    allLinks.trigger('click');
+
+    const events = rootWrapper.emitted('click-link');
+    expect(events).toBeArrayOfSize(allLinks.length);
+
+    const links = events.map(([href]) => href);
+    expect(links).toEqual([
+      'https://appmap.io/slack',
+      'https://appmap.io/docs',
+      'mailto:support@appmap.io',
+    ]);
   });
 });

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -19,6 +19,6 @@
     },
     "lib": ["esnext", "dom", "dom.iterable", "scripthost"]
   },
-  "include": ["types/custom.d.ts", "src/**/*.ts", "src/**/*.tsx", "src/**/*.vue"],
+  "include": ["build/svg.d.ts", "src/**/*.ts", "src/**/*.tsx", "src/**/*.vue"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
This change adds the following two notices for use in Confluence. There's an additional change which emits link clicks as events so they can be passed through an API to (purposefully) circumvent CSP.

![image](https://github.com/getappmap/appmap-js/assets/8737782/7dbe9280-93be-4e21-9ecf-b0123e340da9)
![image](https://github.com/getappmap/appmap-js/assets/8737782/f7a5db41-d690-4e61-93b5-98de782b78b1)
