### PR TITLE
Stop creating multiple default filters in the browser

### DIFF
--- a/packages/components/src/pages/VsCodeExtension.vue
+++ b/packages/components/src/pages/VsCodeExtension.vue
@@ -1208,7 +1208,7 @@ export default {
         }
       }
 
-      if (this.savedFilters.length === 0) {
+      if (savedFilters.length === 0) {
         const defaultFilter = new AppMapFilter();
         const serialized = serializeFilter(defaultFilter);
         const base64encoded = base64UrlEncode(JSON.stringify({ filters: serialized }));


### PR DESCRIPTION
Fixes #1435 

Currently, when opening an AppMap from an AppMap PR report ([like this one](https://getappmap.com/github_artifact?owner=getappmap&repo=appmap-server&run_id=7503869671&base_revision=1d9e16b1783841d0acc60ae8d4a3d163d9283775&head_revision=9361bb62e5ba31f98e375b6b5c3f7701709dd85f&path=head%2Frspec%2FTrialLicenseRequestsController_create_submits_the_new_email_form.appmap.json)) a new `AppMap default` filter will be added each time the page loads, so you can end up with a lot of them:

![Image](https://github.com/getappmap/appmap-js/assets/45714532/9019ef58-da28-4401-b4c1-4642468eeddb)

