### PR TITLE
feat: Export AppMap data as JSON

### DIFF
--- a/packages/components/src/components/ExportJSON.vue
+++ b/packages/components/src/components/ExportJSON.vue
@@ -2,8 +2,6 @@
   <div><slot /></div>
 </template>
 <script>
-import { serializeFilter } from '@appland/models';
-
 export default {
   name: 'v-export-json',
   props: {

--- a/packages/components/src/components/ExportJSON.vue
+++ b/packages/components/src/components/ExportJSON.vue
@@ -1,0 +1,34 @@
+<template>
+  <div><slot /></div>
+</template>
+<script>
+import { serializeFilter } from '@appland/models';
+
+export default {
+  name: 'v-export-json',
+  props: {
+    appMap: {
+      type: Object,
+      required: true,
+    },
+    viewState: {
+      type: Object,
+      required: true,
+    },
+  },
+  methods: {
+    download() {
+      const { appMap, viewState } = this;
+      if (!appMap) return;
+
+      // appMap.toJSON() includes other data that we don't want. It's more a dump of the internal
+      // state of the AppMap object.
+      const appmapData = JSON.parse(JSON.stringify(appMap));
+      if (viewState) {
+        appmapData.viewState = { ...viewState };
+      }
+      this.$root.$emit('exportJSON', appmapData);
+    },
+  },
+};
+</script>

--- a/packages/components/src/components/PopperMenu.vue
+++ b/packages/components/src/components/PopperMenu.vue
@@ -135,7 +135,7 @@ export default {
 
     .popper--v-bottom & {
       top: 100%;
-      margin-top: 1.5rem;
+      margin-top: 0.6rem;
     }
 
     .popper--h-left & {

--- a/packages/components/src/components/sequence/DownloadSequenceDiagram.vue
+++ b/packages/components/src/components/sequence/DownloadSequenceDiagram.vue
@@ -27,39 +27,31 @@ export default {
     },
 
     cleanUpDOM(node) {
-      [...node.querySelectorAll('.sequence-actor')].forEach(
-        (element) => (element.style.position = 'absolute')
-      );
+      node
+        .querySelectorAll('.sequence-actor')
+        .forEach((element) => (element.style.position = 'absolute'));
 
-      [
-        ...node
-          .querySelectorAll('.hide-container')
-          .forEach((element) => (element.style.display = 'none')),
-      ];
+      node
+        .querySelectorAll('.hide-container')
+        .forEach((element) => (element.style.display = 'none'));
 
-      [
-        ...node
-          .querySelectorAll('.collapse-expand')
-          .forEach((element) => (element.style.display = 'none')),
-      ];
+      node
+        .querySelectorAll('.collapse-expand')
+        .forEach((element) => (element.style.display = 'none'));
     },
 
     restoreDOM(node) {
-      [...node.querySelectorAll('.sequence-actor')].forEach(
-        (element) => (element.style.position = 'sticky')
-      );
+      node
+        .querySelectorAll('.sequence-actor')
+        .forEach((element) => (element.style.position = 'sticky'));
 
-      [
-        ...node
-          .querySelectorAll('.hide-container')
-          .forEach((element) => (element.style.display = 'inline-block')),
-      ];
+      node
+        .querySelectorAll('.hide-container')
+        .forEach((element) => (element.style.display = 'inline-block'));
 
-      [
-        ...node
-          .querySelectorAll('.collapse-expand')
-          .forEach((element) => (element.style.display = 'inline-block')),
-      ];
+      node
+        .querySelectorAll('.collapse-expand')
+        .forEach((element) => (element.style.display = 'inline-block'));
     },
   },
 };

--- a/packages/components/src/pages/VsCodeExtension.vue
+++ b/packages/components/src/pages/VsCodeExtension.vue
@@ -168,31 +168,57 @@
               </button>
             </div>
           </v-popper>
-          <v-popper-menu position="bottom right" data-cy="export-button">
+          <v-popper-menu v-if="showDownload" position="bottom left" data-cy="export-button">
             <template v-slot:icon>
-              <ExportIcon class="control-button__icon" />
+              <v-popper
+                class="hover-text-popper"
+                text="View export options"
+                placement="left"
+                text-align="left"
+              >
+                <ExportIcon class="control-button__icon" />
+              </v-popper>
             </template>
             <template v-slot:body>
               <div class="export-options">
-                <v-export-json :app-map="filteredAppMap" :view-state="viewState" ref="exportJSON">
-                  <a
-                    href="#"
-                    ref="exportJSON"
-                    @click="$refs.exportJSON.download()"
-                    data-cy="exportJSON"
-                    >Export JSON</a
-                  >
-                </v-export-json>
-                <v-download-sequence-diagram
-                  ref="exportSVG"
-                  v-if="showDownload"
-                  text="Export in SVG format"
-                >
-                  <a href="#" @click="$refs.exportSVG.download()" data-cy="exportSVG">Export SVG</a>
-                </v-download-sequence-diagram>
+                <div class="export-options__header">Export as...</div>
+                <div class="export-options__body">
+                  <v-export-json :app-map="filteredAppMap" :view-state="viewState" ref="exportJSON">
+                    <button
+                      ref="exportJSON"
+                      @click="$refs.exportJSON.download()"
+                      data-cy="exportJSON"
+                    >
+                      JSON
+                    </button>
+                  </v-export-json>
+                  <v-download-sequence-diagram ref="exportSVG" text="Export in SVG format">
+                    <button @click="$refs.exportSVG.download()" data-cy="exportSVG">SVG</button>
+                  </v-download-sequence-diagram>
+                </div>
               </div>
             </template>
           </v-popper-menu>
+          <v-popper
+            v-else
+            class="hover-text-popper"
+            text="Export as JSON"
+            placement="left"
+            text-align="left"
+            data-cy="export-button"
+          >
+            <v-export-json :app-map="filteredAppMap" :view-state="viewState" ref="exportJSON">
+              <button
+                class="control-button"
+                href="#"
+                ref="exportJSON"
+                @click="$refs.exportJSON.download()"
+                data-cy="exportJSON"
+              >
+                <ExportIcon class="control-button__icon" />
+              </button>
+            </v-export-json>
+          </v-popper>
           <v-popper
             v-if="hasStats"
             class="hover-text-popper hide-small"
@@ -230,7 +256,8 @@
                 :filteredAppMap="filteredAppMap"
                 :isInBrowser="isInBrowser"
                 @setState="(stateString) => setState(stateString)"
-              ></v-filter-menu>
+                class="filter"
+              />
             </template>
           </v-popper-menu>
           <v-popper class="hover-text-popper" text="Reload map" placement="left" text-align="left">
@@ -1596,15 +1623,35 @@ code {
     }
   }
 
-  .export-options a {
-    color: $white;
-    text-decoration: none;
-    font-weight: 700;
-    font-family: $appland-text-font-family;
-    font-size: 0.75rem;
-    transition: $transition;
-    &:hover {
-      color: $blue;
+  .export-options {
+    &__header {
+      padding-bottom: 0.2rem;
+      margin-bottom: 0.7rem;
+      border-bottom: 1px solid lighten($gray3, 15%);
+    }
+
+    &__body {
+      display: flex;
+      margin-bottom: 0.2rem;
+
+      button {
+        background: $light-purple;
+        color: $gray5;
+        text-decoration: none;
+        font-weight: 700;
+        font-family: $appland-text-font-family;
+        font-size: 0.75rem;
+        transition: $transition;
+        border-radius: 5px;
+        border: 0px;
+        margin: 5px;
+        padding: 10px;
+
+        &:hover {
+          background: $dark-purple;
+          cursor: pointer;
+        }
+      }
     }
   }
 

--- a/packages/components/tests/e2e/specs/appmap/export.spec.js
+++ b/packages/components/tests/e2e/specs/appmap/export.spec.js
@@ -1,0 +1,26 @@
+context('Export', () => {
+  context('from the dependency map view', () => {
+    beforeEach(() => {
+      cy.visit('http://localhost:6006/iframe.html?id=pages-vs-code--extension&viewMode=story');
+    });
+
+    it('shows the JSON option (only)', () => {
+      cy.get('[data-cy="export-button"] .popper__button').click();
+      cy.get('.popper__content').contains('Export JSON').should('exist');
+      cy.get('.popper__content').contains('Export SVG').should('not.exist');
+    });
+  });
+  context('from the sequence diagram view', () => {
+    beforeEach(() => {
+      cy.visit(
+        'http://localhost:6006/iframe.html?id=pages-vs-code--extension-with-default-sequence-view'
+      );
+    });
+
+    it('shows JSON and SVG options', () => {
+      cy.get('[data-cy="export-button"] .popper__button').click();
+      cy.get('.popper__content').contains('Export JSON').should('exist');
+      cy.get('.popper__content').contains('Export SVG').should('exist');
+    });
+  });
+});

--- a/packages/components/tests/e2e/specs/appmap/export.spec.js
+++ b/packages/components/tests/e2e/specs/appmap/export.spec.js
@@ -5,9 +5,7 @@ context('Export', () => {
     });
 
     it('shows the JSON option (only)', () => {
-      cy.get('[data-cy="export-button"] .popper__button').click();
-      cy.get('.popper__content').contains('Export JSON').should('exist');
-      cy.get('.popper__content').contains('Export SVG').should('not.exist');
+      cy.get('.popper[data-cy="export-button"]').should('exist');
     });
   });
   context('from the sequence diagram view', () => {
@@ -19,8 +17,8 @@ context('Export', () => {
 
     it('shows JSON and SVG options', () => {
       cy.get('[data-cy="export-button"] .popper__button').click();
-      cy.get('.popper__content').contains('Export JSON').should('exist');
-      cy.get('.popper__content').contains('Export SVG').should('exist');
+      cy.get('.popper__content').contains('JSON').should('exist');
+      cy.get('.popper__content').contains('SVG').should('exist');
     });
   });
 });

--- a/packages/components/tests/e2e/specs/appmap/sequenceDiagram.spec.js
+++ b/packages/components/tests/e2e/specs/appmap/sequenceDiagram.spec.js
@@ -15,7 +15,7 @@ context('AppMap sequence diagram', () => {
 
       cy.get('.sequence-actor[data-actor-id="package:openssl"]').should('not.exist');
 
-      cy.get('.tabs__controls .popper__button').click();
+      cy.get('.tabs__controls [data-cy="filters-button"]').click();
       cy.get('.filters .filters__hide-item').should('have.length', 1);
     });
 

--- a/packages/components/tests/e2e/specs/appmap/viewFilter.spec.js
+++ b/packages/components/tests/e2e/specs/appmap/viewFilter.spec.js
@@ -9,7 +9,7 @@ context('AppMap view filter', () => {
       cy.get('.details-panel-filters .details-panel-filters__item').first().click();
       cy.get('.nodes .node').should('have.length', 2);
 
-      cy.get('.tabs__controls .popper__button').click();
+      cy.get('.tabs__controls [data-cy="filters-button"]').click();
       cy.get('.filters .filters__root').should('have.length', 1);
 
       cy.get('.filters .filters__root .filters__root-icon').click();
@@ -26,20 +26,20 @@ context('AppMap view filter', () => {
       cy.get('.nodes .node').should('have.length', 3);
       cy.get('.filters .filters__root .filters__root-icon').click();
       cy.get('.nodes .node').should('have.length', 9);
-      cy.get('.tabs__controls .popper__button').click();
+      cy.get('.tabs__controls [data-cy="filters-button"]').click();
 
       cy.get('.tabs .tab-btn').contains('Trace View').click();
       cy.get('.trace .trace-node').should('have.length', 4);
-      cy.get('.tabs__controls .popper__button').click();
+      cy.get('.tabs__controls [data-cy="filters-button"]').click();
       cy.get('.filters__checkbox').first().click();
       cy.get('.filters__form-input').first().type('route:GET /admin/orders').parent().submit();
       cy.get('.trace .trace-node').should('have.length', 2);
       cy.get('.filters .filters__root .filters__root-icon').click();
 
-      cy.get('.tabs__controls .popper__button').click();
+      cy.get('.tabs__controls [data-cy="filters-button"]').click();
       cy.get('.tabs .tab-btn').first().click();
       cy.get('.nodes .node').should('have.length', 9);
-      cy.get('.tabs__controls .popper__button').click();
+      cy.get('.tabs__controls [data-cy="filters-button"]').click();
       cy.get('.filters__form-input').first().type('package:app/controllers').parent().submit();
       cy.get('.nodes .node').should('have.length', 3);
     });
@@ -47,7 +47,7 @@ context('AppMap view filter', () => {
     it('when child of package is set as root its children are filtered out', () => {
       cy.get('.nodes .node').should('have.length', 9);
 
-      cy.get('.tabs__controls .popper__button').click();
+      cy.get('.tabs__controls [data-cy="filters-button"]').click();
 
       cy.get('.filters__form-input')
         .first()
@@ -63,7 +63,7 @@ context('AppMap view filter', () => {
     });
 
     it('keyboard navigates through filter suggestions', () => {
-      cy.get('.tabs__controls .popper__button').click();
+      cy.get('.tabs__controls [data-cy="filters-button"]').click();
 
       cy.get('.filters__form-input').first().focus();
       cy.get('.filters__form-suggestions').should('be.visible');
@@ -90,7 +90,7 @@ context('AppMap view filter', () => {
 
       cy.get('.trace .trace-node').should('have.length', 4);
 
-      cy.get('.tabs__controls .popper__button').click();
+      cy.get('.tabs__controls [data-cy="filters-button"]').click();
       cy.get('.filters__checkbox').eq(0).click();
 
       cy.get('.trace .trace-node').should('have.length', 12);
@@ -101,7 +101,7 @@ context('AppMap view filter', () => {
 
       cy.get('.trace .trace-node').should('have.length', 4);
 
-      cy.get('.tabs__controls .popper__button').click();
+      cy.get('.tabs__controls [data-cy="filters-button"]').click();
       cy.get('.filters__checkbox').eq(1).click();
 
       cy.get('.trace .trace-node').should('have.length', 5);
@@ -112,7 +112,7 @@ context('AppMap view filter', () => {
 
       cy.get('.trace .trace-node').should('have.length', 4);
 
-      cy.get('.tabs__controls .popper__button').click();
+      cy.get('.tabs__controls [data-cy="filters-button"]').click();
 
       cy.get('.filters__elapsed input').type('00');
       cy.get('.filters__checkbox').eq(3).click();
@@ -128,7 +128,7 @@ context('AppMap view filter', () => {
 
       cy.get('.nodes .node').should('have.length', 8);
 
-      cy.get('.tabs__controls .popper__button').click();
+      cy.get('.tabs__controls [data-cy="filters-button"]').click();
       cy.get('.filters .filters__hide-item').should('have.length', 1);
 
       cy.get('.filters .filters__hide-item .filters__hide-item-icon').click();
@@ -139,13 +139,13 @@ context('AppMap view filter', () => {
       cy.get('.tabs .tab-btn').contains('Trace View').click();
       cy.get('.trace-node[data-event-id="1"]').click();
 
-      cy.get('.tabs__controls .popper__button').click();
+      cy.get('.tabs__controls [data-cy="filters-button"]').click();
       cy.get('.filters__checkbox').eq(0).click();
 
-      cy.get('.tabs__controls .popper__button').click();
+      cy.get('.tabs__controls [data-cy="filters-button"]').click();
       cy.get('.trace-node[data-event-id="1"].highlight').should('exist');
 
-      cy.get('.tabs__controls .popper__button').click();
+      cy.get('.tabs__controls [data-cy="filters-button"]').click();
       cy.get('.filters__checkbox').eq(0).click();
 
       cy.get('.trace-node[data-event-id="1"].highlight').should('exist');
@@ -171,7 +171,7 @@ context('AppMap view filter', () => {
         cy.wrap($el).should('contain.text', expectedInitial[index]);
       });
 
-      cy.get('.popper__button').click();
+      cy.get('.tabs__controls [data-cy="filters-button"]').click();
       cy.get('.filters__checkbox').eq(2).click();
       cy.get('.sequence-actor').should('have.length', 6);
 
@@ -200,7 +200,7 @@ context('AppMap view filter', () => {
     it('disables the delete and default buttons for AppMap default filter', () => {
       cy.get('.tabs .tab-btn').contains('Trace View').click();
       cy.get('.trace .trace-node').should('have.length', 4);
-      cy.get('.tabs__controls .popper__button').click();
+      cy.get('.tabs__controls [data-cy="filters-button"]').click();
 
       cy.get('.filters__select').find(':selected').should('contain.text', 'AppMap default');
       cy.get('.filters__button-disabled').first().should('contain.text', 'Load');
@@ -212,7 +212,7 @@ context('AppMap view filter', () => {
     it('enables all buttons for a non-default filter', () => {
       cy.get('.tabs .tab-btn').contains('Trace View').click();
       cy.get('.trace .trace-node').should('have.length', 4);
-      cy.get('.tabs__controls .popper__button').click();
+      cy.get('.tabs__controls [data-cy="filters-button"]').click();
 
       cy.get('.filters__select').select('filter');
       cy.get('.filters__select').find(':selected').should('contain.text', 'filter');
@@ -227,7 +227,7 @@ context('AppMap view filter', () => {
       cy.get('.tabs .tab-btn').first().click();
       cy.get('.nodes .node').should('have.length', 9);
 
-      cy.get('.tabs__controls .popper__button').click();
+      cy.get('.tabs__controls [data-cy="filters-button"]').click();
       cy.get('.filters__select').select('filter');
       cy.get('[data-cy="apply-filter-button"]').click();
       cy.get('.nodes .node').should('have.length', 5);
@@ -248,7 +248,7 @@ context('AppMap view filter', () => {
     it('disables the delete and default buttons for AppMap default filter', () => {
       cy.get('.tabs .tab-btn').contains('Trace View').click();
       cy.get('.trace .trace-node').should('have.length', 4);
-      cy.get('.tabs__controls .popper__button').click();
+      cy.get('.tabs__controls [data-cy="filters-button"]').click();
 
       cy.get('.filters__select').find(':selected').should('contain.text', 'AppMap default');
       cy.get('.filters__button-disabled').first().should('contain.text', 'Load');
@@ -258,7 +258,7 @@ context('AppMap view filter', () => {
     });
 
     it('saves a new filter and sets it as default', () => {
-      cy.get('.tabs__controls .popper__button').click();
+      cy.get('.tabs__controls [data-cy="filters-button"]').click();
       cy.get('.filters__select > option').should('have.length', 1);
 
       // save new filter
@@ -279,7 +279,7 @@ context('AppMap view filter', () => {
     });
 
     it('overwrites an existing filter with the same name', () => {
-      cy.get('.tabs__controls .popper__button').click();
+      cy.get('.tabs__controls [data-cy="filters-button"]').click();
 
       // save new filter
       cy.get('.filters__checkbox').eq(2).click();
@@ -303,7 +303,7 @@ context('AppMap view filter', () => {
     });
 
     it('"Limit root events to HTTP" filter is disabled', () => {
-      cy.get('.popper__button').click();
+      cy.get('.tabs__controls [data-cy="filters-button"]').click();
       cy.get('.filters__checkbox input[type="checkbox"]').first().should('not.be.checked');
     });
   });
@@ -316,7 +316,7 @@ context('AppMap view filter', () => {
     });
 
     it('does not show the hide external code checkbox', () => {
-      cy.get('.popper__button').click();
+      cy.get('.tabs__controls [data-cy="filters-button"]').click();
       cy.get('.filters__block-row-content').should('have.length', 7);
       cy.get('.filters__block-row-content').each(($el) =>
         cy.wrap($el).should('not.contain.text', 'Hide external code')

--- a/packages/components/tests/e2e/specs/chat/chatSearch.spec.js
+++ b/packages/components/tests/e2e/specs/chat/chatSearch.spec.js
@@ -77,9 +77,9 @@ context('Chat search', () => {
     // verify that the details panel is visible to ensure that the toolbar width is narrow
     cy.get('.details-panel').should('be.visible');
 
-    // verify that the stats button, refresh button, and fullscreen button are visible
+    // verify that the stats, refresh, export, and fullscreen buttons are visible
     cy.get('.control-button')
-      .should('have.length', 3)
+      .should('have.length', 4)
       .each(($el) => cy.wrap($el).should('be.visible'));
 
     // verify that the filters button is visible

--- a/packages/components/tests/unit/ExportJSON.spec.js
+++ b/packages/components/tests/unit/ExportJSON.spec.js
@@ -1,0 +1,52 @@
+import { createWrapper, mount } from '@vue/test-utils';
+import appMapData from './fixtures/user_page_scenario.appmap.json';
+import { AppMapFilter, buildAppMap, serializeFilter } from '@appland/models';
+
+import ExportJSON from '@/components/ExportJSON.vue';
+
+describe('ExportJSON.vue', () => {
+  const rubyFilter = new AppMapFilter();
+  rubyFilter.declutter.hideExternalPaths.on = true;
+
+  const defaultViewState = {
+    filters: serializeFilter(rubyFilter),
+  };
+
+  const WrapperComponent = {
+    components: { ExportJSON },
+    props: ['appMap', 'viewState'],
+    template: `
+    <ExportJSON ref="export" :appMap="appMap" :viewState="viewState">
+      <a>Export JSON</a>
+    </ExportJSON>
+  `,
+  };
+
+  it('exports JSON when clicked', async () => {
+    const appMap = buildAppMap().source(appMapData).build();
+    const filteredAppMap = rubyFilter.filter(appMap);
+    const wrapper = mount(WrapperComponent, {
+      propsData: { appMap: filteredAppMap, viewState: defaultViewState },
+    });
+    const rootWrapper = createWrapper(wrapper.vm.$root);
+
+    wrapper.vm.$refs.export.download();
+
+    const exportJSONEventParameters = rootWrapper.emitted()['exportJSON'];
+    expect(exportJSONEventParameters).toBeArrayOfSize(1);
+    const exportedData = exportJSONEventParameters[0][0];
+    expect(Object.keys(exportedData).sort()).toStrictEqual([
+      'classMap',
+      'events',
+      'metadata',
+      // 'version', TODO: version should be exported, but isn't somehow.
+      'viewState',
+    ]);
+
+    expect(exportedData.events.length).toEqual(22); // 36 without hideExternalPaths
+    expect(exportedData.viewState.filters.hideExternalPaths.sort()).toEqual([
+      'node_modules',
+      'vendor',
+    ]);
+  });
+});

--- a/packages/components/tests/unit/VsCodeExtension.spec.js
+++ b/packages/components/tests/unit/VsCodeExtension.spec.js
@@ -269,7 +269,6 @@ describe('VsCodeExtension.vue', () => {
     await wrapper.vm.setState(JSON.stringify(state));
     await wrapper.setProps({ allowExport: false });
 
-    await wrapper.find('[data-cy="export-button"] .popper__button').trigger('click');
     expect(wrapper.find('[data-cy="exportSVG"]').exists()).toBe(false);
   });
 
@@ -277,7 +276,7 @@ describe('VsCodeExtension.vue', () => {
     const state = { filters: { hideExternalPaths: ['node_modules', 'vendor'] } };
     await wrapper.vm.setState(JSON.stringify(state));
 
-    await wrapper.find('[data-cy="export-button"] .popper__button').trigger('click');
+    await wrapper.find('[data-cy="export-button"]').trigger('click');
     const exportJSON = wrapper.find('[data-cy="exportJSON"]');
     expect(exportJSON.exists()).toBe(true);
     await exportJSON.trigger('click');

--- a/packages/components/tests/unit/VsCodeExtension.spec.js
+++ b/packages/components/tests/unit/VsCodeExtension.spec.js
@@ -24,7 +24,7 @@ describe('VsCodeExtension.vue', () => {
     default: true,
   };
 
-  beforeEach(() => {
+  beforeEach(async () => {
     wrapper = mount(VsCodeExtension, {
       stubs: {
         'v-diagram-component': true,
@@ -37,7 +37,7 @@ describe('VsCodeExtension.vue', () => {
       },
     });
     rootWrapper = createWrapper(wrapper.vm.$root);
-    wrapper.vm.loadData(data);
+    await wrapper.vm.loadData(data);
     wrapper.vm.$store.commit(RESET_FILTERS);
   });
 
@@ -260,7 +260,8 @@ describe('VsCodeExtension.vue', () => {
     const state = { currentView: 'viewSequence' };
     await wrapper.vm.setState(JSON.stringify(state));
 
-    expect(wrapper.find('[data-cy="export"]').exists()).toBe(true);
+    await wrapper.find('[data-cy="export-button"] .popper__button').trigger('click');
+    expect(wrapper.find('[data-cy="exportSVG"]').exists()).toBe(true);
   });
 
   it('hides the export button when `allowExport` is false', async () => {
@@ -268,7 +269,36 @@ describe('VsCodeExtension.vue', () => {
     await wrapper.vm.setState(JSON.stringify(state));
     await wrapper.setProps({ allowExport: false });
 
-    expect(wrapper.find('[data-cy="export"]').exists()).toBe(false);
+    await wrapper.find('[data-cy="export-button"] .popper__button').trigger('click');
+    expect(wrapper.find('[data-cy="exportSVG"]').exists()).toBe(false);
+  });
+
+  it('can export the current AppMap data as JSON', async () => {
+    const state = { filters: { hideExternalPaths: ['node_modules', 'vendor'] } };
+    await wrapper.vm.setState(JSON.stringify(state));
+
+    await wrapper.find('[data-cy="export-button"] .popper__button').trigger('click');
+    const exportJSON = wrapper.find('[data-cy="exportJSON"]');
+    expect(exportJSON.exists()).toBe(true);
+    await exportJSON.trigger('click');
+
+    const exportJSONEventParameters = rootWrapper.emitted()['exportJSON'];
+    expect(exportJSONEventParameters).toBeArrayOfSize(1);
+    const exportedData = exportJSONEventParameters[0][0];
+
+    expect(Object.keys(exportedData).sort()).toStrictEqual([
+      'classMap',
+      'events',
+      'metadata',
+      // 'version', TODO: version should be exported, but isn't somehow.
+      'viewState',
+    ]);
+
+    expect(exportedData.events.length).toEqual(22); // 36 without hideExternalPaths
+    expect(exportedData.viewState.filters.hideExternalPaths.sort()).toEqual([
+      'node_modules',
+      'vendor',
+    ]);
   });
 
   describe('when in the browser', () => {


### PR DESCRIPTION
Add an Export option that's downloads the AppMap data with the view configuration (selected tab and filters) embedded. It also restores the view configuration when the AppMap data is loaded.

Note: The view filters are applied to the data before download, so if the AppMap is pruned, the pruned-out data will not be included in the download. This is intended to enable users to create much smaller data uploads than they would otherwise be able to, if they always had to upload the entire AppMap JSON.

<img width="238" alt="Screen Shot 2024-01-11 at 2 49 07 PM" src="https://github.com/getappmap/appmap-js/assets/86395/1ab5c6bd-bd5d-4181-87ed-04d32868cfb1">

https://www.loom.com/share/64b87bad09004ca0978a5f4cee8e070a

Fixes #1526 
Related https://github.com/getappmap/vscode-appland/pull/862
