### PR TITLE
feat: Downscore out-of-date AppMaps in full text search

### DIFF
--- a/packages/cli/src/depends.js
+++ b/packages/cli/src/depends.js
@@ -1,10 +1,6 @@
-const fsp = require('fs').promises;
-const { dirname, join: joinPath, isAbsolute, basename } = require('path');
-const { verbose, mtime, processNamedFiles } = require('./utils');
-
-// Gets the file path of a location. Location may include a line number or other info
-// in addition to the file path.
-const parseFilePath = (location) => location.split(':')[0];
+const { dirname } = require('path');
+const { verbose, processNamedFiles } = require('./utils');
+const { default: UpToDate } = require('./lib/UpToDate');
 
 class Depends {
   /**
@@ -13,8 +9,6 @@ class Depends {
   constructor(appMapDir) {
     this.appMapDir = appMapDir;
     this.baseDir = '.';
-    this.mtimes = new Map();
-    this.mtimeCacheHitCount = 0;
   }
 
   /**
@@ -47,20 +41,6 @@ class Depends {
   }
 
   /**
-   * Prepend the baseDir to filePath, unless filePath is absolute.
-   *
-   * @param {string} filePath
-   * @returns string
-   */
-  makeAbsolutePath(filePath) {
-    if (isAbsolute(filePath)) {
-      return filePath;
-    }
-
-    return joinPath(this._baseDir, filePath);
-  }
-
-  /**
    * Compute the AppMaps which are out of date with regard to dependency files.
    * Each result is the name of the AppMap file with the suffix 'appmap.json' stripped.
    * If a callback is provided, the AppMaps names are yielded as they are detected.
@@ -71,106 +51,25 @@ class Depends {
   async depends(callback = undefined) {
     const outOfDateNames = new Set();
 
-    const checkClassMap = async (fileName) => {
-      const indexDir = dirname(fileName);
-      if (basename(indexDir) === 'Inventory') {
-        return;
+    const isClientProvidedFile = (filePath) => this.testLocations.has(filePath);
+
+    const upToDate = new UpToDate();
+    if (this._baseDir) upToDate.baseDir = this._baseDir;
+    if (this.testLocations) upToDate.testFunction = isClientProvidedFile;
+
+    const uptodate = async (classMapFile) => {
+      const appmapName = dirname(classMapFile);
+      const outOfDateCodeLocations = await upToDate.isOutOfDate(appmapName);
+      if (outOfDateCodeLocations) {
+        if (callback) callback(appmapName);
+
+        outOfDateNames.add(appmapName);
       }
-
-      let appmapUpdatedAtStr;
-      try {
-        appmapUpdatedAtStr = await fsp.readFile(joinPath(indexDir, 'mtime'));
-      } catch (err) {
-        if (err.code !== 'ENOENT') console.warn(err);
-        return;
-      }
-      const appmapUpdatedAt = parseFloat(appmapUpdatedAtStr);
-
-      if (verbose()) {
-        console.log(`Checking AppMap ${indexDir} with timestamp ${appmapUpdatedAt}`);
-      }
-
-      const reportOutOfDate = (filePath) => {
-        if (verbose()) {
-          console.log(`${filePath} requires rebuild of AppMap ${indexDir}`);
-        }
-        if (!outOfDateNames.has(indexDir)) {
-          if (callback) {
-            callback(indexDir);
-          }
-          outOfDateNames.add(indexDir);
-        }
-      };
-
-      const classMap = JSON.parse(await fsp.readFile(fileName));
-      const codeLocations = new Set();
-
-      const collectFilePaths = (item) => {
-        if (item.location) {
-          const filePath = parseFilePath(item.location);
-          codeLocations.add(filePath);
-        }
-        if (item.children) {
-          item.children.forEach(collectFilePaths);
-        }
-      };
-      classMap.forEach(collectFilePaths);
-
-      const isClientProvidedFile = (filePath) => this.testLocations.has(filePath);
-
-      const modifiedTime = async (filePath) => {
-        const result = this.mtimes.get(filePath);
-        if (result || result === false) {
-          this.mtimeCacheHitCount += 1;
-          return result;
-        }
-
-        const dependencyFilePath = this.makeAbsolutePath(filePath);
-        let dependencyModifiedAt = await mtime(dependencyFilePath);
-
-        // TODO: Actually, if the dependency file does not exist, we should return true.
-        // However, at this time we can't tell the difference between a dependency file that has
-        // been deleted, and one that never existed in the first place. What does 'never existed in the first place'
-        // mean? Well, unfortunately the Ruby agent (and perhaps others?) will write file locations
-        // like 'JSON' for native functions that don't actually correspond to real files.
-        if (!dependencyModifiedAt) {
-          dependencyModifiedAt = false;
-          if (verbose()) console.log(`[depends] ${dependencyFilePath} does not exist`);
-        }
-
-        this.mtimes.set(filePath, dependencyModifiedAt);
-        return dependencyModifiedAt;
-      };
-
-      const isFileModifiedSince = async (filePath) => {
-        const dependencyModifiedAt = await modifiedTime(filePath);
-        if (dependencyModifiedAt === false) return false;
-
-        const uptodate = appmapUpdatedAt < dependencyModifiedAt;
-        if (!uptodate && verbose()) {
-          console.log(
-            `[depends] ${filePath} timestamp is ${dependencyModifiedAt}, NOT up to date with ${indexDir} (${appmapUpdatedAt})`
-          );
-        }
-
-        return uptodate;
-      };
-
-      const testFunction = this.testLocations ? isClientProvidedFile : isFileModifiedSince;
-
-      await Promise.all(
-        [...codeLocations].map(async (filePath) => {
-          if (await testFunction(filePath)) {
-            if (verbose()) console.debug(`[depends] ${indexDir} is out of date due to ${filePath}`);
-            reportOutOfDate(filePath, indexDir);
-          }
-        })
-      );
     };
 
     await processNamedFiles(this.appMapDir, 'classMap.json', async (fileName) => {
       try {
-        await checkClassMap(fileName);
+        await uptodate(fileName);
       } catch (e) {
         console.log(e.code);
         console.warn(`Error checking uptodate ${fileName}: ${e}`);
@@ -178,7 +77,6 @@ class Depends {
     });
 
     if (verbose()) {
-      console.debug(`File mtime cache hit count: ${this.mtimeCacheHitCount}`);
       console.debug(`Out of date count: ${outOfDateNames.size}`);
     }
 

--- a/packages/cli/src/lib/UpToDate.ts
+++ b/packages/cli/src/lib/UpToDate.ts
@@ -1,0 +1,142 @@
+import { readFile } from 'node:fs/promises';
+import { isCodedError, mtime, verbose } from '../utils';
+import { isAbsolute, join } from 'node:path';
+import assert from 'node:assert';
+import { PathLike } from 'node:fs';
+
+type ClassEntry = {
+  location: string;
+  children?: ClassEntry[];
+};
+
+// Gets the file path of a location. Location may include a line number or other info
+// in addition to the file path.
+const parseFilePath = (location: string) => location.split(':')[0];
+
+export interface AppMapIndex {
+  updatedAt(appmapName: string): Promise<number | undefined>;
+
+  classMap(appmapName: string): Promise<ClassEntry[]>;
+}
+
+class FileAppMapIndex implements AppMapIndex {
+  async updatedAt(appmapName: string): Promise<number | undefined> {
+    let appmapUpdatedAtStr: string;
+    try {
+      appmapUpdatedAtStr = await readFile(join(appmapName, 'mtime'), 'utf-8');
+    } catch (err) {
+      if (!isCodedError(err)) console.warn(err);
+      if (isCodedError(err) && err.code !== 'ENOENT') console.warn(err);
+      return;
+    }
+    return parseFloat(appmapUpdatedAtStr);
+  }
+
+  async classMap(appmapName: string): Promise<ClassEntry[]> {
+    return JSON.parse(await readFile(join(appmapName, 'classMap.json'), 'utf-8'));
+  }
+}
+
+export default class UpToDate {
+  public baseDir: string | undefined;
+  public testFunction: ((sourceFilePath: string) => Promise<boolean>) | undefined;
+  public appMapIndex: AppMapIndex = new FileAppMapIndex();
+  public mtime: (path: PathLike) => Promise<number | undefined> = mtime;
+
+  private mtimes = new Map<string, number | false>();
+  public mtimeLookupCount = 0;
+  public mtimeCacheHits = 0;
+
+  async isOutOfDate(appmapName: string): Promise<undefined | Set<string>> {
+    assert(!appmapName.endsWith('.appmap.json'), 'appmapName should not end with .appmap.json');
+
+    const appmapUpdatedAt = await this.appMapIndex.updatedAt(appmapName);
+    if (appmapUpdatedAt === undefined) {
+      if (verbose()) console.warn(`[UpToDate] Update time for ${appmapName} cannot be determined`);
+      return;
+    }
+
+    if (verbose()) {
+      console.log(`[UpToDate] Checking AppMap ${appmapName} with timestamp ${appmapUpdatedAt}`);
+    }
+
+    const outOfDateNames = new Set<string>();
+    const reportOutOfDate = (filePath: string) => {
+      if (verbose()) console.log(`[UpToDate] ${filePath} requires rebuild of AppMap ${appmapName}`);
+
+      outOfDateNames.add(filePath);
+    };
+
+    const classMap: ClassEntry[] = await this.appMapIndex.classMap(appmapName);
+    const codeLocations = new Set<string>();
+    const collectFilePaths = (classEntry: ClassEntry) => {
+      if (classEntry.location) {
+        const filePath = parseFilePath(classEntry.location);
+        codeLocations.add(filePath);
+      }
+      if (classEntry.children) classEntry.children.forEach(collectFilePaths);
+    };
+    classMap.forEach(collectFilePaths);
+
+    const modifiedTime = async (sourceFilePath: string): Promise<number | false> => {
+      const result = this.mtimes.get(sourceFilePath);
+      if (result || result === false) {
+        this.mtimeCacheHits++;
+        return result;
+      }
+
+      // Eleswhere, we are dealing with logical file names. But here, we need to resolve
+      // the file path to the actual file system path.
+      const resolvedFilePath = this.resolveFilePath(sourceFilePath);
+      const dependencyModifiedAt = (await this.mtime(resolvedFilePath)) || false;
+      this.mtimeLookupCount++;
+
+      if (dependencyModifiedAt === false && verbose())
+        console.log(`[UpToDate] ${sourceFilePath} does not exist`);
+
+      this.mtimes.set(sourceFilePath, dependencyModifiedAt);
+      return dependencyModifiedAt;
+    };
+
+    const isFileModifiedSince = async (sourceFilePath: string) => {
+      const dependencyModifiedAt = await modifiedTime(sourceFilePath);
+      if (dependencyModifiedAt === false) return dependencyModifiedAt;
+
+      const outOfDate = appmapUpdatedAt < dependencyModifiedAt;
+      if (outOfDate && verbose()) {
+        console.log(
+          `[UpToDate] ${appmapName} (${appmapUpdatedAt}) is NOT up to date with ${sourceFilePath} (${dependencyModifiedAt})`
+        );
+      }
+
+      return outOfDate;
+    };
+
+    const test = this.testFunction || isFileModifiedSince;
+    await Promise.all(
+      [...codeLocations].map(async (sourceFilePath) => {
+        if (await test(sourceFilePath)) {
+          if (verbose())
+            console.debug(`[UpToDate] ${appmapName} is out of date due to ${sourceFilePath}`);
+          reportOutOfDate(sourceFilePath);
+        }
+      })
+    );
+
+    return outOfDateNames.size > 0 ? outOfDateNames : undefined;
+  }
+
+  /**
+   * Prepend the baseDir to filePath, unless filePath is absolute.
+   *
+   * @param {string} filePath
+   * @returns string
+   */
+  private resolveFilePath(filePath: string) {
+    if (!this.baseDir) return filePath;
+
+    if (isAbsolute(filePath)) return filePath;
+
+    return join(this.baseDir, filePath);
+  }
+}

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -59,13 +59,21 @@ async function statFile(filePath: PathLike): Promise<Stats | null> {
   }
 }
 
