### PR TITLE
Removed Scoped Style from the Run Config Icon

### DIFF
--- a/packages/components/src/components/install-guide/ProjectPickerRow.vue
+++ b/packages/components/src/components/install-guide/ProjectPickerRow.vue
@@ -456,6 +456,11 @@ export default {
 <style lang="scss" scoped>
 $brightblue: rgba(255, 255, 255, 0.1);
 
+.run-config-icon {
+  width: 22px;
+  transform: translateY(25%);
+}
+
 .page-control-wrap {
   display: flex;
   flex-direction: row;

--- a/packages/components/src/components/install-guide/record-instructions/IntelliJ.vue
+++ b/packages/components/src/components/install-guide/record-instructions/IntelliJ.vue
@@ -158,7 +158,7 @@ export default {
 };
 </script>
 
-<style>
+<style scoped>
 .run-config-icon {
   width: 22px;
   transform: translateY(25%);

--- a/packages/components/src/components/install-guide/record-instructions/IntelliJ.vue
+++ b/packages/components/src/components/install-guide/record-instructions/IntelliJ.vue
@@ -158,7 +158,7 @@ export default {
 };
 </script>
 
-<style scoped>
+<style>
 .run-config-icon {
   width: 22px;
   transform: translateY(25%);


### PR DESCRIPTION
We are starting to use scoped styles in our Vue components, but in the case of SVGs it doesn't work flawlessly. Consequently this line is causing the 'huge logo' problem...

<img width="288" alt="image" src="https://github.com/getappmap/appmap-js/assets/1229326/97eb2ded-cafc-4996-a184-3cfafe4aadc9">

As a fix I am removing the 'scoped' attribute, because it's not really needed. The run config icon should always be icon width. 

Before:

![image](https://github.com/getappmap/appmap-js/assets/1229326/52e1250f-b212-4df3-b294-5dd05dea2af5)


After:

![image](https://github.com/getappmap/appmap-js/assets/1229326/682e098e-1095-407d-beab-f200b76b5f17)

