### PR TITLE
feat: Improve file watcher stat delay

### DIFF
--- a/packages/cli/src/cmds/index/index.ts
+++ b/packages/cli/src/cmds/index/index.ts
@@ -44,12 +44,6 @@ export const builder = (args: yargs.Argv) => {
     type: 'number',
     alias: 'p',
   });
-  args.options('watch-stat-delay', {
-    type: 'number',
-    default: 10,
-    describe: 'delay between stat calls when watching, in milliseconds',
-    hidden: true,
-  });
   return args.strict();
 };
 
@@ -58,7 +52,7 @@ export const handler = async (argv) => {
   handleWorkingDirectory(argv.directory);
   const appmapDir = await locateAppMapDir(argv.appmapDir);
 
-  const { watchStatDelay, watch, port } = argv;
+  const { watch, port } = argv;
 
   const runServer = watch || port !== undefined;
   if (port && !watch) warn(`Note: --port option implies --watch`);
@@ -68,7 +62,7 @@ export const handler = async (argv) => {
 
     log(`Running indexer in watch mode`);
     const cmd = new FingerprintWatchCommand(appmapDir);
-    await cmd.execute(watchStatDelay);
+    await cmd.execute();
 
     if (port !== undefined) {
       const rpcMethods: RpcHandler<any, any>[] = [

--- a/packages/cli/tests/unit/fingerprint/fingerprintWatchCommand.spec.ts
+++ b/packages/cli/tests/unit/fingerprint/fingerprintWatchCommand.spec.ts
@@ -106,7 +106,7 @@ describe(FingerprintWatchCommand, () => {
 
     it('works eventually even if watching files is flaky', async () => {
       cmd = new FingerprintWatchCommand(appMapDir);
-      await cmd.execute();
+      await cmd.execute(0.01, 100);
       cmd.watcher?.removeAllListeners();
       placeMap();
       return verifyIndexSuccess(200, 20);


### PR DESCRIPTION
Don't apply stat delay to the initial scan - startup is blocked until the scan completes, so let it run ASAP.

Remove user configurability of the stat delay. It's not exposed anywhere to the user where it might be useful anyway.