### PR TITLE
feat: appmap.stats RPC

### DIFF
--- a/appmap.yml
+++ b/appmap.yml
@@ -1,2 +1,0 @@
-name: appmap-js
-appmap_dir: dummy

--- a/packages/cli/appmap.yml
+++ b/packages/cli/appmap.yml
@@ -1,15 +1,7 @@
 name: '@appland/appmap'
-language: javascript
 appmap_dir: tmp/appmap
-ordering: chronological
-command: yarn exec jest -t ^(?!.*@appmap-fixme) --filter=./tests/testFilter.js
-recorder: jest
-exclude:
-  - \[anonymous\]
 packages:
-  - regexp: (^|/)node_modules/
-    enabled: false
-  - regexp: ^../
-    enabled: false
-  - regexp: ^
-    enabled: true
+  - path: .
+    exclude:
+      - node_modules
+      - .yarn

--- a/packages/cli/src/cmds/index/index.ts
+++ b/packages/cli/src/cmds/index/index.ts
@@ -17,6 +17,7 @@ import { explainHandler, explainStatusHandler } from '../../rpc/explain/explain'
 import RPCServer from './rpcServer';
 import appmapData from '../../rpc/appmap/data';
 import { loadConfiguration } from '@appland/client';
+import appmapStats from '../../rpc/appmap/stats';
 
 export const command = 'index';
 export const describe =
