### PR TITLE
Fix lint warnings in @appland/components

### DIFF
--- a/packages/components/src/components/DiagramComponent.vue
+++ b/packages/components/src/components/DiagramComponent.vue
@@ -5,7 +5,7 @@
 <script>
 import { ComponentDiagram } from '@appland/diagrams';
 import { CodeObject, Event, ClassMap, CodeObjectType } from '@appland/models';
-import { CLEAR_SELECTION_STACK, SELECT_CODE_OBJECT } from '@/store/vsCode';
+import { SELECT_CODE_OBJECT } from '@/store/vsCode';
 
 export default {
   name: 'v-diagram-component',

--- a/packages/components/src/components/chat/Chat.vue
+++ b/packages/components/src/components/chat/Chat.vue
@@ -104,12 +104,6 @@ class ErrorMessage implements IMessage {
   }
 }
 
-type Suggestion = {
-  title: string;
-  subTitle: string;
-  prompt: string;
-};
-
 export default {
   name: 'v-chat',
   components: {

--- a/packages/components/src/pages/ChatSearch.vue
+++ b/packages/components/src/pages/ChatSearch.vue
@@ -95,7 +95,6 @@ import VChat from '@/components/chat/Chat.vue';
 import VAccordion from '@/components/Accordion.vue';
 import VAppMap from './VsCodeExtension.vue';
 import AppMapRPC from '@/lib/AppMapRPC';
-import _ from 'cypress/types/lodash';
 
 export default {
   name: 'v-chat-search',

--- a/packages/components/src/stories/Accordion.stories.js
+++ b/packages/components/src/stories/Accordion.stories.js
@@ -19,4 +19,4 @@ const Template = (args, { argTypes }) => ({
   `,
 });
 
-export const accordion = Template.bind({});
+export const Accordion = Template.bind({});

--- a/packages/components/src/stories/ChatSearch.stories.js
+++ b/packages/components/src/stories/ChatSearch.stories.js
@@ -10,20 +10,20 @@ export default {
   argTypes: {},
 };
 
-export const chatSearch = (args, { argTypes }) => ({
+export const ChatSearch = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
   components: { VChatSearch },
   template: `<v-chat-search v-bind="$props"></v-chat-search>`,
 });
-chatSearch.args = {};
+ChatSearch.args = {};
 
-export const chatSearchMock = (args, { argTypes }) => ({
+export const ChatSearchMock = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
   components: { VChatSearch },
   template: `<v-chat-search v-bind="$props"></v-chat-search>`,
 });
 
-export const chatSearchMockSearchPrepopulated = (args, { argTypes }) => ({
+export const ChatSearchMockSearchPrepopulated = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
   components: { VChatSearch },
   template: `<v-chat-search v-bind="$props"></v-chat-search>`,
@@ -133,11 +133,11 @@ const mockRpc = (method, params, callback) => {
   }
 };
 
-chatSearchMock.args = {
+ChatSearchMock.args = {
   appmapRpcFn: mockRpc,
 };
 
-chatSearchMockSearchPrepopulated.args = {
+ChatSearchMockSearchPrepopulated.args = {
   appmapRpcFn: mockRpc,
   question: 'How does password reset work?',
 };

--- a/packages/components/src/stories/CodeSnippet.stories.js
+++ b/packages/components/src/stories/CodeSnippet.stories.js
@@ -17,7 +17,7 @@ export default {
   },
 };
 
-export const codeSnippet = (args, { argTypes }) => ({
+export const CodeSnippet = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
   components: { VCodeSnippet },
   template: `<div style="transform: translate(-50%, -50%);left: 50%;top: 50%;position: absolute;">

--- a/packages/components/src/stories/DiagramComponent.stories.js
+++ b/packages/components/src/stories/DiagramComponent.stories.js
@@ -23,7 +23,7 @@ export default {
   },
 };
 
-export const component = (args, { argTypes }) => ({
+export const Component = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
   components: { VDiagramComponent },
   template: '<v-diagram-component v-bind="$props" />',

--- a/packages/components/src/stories/DiagramFlamegraph.stories.js
+++ b/packages/components/src/stories/DiagramFlamegraph.stories.js
@@ -23,7 +23,7 @@ export default {
   argTypes: {},
 };
 
-export const flamegraph = (args, { argTypes }) => ({
+export const Flamegraph = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
   components: { VDiagramFlamegraph },
   store,

--- a/packages/components/src/stories/Diff.stories.js
+++ b/packages/components/src/stories/Diff.stories.js
@@ -13,7 +13,7 @@ export default {
   },
 };
 
-export const diff = (args, { argTypes }) => ({
+export const Diff = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
   components: { VDiff },
   template: '<v-diff v-bind="$props" ref="vsCode" />',

--- a/packages/components/src/stories/FlashMessage.stories.js
+++ b/packages/components/src/stories/FlashMessage.stories.js
@@ -24,4 +24,4 @@ const Template = (args, { argTypes }) => ({
   template: `<v-flash-message v-bind="$props">{{ message }}</v-flash-message>`,
 });
 
-export const flashMessage = Template.bind({});
+export const FlashMessage = Template.bind({});

--- a/packages/components/src/stories/Notification.stories.js
+++ b/packages/components/src/stories/Notification.stories.js
@@ -10,7 +10,7 @@ export default {
   },
 };
 
-export const notification = (args, { argTypes }) => ({
+export const Notification = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
   components: { VNotification },
   template: '<v-notification v-bind="$props"/>',

--- a/packages/components/src/stories/Popper.stories.js
+++ b/packages/components/src/stories/Popper.stories.js
@@ -18,7 +18,7 @@ export default {
   },
 };
 
-export const popper = (args, { argTypes }) => ({
+export const Popper = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
   components: { VPopper },
   template:

--- a/packages/components/src/stories/SignIn.stories.js
+++ b/packages/components/src/stories/SignIn.stories.js
@@ -19,4 +19,4 @@ const Template = (args, { argTypes }) => ({
   template: '<v-sign-in v-bind="$props" ref="vsCode" />',
 });
 
-export const signIn = Template.bind({});
+export const SignIn = Template.bind({});

--- a/packages/components/src/stories/Slider.stories.js
+++ b/packages/components/src/stories/Slider.stories.js
@@ -19,4 +19,4 @@ const Template = (args, { argTypes }) => ({
   `,
 });
 
-export const slider = Template.bind({});
+export const Slider = Template.bind({});

--- a/packages/components/src/stories/Tabs.stories.js
+++ b/packages/components/src/stories/Tabs.stories.js
@@ -10,7 +10,7 @@ export default {
   },
 };
 
-export const tabs = (args, { argTypes }) => ({
+export const Tabs = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
   components: { VTabs, VTab },
   template: `

--- a/packages/components/src/stories/Trace.stories.js
+++ b/packages/components/src/stories/Trace.stories.js
@@ -25,7 +25,7 @@ export default {
   },
 };
 
-export const trace = (args, { argTypes }) => ({
+export const Trace = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
   components: { VDiagramTrace },
   template: `<v-diagram-trace v-bind="$props" @clickEvent="(e) => $store.commit('selectCodeObject', e)" />`,

--- a/packages/components/src/stories/TraceNode.stories.js
+++ b/packages/components/src/stories/TraceNode.stories.js
@@ -15,22 +15,22 @@ const Template = (args, { argTypes }) => ({
   template: `<v-trace-node v-bind="$props" />`,
 });
 
-export const eventDefault = Template.bind({});
-eventDefault.args = {
+export const EventDefault = Template.bind({});
+EventDefault.args = {
   event: appMap.events.find((e) => e.parameters && e.parameters.length > 2),
 };
 
-export const eventSql = Template.bind({});
-eventSql.args = {
+export const EventSql = Template.bind({});
+EventSql.args = {
   event: appMap.events.find((e) => e.sql),
 };
 
-export const eventHttp = Template.bind({});
-eventHttp.args = {
+export const EventHttp = Template.bind({});
+EventHttp.args = {
   event: appMap.events.find((e) => e.httpServerRequest),
 };
 
-export const eventHttpClientRequest = Template.bind({});
-eventHttpClientRequest.args = {
+export const EventHttpClientRequest = Template.bind({});
+EventHttpClientRequest.args = {
   event: appMap.events.find((e) => e.httpClientRequest),
 };

--- a/packages/components/src/stories/ViewFilterMenu.stories.js
+++ b/packages/components/src/stories/ViewFilterMenu.stories.js
@@ -27,5 +27,5 @@ const Template = (args, { argTypes }) => ({
   store,
 });
 
-export const filterMenu = Template.bind({});
-filterMenu.args = { filteredAppMap };
+export const FilterMenu = Template.bind({});
+FilterMenu.args = { filteredAppMap };

--- a/packages/components/src/stories/VsCodeExtension.stories.js
+++ b/packages/components/src/stories/VsCodeExtension.stories.js
@@ -77,27 +77,27 @@ const Template = (args, { argTypes }) => ({
   },
 });
 
-export const extension = Template.bind({});
+export const Extension = Template.bind({});
 
-export const extensionWithDefaultSequenceView = Template.bind({});
-extensionWithDefaultSequenceView.args = {
+export const ExtensionWithDefaultSequenceView = Template.bind({});
+ExtensionWithDefaultSequenceView.args = {
   defaultView: VIEW_SEQUENCE,
 };
 
-export const extensionWithSequenceDiff = Template.bind({});
-extensionWithSequenceDiff.args = {
+export const ExtensionWithSequenceDiff = Template.bind({});
+ExtensionWithSequenceDiff.args = {
   defaultView: VIEW_SEQUENCE,
   scenario: 'mapWithDiff',
   interactive: false,
 };
 
-export const extensionWithSavedFilters = Template.bind({});
-extensionWithSavedFilters.args = {
+export const ExtensionWithSavedFilters = Template.bind({});
+ExtensionWithSavedFilters.args = {
   defaultView: VIEW_SEQUENCE,
   savedFilters,
 };
 
-export const extensionWithNotification = (args, { argTypes }) => ({
+export const ExtensionWithNotification = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
   components: { VVsCodeExtension },
   template: '<v-vs-code-extension v-bind="$props" ref="vsCode" />',
@@ -113,7 +113,7 @@ export const extensionWithNotification = (args, { argTypes }) => ({
   },
 });
 
-export const extensionWithoutHTTP = (args, { argTypes }) => ({
+export const ExtensionWithoutHTTP = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
   components: { VVsCodeExtension },
   template: '<v-vs-code-extension v-bind="$props" ref="vsCode" />',
@@ -122,7 +122,7 @@ export const extensionWithoutHTTP = (args, { argTypes }) => ({
   },
 });
 
-export const extensionWithSlowLoad = (args, { argTypes }) => {
+export const ExtensionWithSlowLoad = (args, { argTypes }) => {
   return {
     props: Object.keys(argTypes),
     components: { VVsCodeExtension },
@@ -142,6 +142,6 @@ export const extensionWithSlowLoad = (args, { argTypes }) => {
   };
 };
 
-extensionWithSlowLoad.args = {
+ExtensionWithSlowLoad.args = {
   defaultView: VIEW_SEQUENCE,
 };

--- a/packages/components/src/stories/VsCodeExtensionEmpty.stories.js
+++ b/packages/components/src/stories/VsCodeExtensionEmpty.stories.js
@@ -7,7 +7,7 @@ export default {
 
 // Controls cannot be set in the URL params until Storybook 6.2 (next release).
 // Until then, use this story for testing Java appmaps.
-export const extensionEmpty = (args, { argTypes }) => ({
+export const ExtensionEmpty = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
   components: { VExtension },
   template: '<v-extension v-bind="$props" ref="vsCode" />',

--- a/packages/components/src/stories/VsCodeExtensionJava.stories.js
+++ b/packages/components/src/stories/VsCodeExtensionJava.stories.js
@@ -14,7 +14,7 @@ export default {
 
 // Controls cannot be set in the URL params until Storybook 6.2 (next release).
 // Until then, use this story for testing Java appmaps.
-export const extensionJava = (args, { argTypes }) => ({
+export const ExtensionJava = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
   components: { VExtension },
   template: '<v-extension v-bind="$props" ref="vsCode" />',

--- a/packages/components/src/stories/install-guide/InstallGuide.stories.js
+++ b/packages/components/src/stories/install-guide/InstallGuide.stories.js
@@ -16,6 +16,9 @@ export default {
   },
 };
 
+// We can't use InstallGuide here because that's the name of the Vue component,
+// so we'll just diable the eslint rule for this line.
+// eslint-disable-next-line storybook/prefer-pascal-case
 export const installGuide = (args, { argTypes }) => ({
   props: Object.keys(argTypes).filter((key) => key !== 'projects'),
   components: { InstallGuide },

--- a/packages/components/src/stories/install-guide/RecordAppMaps.stories.js
+++ b/packages/components/src/stories/install-guide/RecordAppMaps.stories.js
@@ -17,8 +17,8 @@ const Template = (args, { argTypes }) => ({
   template: '<v-record-app-maps v-bind="$props" :status-states="statusStates"/>',
 });
 
-export const railsRspec = Template.bind({});
-railsRspec.args = {
+export const RailsRspec = Template.bind({});
+RailsRspec.args = {
   project: {
     name: 'MyOtherProject',
     score: 3,
@@ -40,8 +40,8 @@ railsRspec.args = {
   complete: true,
 };
 
-export const railsOnly = Template.bind({});
-railsOnly.args = {
+export const RailsOnly = Template.bind({});
+RailsOnly.args = {
   project: {
     name: 'MyOtherProject',
     score: 3,
@@ -63,8 +63,8 @@ railsOnly.args = {
   complete: true,
 };
 
-export const rspecOnly = Template.bind({});
-rspecOnly.args = {
+export const RspecOnly = Template.bind({});
+RspecOnly.args = {
   project: {
     name: 'MyOtherProject',
     score: 3,
@@ -86,8 +86,8 @@ rspecOnly.args = {
   complete: true,
 };
 
-export const rubyOnly = Template.bind({});
-rubyOnly.args = {
+export const RubyOnly = Template.bind({});
+RubyOnly.args = {
   project: {
     name: 'MyOtherProject',
     score: 3,
@@ -101,8 +101,8 @@ rubyOnly.args = {
   complete: true,
 };
 
-export const vscodeJUnitSpring = Template.bind({});
-vscodeJUnitSpring.args = {
+export const VscodeJUnitSpring = Template.bind({});
+VscodeJUnitSpring.args = {
   project: {
     name: 'MyOtherProject',
     score: 3,
@@ -124,8 +124,8 @@ vscodeJUnitSpring.args = {
   complete: true,
 };
 
-export const intellijJUnitSpring = Template.bind({});
-intellijJUnitSpring.args = {
+export const IntellijJUnitSpring = Template.bind({});
+IntellijJUnitSpring.args = {
   project: {
     name: 'MyOtherProject',
     score: 3,
@@ -147,8 +147,8 @@ intellijJUnitSpring.args = {
   complete: true,
 };
 
-export const intellijJUnit = Template.bind({});
-intellijJUnit.args = {
+export const IntellijJUnit = Template.bind({});
+IntellijJUnit.args = {
   project: {
     name: 'MyOtherProject',
     score: 3,
@@ -166,8 +166,8 @@ intellijJUnit.args = {
   complete: true,
 };
 
-export const intellijSpring = Template.bind({});
-intellijSpring.args = {
+export const IntellijSpring = Template.bind({});
+IntellijSpring.args = {
   project: {
     name: 'MyOtherProject',
     score: 3,
@@ -185,8 +185,8 @@ intellijSpring.args = {
   complete: true,
 };
 
-export const flaskUnittest = Template.bind({});
-flaskUnittest.args = {
+export const FlaskUnittest = Template.bind({});
+FlaskUnittest.args = {
   project: {
     name: 'MyProject',
     score: 3,
@@ -207,8 +207,8 @@ flaskUnittest.args = {
   editor: 'vscode',
 };
 
-export const pythonOnly = Template.bind({});
-pythonOnly.args = {
+export const PythonOnly = Template.bind({});
+PythonOnly.args = {
   project: {
     name: 'MyProject',
     score: 3,
@@ -221,8 +221,8 @@ pythonOnly.args = {
   editor: 'vscode',
 };
 
-export const noWebOrTestFramework = Template.bind({});
-noWebOrTestFramework.args = {
+export const NoWebOrTestFramework = Template.bind({});
+NoWebOrTestFramework.args = {
   project: {
     name: 'MyOtherProject',
     score: 3,
@@ -244,8 +244,8 @@ noWebOrTestFramework.args = {
   complete: true,
 };
 
-export const unsupportedLanguage = Template.bind({});
-unsupportedLanguage.args = {
+export const UnsupportedLanguage = Template.bind({});
+UnsupportedLanguage.args = {
   project: {
     name: 'MyOtherProject',
     score: 3,

--- a/packages/components/src/stories/install-guide/Status.stories.js
+++ b/packages/components/src/stories/install-guide/Status.stories.js
@@ -50,4 +50,4 @@ const Template = (args, { argTypes }) => ({
   `,
 });
 
-export const installStatus = Template.bind({});
+export const InstallStatus = Template.bind({});


### PR DESCRIPTION
Linting in `@appland/components` is currently noisy and difficult to read, mostly because of the storybook rule `storybook/prefer-pascal-case`. This PR fixes the linting warnings:

```
/home/ahtrotta/projects/appmap/appmap-js/packages/components/src/components/DiagramComponent.vue
  8:10  warning  'CLEAR_SELECTION_STACK' is defined but never used  @typescript-eslint/no-unused-vars

/home/ahtrotta/projects/appmap/appmap-js/packages/components/src/components/chat/Chat.vue
  107:6  warning  'Suggestion' is defined but never used  @typescript-eslint/no-unused-vars

/home/ahtrotta/projects/appmap/appmap-js/packages/components/src/pages/ChatSearch.vue
  98:8  warning  '_' is defined but never used  @typescript-eslint/no-unused-vars

/home/ahtrotta/projects/appmap/appmap-js/packages/components/src/stories/Accordion.stories.js
  22:14  warning  The story should use PascalCase notation: accordion  storybook/prefer-pascal-case

/home/ahtrotta/projects/appmap/appmap-js/packages/components/src/stories/ChatSearch.stories.js
  13:14  warning  The story should use PascalCase notation: chatSearch                        storybook/prefer-pascal-case
  20:14  warning  The story should use PascalCase notation: chatSearchMock                    storybook/prefer-pascal-case
  26:14  warning  The story should use PascalCase notation: chatSearchMockSearchPrepopulated  storybook/prefer-pascal-case

/home/ahtrotta/projects/appmap/appmap-js/packages/components/src/stories/CodeSnippet.stories.js
  20:14  warning  The story should use PascalCase notation: codeSnippet  storybook/prefer-pascal-case

/home/ahtrotta/projects/appmap/appmap-js/packages/components/src/stories/DiagramComponent.stories.js
  26:14  warning  The story should use PascalCase notation: component  storybook/prefer-pascal-case

/home/ahtrotta/projects/appmap/appmap-js/packages/components/src/stories/DiagramFlamegraph.stories.js
  26:14  warning  The story should use PascalCase notation: flamegraph  storybook/prefer-pascal-case

/home/ahtrotta/projects/appmap/appmap-js/packages/components/src/stories/Diff.stories.js
  16:14  warning  The story should use PascalCase notation: diff  storybook/prefer-pascal-case

/home/ahtrotta/projects/appmap/appmap-js/packages/components/src/stories/FlashMessage.stories.js
  27:14  warning  The story should use PascalCase notation: flashMessage  storybook/prefer-pascal-case

/home/ahtrotta/projects/appmap/appmap-js/packages/components/src/stories/Notification.stories.js
  13:14  warning  The story should use PascalCase notation: notification  storybook/prefer-pascal-case

/home/ahtrotta/projects/appmap/appmap-js/packages/components/src/stories/Popper.stories.js
  21:14  warning  The story should use PascalCase notation: popper  storybook/prefer-pascal-case

/home/ahtrotta/projects/appmap/appmap-js/packages/components/src/stories/SignIn.stories.js
  22:14  warning  The story should use PascalCase notation: signIn  storybook/prefer-pascal-case

/home/ahtrotta/projects/appmap/appmap-js/packages/components/src/stories/Slider.stories.js
  22:14  warning  The story should use PascalCase notation: slider  storybook/prefer-pascal-case

/home/ahtrotta/projects/appmap/appmap-js/packages/components/src/stories/Tabs.stories.js
  13:14  warning  The story should use PascalCase notation: tabs  storybook/prefer-pascal-case

/home/ahtrotta/projects/appmap/appmap-js/packages/components/src/stories/Trace.stories.js
  28:14  warning  The story should use PascalCase notation: trace  storybook/prefer-pascal-case

/home/ahtrotta/projects/appmap/appmap-js/packages/components/src/stories/TraceNode.stories.js
  18:14  warning  The story should use PascalCase notation: eventDefault            storybook/prefer-pascal-case
  23:14  warning  The story should use PascalCase notation: eventSql                storybook/prefer-pascal-case
  28:14  warning  The story should use PascalCase notation: eventHttp               storybook/prefer-pascal-case
  33:14  warning  The story should use PascalCase notation: eventHttpClientRequest  storybook/prefer-pascal-case

/home/ahtrotta/projects/appmap/appmap-js/packages/components/src/stories/ViewFilterMenu.stories.js
  30:14  warning  The story should use PascalCase notation: filterMenu  storybook/prefer-pascal-case

/home/ahtrotta/projects/appmap/appmap-js/packages/components/src/stories/VsCodeExtension.stories.js
   80:14  warning  The story should use PascalCase notation: extension                         storybook/prefer-pascal-case
   82:14  warning  The story should use PascalCase notation: extensionWithDefaultSequenceView  storybook/prefer-pascal-case
   87:14  warning  The story should use PascalCase notation: extensionWithSequenceDiff         storybook/prefer-pascal-case
   94:14  warning  The story should use PascalCase notation: extensionWithSavedFilters         storybook/prefer-pascal-case
  100:14  warning  The story should use PascalCase notation: extensionWithNotification         storybook/prefer-pascal-case
  116:14  warning  The story should use PascalCase notation: extensionWithoutHTTP              storybook/prefer-pascal-case
  125:14  warning  The story should use PascalCase notation: extensionWithSlowLoad             storybook/prefer-pascal-case

/home/ahtrotta/projects/appmap/appmap-js/packages/components/src/stories/VsCodeExtensionEmpty.stories.js
  10:14  warning  The story should use PascalCase notation: extensionEmpty  storybook/prefer-pascal-case

/home/ahtrotta/projects/appmap/appmap-js/packages/components/src/stories/VsCodeExtensionJava.stories.js
  17:14  warning  The story should use PascalCase notation: extensionJava  storybook/prefer-pascal-case

/home/ahtrotta/projects/appmap/appmap-js/packages/components/src/stories/install-guide/InstallGuide.stories.js
  19:14  warning  The story should use PascalCase notation: installGuide  storybook/prefer-pascal-case

/home/ahtrotta/projects/appmap/appmap-js/packages/components/src/stories/install-guide/RecordAppMaps.stories.js
   20:14  warning  The story should use PascalCase notation: railsRspec            storybook/prefer-pascal-case
   43:14  warning  The story should use PascalCase notation: railsOnly             storybook/prefer-pascal-case
   66:14  warning  The story should use PascalCase notation: rspecOnly             storybook/prefer-pascal-case
   89:14  warning  The story should use PascalCase notation: rubyOnly              storybook/prefer-pascal-case
  104:14  warning  The story should use PascalCase notation: vscodeJUnitSpring     storybook/prefer-pascal-case
  127:14  warning  The story should use PascalCase notation: intellijJUnitSpring   storybook/prefer-pascal-case
  150:14  warning  The story should use PascalCase notation: intellijJUnit         storybook/prefer-pascal-case
  169:14  warning  The story should use PascalCase notation: intellijSpring        storybook/prefer-pascal-case
  188:14  warning  The story should use PascalCase notation: flaskUnittest         storybook/prefer-pascal-case
  210:14  warning  The story should use PascalCase notation: pythonOnly            storybook/prefer-pascal-case
  224:14  warning  The story should use PascalCase notation: noWebOrTestFramework  storybook/prefer-pascal-case
  247:14  warning  The story should use PascalCase notation: unsupportedLanguage   storybook/prefer-pascal-case

/home/ahtrotta/projects/appmap/appmap-js/packages/components/src/stories/install-guide/Status.stories.js
  53:14  warning  The story should use PascalCase notation: installStatus  storybook/prefer-pascal-case

✖ 46 problems (0 errors, 46 warnings)
```