### PR TITLE
feat: Display code selection as a separate field in Navie UI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   pull_request:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/packages/cli/src/rpc/explain/explain.ts
+++ b/packages/cli/src/rpc/explain/explain.ts
@@ -28,6 +28,7 @@ export default class Explain extends EventEmitter {
   constructor(
     public appmapDir: string,
     public question: string,
+    public codeSelection: string | undefined,
     public status: ExplainRpc.ExplainStatusResponse
   ) {
     super();
@@ -73,7 +74,10 @@ export default class Explain extends EventEmitter {
           self.emit('error', rpcError);
         },
       })
-    ).inputPrompt(this.question, { threadId: self.status.threadId, tool: 'explain' });
+    ).inputPrompt(
+      { question: this.question, codeSelection: this.codeSelection },
+      { threadId: self.status.threadId, tool: 'explain' }
+    );
   }
 
   async searchContext(data: SearchContextOptions): Promise<SearchContextResponse> {
@@ -117,13 +121,14 @@ export default class Explain extends EventEmitter {
 async function explain(
   appmapDir: string,
   question: string,
+  codeSelection: string | undefined,
   threadId: string | undefined
 ): Promise<ExplainRpc.ExplainResponse> {
   const status: ExplainRpc.ExplainStatusResponse = {
     step: ExplainRpc.Step.NEW,
     threadId,
   };
-  const explain = new Explain(appmapDir, question, status);
+  const explain = new Explain(appmapDir, question, codeSelection, status);
   return new Promise<ExplainRpc.ExplainResponse>((resolve, reject) => {
     let isFirst = true;
 
@@ -155,7 +160,7 @@ const explainHandler: (
   return {
     name: ExplainRpc.ExplainFunctionName,
     handler: async (options: ExplainRpc.ExplainOptions) =>
-      await explain(appmapDir, options.question, options.threadId),
+      await explain(appmapDir, options.question, options.codeSelection, options.threadId),
   };
 };
 

--- a/packages/cli/src/rpc/explain/lookupSourceCode.ts
+++ b/packages/cli/src/rpc/explain/lookupSourceCode.ts
@@ -43,7 +43,7 @@ export default async function lookupSourceCode(location: string): Promise<string
     candidate.endsWith(requestedFileName)
   );
   if (candidates.length === 0) {
-    warn(chalk.gray(`Could not find file ${requestedFileName}`));
+    warn(chalk.gray(`File not found in the workspace: ${requestedFileName}`));
     return;
   }
   candidates.sort((a, b) => a.length - b.length);

--- a/packages/client/src/aiClient.ts
+++ b/packages/client/src/aiClient.ts
@@ -22,6 +22,18 @@ export type Callbacks = {
   onError?: (error: Error) => void;
 };
 
+type UserInput = {
+  question: string;
+  codeSelection?: string;
+};
+
+type Prompt = {
+  prompt: string;
+  codeSelection?: string;
+  threadId?: string;
+  tool?: string;
+};
+
 export default class AIClient {
   constructor(private readonly socket: Socket, private readonly callbacks: Callbacks) {
     this.socket.on('exception', (error: Error) => {
@@ -83,12 +95,15 @@ export default class AIClient {
     }
   }
 
-  inputPrompt(input: string, options?: InputPromptOptions): void {
-    this.socket.emit('prompt', {
-      prompt: input,
+  inputPrompt(input: string | UserInput, options?: InputPromptOptions): void {
+    const question = typeof input === 'string' ? input : input.question;
+    const prompt: Prompt = {
+      prompt: question,
+      codeSelection: typeof input === 'string' ? undefined : input.codeSelection,
       threadId: options?.threadId,
       tool: options?.tool,
-    });
+    };
+    this.socket.emit('prompt', prompt);
   }
 
   panic(error: Error): void {

--- a/packages/components/build/vue.d.ts
+++ b/packages/components/build/vue.d.ts
@@ -1,0 +1,4 @@
+declare module '*.vue' {
+  import Vue from 'vue';
+  export default Vue;
+}

--- a/packages/components/src/components/chat-search/CodeSelection.vue
+++ b/packages/components/src/components/chat-search/CodeSelection.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="code-snippet">
-    <h3>Explaining code snippet:</h3>
+  <div class="code-selection">
+    <h3>Explaining code selection:</h3>
     <div class="code">
       <pre>
         {{ code }}
@@ -10,7 +10,7 @@
 </template>
 <script lang="ts">
 export default {
-  name: 'v-code-snippet',
+  name: 'v-code-selection',
   props: {
     code: {
       type: String,
@@ -21,7 +21,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.code-snippet {
+.code-selection {
   margin-top: 1rem;
   margin-bottom: 1rem;
   padding: 1rem;

--- a/packages/components/src/components/chat-search/CodeSnippet.vue
+++ b/packages/components/src/components/chat-search/CodeSnippet.vue
@@ -1,0 +1,45 @@
+<template>
+  <div class="code-snippet">
+    <h3>Explaining code snippet:</h3>
+    <div class="code">
+      <pre>
+        {{ code }}
+      </pre>
+    </div>
+  </div>
+</template>
+<script lang="ts">
+export default {
+  name: 'v-code-snippet',
+  props: {
+    code: {
+      type: String,
+      required: true,
+    },
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.code-snippet {
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+  padding: 1rem;
+  background-color: $gray1;
+  border-radius: 0.25rem;
+
+  color: $gray4;
+
+  h3 {
+    margin-top: 0;
+    margin-bottom: 0.5rem;
+    font-size: 0.9rem;
+  }
+
+  .code {
+    width: 100%;
+    font-family: 'Courier New', Courier, monospace;
+    font-size: 0.8rem;
+  }
+}
+</style>

--- a/packages/components/src/components/chat-search/Instructions.vue
+++ b/packages/components/src/components/chat-search/Instructions.vue
@@ -1,0 +1,115 @@
+<template>
+  <div class="instructions">
+    <h2>Navie, the AppMap AI</h2>
+    <div>
+      <h3>How Navie Works</h3>
+      <p>
+        Each chat with Navie begins by analyzing your AppMaps. AppMaps are detailed recordings of
+        your code behavior that you create by running your app with the AppMap agent or language
+        library enabled. Naive uses the data in AppMaps (which includes dynamic information like
+        database queries and web requests) as well as snippets of your code, to provide tailored
+        responses and suggestions.
+      </p>
+      <p>
+        Navie reports how many AppMaps were reviewed and the number of relevant source files used
+        for each response. Accuracy improves as you create more diverse and up-to-date AppMaps. You
+        can accomplish this by regularly interacting with your application and recording traces.
+      </p>
+      <p>
+        <strong>Remember!</strong> The better your AppMaps match your question, the better Navie's
+        answers will be.
+      </p>
+    </div>
+    <div v-if="appmapStats">
+      <h3>Your AppMaps</h3>
+      <p v-if="appmapStats.numAppMaps">
+        You have <strong>{{ appmapStats.numAppMaps }}</strong> AppMaps in your workspace. These
+        AppMaps contain <strong>{{ appmapStats.packages.length }}</strong> packages and
+        <strong>{{ appmapStats.classes.length }}</strong> classes.
+        <span v-if="appmapStats.routes.length"
+          >Your AppMaps contain <strong>{{ appmapStats.routes.length }}</strong> HTTP server routes
+        </span>
+        <span v-if="appmapStats.tables.length">
+          <span v-if="appmapStats.routes.length">and </span>
+          <span v-else>Your AppMaps contain </span
+          ><strong>{{ appmapStats.tables.length }}</strong> SQL tables</span
+        >.
+      </p>
+      <div data-cy="no-appmaps" v-else>
+        <p>
+          ⚠️ You don't have any AppMaps in your workspace. Before you can use Navie, you'll need to
+          create some.
+        </p>
+        <p>
+          Navie uses AppMap diagrams, data, and snippets of your code code to understand your
+          software and make suggestions. Navie’s accuracy improves as you make more AppMaps.
+        </p>
+        <p>
+          Each recording method targets different scenarios and provides various levels of detail
+          and control. For detailed instructions, visit
+          <a
+            href="https://appmap.io/docs/setup-appmap-in-your-code-editor/how-appmap-works.html"
+            _target="blank"
+            >AppMap Documentation</a
+          >. Example methods include the following:
+        </p>
+        <dl>
+          <dt>Requests recording</dt>
+          <dd>
+            Records an AppMap for every HTTP server request handled by a web application. It's
+            interactive and generates AppMaps continuously.
+          </dd>
+          <dt>Test case recording</dt>
+          <dd>
+            Creates an AppMap for each test case in supported frameworks, naming files after test
+            cases.
+          </dd>
+          <dt>Remote recording</dt>
+          <dd>
+            Similar to requests recording but includes non-HTTP activities. It starts and stops via
+            HTTP commands to the AppMap agent.
+          </dd>
+          <dt>Code block recording</dt>
+          <dd>
+            Records a single AppMap for a code block. It's useful for recording a specific feature
+            or bug fix.
+          </dd>
+          <dt>Process recording</dt>
+          <dd>
+            Records all configured code activities from application start to shutdown. It's useful
+            for recording a specific feature or bug fix.
+          </dd>
+        </dl>
+      </div>
+    </div>
+  </div>
+</template>
+<script lang="ts">
+export default {
+  name: 'v-instructions',
+  props: {
+    appmapStats: {
+      type: Object,
+    },
+  },
+};
+</script>
+<style lang="scss" scoped>
+.instructions {
+  font-size: 0.9rem;
+  color: $white;
+
+  h2 {
+    font-size: 1;
+  }
+
+  h3 {
+    font-size: 0.9rem;
+  }
+
+  a {
+    color: $white;
+    text-decoration: underline;
+  }
+}
+</style>

--- a/packages/components/src/components/chat-search/MatchInstructions.vue
+++ b/packages/components/src/components/chat-search/MatchInstructions.vue
@@ -1,0 +1,44 @@
+<template>
+  <div class="instructions" data-cy="match-instructions">
+    <h2>AppMap search results</h2>
+    <div class="content">
+      <p>
+        Of the <strong>{{ appmapStats.numAppMaps }}</strong> AppMaps available in your project,
+        <strong>{{ searchResponse.results.length }}</strong> of them have been selected to help
+        answer your question. <strong>Remember!</strong> The better your AppMaps match your
+        question, the better Navie's answers will be.
+      </p>
+    </div>
+  </div>
+</template>
+<script lang="ts">
+export default {
+  name: 'v-instructions',
+  props: {
+    appmapStats: {
+      type: Object,
+      required: true,
+    },
+    searchResponse: {
+      type: Object,
+      required: true,
+    },
+  },
+};
+</script>
+<style lang="scss" scoped>
+.instructions {
+  font-size: 0.9rem;
+  color: $gray4;
+
+  h2 {
+    color: $white;
+    margin-bottom: 0;
+    margin-top: 0;
+  }
+
+  p {
+    margin: 0;
+  }
+}
+</style>

--- a/packages/components/src/components/chat-search/NoMatchInstructions.vue
+++ b/packages/components/src/components/chat-search/NoMatchInstructions.vue
@@ -1,0 +1,38 @@
+<template>
+  <div class="instructions" data-cy="no-match-instructions">
+    <div>
+      <h2>No relevant AppMaps found</h2>
+      <div class="content">
+        <p>
+          Of the <strong>{{ appmapStats.numAppMaps }}</strong> AppMaps available in your project,
+          <strong>None</strong> of them seem to be relevant enough to your question.
+        </p>
+        <p>
+          The best way to improve your search results is to record more AppMaps that are relevant to
+          the question you want to ask.
+        </p>
+      </div>
+    </div>
+  </div>
+</template>
+<script lang="ts">
+export default {
+  name: 'v-no-match-instructions',
+  props: {
+    appmapStats: {
+      type: Object,
+      required: true,
+    },
+  },
+};
+</script>
+<style lang="scss" scoped>
+.instructions {
+  font-size: 0.9rem;
+  color: $gray4;
+
+  h2 {
+    color: $white;
+  }
+}
+</style>

--- a/packages/components/src/components/chat/Chat.vue
+++ b/packages/components/src/components/chat/Chat.vue
@@ -25,6 +25,7 @@
         :id="message.messageId"
         :sentiment="message.sentiment"
         :tools="message.tools"
+        :complete="message.complete"
         @change-sentiment="onSentimentChange"
       />
       <v-suggestion-grid :suggestions="suggestions" @suggest="onSuggestion" v-if="!isChatting" />
@@ -59,8 +60,6 @@ import Vue from 'vue';
 import VUserMessage from '@/components/chat/UserMessage.vue';
 import VChatInput from '@/components/chat/ChatInput.vue';
 import VSuggestionGrid from '@/components/chat/SuggestionGrid.vue';
-import VSpinner from '@/components/Spinner.vue';
-import VLoaderIcon from '@/assets/eva_loader-outline.svg';
 import VAppMapNavieLogo from '@/assets/appmap-full-logo.svg';
 import VButton from '@/components/Button.vue';
 import { AI } from '@appland/client';
@@ -75,6 +74,7 @@ interface IMessage {
   message: string;
   isUser: boolean;
   isError: boolean;
+  complete?: boolean;
   messageId?: string;
   sentiment?: number;
   tools?: ITool[];
@@ -86,6 +86,7 @@ class UserMessage implements IMessage {
   public readonly isUser = true;
   public readonly isError = false;
   public readonly tools = undefined;
+  public readonly complete = true;
 
   constructor(public content: string) {}
 }
@@ -93,6 +94,7 @@ class UserMessage implements IMessage {
 class AssistantMessage implements IMessage {
   public content = '';
   public sentiment = undefined;
+  public complete = false;
   public readonly isUser = false;
   public readonly isError = false;
   public readonly tools = [];
@@ -107,6 +109,7 @@ class AssistantMessage implements IMessage {
 class ErrorMessage implements IMessage {
   public readonly messageId = undefined;
   public readonly sentiment = undefined;
+  public readonly complete = true;
   public readonly isUser = false;
   public readonly isError = true;
 
@@ -240,7 +243,8 @@ export default {
     onSuggestion(prompt: string) {
       if (this.suggestionSpeaker === 'system') {
         // Make it look like the AI is typing
-        const assistantMessage = new AssistantMessage('suggested-message');
+        const assistantMessage = new AssistantMessage();
+        assistantMessage.complete = true;
         assistantMessage.append(prompt);
         this.messages.push(assistantMessage);
       } else {

--- a/packages/components/src/components/chat/Chat.vue
+++ b/packages/components/src/components/chat/Chat.vue
@@ -15,6 +15,13 @@
         New chat
       </v-button>
     </div>
+    <v-code-selection
+      v-if="codeSelection"
+      ref="vcode-snippet"
+      class="chat-code-snippet"
+      :code="codeSelection"
+    >
+    </v-code-selection>
     <div class="messages" data-cy="messages" ref="messages" @scroll="manageScroll">
       <v-user-message
         v-for="(message, i) in messages"
@@ -63,6 +70,7 @@
 import Vue from 'vue';
 import VUserMessage from '@/components/chat/UserMessage.vue';
 import VChatInput from '@/components/chat/ChatInput.vue';
+import VCodeSelection from '@/components/chat-search/CodeSelection.vue';
 import VSuggestionGrid from '@/components/chat/SuggestionGrid.vue';
 import VAppMapNavieLogo from '@/assets/appmap-full-logo.svg';
 import VButton from '@/components/Button.vue';
@@ -129,6 +137,7 @@ export default {
   components: {
     VUserMessage,
     VChatInput,
+    VCodeSelection,
     VSuggestionGrid,
     VAppMapNavieLogo,
     VButton,
@@ -137,6 +146,10 @@ export default {
     // Initial question to ask
     question: {
       type: String,
+    },
+    codeSelection: {
+      type: String,
+      required: false,
     },
     sendMessage: {
       type: Function, // UserMessageHandler

--- a/packages/components/src/components/chat/Chat.vue
+++ b/packages/components/src/components/chat/Chat.vue
@@ -28,7 +28,11 @@
         :complete="message.complete"
         @change-sentiment="onSentimentChange"
       />
-      <v-suggestion-grid :suggestions="suggestions" @suggest="onSuggestion" v-if="!isChatting" />
+      <v-suggestion-grid
+        :suggestions="suggestions"
+        @suggest="onSuggestion"
+        v-if="suggestionsEnabled"
+      />
     </div>
     <div v-if="!authorized" class="status-unauthorized status-container">
       <div class="status-label">
@@ -141,6 +145,10 @@ export default {
       type: Array,
       required: false,
     },
+    disableSuggestions: {
+      type: Boolean,
+      default: false,
+    },
     suggestionSpeaker: {
       type: String,
       default: 'system',
@@ -160,6 +168,9 @@ export default {
   computed: {
     inputPlaceholder() {
       return 'How can I help?';
+    },
+    suggestionsEnabled() {
+      return this.disableSuggestions !== true && !this.isChatting;
     },
     isChatting(): boolean {
       return this.messages.length > 0;

--- a/packages/components/src/components/chat/Chat.vue
+++ b/packages/components/src/components/chat/Chat.vue
@@ -64,9 +64,9 @@ import VAppMapNavieLogo from '@/assets/appmap-full-logo.svg';
 import VButton from '@/components/Button.vue';
 import { AI } from '@appland/client';
 
-interface ITool {
+export interface ITool {
   title: string;
-  status: string;
+  status?: string;
   complete?: boolean;
 }
 

--- a/packages/components/src/components/chat/Chat.vue
+++ b/packages/components/src/components/chat/Chat.vue
@@ -243,6 +243,11 @@ export default {
     onComplete() {
       this.resetStateVariables();
     },
+    onNoMatch() {
+      // If the AI was not able to produce a useful response, don't persist the thread.
+      // This is used by Explain when no AppMaps can be found to match the question.
+      this.threadId = undefined;
+    },
     clear() {
       this.threadId = undefined;
       this.messages.splice(0);

--- a/packages/components/src/components/chat/Loader.vue
+++ b/packages/components/src/components/chat/Loader.vue
@@ -1,0 +1,43 @@
+<template>
+  <div class="loader">
+    <div class="dot" />
+    <div class="dot" :style="{ 'animation-delay': '0.15s' }" />
+    <div class="dot" :style="{ 'animation-delay': '0.3s' }" />
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+
+export default Vue.extend({
+  name: 'v-loader',
+});
+</script>
+
+<style lang="scss" scoped>
+@keyframes loading {
+  0%,
+  100% {
+    transform: translateY(100%) scaleX(1.2);
+  }
+  50% {
+    transform: translateY(-100%) scaleY(1.1);
+  }
+}
+
+.loader {
+  display: flex;
+  align-items: center;
+  height: 100%;
+  width: 100%;
+  gap: 12%;
+
+  .dot {
+    aspect-ratio: 1 / 1;
+    width: 33%;
+    border-radius: 2em;
+    background-color: #7196f6;
+    animation: 1s infinite loading ease-in-out;
+  }
+}
+</style>

--- a/packages/components/src/components/chat/SuggestionGrid.vue
+++ b/packages/components/src/components/chat/SuggestionGrid.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="suggestion-grid" v-if="suggestions.length">
-    <p>Not sure? Here are some useful starting points:</p>
+    <p>Here are some useful starting points:</p>
     <div class="grid">
       <v-suggestion-card
         v-for="(s, i) in suggestions"

--- a/packages/components/src/components/chat/ToolStatus.vue
+++ b/packages/components/src/components/chat/ToolStatus.vue
@@ -1,0 +1,69 @@
+<template>
+  <div :class="{ 'tool-status': 1, 'tool-status--complete': complete }" data-cy="tool-status">
+    <v-check v-if="complete" class="tool-status__loader" />
+    <v-loader v-else class="tool-status__loader" />
+    <div class="tool-status__info">
+      <div class="tool-status__action" data-cy="title">{{ title }}</div>
+      <div class="tool-status__status" data-cy="status">{{ status }}</div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+import VLoader from '@/components/chat/Loader.vue';
+import VCheck from '@/assets/check.svg';
+
+export default Vue.extend({
+  name: 'v-tool-status',
+  components: {
+    VLoader,
+    VCheck,
+  },
+  props: {
+    title: String,
+    status: String,
+    complete: {
+      type: Boolean,
+      default: false,
+    },
+  },
+});
+</script>
+
+<style lang="scss" scoped>
+.tool-status {
+  display: grid;
+  grid-template-columns: 1.5rem 1fr;
+  flex-direction: column;
+  border: 1px solid #7289c5;
+  border-radius: $border-radius;
+  padding: 0.5rem;
+  width: fit-content;
+  color: #ececec;
+  align-items: stretch;
+
+  &__info {
+    grid-column: 2;
+    padding-left: 0.5rem;
+  }
+
+  &__action {
+    font-size: 0.8rem;
+    font-weight: 600;
+  }
+
+  &__status {
+    font-size: 0.75rem;
+  }
+
+  &__loader {
+    justify-self: center;
+    width: 75%;
+
+    path {
+      fill: #ececec;
+    }
+  }
+}
+</style>

--- a/packages/components/src/components/chat/UserMessage.vue
+++ b/packages/components/src/components/chat/UserMessage.vue
@@ -11,7 +11,18 @@
     </div>
     <div class="name">{{ name }}</div>
     <div class="message-body" data-cy="message-text" v-if="isUser">{{ message }}</div>
-    <div class="message-body" data-cy="message-text" v-else v-html="renderedMarkdown" />
+    <div class="message-body" data-cy="message-text" v-else>
+      <div class="tools" v-if="tools.length">
+        <v-tool-status
+          v-for="(tool, i) in tools"
+          :key="i"
+          :complete="tool.complete"
+          :title="tool.title"
+          :status="tool.status"
+        />
+      </div>
+      <div v-html="renderedMarkdown" />
+    </div>
     <div class="buttons">
       <span
         v-if="!isUser && id"
@@ -49,6 +60,7 @@ import VNavieCompass from '@/assets/compass-icon.svg';
 import VUserAvatar from '@/assets/user-avatar.svg';
 import VThumbIcon from '@/assets/thumb.svg';
 import VButton from '@/components/Button.vue';
+import VToolStatus from '@/components/chat/ToolStatus.vue';
 
 import { Marked, Renderer } from 'marked';
 import { markedHighlight } from 'marked-highlight';
@@ -95,6 +107,7 @@ export default {
     VUserAvatar,
     VThumbIcon,
     VButton,
+    VToolStatus,
   },
 
   props: {
@@ -112,6 +125,9 @@ export default {
     },
     sentiment: {
       default: 0,
+    },
+    tools: {
+      default: () => [],
     },
   },
 
@@ -333,6 +349,10 @@ export default {
     }
   }
 
+  .tools {
+    padding-bottom: 0.5rem;
+  }
+
   .md-code-snippet {
     margin: 1rem 0;
     border-radius: $border-radius;
@@ -416,11 +436,11 @@ export default {
     margin-block-end: 1em;
   }
 
-  & > p:first-child {
+  span > :first-child {
     margin-top: 0;
   }
 
-  & > p:last-child {
+  span > :last-child {
     margin-bottom: 0;
   }
 }

--- a/packages/components/src/components/chat/UserMessage.vue
+++ b/packages/components/src/components/chat/UserMessage.vue
@@ -162,7 +162,13 @@ export default {
           if (!nextNode) {
             const cursor = dom.ownerDocument.createElement('span');
             cursor.classList.add('cursor');
-            node?.parentElement?.appendChild(cursor);
+
+            let target = node?.parentElement;
+            if (!target && this.tools.every((t) => t.complete)) {
+              target = dom;
+            }
+
+            target?.appendChild(cursor);
             break;
           }
 

--- a/packages/components/src/components/mixins/authenticatedClient.js
+++ b/packages/components/src/components/mixins/authenticatedClient.js
@@ -18,6 +18,12 @@ export default {
       },
       immediate: true,
     },
+    apiUrl: {
+      handler() {
+        this.updateClientConfiguration();
+      },
+      immediate: true,
+    },
   },
   methods: {
     updateClientConfiguration() {

--- a/packages/components/src/lib/AppMapRPC.ts
+++ b/packages/components/src/lib/AppMapRPC.ts
@@ -2,6 +2,17 @@ import { browserClient, reportError } from './RPC';
 
 import { EventEmitter } from 'events';
 
+type ExplainOptions = {
+  question: string;
+  codeSelection?: string;
+  threadId?: string;
+};
+
+type UserInput = {
+  question: string;
+  codeSelection?: string;
+};
+
 export class ExplainRequest extends EventEmitter {
   client: any;
 
@@ -11,11 +22,25 @@ export class ExplainRequest extends EventEmitter {
     this.client = client;
   }
 
-  explain(input: string, threadId?: string): Promise<string> {
+  explain(input: string | UserInput, threadId?: string): Promise<string> {
+    let question: string;
+    let codeSelection: string | undefined;
+    if (typeof input === 'string') {
+      question = input;
+    } else {
+      question = input.question;
+      codeSelection = input.codeSelection;
+    }
+    const explainOptions: ExplainOptions = {
+      question,
+      threadId,
+      codeSelection,
+    };
+
     return new Promise<string>((resolve, reject) => {
       this.client.request(
         'explain',
-        { threadId, question: input },
+        explainOptions,
         (err: any, error: any, response: { userMessageId: string; threadId: string }) => {
           if (err || error) return reportError(reject, err, error);
 

--- a/packages/components/src/lib/AppMapRPC.ts
+++ b/packages/components/src/lib/AppMapRPC.ts
@@ -85,6 +85,16 @@ export default class AppMapRPC {
     this.client = typeof portOrClient === 'number' ? browserClient(portOrClient) : portOrClient;
   }
 
+  appmapStats(): Promise<any> {
+    return new Promise((resolve, reject) => {
+      this.client.request('appmap.stats', {}, function (err: any, error: any, result: any) {
+        if (err || error) return reportError(reject, err, error);
+
+        resolve(result);
+      });
+    });
+  }
+
   appmapData(appmapId: string, filter: any): Promise<string> {
     return new Promise((resolve, reject) => {
       this.client.request(

--- a/packages/components/src/pages/ChatSearch.vue
+++ b/packages/components/src/pages/ChatSearch.vue
@@ -6,21 +6,15 @@
     @mouseleave="stopResizing"
   >
     <div class="chat-container" data-cy="resize-left" ref="chatContainer">
-      <v-code-snippet
-        v-if="codeSnippet"
-        ref="vcode-snippet"
-        class="chat-code-snippet"
-        :code="codeSnippet"
-      >
-      </v-code-snippet>
       <v-chat
         class="chat-search-chat"
         ref="vchat"
         :send-message="sendMessage"
         :status-label="searchStatusLabel"
-        :disable-suggestions="codeSnippet !== undefined"
+        :disable-suggestions="codeSelection !== undefined"
         @clear="clear"
         :question="question"
+        :code-selection="codeSelection"
       />
     </div>
     <div
@@ -113,7 +107,6 @@
 <script lang="ts">
 //@ts-nocheck
 import VChat from '@/components/chat/Chat.vue';
-import VCodeSnippet from '@/components/chat-search/CodeSnippet.vue';
 import VAccordion from '@/components/Accordion.vue';
 import VInstructions from '@/components/chat-search/Instructions.vue';
 import VMatchInstructions from '@/components/chat-search/MatchInstructions.vue';
@@ -127,7 +120,6 @@ export default {
   name: 'v-chat-search',
   components: {
     VChat,
-    VCodeSnippet,
     VAppMap,
     VAccordion,
     VInstructions,
@@ -139,7 +131,7 @@ export default {
     question: {
       type: String,
     },
-    codeSnippet: {
+    codeSelection: {
       type: String,
     },
     appmapRpcPort: {
@@ -322,7 +314,12 @@ export default {
           }
         });
         this.ask.on('complete', onComplete);
-        this.ask.explain(message, this.$refs.vchat.threadId).catch(onError);
+        this.ask
+          .explain(
+            { question: message, codeSelection: this.codeSelection },
+            this.$refs.vchat.threadId
+          )
+          .catch(onError);
       });
     },
     async loadAppMapStats() {
@@ -435,6 +432,7 @@ $border-color: darken($gray4, 10%);
   .instructions {
     padding: 0 1rem;
     margin: 1rem auto;
+    min-width: 20rem;
   }
 
   .search-container {

--- a/packages/components/src/pages/ChatSearch.vue
+++ b/packages/components/src/pages/ChatSearch.vue
@@ -6,11 +6,19 @@
     @mouseleave="stopResizing"
   >
     <div class="chat-container" data-cy="resize-left" ref="chatContainer">
+      <v-code-snippet
+        v-if="codeSnippet"
+        ref="vcode-snippet"
+        class="chat-code-snippet"
+        :code="codeSnippet"
+      >
+      </v-code-snippet>
       <v-chat
         class="chat-search-chat"
         ref="vchat"
         :send-message="sendMessage"
         :status-label="searchStatusLabel"
+        :disable-suggestions="codeSnippet !== undefined"
         @clear="clear"
         :question="question"
       />
@@ -105,6 +113,7 @@
 <script lang="ts">
 //@ts-nocheck
 import VChat from '@/components/chat/Chat.vue';
+import VCodeSnippet from '@/components/chat-search/CodeSnippet.vue';
 import VAccordion from '@/components/Accordion.vue';
 import VInstructions from '@/components/chat-search/Instructions.vue';
 import VMatchInstructions from '@/components/chat-search/MatchInstructions.vue';
@@ -118,6 +127,7 @@ export default {
   name: 'v-chat-search',
   components: {
     VChat,
+    VCodeSnippet,
     VAppMap,
     VAccordion,
     VInstructions,
@@ -127,6 +137,9 @@ export default {
   mixins: [authenticatedClient],
   props: {
     question: {
+      type: String,
+    },
+    codeSnippet: {
       type: String,
     },
     appmapRpcPort: {
@@ -383,6 +396,9 @@ $border-color: darken($gray4, 10%);
     overflow: hidden;
     min-width: 375px;
     width: 40vw;
+
+    display: flex;
+    flex-direction: column;
 
     background: radial-gradient(circle, lighten($gray2, 10%) 0%, rgba(0, 0, 0, 0) 80%);
     background-repeat: no-repeat, repeat, repeat;

--- a/packages/components/src/pages/ChatSearch.vue
+++ b/packages/components/src/pages/ChatSearch.vue
@@ -112,6 +112,7 @@ import VNoMatchInstructions from '@/components/chat-search/NoMatchInstructions.v
 import VAppMap from './VsCodeExtension.vue';
 import AppMapRPC from '@/lib/AppMapRPC';
 import authenticatedClient from '@/components/mixins/authenticatedClient';
+import type { ITool } from '@/components/chat/Chat.vue';
 
 export default {
   name: 'v-chat-search',
@@ -256,11 +257,19 @@ export default {
 
       let myThreadId: string | undefined;
       return new Promise((resolve, reject) => {
+        // If we can't find a system message, this is a new chat.
+        // We could potentially use the status to determine whether or not
+        // to add a new tool, but this will be more reactive.
+        const isNewChat = !Boolean(this.$refs.vchat.getMessage({ isUser: false }));
         const systemMessage = this.$refs.vchat.addSystemMessage();
-        const tool = {
-          title: 'Searching for AppMaps',
-        };
-        systemMessage.tools.push(tool);
+        let tool: ITool | undefined;
+
+        if (isNewChat) {
+          tool = {
+            title: 'Searching for AppMaps',
+          };
+          systemMessage.tools.push(tool);
+        }
 
         const onComplete = () => {
           this.searching = false;
@@ -290,10 +299,13 @@ export default {
           if (!this.searchResponse && status.searchResponse) {
             this.searchResponse = status.searchResponse;
 
-            const numResults = this.searchResponse.results.length;
-            tool.title = 'Searched for AppMaps';
-            tool.status = `Found ${numResults} relevant recording${numResults === 1 ? '' : 's'}`;
-            tool.complete = true;
+            // Update the tool status to reflect the fact that we've found some AppMaps
+            if (tool) {
+              const numResults = this.searchResponse.results.length;
+              tool.title = 'Searched for AppMaps';
+              tool.status = `Found ${numResults} relevant recording${numResults === 1 ? '' : 's'}`;
+              tool.complete = true;
+            }
           }
         });
         this.ask.on('complete', onComplete);
@@ -358,12 +370,13 @@ $border-color: darken($gray4, 10%);
 
 .chat-search-container {
   display: grid;
-  grid-template-columns: auto auto auto;
+  grid-template-columns: auto auto 1fr;
   min-width: 100%;
-  max-width: 100%;
-  min-height: 100vh;
+  max-width: 100vw;
+  min-height: 100%;
   max-height: 100vh;
-  overflow-y: auto;
+  height: 100%;
+  overflow-y: hidden;
   background-color: $gray2;
 
   .chat-container {
@@ -396,9 +409,8 @@ $border-color: darken($gray4, 10%);
   .context-container {
     font-size: 1rem;
     color: $white;
-    // padding: 0 1rem 1rem 2rem;
-    flex: 2;
-    display: flex;
+    grid-template-rows: auto 1fr;
+    display: grid;
     flex-direction: column;
     overflow-y: auto;
     background-color: $black;
@@ -410,6 +422,7 @@ $border-color: darken($gray4, 10%);
   }
 
   .search-container {
+    max-height: 100vh;
     h2 {
       font-size: 1.2rem;
       margin-bottom: 0.4rem;
@@ -449,6 +462,7 @@ $border-color: darken($gray4, 10%);
 
     .appmap {
       overflow-y: auto;
+      height: 100% !important;
     }
 
     .appmap-empty {

--- a/packages/components/src/pages/ChatSearch.vue
+++ b/packages/components/src/pages/ChatSearch.vue
@@ -357,8 +357,8 @@ export default {
 $border-color: darken($gray4, 10%);
 
 .chat-search-container {
-  display: flex;
-  flex-direction: row;
+  display: grid;
+  grid-template-columns: auto auto auto;
   min-width: 100%;
   max-width: 100%;
   min-height: 100vh;
@@ -368,8 +368,8 @@ $border-color: darken($gray4, 10%);
 
   .chat-container {
     overflow: hidden;
-    width: 40%;
     min-width: 375px;
+    width: 40vw;
 
     background: radial-gradient(circle, lighten($gray2, 10%) 0%, rgba(0, 0, 0, 0) 80%);
     background-repeat: no-repeat, repeat, repeat;

--- a/packages/components/src/stories/ChatSearch.stories.js
+++ b/packages/components/src/stories/ChatSearch.stories.js
@@ -24,6 +24,12 @@ export const ChatSearchMock = (args, { argTypes }) => ({
   template: `<v-chat-search v-bind="$props"></v-chat-search>`,
 });
 
+export const ChatSearchMockWithCodeSnippet = (args, { argTypes }) => ({
+  props: Object.keys(argTypes),
+  components: { VChatSearch },
+  template: `<v-chat-search v-bind="$props"></v-chat-search>`,
+});
+
 export const ChatSearchMockWithFilters = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
   components: { VChatSearch },
@@ -181,6 +187,26 @@ const emptyMockRpc = buildMockRpc(EmptySearchResponse, []);
 
 ChatSearchMock.args = {
   appmapRpcFn: nonEmptyMockRpc,
+};
+
+const codeSnippet = `class UsersController < ApplicationController
+  before_action :correct_user,   only: [:edit, :update]
+  before_action :admin_user,     only: :destroy
+  
+  def index
+    @users = User.where(activated: true).paginate(page: params[:page])
+  end
+  
+  def show
+    @user = User.find(params[:id])
+    redirect_to root_url and return unless @user.activated?
+  end
+`;
+
+ChatSearchMockWithCodeSnippet.args = {
+  codeSnippet,
+  appmapRpcFn: nonEmptyMockRpc,
+  savedFilters,
 };
 
 ChatSearchMockWithFilters.args = {

--- a/packages/components/src/stories/ChatSearch.stories.js
+++ b/packages/components/src/stories/ChatSearch.stories.js
@@ -5,6 +5,20 @@ import petclinicData from './data/java_scenario.json';
 import longPackageData from './data/long-package.appmap.json';
 import savedFilters from './data/saved_filters.js';
 
+const codeSelection = `class UsersController < ApplicationController
+  before_action :correct_user,   only: [:edit, :update]
+  before_action :admin_user,     only: :destroy
+  
+  def index
+    @users = User.where(activated: true).paginate(page: params[:page])
+  end
+  
+  def show
+    @user = User.find(params[:id])
+    redirect_to root_url and return unless @user.activated?
+  end
+`;
+
 export default {
   title: 'Pages/ChatSearch',
   component: VChatSearch,
@@ -18,13 +32,22 @@ export const ChatSearch = (args, { argTypes }) => ({
 });
 ChatSearch.args = {};
 
+export const ChatSearchWithCodeSelection = (args, { argTypes }) => ({
+  props: Object.keys(argTypes),
+  components: { VChatSearch },
+  template: `<v-chat-search v-bind="$props"></v-chat-search>`,
+});
+ChatSearchWithCodeSelection.args = {
+  codeSelection,
+};
+
 export const ChatSearchMock = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
   components: { VChatSearch },
   template: `<v-chat-search v-bind="$props"></v-chat-search>`,
 });
 
-export const ChatSearchMockWithCodeSnippet = (args, { argTypes }) => ({
+export const ChatSearchMockWithCodeSelection = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
   components: { VChatSearch },
   template: `<v-chat-search v-bind="$props"></v-chat-search>`,
@@ -189,22 +212,8 @@ ChatSearchMock.args = {
   appmapRpcFn: nonEmptyMockRpc,
 };
 
-const codeSnippet = `class UsersController < ApplicationController
-  before_action :correct_user,   only: [:edit, :update]
-  before_action :admin_user,     only: :destroy
-  
-  def index
-    @users = User.where(activated: true).paginate(page: params[:page])
-  end
-  
-  def show
-    @user = User.find(params[:id])
-    redirect_to root_url and return unless @user.activated?
-  end
-`;
-
-ChatSearchMockWithCodeSnippet.args = {
-  codeSnippet,
+ChatSearchMockWithCodeSelection.args = {
+  codeSelection,
   appmapRpcFn: nonEmptyMockRpc,
   savedFilters,
 };

--- a/packages/components/src/stories/ChatSearch.stories.js
+++ b/packages/components/src/stories/ChatSearch.stories.js
@@ -77,6 +77,7 @@ const DATA_KEYS = Object.keys(DATA_BY_PATH);
 let requestIndex = 0;
 let statusIndex = 0;
 const userMessageId = 'user-message-id';
+const systemMessageId = 'system-message-id';
 const threadId = 'thread-id';
 
 const NonEmptySearchResponse = {

--- a/packages/components/src/stories/ChatSearchInstructions.stories.js
+++ b/packages/components/src/stories/ChatSearchInstructions.stories.js
@@ -1,0 +1,33 @@
+import VInstructions from '@/components/chat-search/Instructions.vue';
+
+export default {
+  title: 'Pages/ChatSearch/Instructions',
+  component: VInstructions,
+  argTypes: {},
+};
+
+const Template = (args, { argTypes }) => ({
+  props: Object.keys(argTypes),
+  components: { VInstructions },
+  template: `<div style="background-color: #262C40; padding: 1rem; font-family: system-ui;"><v-instructions v-bind="$props"></v-instructions></div>`,
+});
+
+export const InstructionsBeforeAppMapStats = Template.bind({});
+
+const appmapStats = {
+  packages: ['app/controllers', 'app/helpers', 'app/models'],
+  classes: ['User', 'UsersController', 'SessionsController'],
+  routes: ['GET /users', 'GET /users/:id', 'GET /signup', 'POST /signup'],
+  tables: ['users', 'microposts'],
+  numAppMaps: 100,
+};
+
+export const Instructions = Template.bind({});
+Instructions.args = {
+  appmapStats,
+};
+
+export const InstructionsNoAppMaps = Template.bind({});
+InstructionsNoAppMaps.args = {
+  appmapStats: { numAppMaps: 0 },
+};

--- a/packages/components/src/stories/ChatSearchNoMatchInstructions.stories.js
+++ b/packages/components/src/stories/ChatSearchNoMatchInstructions.stories.js
@@ -1,0 +1,22 @@
+import VNoMatchInstructions from '@/components/chat-search/NoMatchInstructions.vue';
+
+export default {
+  title: 'Pages/ChatSearch/NoMatchInstructions',
+  component: VNoMatchInstructions,
+  argTypes: {},
+};
+
+const appmapStats = {
+  numAppMaps: 100,
+};
+
+const Template = (args, { argTypes }) => ({
+  props: Object.keys(argTypes),
+  components: { VNoMatchInstructions },
+  template: `<div style="background-color: #262C40; padding: 1rem; font-family: system-ui;"><v-no-match-instructions v-bind="$props"></v-no-match-instructions></div>`,
+});
+
+export const NoMatchInstructions = Template.bind({});
+NoMatchInstructions.args = {
+  appmapStats,
+};

--- a/packages/components/src/stories/ChatTools.stories.js
+++ b/packages/components/src/stories/ChatTools.stories.js
@@ -1,0 +1,19 @@
+import VToolStatus from '@/components/chat/ToolStatus.vue';
+import './scss/vscode.scss';
+
+export default {
+  title: 'Pages/Chat/Tools',
+  component: VToolStatus,
+  argTypes: {},
+};
+
+export const Search = (args, { argTypes }) => ({
+  props: Object.keys(argTypes),
+  components: { VToolStatus },
+  template: `<v-tool-status v-bind="$props" />`,
+});
+Search.args = {
+  title: 'Searched for AppMaps',
+  status: 'Found 3 relevant recordings',
+  complete: true,
+};

--- a/packages/components/tests/e2e/specs/appmap/sequenceDiagramDiff.spec.js
+++ b/packages/components/tests/e2e/specs/appmap/sequenceDiagramDiff.spec.js
@@ -13,7 +13,8 @@ context('Sequence Diagram', () => {
   });
 
   it('sidebar buttons are disabled', () => {
-    cy.get('div:nth-child(40) > div.call-line-segment.label-span.arrow-base').click();
+    cy.get('div[data-event-ids="538"] .self-call').scrollIntoView();
+    cy.get('div[data-event-ids="538"] .self-call .name').click();
     cy.get('.details-panel-header__ghost-link .details-btn').each(($btn) => {
       // For each button, check if it has the attribute 'disabled'
       cy.wrap($btn).should('have.attr', 'disabled');

--- a/packages/components/tests/e2e/specs/chat/chatSearch.spec.js
+++ b/packages/components/tests/e2e/specs/chat/chatSearch.spec.js
@@ -13,8 +13,7 @@ context('Chat search', () => {
         delay: 0,
       })
       .get('[data-cy="explain-status"]', { timeout: 1000 })
-      .should('be.visible')
-      .should('contain.text', 'Optimizing search terms...');
+      .should('be.visible');
 
     cy.get('[data-cy="explain-status"]', { timeout: 1000 }).should(
       'contain.text',

--- a/packages/components/tests/e2e/specs/chat/chatSearch.spec.js
+++ b/packages/components/tests/e2e/specs/chat/chatSearch.spec.js
@@ -6,26 +6,6 @@ context('Chat search', () => {
     cy.viewport(1280, 720);
   });
 
-  it('renders the current state', () => {
-    cy.get('[data-cy="chat-input"]', { timeout: 25000 })
-      .type('Hello world{enter}', {
-        waitForAnimations: false,
-        delay: 0,
-      })
-      .get('[data-cy="explain-status"]', { timeout: 1000 })
-      .should('be.visible');
-
-    cy.get('[data-cy="explain-status"]', { timeout: 1000 }).should(
-      'contain.text',
-      'Explaining with AI...'
-    );
-
-    cy.get('[data-actor="system"] [data-cy="message-text"]').should(
-      'contain.text',
-      'Based on the code snippets provided'
-    );
-  });
-
   it('switches AppMaps', () => {
     cy.get('[data-cy="chat-input"]', { timeout: 25000 }).type('Hello world{enter}');
 

--- a/packages/components/tests/unit/chat/ChatComponent.spec.js
+++ b/packages/components/tests/unit/chat/ChatComponent.spec.js
@@ -121,7 +121,6 @@ describe('components/Chat.vue', () => {
       wrapper.vm.addToken('Hello from the system', threadId, messageId);
       await wrapper.vm.$nextTick();
 
-      expect(wrapper.vm.loading).toBe(true);
       expect(wrapper.find('[data-actor="user"] [data-cy="message-text"]').exists()).toBe(true);
       expect(wrapper.find('[data-actor="system"] [data-cy="message-text"]').exists()).toBe(true);
 
@@ -136,11 +135,6 @@ describe('components/Chat.vue', () => {
 
     it('clears the thread id', async () => {
       expect(wrapper.vm.threadId).toBeUndefined();
-    });
-
-    it('hides the progress indicator', () => {
-      expect(wrapper.vm.loading).toBe(false);
-      expect(wrapper.find('[data-cy="status-container"]').exists()).toBe(false);
     });
 
     it('ignores subsequent messages on the old thread-id', async () => {

--- a/packages/components/tests/unit/chat/ChatSearch.spec.js
+++ b/packages/components/tests/unit/chat/ChatSearch.spec.js
@@ -159,6 +159,18 @@ describe('pages/ChatSearch.vue', () => {
         expect(wrapper.find('[data-cy="match-instructions"]').exists()).toBe(true);
         expect(wrapper.find('[data-cy="no-match-instructions"]').exists()).toBe(false);
       });
+
+      it('only renders the search status once', async () => {
+        const { wrapper } = await performSearch();
+
+        expect(wrapper.findAll('[data-cy="tool-status"]').length).toBe(1);
+
+        wrapper.vm.sendMessage('How do I reset my password?');
+        await wrapper.vm.$nextTick();
+
+        console.log(wrapper.html());
+        expect(wrapper.findAll('[data-cy="tool-status"]').length).toBe(1);
+      });
     });
 
     describe('but no AppMaps match the question', () => {

--- a/packages/components/tests/unit/chat/authentication.spec.js
+++ b/packages/components/tests/unit/chat/authentication.spec.js
@@ -25,7 +25,7 @@ describe('Authentication', () => {
   });
 
   it('authenticates ChatSearch', async () => {
-    const wrapper = mount(VChatSearch, { propsData: { apiKey, apiUrl } });
+    const wrapper = mount(VChatSearch, { propsData: { apiKey, apiUrl, appmapRpcFn: () => true } });
     await wrapper.vm.$nextTick();
     expect(loadConfiguration()).toStrictEqual({
       apiKey,

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -19,6 +19,6 @@
     },
     "lib": ["esnext", "dom", "dom.iterable", "scripthost"]
   },
-  "include": ["build/svg.d.ts", "src/**/*.ts", "src/**/*.tsx", "src/**/*.vue"],
+  "include": ["build/svg.d.ts", "build/vue.d.ts", "src/**/*.ts", "src/**/*.tsx", "src/**/*.vue"],
   "exclude": ["node_modules"]
 }

--- a/packages/rpc/src/explain.ts
+++ b/packages/rpc/src/explain.ts
@@ -16,6 +16,7 @@ export namespace ExplainRpc {
 
   export type ExplainOptions = {
     question: string;
+    codeSelection?: string;
     threadId?: string;
   };
 


### PR DESCRIPTION
When the user initiates a search using the "light bulb", preserve that snippet in the Navie UI, and use it as context for the user's question.

## Rough example

<img width="609" alt="Screen Shot 2024-01-26 at 4 40 04 PM" src="https://github.com/getappmap/appmap-js/assets/86395/5a1b58db-cb97-46e0-bf2a-d551ef9d3e77">