@@ -73,6 +74,7 @@ export const handler = async (argv) => {
       const rpcMethods: RpcHandler<any, any>[] = [
         numProcessed(cmd),
         search(appmapDir),
+        appmapStats(appmapDir),
         appmapFilter(),
         appmapData(),
         metadata(),

--- a/packages/cli/src/rpc/appmap/filter.ts
+++ b/packages/cli/src/rpc/appmap/filter.ts
@@ -22,6 +22,7 @@ export async function appmapFilterHandler(
 
   return filter.filter(appmap, []) as unknown as Record<string, unknown>;
 }
+
 export default function appmapFilter(): RpcHandler<
   AppMapRpc.FilterOptions,
   AppMapRpc.FilterResponse

--- a/packages/cli/src/rpc/appmap/stats.ts
+++ b/packages/cli/src/rpc/appmap/stats.ts
@@ -1,0 +1,44 @@
+import { AppMapRpc } from '@appland/rpc';
+import { RpcHandler } from '../rpc';
+import { processNamedFiles } from '../../utils';
+import { readFile } from 'fs/promises';
+
+export async function appmapStatsHandler(appmapDir: string): Promise<AppMapRpc.StatsResponse> {
+  const packages = new Set<string>();
+  const classes = new Set<string>();
+  const routes = new Set<string>();
+  const tables = new Set<string>();
+
+  const collectStrings = (values: Set<string>): ((file: string) => Promise<void>) => {
+    return async (file: string): Promise<void> => {
+      for (const value of JSON.parse(await readFile(file, 'utf-8'))) values.add(value);
+    };
+  };
+
+  await processNamedFiles(appmapDir, 'canonical.packages.json', collectStrings(packages));
+  await processNamedFiles(appmapDir, 'canonical.classes.json', collectStrings(classes));
+  await processNamedFiles(
+    appmapDir,
+    'canonical.httpServerRequests.json',
+    async (file: string): Promise<void> => {
+      for (const value of JSON.parse(await readFile(file, 'utf-8'))) routes.add(value.route);
+    }
+  );
+  await processNamedFiles(appmapDir, 'canonical.sqlTables.json', collectStrings(tables));
+  let numAppMaps = 0;
+  await processNamedFiles(appmapDir, 'metadata.json', async () => numAppMaps++);
+
+  return {
+    packages: Array.from(packages).sort(),
+    classes: Array.from(classes).sort(),
+    routes: Array.from(routes).sort(),
+    tables: Array.from(tables).sort(),
+    numAppMaps,
+  };
+}
+
+export default function appmapStats(
+  appmapDir: string
+): RpcHandler<AppMapRpc.StatsOptions, AppMapRpc.StatsResponse> {
+  return { name: AppMapRpc.StatsFunctionName, handler: () => appmapStatsHandler(appmapDir) };
+}

--- a/packages/cli/tests/integration/buildRPC.ts
+++ b/packages/cli/tests/integration/buildRPC.ts
@@ -5,6 +5,7 @@ import { RpcHandler } from '../../src/rpc/rpc';
 import { numProcessed } from '../../src/rpc/index/numProcessed';
 import { search } from '../../src/rpc/search/search';
 import appmapData from '../../src/rpc/appmap/data';
+import appmapStats from '../../src/rpc/appmap/stats';
 import metadata from '../../src/rpc/appmap/metadata';
 import sequenceDiagram from '../../src/rpc/appmap/sequenceDiagram';
 import { explainHandler, explainStatusHandler } from '../../src/rpc/explain/explain';
@@ -24,6 +25,7 @@ export async function buildRPC(): Promise<RPC> {
   const handlers: RpcHandler<any, any>[] = [
     numProcessed(fingerprintWatchCommand),
     search('.'),
+    appmapStats('.'),
     appmapData(),
     metadata(),
     sequenceDiagram(),

--- a/packages/cli/tests/integration/rpc.appmap.spec.ts
+++ b/packages/cli/tests/integration/rpc.appmap.spec.ts
@@ -12,6 +12,31 @@ describe('RPC', () => {
   afterEach(async () => await rpcTest.teardownEach());
   afterAll(async () => await rpcTest.teardownAll());
 
+  describe('appmap.stats', () => {
+    it('can be retrieved', async () => {
+      const options: AppMapRpc.StatsOptions = {};
+      const response = await rpcTest.client.request(AppMapRpc.StatsFunctionName, options);
+      expect(response.error).toBeFalsy();
+      const stats = response.result;
+      expect(stats.numAppMaps).toEqual(2);
+      expect(stats.packages).toEqual(['app/controllers', 'app/models', 'json', 'openssl']);
+      expect(stats.classes).toEqual([
+        'app/controllers/API::APIKeysController',
+        'app/controllers/OrganizationsController',
+        'app/models/ApiKey',
+        'app/models/Configuration',
+        'app/models/User',
+        'app/models/User::Show',
+        'json/JSON::Ext::Generator::State',
+        'json/JSON::Ext::Parser',
+        'openssl/Digest::Instance',
+        'openssl/OpenSSL::Cipher',
+      ]);
+      expect(stats.routes).toEqual(['DELETE /api/api_keys', 'GET /organizations/new']);
+      expect(stats.tables).toEqual(['api_keys', 'pg_attribute', 'pg_type', 'users']);
+    });
+  });
+
   describe('appmap.metadata', () => {
     it('can be retrieved', async () => {
       const options: AppMapRpc.MetadataOptions = {

--- a/packages/rpc/src/appmap.ts
+++ b/packages/rpc/src/appmap.ts
@@ -1,8 +1,19 @@
 export namespace AppMapRpc {
+  export const StatsFunctionName = 'appmap.stats';
   export const DataFunctionName = 'appmap.data';
   export const FilterFunctionName = 'appmap.filter';
   export const MetadataFunctionName = 'appmap.metadata';
   export const SequenceDiagramFunctionName = 'appmap.sequenceDiagram';
+
+  export type StatsOptions = {};
+
+  export type StatsResponse = {
+    packages: string[];
+    classes: string[];
+    routes: string[];
+    tables: string[];
+    numAppMaps: number;
+  };
 
   export type FilterOptions = {
     appmap: string;


### PR DESCRIPTION
Provide RPC command `appmap.stats`, which includes summary information about the AppMaps available in the workspace.

This PR is the basis for https://github.com/getappmap/appmap-js/pull/1547 , and includes the RPC and CLI changes (only).
