### PR TITLE
Map controls are responsive to column width

### DIFF
--- a/packages/components/src/components/PopperMenu.vue
+++ b/packages/components/src/components/PopperMenu.vue
@@ -121,9 +121,10 @@ export default {
         max-height: inherit !important;
         width: inherit !important;
         height: inherit !important;
-        margin-top: 0 !important;
+        margin: 0 !important;
         border-radius: 0 !important;
         z-index: 1000;
+        transform: none !important;
       }
     }
 
@@ -143,6 +144,11 @@ export default {
 
     .popper--h-right & {
       left: 0;
+    }
+    .narrow & {
+      left: unset !important;
+      right: unset !important;
+      transform: translateX(-50%);
     }
 
     h2 {

--- a/packages/components/src/components/Tabs.vue
+++ b/packages/components/src/components/Tabs.vue
@@ -104,6 +104,10 @@ export default {
     padding-top: 0.4rem;
     z-index: 100;
     position: absolute;
+
+    @media (max-width: 900px) {
+      overflow: auto;
+    }
   }
 
   &__group {
@@ -136,32 +140,29 @@ export default {
   }
 }
 
-@media (max-width: 1100px) {
-  .tabs {
-    &__header {
-      flex-direction: column-reverse;
-      min-height: 70px;
-      padding-top: 0.5rem;
-      height: auto;
-      gap: 0.4rem;
-      justify-content: end;
-      overflow-y: hidden;
-    }
-    &__group {
-      align-self: center;
-      justify-content: center;
-    }
-    &__notification {
-      align-self: center;
-    }
-    &__content {
-      padding-top: 70px !important;
-    }
-    &__controls {
-      gap: 1rem;
-      position: fixed;
-      top: 0.5rem;
-    }
+.narrow {
+  .tabs__header {
+    flex-direction: column-reverse;
+    min-height: 70px;
+    padding-top: 0.5rem;
+    height: auto;
+    gap: 0.4rem;
+    justify-content: end;
+  }
+  .tabs__group {
+    align-self: center;
+    justify-content: center;
+  }
+  .tabs__notification {
+    align-self: center;
+  }
+  .tabs__content {
+    padding-top: 70px;
+  }
+  .tabs__controls {
+    gap: 1rem;
+    top: 0.5rem;
+    margin-bottom: 0.3rem;
   }
 }
 </style>

--- a/packages/components/src/pages/ChatSearch.vue
+++ b/packages/components/src/pages/ChatSearch.vue
@@ -358,7 +358,6 @@ $border-color: darken($gray4, 10%);
   .search-container {
     font-size: 1rem;
     color: $white;
-    // padding: 0 1rem 1rem 2rem;
     flex: 2;
     display: flex;
     flex-direction: column;

--- a/packages/components/src/pages/VsCodeExtension.vue
+++ b/packages/components/src/pages/VsCodeExtension.vue
@@ -10,7 +10,7 @@
     data-cy="app"
   >
     <div class="loader"></div>
-    <div :class="leftColumnClasses" ref="mainColumnLeft">
+    <div :class="leftColumnClasses" ref="mainColumnLeft" @transitionend="detailsPanelTransitionEnd">
       <transition name="slide-in-from-left">
         <v-details-panel
           v-if="showDetailsPanel"
@@ -48,8 +48,13 @@
       </div>
     </div>
 
-    <div class="main-column main-column--right">
-      <v-tabs @activateTab="onChangeTab" ref="tabs" :initial-tab="defaultView">
+    <div class="main-column main-column--right" ref="mainColumnRight">
+      <v-tabs
+        @activateTab="onChangeTab"
+        ref="tabs"
+        :initial-tab="defaultView"
+        :class="[isNarrow ? 'narrow' : '']"
+      >
         <v-search-bar
           v-if="!isGiantAppMap"
           ref="searchBar"
@@ -197,6 +202,7 @@
             v-if="!isPrecomputedSequenceDiagram && !isGiantAppMap"
             :isHighlight="filtersChanged"
             data-cy="filters-button"
+            :class="[isNarrow ? 'narrow' : '']"
           >
             <template v-slot:icon>
               <v-popper
@@ -445,6 +451,7 @@ export default {
       isActive: true,
       isFullscreen: false,
       showDetailsPanel: false,
+      rightColumnWidth: 0,
     };
   },
   mixins: [EmitLinkMixin],
@@ -567,7 +574,6 @@ export default {
     classes() {
       return this.isLoading ? 'app--loading' : '';
     },
-
     leftColumnClasses() {
       return {
         'main-column': true,
@@ -575,7 +581,6 @@ export default {
         'manual-resizing': this.isPanelResizing,
       };
     },
-
     isInBrowser() {
       return window.location.protocol.includes('http');
     },
@@ -807,8 +812,14 @@ export default {
     fullscreenIcon() {
       return this.isFullscreen ? FullscreenExitIcon : FullscreenEnterIcon;
     },
+    isNarrow() {
+      return Number.isFinite(this.rightColumnWidth) && this.rightColumnWidth < 685;
+    },
   },
   methods: {
+    detailsPanelTransitionEnd() {
+      this.rightColumnWidth = this.$refs.mainColumnRight.offsetWidth;
+    },
     loadData(appMap, sequenceDiagram) {
       if (sequenceDiagram) {
         this.sequenceDiagramDiffMode = true;
@@ -1131,6 +1142,7 @@ export default {
       }
     },
     stopResizing() {
+      this.rightColumnWidth = this.$refs.mainColumnRight.offsetWidth;
       document.body.style.userSelect = '';
       this.isPanelResizing = false;
     },
@@ -1340,6 +1352,7 @@ export default {
     browserPrefixes.forEach((prefix) => {
       this.$el.addEventListener(prefix + 'fullscreenchange', this.checkFullscreen);
     });
+    this.rightColumnWidth = this.$refs.mainColumnRight.offsetWidth;
   },
   beforeUpdate() {
     if (this.isGiantAppMap) {

--- a/packages/components/tests/e2e/specs/appmap/viewFilter.spec.js
+++ b/packages/components/tests/e2e/specs/appmap/viewFilter.spec.js
@@ -26,6 +26,7 @@ context('AppMap view filter', () => {
       cy.get('.nodes .node').should('have.length', 3);
       cy.get('.filters .filters__root .filters__root-icon').click();
       cy.get('.nodes .node').should('have.length', 9);
+      cy.get('.tabs__controls .popper__button').click();
 
       cy.get('.tabs .tab-btn').contains('Trace View').click();
       cy.get('.trace .trace-node').should('have.length', 4);

--- a/packages/components/tests/e2e/specs/chat/chatSearch.spec.js
+++ b/packages/components/tests/e2e/specs/chat/chatSearch.spec.js
@@ -70,4 +70,19 @@ context('Chat search', () => {
       timeout: 10000,
     }).should('not.exist');
   });
+
+  it('shows all toolbar icons', () => {
+    cy.get('[data-cy="chat-input"]', { timeout: 25000 }).type('Hello world{enter}');
+
+    // verify that the details panel is visible to ensure that the toolbar width is narrow
+    cy.get('.details-panel').should('be.visible');
+
+    // verify that the stats button, refresh button, and fullscreen button are visible
+    cy.get('.control-button')
+      .should('have.length', 3)
+      .each(($el) => cy.wrap($el).should('be.visible'));
+
+    // verify that the filters button is visible
+    cy.get('[data-cy="filters-button"]').should('be.visible');
+  });
 });


### PR DESCRIPTION
Fixes #1522 

This PR fixes the issue where the AppMap control buttons were being clipped in the Chat Search interface. Instead of using the width of the viewport for responsive styling, this PR uses the width of the AppMap view component.

## Before

![image](https://github.com/getappmap/appmap-js/assets/45714532/3871279d-5b00-4eb6-b310-c3e9448aef3f)

## After

![image](https://github.com/getappmap/appmap-js/assets/45714532/903914b9-3941-4ecd-bfe3-bfb92fca7f7a)
