### PR TITLE
fix: Empty or invalid Navie responses

### DIFF
--- a/packages/cli/src/rpc/explain/explain.ts
+++ b/packages/cli/src/rpc/explain/explain.ts
@@ -150,6 +150,20 @@ async function explain(
       searchStatusByUserMessageId.set(userMessageId, status);
       first() && resolve({ userMessageId, threadId });
     });
+
+    // If the request completes here, consider it an error. This would mean that the
+    // remote server terminated our connection early.
+    explain.on(
+      'complete',
+      () =>
+        first() &&
+        reject(
+          RpcError.fromException(
+            new Error(status.explanation?.join('') || 'The response completed unexpectedly')
+          )
+        )
+    );
+
     explain.explain().catch((err: Error) => first() && reject(RpcError.fromException(err)));
   });
 }

--- a/packages/components/src/components/chat/Chat.vue
+++ b/packages/components/src/components/chat/Chat.vue
@@ -291,11 +291,6 @@ export default {
         this.ask(prompt);
       }
     },
-    onNoMatch() {
-      // If the AI was not able to produce a useful response, don't persist the thread.
-      // This is used by Explain when no AppMaps can be found to match the question.
-      this.threadId = undefined;
-    },
     clear() {
       this.threadId = undefined;
       this.messages.splice(0);

--- a/packages/components/src/pages/ChatSearch.vue
+++ b/packages/components/src/pages/ChatSearch.vue
@@ -191,8 +191,6 @@ export default {
       }
       if (searchResponse.results.length > 0) {
         this.selectedSearchResultId = searchResponse.results[0].id;
-      } else {
-        this.$refs.vchat.onNoMatch();
       }
     },
     selectedSearchResultId: async function (newVal) {

--- a/packages/components/tests/unit/chat/ChatSearch.spec.js
+++ b/packages/components/tests/unit/chat/ChatSearch.spec.js
@@ -256,6 +256,14 @@ describe('pages/ChatSearch.vue', () => {
         return { messagesCalled, wrapper };
       };
 
+      it('states that no matches were found', async () => {
+        const { wrapper } = await performSearch();
+
+        expect(wrapper.find('[data-cy="tool-status"]').text()).toContain(
+          'Found 0 relevant recordings'
+        );
+      });
+
       it('makes expected RPC calls', async () => {
         const { messagesCalled } = await performSearch();
 
@@ -265,10 +273,10 @@ describe('pages/ChatSearch.vue', () => {
         });
       });
 
-      it('clears the thread id', async () => {
+      it('retains the thread id', async () => {
         const { wrapper } = await performSearch();
 
-        expect(wrapper.vm.$refs.vchat.threadId).toBeUndefined();
+        expect(wrapper.vm.$refs.vchat.threadId).toEqual(threadId);
       });
 
       it('shows the "no match" instructions', async () => {


### PR DESCRIPTION
This PR fixes two issues:
1. Responses were not being streamed in if the user had no AppMap matches
2. If the user had not agreed to the latest EULA, the socket would close without notifying the user

Resolves #1601 
Resolves #1602 