+export type CodedError = { code: string };
+
+export function isCodedError(error: any): error is CodedError {
+  if (!error.code) return false;
+
+  return typeof error.code === 'string';
+}
+
 /**
  * Gets the last modified time of a file.
  *
  * @returns file mtime in ms, or null if the file does not exist or
  * is not a file.
  */
-export async function mtime(filePath: PathLike): Promise<number | null> {
+export async function mtime(filePath: PathLike): Promise<number | undefined> {
   // NB: 'ctime' is actually the time that the stats of the file were last changed.
   // And 'birthtime' is not guaranteed across platforms.
   // Therefore mtime is the most reliable indicator of when the file was created,
@@ -74,7 +82,7 @@ export async function mtime(filePath: PathLike): Promise<number | null> {
 
   const fileStat = await statFile(filePath);
   if (!fileStat || !fileStat.isFile()) {
-    return null;
+    return;
   }
   return fileStat.mtimeMs;
 }

--- a/packages/cli/tests/unit/depends.spec.ts
+++ b/packages/cli/tests/unit/depends.spec.ts
@@ -60,7 +60,7 @@ describe('Depends', () => {
     const result: any[] = [];
     const fn = new Depends(appMapDir);
     fn.files = ['app/models/user.rb'];
-    await fn.depends((file) => result.push(file));
+    await fn.depends((file: string) => result.push(file));
     expect(result).toEqual([expected]);
   });
 });

