### PR TITLE
Navie instructions link to record appmaps page

### DIFF
--- a/packages/components/src/components/chat-search/Instructions.vue
+++ b/packages/components/src/components/chat-search/Instructions.vue
@@ -5,7 +5,10 @@
       <h3>How Navie Works</h3>
       <p>
         Each chat with Navie begins by analyzing your AppMaps. AppMaps are detailed recordings of
-        your code behavior that you create by running your app with the AppMap agent or language
+        your code behavior that
+        <a href="#" @click.prevent="openRecordInstructions"
+          >you create by running your app with the AppMap agent or language</a
+        >
         library enabled. Naive uses the data in AppMaps (which includes dynamic information like
         database queries and web requests) as well as snippets of your code, to provide tailored
         responses and suggestions.
@@ -38,7 +41,7 @@
       <div data-cy="no-appmaps" v-else>
         <p>
           ⚠️ You don't have any AppMaps in your workspace. Before you can use Navie, you'll need to
-          create some.
+          <a href="#" @click.prevent="openRecordInstructions">create some</a>.
         </p>
         <p>
           Navie uses AppMap diagrams, data, and snippets of your code code to understand your
@@ -84,12 +87,19 @@
     </div>
   </div>
 </template>
-<script lang="ts">
+<script>
 export default {
   name: 'v-instructions',
+
   props: {
     appmapStats: {
       type: Object,
+    },
+  },
+
+  methods: {
+    openRecordInstructions() {
+      this.$root.$emit('open-record-instructions');
     },
   },
 };
@@ -108,8 +118,14 @@ export default {
   }
 
   a {
-    color: $white;
-    text-decoration: underline;
+    text-decoration: none;
+    color: $lightblue;
+
+    &:hover {
+      color: $blue;
+      transition: $transition;
+      cursor: pointer;
+    }
   }
 }
 </style>

--- a/packages/components/src/components/chat-search/NoMatchInstructions.vue
+++ b/packages/components/src/components/chat-search/NoMatchInstructions.vue
@@ -8,20 +8,29 @@
           <strong>None</strong> of them seem to be relevant enough to your question.
         </p>
         <p>
-          The best way to improve your search results is to record more AppMaps that are relevant to
-          the question you want to ask.
+          The best way to improve your search results is to
+          <a href="#" @click.prevent="openRecordInstructions">record more AppMaps</a> that are
+          relevant to the question you want to ask.
         </p>
       </div>
     </div>
   </div>
 </template>
-<script lang="ts">
+<script>
 export default {
   name: 'v-no-match-instructions',
+
   props: {
     appmapStats: {
       type: Object,
       required: true,
+      default: () => ({ numAppMaps: 0 }),
+    },
+  },
+
+  methods: {
+    openRecordInstructions() {
+      this.$root.$emit('open-record-instructions');
     },
   },
 };
@@ -33,6 +42,17 @@ export default {
 
   h2 {
     color: $white;
+  }
+
+  a {
+    text-decoration: none;
+    color: $lightblue;
+
+    &:hover {
+      color: $blue;
+      transition: $transition;
+      cursor: pointer;
+    }
   }
 }
 </style>


### PR DESCRIPTION
Adds links in the Navie instructions that open the `Record AppMaps` instruction page when clicked.

## Before

![image](https://github.com/getappmap/appmap-js/assets/45714532/30a7bb96-71d5-45bd-924d-ec970397fe50)

![image](https://github.com/getappmap/appmap-js/assets/45714532/71923f70-f78c-4b77-9304-368b7aabe460)


## After

![image](https://github.com/getappmap/appmap-js/assets/45714532/70d55182-98d1-4255-b791-6d4c1149287d)

![image](https://github.com/getappmap/appmap-js/assets/45714532/1f4243e0-78d3-408b-926a-c0ba90dc7346)
