### PR TITLE
fix: Prevent read from undefined if no matches are found

### DIFF
--- a/packages/cli/src/fulltext/AppMapIndex.ts
+++ b/packages/cli/src/fulltext/AppMapIndex.ts
@@ -147,6 +147,9 @@ export async function removeNonExistentMatches(matches: lunr.Index.Result[]) {
 }
 
 export function scoreMatches(matches: lunr.Index.Result[]): Map<ScoreStats, number> {
+  const scoreStats = new Map<ScoreStats, number>();
+  if (!matches.length) return scoreStats;
+
   const numResults = matches.length;
   const maxScore = matches.reduce((acc, match) => Math.max(acc, match.score), 0);
   const medianScore = matches[Math.floor(numResults / 2)].score;
@@ -178,7 +181,6 @@ export function scoreMatches(matches: lunr.Index.Result[]): Map<ScoreStats, numb
     );
   }
 
-  const scoreStats = new Map<ScoreStats, number>();
   scoreStats.set(ScoreStats.Max, maxScore);
   scoreStats.set(ScoreStats.Median, medianScore);
   scoreStats.set(ScoreStats.Mean, meanScore);

--- a/packages/cli/tests/unit/fulltext/AppMapIndex.spec.ts
+++ b/packages/cli/tests/unit/fulltext/AppMapIndex.spec.ts
@@ -68,6 +68,21 @@ describe('AppMapIndex', () => {
       });
     });
 
+    describe('when search results are not found', () => {
+      it('returns an expected result', async () => {
+        const index = new AppMapIndex('appmapDir', {
+          search: jest.fn().mockReturnValue([]),
+        } as any);
+        const searchResults = await index.search('');
+        expect(searchResults).toStrictEqual({
+          type: 'appmap',
+          results: [],
+          stats: {},
+          numResults: 0,
+        });
+      });
+    });
+
     it(`reports statistics`, async () => {
       mockUpToDate();
 


### PR DESCRIPTION
This fixes the following issue
```txt
227802 [Stderr] Stack trace: TypeError: Cannot read properties of undefined (reading 'score')
227802 [Stderr]     at scoreMatches (/home/divide/.config/Code/User/globalStorage/appland.appmap/node_modules/@appland/appmap/built/fulltext/AppMapIndex.js:109:61)
227802 [Stderr]     at AppMapIndex.search (/home/divide/.config/Code/User/globalStorage/appland.appmap/node_modules/@appland/appmap/built/fulltext/AppMapIndex.js:184:28)
227802 [Stderr]     at async AppMapIndex.search (/home/divide/.config/Code/User/globalStorage/appland.appmap/node_modules/@appland/appmap/built/fulltext/AppMapIndex.js:193:16)
227802 [Stderr]     at async handler (/home/divide/.config/Code/User/globalStorage/appland.appmap/node_modules/@appland/appmap/built/rpc/search/search.js:17:34)
227802 [Stderr]     at async search (/home/divide/.config/Code/User/globalStorage/appland.appmap/node_modules/@appland/appmap/built/rpc/explain/search.js:9:28)
227802 [Stderr]     at async Explain.searchContext (/home/divide/.config/Code/User/globalStorage/appland.appmap/node_modules/@appland/appmap/built/rpc/explain/explain.js:78:32)
227802 [Stderr]     at async Object.onRequestContext (/home/divide/.config/Code/User/globalStorage/appland.appmap/node_modules/@appland/appmap/built/rpc/explain/explain.js:45:24)
227802 [Stderr]     at async AIClient.handleMessage (/home/divide/.config/Code/User/globalStorage/appland.appmap/node_modules/@appland/appmap/node_modules/@appland/client/dist/src/aiClient.js:64:33)
```