### PR TITLE
feat: Add AppMaps context to Navie

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   pull_request:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/packages/components/build/vue.d.ts
+++ b/packages/components/build/vue.d.ts
@@ -1,0 +1,4 @@
+declare module '*.vue' {
+  import Vue from 'vue';
+  export default Vue;
+}

--- a/packages/components/src/components/chat-search/Instructions.vue
+++ b/packages/components/src/components/chat-search/Instructions.vue
@@ -1,0 +1,115 @@
+<template>
+  <div class="instructions">
+    <h2>Navie, the AppMap AI</h2>
+    <div>
+      <h3>How Navie Works</h3>
+      <p>
+        Each chat with Navie begins by analyzing your AppMaps. AppMaps are detailed recordings of
+        your code behavior that you create by running your app with the AppMap agent or language
+        library enabled. Naive uses the data in AppMaps (which includes dynamic information like
+        database queries and web requests) as well as snippets of your code, to provide tailored
+        responses and suggestions.
+      </p>
+      <p>
+        Navie reports how many AppMaps were reviewed and the number of relevant source files used
+        for each response. Accuracy improves as you create more diverse and up-to-date AppMaps. You
+        can accomplish this by regularly interacting with your application and recording traces.
+      </p>
+      <p>
+        <strong>Remember!</strong> The better your AppMaps match your question, the better Navie's
+        answers will be.
+      </p>
+    </div>
+    <div v-if="appmapStats">
+      <h3>Your AppMaps</h3>
+      <p v-if="appmapStats.numAppMaps">
+        You have <strong>{{ appmapStats.numAppMaps }}</strong> AppMaps in your workspace. These
+        AppMaps contain <strong>{{ appmapStats.packages.length }}</strong> packages and
+        <strong>{{ appmapStats.classes.length }}</strong> classes.
+        <span v-if="appmapStats.routes.length"
+          >Your AppMaps contain <strong>{{ appmapStats.routes.length }}</strong> HTTP server routes
+        </span>
+        <span v-if="appmapStats.tables.length">
+          <span v-if="appmapStats.routes.length">and </span>
+          <span v-else>Your AppMaps contain </span
+          ><strong>{{ appmapStats.tables.length }}</strong> SQL tables</span
+        >.
+      </p>
+      <div data-cy="no-appmaps" v-else>
+        <p>
+          ⚠️ You don't have any AppMaps in your workspace. Before you can use Navie, you'll need to
+          create some.
+        </p>
+        <p>
+          Navie uses AppMap diagrams, data, and snippets of your code code to understand your
+          software and make suggestions. Navie’s accuracy improves as you make more AppMaps.
+        </p>
+        <p>
+          Each recording method targets different scenarios and provides various levels of detail
+          and control. For detailed instructions, visit
+          <a
+            href="https://appmap.io/docs/setup-appmap-in-your-code-editor/how-appmap-works.html"
+            _target="blank"
+            >AppMap Documentation</a
+          >. Example methods include the following:
+        </p>
+        <dl>
+          <dt>Requests recording</dt>
+          <dd>
+            Records an AppMap for every HTTP server request handled by a web application. It's
+            interactive and generates AppMaps continuously.
+          </dd>
+          <dt>Test case recording</dt>
+          <dd>
+            Creates an AppMap for each test case in supported frameworks, naming files after test
+            cases.
+          </dd>
+          <dt>Remote recording</dt>
+          <dd>
+            Similar to requests recording but includes non-HTTP activities. It starts and stops via
+            HTTP commands to the AppMap agent.
+          </dd>
+          <dt>Code block recording</dt>
+          <dd>
+            Records a single AppMap for a code block. It's useful for recording a specific feature
+            or bug fix.
+          </dd>
+          <dt>Process recording</dt>
+          <dd>
+            Records all configured code activities from application start to shutdown. It's useful
+            for recording a specific feature or bug fix.
+          </dd>
+        </dl>
+      </div>
+    </div>
+  </div>
+</template>
+<script lang="ts">
+export default {
+  name: 'v-instructions',
+  props: {
+    appmapStats: {
+      type: Object,
+    },
+  },
+};
+</script>
+<style lang="scss" scoped>
+.instructions {
+  font-size: 0.9rem;
+  color: $white;
+
+  h2 {
+    font-size: 1;
+  }
+
+  h3 {
+    font-size: 0.9rem;
+  }
+
+  a {
+    color: $white;
+    text-decoration: underline;
+  }
+}
+</style>