--- a/packages/cli/tests/unit/lib/UpToDate.spec.ts
+++ b/packages/cli/tests/unit/lib/UpToDate.spec.ts
@@ -1,0 +1,83 @@
+import UpToDate, { AppMapIndex } from '../../../src/lib/UpToDate';
+import { verbose } from '../../../src/utils';
+
+describe('UpToDate', () => {
+  beforeAll(() => verbose(process.env.DEBUG === 'true'));
+  afterEach(() => jest.resetAllMocks());
+
+  const aSecondAgo = Date.now() - 1000;
+
+  let appMapIndex: AppMapIndex;
+  let upToDate: UpToDate;
+
+  describe('when the AppMap file mtime cannot be determined', () => {
+    beforeEach(() => {
+      const updatedAt = jest.fn().mockResolvedValue(undefined);
+      appMapIndex = {
+        updatedAt,
+      } as any;
+      upToDate = new UpToDate();
+      upToDate.appMapIndex = appMapIndex;
+    });
+
+    it('should return undefined', async () => {
+      const result = await upToDate.isOutOfDate('appmap');
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('with ClassMap', () => {
+    beforeEach(() => {
+      const updatedAt = jest.fn().mockResolvedValue(aSecondAgo);
+      appMapIndex = {
+        updatedAt,
+        classMap: jest.fn().mockResolvedValue([
+          {
+            location: 'file1.rb',
+            children: [
+              {
+                location: 'file2.rb',
+              },
+            ],
+          },
+        ]),
+      } as any;
+      upToDate = new UpToDate();
+      upToDate.appMapIndex = appMapIndex;
+    });
+
+    it('determines the modification time of each file once', async () => {
+      // It doesn't matter for this test what the result is
+      upToDate.mtime = jest.fn().mockResolvedValue(aSecondAgo - 1000);
+
+      await upToDate.isOutOfDate('appmap');
+      expect(upToDate.mtime).toHaveBeenCalledTimes(2);
+      expect(upToDate.mtimeCacheHits).toBe(0);
+
+      await upToDate.isOutOfDate('appmap');
+      expect(upToDate.mtime).toHaveBeenCalledTimes(2);
+      expect(upToDate.mtimeCacheHits).toBe(2);
+    });
+
+    describe('when source files are older than the AppMap file', () => {
+      beforeEach(() => {
+        upToDate.mtime = jest.fn().mockResolvedValue(aSecondAgo - 1000);
+      });
+
+      it('should return undefined', async () => {
+        const result = await upToDate.isOutOfDate('appmap');
+        expect(result).toBeUndefined();
+      });
+    });
+    describe('when a source file is newer than the AppMap file', () => {
+      beforeEach(() => {
+        upToDate.mtime = jest.fn().mockResolvedValue(aSecondAgo + 1000);
+      });
+
+      it('should return the relevant set of source files', async () => {
+        const result = await upToDate.isOutOfDate('appmap');
+        expect(result).toEqual(new Set(['file1.rb', 'file2.rb']));
+      });
+    });
+  });
+});

--- a/packages/cli/tests/unit/lib/UpToDate.spec.ts
+++ b/packages/cli/tests/unit/lib/UpToDate.spec.ts
@@ -3,7 +3,7 @@ import { verbose } from '../../../src/utils';
 
 describe('UpToDate', () => {
   beforeAll(() => verbose(process.env.DEBUG === 'true'));
-  afterEach(() => jest.resetAllMocks());
+  afterEach(() => jest.restoreAllMocks());
 
   const aSecondAgo = Date.now() - 1000;
 


### PR DESCRIPTION
When searching client-side for AppMaps to match a set of keywords, apply a score penalty to AppMaps that are out-of-date.

The penalty is hard-coded here as `0.5 * stddev`

## TODO

- [x] It's not necessary to compute out-of-date for every search result. 
- [x] Apply a score penalty of 1/2 stddev.

