### PR TITLE
Update @appland/components to 4.0.0 in @appland/cli

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -85,7 +85,7 @@
   ],
   "dependencies": {
     "@appland/client": "workspace:^1.15.0",
-    "@appland/components": "workspace:^3.21.2",
+    "@appland/components": "workspace:^4.0.0",
     "@appland/diagrams": "workspace:^1.8.0",
     "@appland/models": "workspace:^2.10.0",
     "@appland/openapi": "workspace:^1.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -177,7 +177,7 @@ __metadata:
   dependencies:
     "@appland/appmap-agent-js": 14.2.0
     "@appland/client": "workspace:^1.15.0"
-    "@appland/components": "workspace:^3.21.2"
+    "@appland/components": "workspace:^4.0.0"
     "@appland/diagrams": "workspace:^1.8.0"
     "@appland/models": "workspace:^2.10.0"
     "@appland/openapi": "workspace:^1.8.0"
@@ -320,7 +320,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@appland/components@workspace:^3.21.2, @appland/components@workspace:packages/components":
+"@appland/components@workspace:^4.0.0, @appland/components@workspace:packages/components":
   version: 0.0.0-use.local
   resolution: "@appland/components@workspace:packages/components"
   dependencies:


### PR DESCRIPTION
The CLI is [not building correctly](https://github.com/getappmap/appmap-js/actions/runs/7878989013/job/21498405134?pr=1589#step:3:58) because `@appland/components` got released with a new major version. This updates the CLI so that it builds successfully.