--- a/packages/components/src/components/chat-search/MatchInstructions.vue
+++ b/packages/components/src/components/chat-search/MatchInstructions.vue
@@ -1,0 +1,44 @@
+<template>
+  <div class="instructions" data-cy="match-instructions">
+    <h2>AppMap search results</h2>
+    <div class="content">
+      <p>
+        Of the <strong>{{ appmapStats.numAppMaps }}</strong> AppMaps available in your project,
+        <strong>{{ searchResponse.results.length }}</strong> of them have been selected to help
+        answer your question. <strong>Remember!</strong> The better your AppMaps match your
+        question, the better Navie's answers will be.
+      </p>
+    </div>
+  </div>
+</template>
+<script lang="ts">
+export default {
+  name: 'v-instructions',
+  props: {
+    appmapStats: {
+      type: Object,
+      required: true,
+    },
+    searchResponse: {
+      type: Object,
+      required: true,
+    },
+  },
+};
+</script>
+<style lang="scss" scoped>
+.instructions {
+  font-size: 0.9rem;
+  color: $gray4;
+
+  h2 {
+    color: $white;
+    margin-bottom: 0;
+    margin-top: 0;
+  }
+
+  p {
+    margin: 0;
+  }
+}
+</style>

--- a/packages/components/src/components/chat-search/NoMatchInstructions.vue
+++ b/packages/components/src/components/chat-search/NoMatchInstructions.vue
@@ -1,0 +1,38 @@
+<template>
+  <div class="instructions" data-cy="no-match-instructions">
+    <div>
+      <h2>No relevant AppMaps found</h2>
+      <div class="content">
+        <p>
+          Of the <strong>{{ appmapStats.numAppMaps }}</strong> AppMaps available in your project,
+          <strong>None</strong> of them seem to be relevant enough to your question.
+        </p>
+        <p>
+          The best way to improve your search results is to record more AppMaps that are relevant to
+          the question you want to ask.
+        </p>
+      </div>
+    </div>
+  </div>
+</template>
+<script lang="ts">
+export default {
+  name: 'v-no-match-instructions',
+  props: {
+    appmapStats: {
+      type: Object,
+      required: true,
+    },
+  },
+};
+</script>
+<style lang="scss" scoped>
+.instructions {
+  font-size: 0.9rem;
+  color: $gray4;
+
+  h2 {
+    color: $white;
+  }
+}
+</style>

--- a/packages/components/src/components/chat/Chat.vue
+++ b/packages/components/src/components/chat/Chat.vue
@@ -25,6 +25,7 @@
         :id="message.messageId"
         :sentiment="message.sentiment"
         :tools="message.tools"
+        :complete="message.complete"
         @change-sentiment="onSentimentChange"
       />
       <v-suggestion-grid :suggestions="suggestions" @suggest="onSuggestion" v-if="!isChatting" />
@@ -59,8 +60,6 @@ import Vue from 'vue';
 import VUserMessage from '@/components/chat/UserMessage.vue';
 import VChatInput from '@/components/chat/ChatInput.vue';
 import VSuggestionGrid from '@/components/chat/SuggestionGrid.vue';
-import VSpinner from '@/components/Spinner.vue';
-import VLoaderIcon from '@/assets/eva_loader-outline.svg';
 import VAppMapNavieLogo from '@/assets/appmap-full-logo.svg';
 import VButton from '@/components/Button.vue';
 import { AI } from '@appland/client';
@@ -75,6 +74,7 @@ interface IMessage {
   message: string;
   isUser: boolean;
   isError: boolean;
+  complete?: boolean;
   messageId?: string;
   sentiment?: number;
   tools?: ITool[];
@@ -86,6 +86,7 @@ class UserMessage implements IMessage {
   public readonly isUser = true;
   public readonly isError = false;
   public readonly tools = undefined;
+  public readonly complete = true;
 
   constructor(public content: string) {}
 }
@@ -93,6 +94,7 @@ class UserMessage implements IMessage {
 class AssistantMessage implements IMessage {
   public content = '';
   public sentiment = undefined;
+  public complete = false;
   public readonly isUser = false;
   public readonly isError = false;
   public readonly tools = [];
@@ -107,6 +109,7 @@ class AssistantMessage implements IMessage {
 class ErrorMessage implements IMessage {
   public readonly messageId = undefined;
   public readonly sentiment = undefined;
+  public readonly complete = true;
   public readonly isUser = false;
   public readonly isError = true;
 
@@ -240,7 +243,8 @@ export default {
     onSuggestion(prompt: string) {
       if (this.suggestionSpeaker === 'system') {
         // Make it look like the AI is typing
-        const assistantMessage = new AssistantMessage('suggested-message');
+        const assistantMessage = new AssistantMessage();
+        assistantMessage.complete = true;
         assistantMessage.append(prompt);
         this.messages.push(assistantMessage);
       } else {

--- a/packages/components/src/components/chat/Chat.vue
+++ b/packages/components/src/components/chat/Chat.vue
@@ -64,9 +64,9 @@ import VAppMapNavieLogo from '@/assets/appmap-full-logo.svg';
 import VButton from '@/components/Button.vue';
 import { AI } from '@appland/client';
 
-interface ITool {
+export interface ITool {
   title: string;
-  status: string;
+  status?: string;
   complete?: boolean;
 }
 

--- a/packages/components/src/components/chat/Chat.vue
+++ b/packages/components/src/components/chat/Chat.vue
@@ -243,6 +243,11 @@ export default {
     onComplete() {
       this.resetStateVariables();
     },
+    onNoMatch() {
+      // If the AI was not able to produce a useful response, don't persist the thread.
+      // This is used by Explain when no AppMaps can be found to match the question.
+      this.threadId = undefined;
+    },
     clear() {
       this.threadId = undefined;
       this.messages.splice(0);

--- a/packages/components/src/components/chat/Loader.vue
+++ b/packages/components/src/components/chat/Loader.vue
@@ -1,0 +1,43 @@
+<template>
+  <div class="loader">
+    <div class="dot" />
+    <div class="dot" :style="{ 'animation-delay': '0.15s' }" />
+    <div class="dot" :style="{ 'animation-delay': '0.3s' }" />
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+
+export default Vue.extend({
+  name: 'v-loader',
+});
+</script>
+
+<style lang="scss" scoped>
+@keyframes loading {
+  0%,
+  100% {
+    transform: translateY(100%) scaleX(1.2);
+  }
+  50% {
+    transform: translateY(-100%) scaleY(1.1);
+  }
+}
+
+.loader {
+  display: flex;
+  align-items: center;
+  height: 100%;
+  width: 100%;
+  gap: 12%;
+
+  .dot {
+    aspect-ratio: 1 / 1;
+    width: 33%;
+    border-radius: 2em;
+    background-color: #7196f6;
+    animation: 1s infinite loading ease-in-out;
+  }
+}
+</style>

--- a/packages/components/src/components/chat/SuggestionGrid.vue
+++ b/packages/components/src/components/chat/SuggestionGrid.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="suggestion-grid" v-if="suggestions.length">
-    <p>Not sure? Here are some useful starting points:</p>
+    <p>Here are some useful starting points:</p>
     <div class="grid">
       <v-suggestion-card
         v-for="(s, i) in suggestions"

--- a/packages/components/src/components/chat/ToolStatus.vue
+++ b/packages/components/src/components/chat/ToolStatus.vue
@@ -1,0 +1,69 @@
+<template>
+  <div :class="{ 'tool-status': 1, 'tool-status--complete': complete }" data-cy="tool-status">
+    <v-check v-if="complete" class="tool-status__loader" />
+    <v-loader v-else class="tool-status__loader" />
+    <div class="tool-status__info">
+      <div class="tool-status__action" data-cy="title">{{ title }}</div>
+      <div class="tool-status__status" data-cy="status">{{ status }}</div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+import VLoader from '@/components/chat/Loader.vue';
+import VCheck from '@/assets/check.svg';
+
+export default Vue.extend({
+  name: 'v-tool-status',
+  components: {
+    VLoader,
+    VCheck,
+  },
+  props: {
+    title: String,
+    status: String,
+    complete: {
+      type: Boolean,
+      default: false,
+    },
+  },
+});
+</script>
+
+<style lang="scss" scoped>
+.tool-status {
+  display: grid;
+  grid-template-columns: 1.5rem 1fr;
+  flex-direction: column;
+  border: 1px solid #7289c5;
+  border-radius: $border-radius;
+  padding: 0.5rem;
+  width: fit-content;
+  color: #ececec;
+  align-items: stretch;
+
+  &__info {
+    grid-column: 2;
+    padding-left: 0.5rem;
+  }
+
+  &__action {
+    font-size: 0.8rem;
+    font-weight: 600;
+  }
+
+  &__status {
+    font-size: 0.75rem;
+  }
+
+  &__loader {
+    justify-self: center;
+    width: 75%;
+
+    path {
+      fill: #ececec;
+    }
+  }
+}
+</style>

--- a/packages/components/src/components/chat/UserMessage.vue
+++ b/packages/components/src/components/chat/UserMessage.vue
@@ -11,7 +11,18 @@
     </div>
     <div class="name">{{ name }}</div>
     <div class="message-body" data-cy="message-text" v-if="isUser">{{ message }}</div>
-    <div class="message-body" data-cy="message-text" v-else v-html="renderedMarkdown" />
+    <div class="message-body" data-cy="message-text" v-else>
+      <div class="tools" v-if="tools.length">
+        <v-tool-status
+          v-for="(tool, i) in tools"
+          :key="i"
+          :complete="tool.complete"
+          :title="tool.title"
+          :status="tool.status"
+        />
+      </div>
+      <div v-html="renderedMarkdown" />
+    </div>
     <div class="buttons">
       <span
         v-if="!isUser && id"
@@ -49,6 +60,7 @@ import VNavieCompass from '@/assets/compass-icon.svg';
 import VUserAvatar from '@/assets/user-avatar.svg';
 import VThumbIcon from '@/assets/thumb.svg';
 import VButton from '@/components/Button.vue';
+import VToolStatus from '@/components/chat/ToolStatus.vue';
 
 import { Marked, Renderer } from 'marked';
 import { markedHighlight } from 'marked-highlight';
@@ -95,6 +107,7 @@ export default {
     VUserAvatar,
     VThumbIcon,
     VButton,
+    VToolStatus,
   },
 
   props: {
@@ -112,6 +125,9 @@ export default {
     },
     sentiment: {
       default: 0,
+    },
+    tools: {
+      default: () => [],
     },
   },
 
@@ -333,6 +349,10 @@ export default {
     }
   }
 
+  .tools {
+    padding-bottom: 0.5rem;
+  }
+
   .md-code-snippet {
     margin: 1rem 0;
     border-radius: $border-radius;
@@ -416,11 +436,11 @@ export default {
     margin-block-end: 1em;
   }
 
-  & > p:first-child {
+  span > :first-child {
     margin-top: 0;
   }
 
-  & > p:last-child {
+  span > :last-child {
     margin-bottom: 0;
   }
 }

--- a/packages/components/src/components/chat/UserMessage.vue
+++ b/packages/components/src/components/chat/UserMessage.vue
@@ -162,7 +162,13 @@ export default {
           if (!nextNode) {
             const cursor = dom.ownerDocument.createElement('span');
             cursor.classList.add('cursor');
-            node?.parentElement?.appendChild(cursor);
+
+            let target = node?.parentElement;
+            if (!target && this.tools.every((t) => t.complete)) {
+              target = dom;
+            }
+
+            target?.appendChild(cursor);
             break;
           }
 

--- a/packages/components/src/lib/AppMapRPC.ts
+++ b/packages/components/src/lib/AppMapRPC.ts
@@ -85,6 +85,16 @@ export default class AppMapRPC {
     this.client = typeof portOrClient === 'number' ? browserClient(portOrClient) : portOrClient;
   }
 
+  appmapStats(): Promise<any> {
+    return new Promise((resolve, reject) => {
+      this.client.request('appmap.stats', {}, function (err: any, error: any, result: any) {
+        if (err || error) return reportError(reject, err, error);
+
+        resolve(result);
+      });
+    });
+  }
+
   appmapData(appmapId: string, filter: any): Promise<string> {
     return new Promise((resolve, reject) => {
       this.client.request(

--- a/packages/components/src/pages/ChatSearch.vue
+++ b/packages/components/src/pages/ChatSearch.vue
@@ -20,45 +20,46 @@
       data-cy="resize-handle"
       @mousedown="startResizing"
     ></div>
-    <div class="search-container">
-      <div class="search-results-container">
-        <div class="search-results-header">
-          <div>
-            <h2>AppMap search results</h2>
-            <div v-if="searchResponse">
-              <div class="search-results-subheader">
-                Showing top {{ searchResponse.results.length }} of
-                {{ searchResponse.numResults }}
-              </div>
+    <div class="search-container" v-if="searchResponse">
+      <template v-if="searchResponse.results.length">
+        <div class="search-results-container">
+          <div class="search-results-header">
+            <v-match-instructions :appmap-stats="appmapStats" :search-response="searchResponse" />
+            <div class="search-results-list-container">
+              <select
+                class="search-results-list"
+                v-model="selectedSearchResultId"
+                v-if="selectedSearchResultId"
+                data-cy="appmap-list"
+              >
+                <option
+                  v-for="result in searchResponse.results"
+                  :value="result.id"
+                  :key="result.id"
+                >
+                  {{ result.metadata.name || result.appmap }}
+                </option>
+              </select>
             </div>
-            <div class="search-results-subheader" v-else>
-              <p v-if="!searching">Start a conversation to find and explore AppMaps</p>
-              <p v-else>Searching...</p>
-            </div>
-          </div>
-          <div class="search-results-list-container" v-if="searchResponse">
-            <select
-              class="search-results-list"
-              v-model="selectedSearchResultId"
-              v-if="selectedSearchResultId"
-              data-cy="appmap-list"
-            >
-              <option v-for="result in searchResponse.results" :value="result.id" :key="result.id">
-                {{ result.metadata.name || result.appmap }}
-              </option>
-            </select>
           </div>
         </div>
-      </div>
-      <v-app-map
-        v-if="selectedSearchResult"
-        :allow-fullscreen="true"
-        :saved-filters="savedFilters"
-        ref="vappmap"
-        class="appmap"
-      >
-      </v-app-map>
-      <div v-else class="appmap-empty"></div>
+        <v-app-map
+          v-if="selectedSearchResult"
+          :allow-fullscreen="true"
+          :saved-filters="savedFilters"
+          ref="vappmap"
+          class="appmap"
+        >
+        </v-app-map>
+        <div v-else class="appmap-empty"></div>
+      </template>
+      <template v-else>
+        <v-no-match-instructions
+          class="no-match-instructions"
+          :appmap-stats="appmapStats"
+          v-if="appmapStats"
+        />
+      </template>
       <v-accordion
         v-if="enableDiagnostics"
         class="diagnostics"
@@ -97,6 +98,7 @@
         </ul>
       </v-accordion>
     </div>
+    <v-instructions v-else class="instructions" :appmap-stats="appmapStats" />
   </div>
 </template>
 
@@ -104,6 +106,9 @@
 //@ts-nocheck
 import VChat from '@/components/chat/Chat.vue';
 import VAccordion from '@/components/Accordion.vue';
+import VInstructions from '@/components/chat-search/Instructions.vue';
+import VMatchInstructions from '@/components/chat-search/MatchInstructions.vue';
+import VNoMatchInstructions from '@/components/chat-search/NoMatchInstructions.vue';
 import VAppMap from './VsCodeExtension.vue';
 import AppMapRPC from '@/lib/AppMapRPC';
 import authenticatedClient from '@/components/mixins/authenticatedClient';
@@ -114,6 +119,9 @@ export default {
     VChat,
     VAppMap,
     VAccordion,
+    VInstructions,
+    VMatchInstructions,
+    VNoMatchInstructions,
   },
   mixins: [authenticatedClient],
   props: {
@@ -148,6 +156,7 @@ export default {
       initialPanelWidth: 0,
       initialClientX: 0,
       searchStatusLabel: undefined,
+      appmapStats: undefined,
       searchStatusLabels: {
         'build-vector-terms': 'Optimizing search terms',
         'search-appmaps': 'Searching AppMaps',
@@ -176,8 +185,11 @@ export default {
         (result as any).metadata = metadata;
         resultId += 1;
       }
-      if (searchResponse.results.length > 0)
+      if (searchResponse.results.length > 0) {
         this.selectedSearchResultId = searchResponse.results[0].id;
+      } else {
+        this.$refs.vchat.onNoMatch();
+      }
     },
     selectedSearchResultId: async function (newVal) {
       const updateAppMapData = async () => {
@@ -238,8 +250,7 @@ export default {
       this.$store.commit(SET_SAVED_FILTERS, updatedFilters);
     },
     async sendMessage(message: string) {
-      const search = this.rpcClient();
-      this.ask = search.explain();
+      this.ask = this.rpcClient().explain();
       this.searching = true;
       this.lastStatusLabel = undefined;
 
@@ -267,14 +278,21 @@ export default {
         this.ask.on('error', onError);
         this.ask.on('status', (status) => {
           this.searchStatus = status;
-          if (!this.searchResponse && status.searchResponse)
+          if (!this.searchResponse && status.searchResponse) {
             this.searchResponse = status.searchResponse;
+          }
         });
         this.ask.on('complete', onComplete);
         this.ask.explain(message, this.$refs.vchat.threadId).catch(onError);
       });
     },
+    async loadAppMapStats() {
+      const rpc = this.rpcClient();
+      this.appmapStats = await rpc.appmapStats();
+    },
     clear() {
+      this.searching = false;
+      this.searchStatus = undefined;
       this.searchResponse = undefined;
       this.searchStatus = undefined;
       this.selectedSearchResultId = undefined;
@@ -282,6 +300,7 @@ export default {
       this.searchStatusLabel = undefined;
       this.ask?.removeAllListeners();
       this.searching = false;
+      this.loadAppMapStats();
     },
     toggleDiagonstics() {
       this.showDiagnostics = !this.showDiagnostics;
@@ -313,6 +332,9 @@ export default {
       document.body.style.userSelect = '';
       this.isPanelResizing = false;
     },
+  },
+  async mounted() {
+    this.loadAppMapStats();
   },
 };
 </script>
@@ -355,7 +377,9 @@ $border-color: darken($gray4, 10%);
       background: rgba(255, 255, 255, 0.1);
     }
   }
-  .search-container {
+
+  .search-container,
+  .context-container {
     font-size: 1rem;
     color: $white;
     flex: 2;
@@ -363,7 +387,14 @@ $border-color: darken($gray4, 10%);
     flex-direction: column;
     overflow-y: auto;
     background-color: $black;
+  }
 
+  .instructions {
+    padding: 0 1rem;
+    margin: 1rem auto;
+  }
+
+  .search-container {
     h2 {
       font-size: 1.2rem;
       margin-bottom: 0.4rem;
@@ -374,11 +405,6 @@ $border-color: darken($gray4, 10%);
       display: grid;
       grid-template-columns: 1fr auto;
       margin-bottom: 1rem;
-    }
-
-    .search-results-subheader {
-      font-size: 0.8rem;
-      color: $gray4;
     }
 
     .search-results-list-container {

--- a/packages/components/src/pages/ChatSearch.vue
+++ b/packages/components/src/pages/ChatSearch.vue
@@ -357,8 +357,8 @@ export default {
 $border-color: darken($gray4, 10%);
 
 .chat-search-container {
-  display: flex;
-  flex-direction: row;
+  display: grid;
+  grid-template-columns: auto auto auto;
   min-width: 100%;
   max-width: 100%;
   min-height: 100vh;
@@ -368,8 +368,8 @@ $border-color: darken($gray4, 10%);
 
   .chat-container {
     overflow: hidden;
-    width: 40%;
     min-width: 375px;
+    width: 40vw;
 
     background: radial-gradient(circle, lighten($gray2, 10%) 0%, rgba(0, 0, 0, 0) 80%);
     background-repeat: no-repeat, repeat, repeat;

--- a/packages/components/src/stories/ChatSearch.stories.js
+++ b/packages/components/src/stories/ChatSearch.stories.js
@@ -77,6 +77,7 @@ const DATA_KEYS = Object.keys(DATA_BY_PATH);
 let requestIndex = 0;
 let statusIndex = 0;
 const userMessageId = 'user-message-id';
+const systemMessageId = 'system-message-id';
 const threadId = 'thread-id';
 
 const NonEmptySearchResponse = {

--- a/packages/components/src/stories/ChatSearchInstructions.stories.js
+++ b/packages/components/src/stories/ChatSearchInstructions.stories.js
@@ -1,0 +1,33 @@
+import VInstructions from '@/components/chat-search/Instructions.vue';
+
+export default {
+  title: 'Pages/ChatSearch/Instructions',
+  component: VInstructions,
+  argTypes: {},
+};
+
+const Template = (args, { argTypes }) => ({
+  props: Object.keys(argTypes),
+  components: { VInstructions },
+  template: `<div style="background-color: #262C40; padding: 1rem; font-family: system-ui;"><v-instructions v-bind="$props"></v-instructions></div>`,
+});
+
+export const InstructionsBeforeAppMapStats = Template.bind({});
+
+const appmapStats = {
+  packages: ['app/controllers', 'app/helpers', 'app/models'],
+  classes: ['User', 'UsersController', 'SessionsController'],
+  routes: ['GET /users', 'GET /users/:id', 'GET /signup', 'POST /signup'],
+  tables: ['users', 'microposts'],
+  numAppMaps: 100,
+};
+
+export const Instructions = Template.bind({});
+Instructions.args = {
+  appmapStats,
+};
+
+export const InstructionsNoAppMaps = Template.bind({});
+InstructionsNoAppMaps.args = {
+  appmapStats: { numAppMaps: 0 },
+};

--- a/packages/components/src/stories/ChatSearchNoMatchInstructions.stories.js
+++ b/packages/components/src/stories/ChatSearchNoMatchInstructions.stories.js
@@ -1,0 +1,22 @@
+import VNoMatchInstructions from '@/components/chat-search/NoMatchInstructions.vue';
+
+export default {
+  title: 'Pages/ChatSearch/NoMatchInstructions',
+  component: VNoMatchInstructions,
+  argTypes: {},
+};
+
+const appmapStats = {
+  numAppMaps: 100,
+};
+
+const Template = (args, { argTypes }) => ({
+  props: Object.keys(argTypes),
+  components: { VNoMatchInstructions },
+  template: `<div style="background-color: #262C40; padding: 1rem; font-family: system-ui;"><v-no-match-instructions v-bind="$props"></v-no-match-instructions></div>`,
+});
+
+export const NoMatchInstructions = Template.bind({});
+NoMatchInstructions.args = {
+  appmapStats,
+};

--- a/packages/components/src/stories/ChatTools.stories.js
+++ b/packages/components/src/stories/ChatTools.stories.js
@@ -1,0 +1,19 @@
+import VToolStatus from '@/components/chat/ToolStatus.vue';
+import './scss/vscode.scss';
+
+export default {
+  title: 'Pages/Chat/Tools',
+  component: VToolStatus,
+  argTypes: {},
+};
+
+export const Search = (args, { argTypes }) => ({
+  props: Object.keys(argTypes),
+  components: { VToolStatus },
+  template: `<v-tool-status v-bind="$props" />`,
+});
+Search.args = {
+  title: 'Searched for AppMaps',
+  status: 'Found 3 relevant recordings',
+  complete: true,
+};

--- a/packages/components/tests/e2e/specs/appmap/sequenceDiagramDiff.spec.js
+++ b/packages/components/tests/e2e/specs/appmap/sequenceDiagramDiff.spec.js
@@ -14,6 +14,8 @@ context('Sequence Diagram', () => {
 
   it('sidebar buttons are disabled', () => {
     cy.get('.event-name').contains('gravatar_for').click();
+    cy.get('div[data-event-ids="538"] .self-call').scrollIntoView();
+    cy.get('div[data-event-ids="538"] .self-call .name').click();
     cy.get('.details-panel-header__ghost-link .details-btn').each(($btn) => {
       // For each button, check if it has the attribute 'disabled'
       cy.wrap($btn).should('have.attr', 'disabled');

--- a/packages/components/tests/e2e/specs/chat/chatSearch.spec.js
+++ b/packages/components/tests/e2e/specs/chat/chatSearch.spec.js
@@ -13,8 +13,7 @@ context('Chat search', () => {
         delay: 0,
       })
       .get('[data-cy="explain-status"]', { timeout: 1000 })
-      .should('be.visible')
-      .should('contain.text', 'Optimizing search terms...');
+      .should('be.visible');
 
     cy.get('[data-cy="explain-status"]', { timeout: 1000 }).should(
       'contain.text',

--- a/packages/components/tests/e2e/specs/chat/chatSearch.spec.js
+++ b/packages/components/tests/e2e/specs/chat/chatSearch.spec.js
@@ -6,26 +6,6 @@ context('Chat search', () => {
     cy.viewport(1280, 720);
   });
 
-  it('renders the current state', () => {
-    cy.get('[data-cy="chat-input"]', { timeout: 25000 })
-      .type('Hello world{enter}', {
-        waitForAnimations: false,
-        delay: 0,
-      })
-      .get('[data-cy="explain-status"]', { timeout: 1000 })
-      .should('be.visible');
-
-    cy.get('[data-cy="explain-status"]', { timeout: 1000 }).should(
-      'contain.text',
-      'Explaining with AI...'
-    );
-
-    cy.get('[data-actor="system"] [data-cy="message-text"]').should(
-      'contain.text',
-      'Based on the code snippets provided'
-    );
-  });
-
   it('switches AppMaps', () => {
     cy.get('[data-cy="chat-input"]', { timeout: 25000 }).type('Hello world{enter}');
 

--- a/packages/components/tests/unit/chat/ChatComponent.spec.js
+++ b/packages/components/tests/unit/chat/ChatComponent.spec.js
@@ -121,7 +121,6 @@ describe('components/Chat.vue', () => {
       wrapper.vm.addToken('Hello from the system', threadId, messageId);
       await wrapper.vm.$nextTick();
 
-      expect(wrapper.vm.loading).toBe(true);
       expect(wrapper.find('[data-actor="user"] [data-cy="message-text"]').exists()).toBe(true);
       expect(wrapper.find('[data-actor="system"] [data-cy="message-text"]').exists()).toBe(true);
 
@@ -136,11 +135,6 @@ describe('components/Chat.vue', () => {
 
     it('clears the thread id', async () => {
       expect(wrapper.vm.threadId).toBeUndefined();
-    });
-
-    it('hides the progress indicator', () => {
-      expect(wrapper.vm.loading).toBe(false);
-      expect(wrapper.find('[data-cy="status-container"]').exists()).toBe(false);
     });
 
     it('ignores subsequent messages on the old thread-id', async () => {

--- a/packages/components/tests/unit/chat/ChatSearch.spec.js
+++ b/packages/components/tests/unit/chat/ChatSearch.spec.js
@@ -159,6 +159,18 @@ describe('pages/ChatSearch.vue', () => {
         expect(wrapper.find('[data-cy="match-instructions"]').exists()).toBe(true);
         expect(wrapper.find('[data-cy="no-match-instructions"]').exists()).toBe(false);
       });
+
+      it('only renders the search status once', async () => {
+        const { wrapper } = await performSearch();
+
+        expect(wrapper.findAll('[data-cy="tool-status"]').length).toBe(1);
+
+        wrapper.vm.sendMessage('How do I reset my password?');
+        await wrapper.vm.$nextTick();
+
+        console.log(wrapper.html());
+        expect(wrapper.findAll('[data-cy="tool-status"]').length).toBe(1);
+      });
     });
 
     describe('but no AppMaps match the question', () => {

--- a/packages/components/tests/unit/chat/authentication.spec.js
+++ b/packages/components/tests/unit/chat/authentication.spec.js
@@ -25,7 +25,7 @@ describe('Authentication', () => {
   });
 
   it('authenticates ChatSearch', async () => {
-    const wrapper = mount(VChatSearch, { propsData: { apiKey, apiUrl } });
+    const wrapper = mount(VChatSearch, { propsData: { apiKey, apiUrl, appmapRpcFn: () => true } });
     await wrapper.vm.$nextTick();
     expect(loadConfiguration()).toStrictEqual({
       apiKey,

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -19,6 +19,6 @@
     },
     "lib": ["esnext", "dom", "dom.iterable", "scripthost"]
   },
-  "include": ["build/svg.d.ts", "src/**/*.ts", "src/**/*.tsx", "src/**/*.vue"],
+  "include": ["build/svg.d.ts", "build/vue.d.ts", "src/**/*.ts", "src/**/*.tsx", "src/**/*.vue"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
Builds on https://github.com/getappmap/appmap-js/pull/1551 , adding Components changes (only).

Shows stats about the available AppMaps, plus "how it works" and some tips.

<img width="1287" alt="Screen Shot 2024-01-19 at 10 01 12 AM" src="https://github.com/getappmap/appmap-js/assets/86395/6573be41-0043-4be6-bfda-819520da971f">

If no maps are found, the user sees something like this:

<img width="1030" alt="Screen Shot 2024-01-18 at 2 18 15 PM" src="https://github.com/getappmap/appmap-js/assets/86395/ab9ae8f5-dcb7-4119-a1ed-d28c10cd32bd">

If maps are found, a bit of information is shown about that:

<img width="770" alt="Screen Shot 2024-01-19 at 10 01 47 AM" src="https://github.com/getappmap/appmap-js/assets/86395/d840a0ae-6aa7-4cd0-95da-3deb482918d9">

## TODO

- [x] Skip the Explain step if no AppMaps match the user's question. This should be done automatically by the backend in api-services.
- [x] What should happen if the Workspace contains no AppMaps? For current behavior, see http://localhost:6006/?path=/story/pages-chatsearch-instructions--instructions-no-app-maps
- [x] If no AppMaps match the question, reset the thread id to begin a new session. This will ensure that the user's next question will re-search the AppMaps.

Fixes #1548 