### PR TITLE
feat: @appland/navie

### DIFF
--- a/packages/cli/.appmapignore
+++ b/packages/cli/.appmapignore
@@ -1,0 +1,2 @@
+tests/unit/fixtures
+

--- a/packages/cli/.gitignore
+++ b/packages/cli/.gitignore
@@ -1,4 +1,5 @@
 built
 tests/output
 tests/unit/fixtures/compare/.appmap/change-report/testBase-testHead/report.md
-
+tests/unit/fixtures/malformedParentId/user_page_scenario/
+tests/unit/fixtures/ruby/.appmap/run-stats/

--- a/packages/cli/src/fulltext/AppMapIndex.ts
+++ b/packages/cli/src/fulltext/AppMapIndex.ts
@@ -259,14 +259,16 @@ export default class AppMapIndex {
 
     const scoreStats = scoreMatches(matches);
 
-    if (options.maxResults && numResults > options.maxResults)
-      if (verbose()) log(`[FullText] Limiting to the top ${options.maxResults} matches`);
-
     matches = await downscoreOutOfDateMatches(
       scoreStats,
       matches,
       options.maxResults || matches.length
     );
+
+    if (options.maxResults && numResults > options.maxResults) {
+      if (verbose()) log(`[FullText] Limiting to the top ${options.maxResults} matches`);
+      matches = matches.slice(0, options.maxResults);
+    }
 
     return reportMatches(matches, scoreStats, numResults);
   }

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -39,7 +39,6 @@ export function splitCamelized(str: string): string {
   const result = new Array<string>();
   let last = 0;
   for (let i = 1; i < str.length; i++) {
-    const pc = str[i - 1];
     const c = str[i];
     const isUpper = c >= 'A' && c <= 'Z';
     if (isUpper) {

--- a/packages/navie/.eslintrc.js
+++ b/packages/navie/.eslintrc.js
@@ -1,0 +1,48 @@
+/* eslint-disable eslint-comments/disable-enable-pair */
+/* eslint-disable @typescript-eslint/no-var-requires */
+const path = require('path');
+
+module.exports = {
+  plugins: ['@typescript-eslint', 'eslint-comments', 'jest', 'promise', 'unicorn'],
+  extends: [
+    'airbnb-base',
+    'airbnb-typescript/base',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:@typescript-eslint/recommended-requiring-type-checking',
+    'plugin:eslint-comments/recommended',
+    'plugin:jest/recommended',
+    'plugin:promise/recommended',
+    'prettier',
+  ],
+  env: {
+    node: true,
+    browser: true,
+    jest: true,
+  },
+  parserOptions: {
+    project: path.join(__dirname, 'tsconfig.json'),
+  },
+  root: true,
+  rules: {
+    'no-param-reassign': ['error', { props: false }],
+    'no-console': process.env.NODE_ENV === 'production' ? 'warn' : 'off',
+    'no-debugger': process.env.NODE_ENV === 'production' ? 'warn' : 'off',
+    '@typescript-eslint/lines-between-class-members': 'off',
+    'no-restricted-syntax': 'off',
+    'import/no-cycle': 'off',
+    'prettier/prettier': ['error'],
+  },
+  overrides: [
+    {
+      files: ['*.js'],
+      extends: ['eslint:recommended', 'airbnb-base', 'prettier'],
+      parserOptions: {
+        project: path.join(__dirname, 'jsconfig.json'),
+      },
+      plugins: ['prettier'],
+      rules: {
+        'unicorn/prefer-module': 'off',
+      },
+    },
+  ],
+};

--- a/packages/navie/.eslintrc.js
+++ b/packages/navie/.eslintrc.js
@@ -31,6 +31,7 @@ module.exports = {
     'no-restricted-syntax': 'off',
     'import/no-cycle': 'off',
     'prettier/prettier': ['error'],
+    'max-classes-per-file': 'off',
   },
   overrides: [
     {

--- a/packages/navie/LICENSE.txt
+++ b/packages/navie/LICENSE.txt
@@ -1,0 +1,25 @@
+The Software is provided to you by the Licensor under the License, as defined below, subject to the following condition.
+
+Without limiting other conditions in the License, the grant of rights under the License will not include,
+and the License does not grant to you, the right to Sell the Software.
+
+For purposes of the foregoing, “Sell” means practicing any or all of the rights granted to you under the License to provide to third parties,
+for a fee or other consideration (including without limitation fees for hosting or consulting/ support services related to the Software),
+a product or service whose value derives, entirely or substantially, from the functionality of the Software.
+Any license notice or attribution required by the License must also include this Commons Clause License Condition notice.
+
+Software: @appland/navie
+
+License: MIT License
+
+Copyright 2024, AppLand Inc
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/navie/appmap.yml
+++ b/packages/navie/appmap.yml
@@ -1,0 +1,3 @@
+name: '@appland/navie'
+language: javascript
+appmap_dir: tmp/appmap

--- a/packages/navie/jest.config.js
+++ b/packages/navie/jest.config.js
@@ -1,0 +1,6 @@
+/** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testTimeout: Number.parseInt(process.env.TEST_TIMEOUT, 10) || 5000,
+};

--- a/packages/navie/jsconfig.json
+++ b/packages/navie/jsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "moduleResolution": "node"
+  },
+  "include": ["*.js"]
+}

--- a/packages/navie/package.json
+++ b/packages/navie/package.json
@@ -36,7 +36,7 @@
     "ts-jest": "^29.0.5",
     "ts-node": "^10.4.0",
     "tsc": "^2.0.3",
-    "typescript": "^4.5.4"
+    "typescript": "^4.9.5"
   },
   "dependencies": {
     "@langchain/core": "^0.1.32",

--- a/packages/navie/package.json
+++ b/packages/navie/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "build": "tsc",
     "watch": "tsc --watch",
+    "test": "jest",
     "lint": "eslint"
   },
   "publishConfig": {

--- a/packages/navie/package.json
+++ b/packages/navie/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@appland/navie",
+  "version": "1.0.0",
+  "description": "",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc --watch",
+    "lint": "eslint"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "author": "AppLand, Inc.",
+  "license": "MIT + Commons Clause",
+  "devDependencies": {
+    "@types/jest": "^29.4.1",
+    "@types/node": "^17.0.2",
+    "@typescript-eslint/eslint-plugin": "^5.51.0",
+    "@typescript-eslint/parser": "^5.7.0",
+    "eslint": "^8.4.1",
+    "eslint-config-airbnb-base": "^15.0.0",
+    "eslint-config-airbnb-typescript": "^17.0.0",
+    "eslint-config-prettier": "^8.3.0",
+    "eslint-formatter-pretty": "^4.1.0",
+    "eslint-plugin-eslint-comments": "^3.2.0",
+    "eslint-plugin-import": "^2.25.3",
+    "eslint-plugin-jest": "^25.3.0",
+    "eslint-plugin-promise": "^6.0.1",
+    "eslint-plugin-unicorn": "^39.0.0",
+    "jest": "^29.5.0",
+    "ts-jest": "^29.0.5",
+    "ts-node": "^10.4.0",
+    "tsc": "^2.0.3",
+    "typescript": "^4.5.4"
+  },
+  "dependencies": {
+    "@langchain/core": "^0.1.32",
+    "@langchain/openai": "^0.0.15",
+    "langchain": "^0.1.25",
+    "openai": "^4.28.0"
+  }
+}

--- a/packages/navie/src/chat-openai.ts
+++ b/packages/navie/src/chat-openai.ts
@@ -1,0 +1,8 @@
+import { ChatOpenAI, OpenAIChatInput } from '@langchain/openai';
+
+export default function buildChatOpenAI(chatInput: Partial<OpenAIChatInput>): ChatOpenAI {
+  if (!process.env.OPENAI_API_KEY) throw new Error('OPENAI_API_KEY is not set');
+
+  chatInput.openAIApiKey = process.env.OPENAI_API_KEY;
+  return new ChatOpenAI(chatInput);
+}

--- a/packages/navie/src/context.ts
+++ b/packages/navie/src/context.ts
@@ -1,0 +1,19 @@
+export type ContextRequest = {
+  type: 'search';
+  vectorTerms: string[];
+  tokenCount: number;
+};
+
+export type ContextItem = {
+  name: string;
+  score?: number;
+  content: string;
+};
+
+export type ContextResponse = {
+  sequenceDiagrams: string[];
+  codeSnippets: { [key: string]: string };
+  codeObjects: string[];
+};
+
+export type ContextProvider = (request: ContextRequest) => Promise<ContextResponse>;

--- a/packages/navie/src/explain.ts
+++ b/packages/navie/src/explain.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-classes-per-file */
 import Message, { CHARACTERS_PER_TOKEN } from './message';
 import MemoryService from './services/memory-service';
 import VectorTermsService from './services/vector-terms-service';

--- a/packages/navie/src/explain.ts
+++ b/packages/navie/src/explain.ts
@@ -1,0 +1,226 @@
+/* eslint-disable max-classes-per-file */
+import Message, { CHARACTERS_PER_TOKEN } from './message';
+import MemoryService from './services/memory-service';
+import VectorTermsService from './services/vector-terms-service';
+import CompletionService, { OpenAICompletionService } from './services/completion-service';
+import InteractionHistory, {
+  InteractionEvent,
+  InteractionHistoryEvents,
+  PromptInteractionEvent,
+} from './interaction-history';
+import LookupContextService from './services/lookup-context-service';
+import ApplyContextService from './services/apply-context-service';
+import { ContextProvider, ContextResponse } from './context';
+import ProjectInfoService from './services/project-info-service';
+import { ProjectInfoProvider } from './project-info';
+import CodeSelectionService from './services/code-selection-service';
+import QuestionService from './services/question-service';
+
+const AGENT_INFO_PROMPT = `**Task: Explaining Code, Analyzing Code, Generating Code**
+
+**About you**
+
+Your job is to explain code, analyze code, and generate code using a combination of 
+AppMap data and code snippets. Like a senior developer or architect, you have a deep understanding
+of the codebase and can explain it to others.
+
+You are created and maintained by AppMap Inc, and are available to AppMap users as a service.
+
+**About the user**
+
+The user is a software developer who is trying to understand, maintain and enhance a codebase. You can
+expect the user to be proficient in software development, but they don't have expertise how this code base works.
+
+You do not need to explain the importance of planning and testing, as the user is already aware of these
+concepts. You should focus on explaining the code and generating code.
+
+**Providing help with AppMap**
+
+If the user needs assistance with making AppMaps, you should direct them based on the language in use:
+
+- **Ruby** - https://appmap.io/docs/reference/appmap-ruby
+- **Python** - https://appmap.io/docs/reference/appmap-python
+- **Java** - https://appmap.io/docs/reference/appmap-java
+- **JavaScript, Node.js and TypeScript** - https://appmap.io/docs/reference/appmap-node
+
+\`appmap-node\` is the new AppMap agent for JavaScript, Node.js and TypeScript. To use it to make AppMaps, the
+user runs their command with the prefix \`npx appmap-node\`.
+
+Your guidance should be directed towards using AppMap in the developer's local environment, such as
+their code editor. Don't suggest configuration of production systems unless the user specifically asks
+about that. If the user asks about configuration of AppMap in production, make sure you include an advisory
+about the security and data protection implications of recording AppMaps in production.
+
+For Ruby environments, you do not generally need to advise the user to export the environment variable
+APPMAP=true, since AppMap will generally be enabled by default in development and test environments.
+
+When advising the user to use "remote recording", you should advise the user to utilize the AppMap
+extension features of their code editor. Remote recordings are not saved to the \`appmap_dir\` location.
+
+Do not suggest that the user upload any AppMaps to any AppMap-hosted service (e.g. "AppMap Cloud"), as no
+such services are offered at this time. If the user wants to upload and share AppMaps, you should suggest
+that they use the AppMap plugin for Atlassian Confluence.
+
+**Your response**
+
+1. **Markdown**: Respond using Markdown.
+
+2. **Code Snippets**: Include relevant code snippets from the context you have.
+  Ensure that code formatting is consistent and easy to read.
+
+3. **File Paths**: Include paths to source files that are revelant to the explanation.
+
+4. **Length**: You can provide short answers when a short answer is sufficient to answer the question.
+  Otherwise, you should provide a long answer.
+
+Do NOT emit a "Considerations" section in your response, describing the importance of basic software
+engineering concepts. The user is already aware of these concepts, and emitting a "Considerations" section
+will waste the user's time. The user wants direct answers to their questions.
+`;
+
+export type ChatHistory = Message[];
+
+export interface ClientRequest {
+  question: string;
+  codeSelection?: string;
+}
+
+export class ExplainOptions {
+  modelName = 'gpt-4-0125-preview';
+  tokenLimit = 8000;
+  temperature = 0.4;
+  responseTokens = 1000;
+}
+
+export class CodeExplainerService {
+  constructor(
+    public readonly interactionHistory: InteractionHistory,
+    private readonly completionService: CompletionService,
+    private readonly questionService: QuestionService,
+    private readonly codeSelectionService: CodeSelectionService,
+    private readonly projectInfoService: ProjectInfoService,
+    private readonly vectorTermsService: VectorTermsService,
+    private readonly lookupContextService: LookupContextService,
+    private readonly applyContextService: ApplyContextService,
+    private readonly memoryService: MemoryService
+  ) {}
+
+  async *execute(
+    clientRequest: ClientRequest,
+    options: ExplainOptions,
+    chatHistory?: ChatHistory
+  ): AsyncIterable<string> {
+    const { question, codeSelection } = clientRequest;
+    const tokensAvailable = (): number =>
+      options.tokenLimit - options.responseTokens - this.interactionHistory.computeTokenSize();
+
+    this.interactionHistory.addEvent(
+      new PromptInteractionEvent('agentInfo', 'system', AGENT_INFO_PROMPT)
+    );
+    this.questionService.addSystemPrompt();
+    this.questionService.applyQuestion(question);
+    if (codeSelection) {
+      this.codeSelectionService.addSystemPrompt();
+      this.codeSelectionService.applyCodeSelection(codeSelection);
+    }
+    const projectInfo = await this.projectInfoService.lookupProjectInfo();
+
+    const hasAppMaps =
+      projectInfo.appmapStats?.numAppMaps && projectInfo.appmapStats.numAppMaps > 0;
+    if (!hasAppMaps) {
+      // TODO: For now, this is only advisory. We'll continue with the explanation,
+      // because the user may be asking a general programming question.
+      this.interactionHistory.log('No AppMaps exist in the project');
+    }
+
+    let context: ContextResponse | undefined;
+    if (hasAppMaps) {
+      const aggregateQuestion = [
+        question,
+        ...(chatHistory || [])
+          .filter((message) => message.role === 'user')
+          .map((message) => message.content),
+        codeSelection,
+      ]
+        .filter(Boolean)
+        .join('\n\n');
+
+      const vectorTerms = await this.vectorTermsService.suggestTerms(aggregateQuestion);
+      context = await this.lookupContextService.lookupContext({
+        vectorTerms,
+        tokenCount: tokensAvailable(),
+        type: 'search',
+      });
+      if (context) {
+        this.applyContextService.addSystemPrompts(context);
+
+        this.applyContextService.applyContext(context, tokensAvailable() * CHARACTERS_PER_TOKEN);
+      }
+    }
+
+    const hasChatHistory = chatHistory && chatHistory.length > 0;
+    if (hasChatHistory) {
+      await this.memoryService.predictSummary(chatHistory);
+    }
+
+    const response = this.completionService.complete();
+    for await (const token of response) {
+      yield token;
+    }
+  }
+}
+
+export interface IExplain extends InteractionHistoryEvents {
+  execute(): AsyncIterable<string>;
+}
+
+export default function explain(
+  clientRequest: ClientRequest,
+  contextProvider: ContextProvider,
+  projectInfoProvider: ProjectInfoProvider,
+  options: ExplainOptions,
+  chatHistory?: ChatHistory
+): IExplain {
+  const interactionHistory = new InteractionHistory();
+  const completionService = new OpenAICompletionService(
+    interactionHistory,
+    options.modelName,
+    options.temperature
+  );
+  const questionService = new QuestionService(interactionHistory);
+  const codeSelectionService = new CodeSelectionService(interactionHistory);
+  const vectorTermsService = new VectorTermsService(
+    interactionHistory,
+    options.modelName,
+    options.temperature
+  );
+  const projectInfoService = new ProjectInfoService(interactionHistory, projectInfoProvider);
+  const lookupContextService = new LookupContextService(interactionHistory, contextProvider);
+  const applyContextService = new ApplyContextService(interactionHistory);
+  const memoryService = new MemoryService(
+    interactionHistory,
+    options.modelName,
+    options.temperature
+  );
+
+  const codeExplainerService = new CodeExplainerService(
+    interactionHistory,
+    completionService,
+    questionService,
+    codeSelectionService,
+    projectInfoService,
+    vectorTermsService,
+    lookupContextService,
+    applyContextService,
+    memoryService
+  );
+
+  return {
+    on: (event: 'event', listener: (event: InteractionEvent) => void) => {
+      interactionHistory.on(event, listener);
+    },
+    execute() {
+      return codeExplainerService.execute(clientRequest, options, chatHistory);
+    },
+  };
+}

--- a/packages/navie/src/explain.ts
+++ b/packages/navie/src/explain.ts
@@ -78,6 +78,34 @@ engineering concepts. The user is already aware of these concepts, and emitting 
 will waste the user's time. The user wants direct answers to their questions.
 `;
 
+const MAKE_APPMAPS_PROMPT = `**Making AppMaps**
+
+If the user's project does not contain any AppMaps, you should advise the user to make AppMaps.
+
+Provide best practices for making AppMaps, taking into account the following considerations:
+
+- **Language**: The programming language in use.
+- **Frameworks**: The user's application and testing frameworks.
+- **IDE**: The user's code editor.
+
+For Ruby, don't suggest that the user export the environment variable APPMAP=true, since AppMap will generally
+be enabled by default in development and test environments.
+
+When advising the user to use "remote recording", you should advise the user to utilize the AppMap extension
+features of their code editor. Remote recordings are not saved to the \`appmap_dir\` location.
+
+Do not suggest that the user upload any AppMaps to any AppMap-hosted service (e.g. "AppMap Cloud"), as no
+such services are offered at this time. If the user wants to upload and share AppMaps, you should suggest
+that they use the AppMap plugin for Atlassian Confluence.
+
+When helping the user make AppMaps for JavaScript, Node.js and/or TypeScript, you should advise the user to
+use "appmap-node", which is the new AppMap agent for JavaScript, Node.js and TypeScript. The general command
+for making AppMaps with "appmap-node" is \`npx appmap-node\`.
+
+Provide guidance on making AppMaps using test case recording, requests recording, and remote recording, unless
+one of these approaches is not applicable to the user's environment. 
+`;
+
 export type ChatHistory = Message[];
 
 export interface ClientRequest {
@@ -131,6 +159,12 @@ export class CodeExplainerService {
       // TODO: For now, this is only advisory. We'll continue with the explanation,
       // because the user may be asking a general programming question.
       this.interactionHistory.log('No AppMaps exist in the project');
+      this.interactionHistory.addEvent(
+        new PromptInteractionEvent('makeAppMaps', 'system', MAKE_APPMAPS_PROMPT)
+      );
+      this.interactionHistory.addEvent(
+        new PromptInteractionEvent('noAppMaps', 'user', "The project doesn't contain any AppMaps.")
+      );
     }
 
     let context: ContextResponse | undefined;

--- a/packages/navie/src/index.ts
+++ b/packages/navie/src/index.ts
@@ -1,0 +1,9 @@
+/* eslint-disable import/prefer-default-export */
+export { default as Message } from './message';
+export * from './context';
+export { default as InteractionState } from './interaction-state';
+export { default as explain } from './explain';
+export * as Context from './context';
+export * as ProjectInfo from './project-info';
+export * as Explain from './explain';
+export * as InteractionHistory from './interaction-history';

--- a/packages/navie/src/interaction-history.ts
+++ b/packages/navie/src/interaction-history.ts
@@ -1,9 +1,7 @@
-/* eslint-disable max-classes-per-file */
 import EventEmitter from 'events';
 import InteractionState from './interaction-state';
 import { ContextItem, ContextResponse } from './context';
 import { PromptType } from './prompt';
-import { warn } from 'console';
 import { CHARACTERS_PER_TOKEN } from './message';
 
 const SNIPPET_LENGTH = 800;

--- a/packages/navie/src/interaction-history.ts
+++ b/packages/navie/src/interaction-history.ts
@@ -1,0 +1,160 @@
+/* eslint-disable max-classes-per-file */
+import EventEmitter from 'events';
+import InteractionState from './interaction-state';
+import { ContextItem, ContextResponse } from './context';
+import { PromptType } from './prompt';
+import { warn } from 'console';
+import { CHARACTERS_PER_TOKEN } from './message';
+
+const SNIPPET_LENGTH = 800;
+
+function contentSnippet(content: string, maxLength = SNIPPET_LENGTH): string {
+  if (content.length < maxLength) return content;
+
+  return `${content.slice(0, maxLength)}... (${content.length})`;
+}
+
+export abstract class InteractionEvent {
+  constructor(public name: string) {}
+
+  abstract get message(): string;
+
+  abstract updateState(state: InteractionState): void;
+}
+
+export class PromptInteractionEvent extends InteractionEvent {
+  constructor(
+    public name: PromptType | string,
+    public role: 'user' | 'system',
+    public content: string,
+    public prefix?: string
+  ) {
+    super(name);
+  }
+
+  get message() {
+    return `[prompt] ${this.role}: ${contentSnippet(this.fullContent)}`;
+  }
+
+  get fullContent(): string {
+    return [this.prefix, this.content].filter(Boolean).join(' ');
+  }
+
+  updateState(state: InteractionState) {
+    state.messages.push({ content: this.fullContent, role: this.role });
+  }
+}
+
+export class VectorTermsInteractionEvent extends InteractionEvent {
+  constructor(public terms: string[]) {
+    super('vectorTerms');
+  }
+
+  get message() {
+    return `[vectorTerms] ${this.terms.join(' ')}`;
+  }
+
+  updateState(state: InteractionState) {
+    for (const term of this.terms) state.vectorTerms.push(term);
+  }
+}
+
+export class CompletionEvent extends InteractionEvent {
+  constructor(public model: string, public temperature: number) {
+    super('completion');
+  }
+
+  get message() {
+    return `[completion] ${this.model} ${this.temperature}`;
+  }
+
+  updateState(state: InteractionState) {
+    state.completionModel = this.model;
+    state.completionTemperature = this.temperature;
+  }
+}
+
+export class ContextLookupEvent extends InteractionEvent {
+  constructor(public context: ContextResponse | undefined) {
+    super('contextLookup');
+  }
+
+  get message() {
+    if (!this.context) return `[contextLookup] not found`;
+
+    const diagramCount = this.context.sequenceDiagrams.length;
+    const snippetCount = Object.keys(this.context.codeSnippets).length;
+    const dataRequestCount = this.context.codeObjects.length;
+
+    return `[contextLookup] ${diagramCount} diagrams, ${snippetCount} snippets, ${dataRequestCount} data requests`;
+  }
+
+  updateState(state: InteractionState) {
+    state.contextAvailable = this.context;
+  }
+}
+
+export class ContextItemEvent extends InteractionEvent {
+  constructor(public contextItem: ContextItem, public file?: string) {
+    super('contextItem');
+  }
+
+  get message() {
+    return [
+      `[${this.contextItem.name}]`,
+      this.file ? `${this.file}: ` : undefined,
+      contentSnippet(this.contextItem.content),
+    ]
+      .filter(Boolean)
+      .join(' ');
+  }
+
+  updateState(state: InteractionState) {
+    const content = [
+      `[${this.contextItem.name}]`,
+      [this.file, this.contextItem.content].filter(Boolean).join(': '),
+    ]
+      .filter(Boolean)
+      .join(' ');
+    state.messages.push({ content, role: 'user' });
+  }
+}
+
+export interface InteractionHistoryEvents {
+  on(event: 'event', listener: (event: InteractionEvent) => void): void;
+}
+
+export default class InteractionHistory extends EventEmitter implements InteractionHistoryEvents {
+  public readonly events: InteractionEvent[] = [];
+
+  // eslint-disable-next-line class-methods-use-this
+  log(message: string) {
+    console.log(message);
+  }
+
+  addEvent(event: InteractionEvent) {
+    this.emit('event', event);
+    this.events.push(event);
+  }
+
+  clear() {
+    this.events.splice(0, this.events.length);
+  }
+
+  computeTokenSize(): number {
+    const state = this.buildState();
+    const tokenCharacters = state.messages
+      .map((message) => message.content.length)
+      .reduce((a, b) => a + b, 0);
+
+    return Math.round(tokenCharacters / CHARACTERS_PER_TOKEN);
+  }
+
+  buildState(): InteractionState {
+    const state = new InteractionState();
+    for (const event of this.events) {
+      event.updateState(state);
+    }
+    return state;
+  }
+}

--- a/packages/navie/src/interaction-state.ts
+++ b/packages/navie/src/interaction-state.ts
@@ -1,0 +1,19 @@
+/* eslint-disable no-underscore-dangle */
+import { ContextItem, ContextResponse } from './context';
+import Message from './message';
+
+export default class InteractionState {
+  public readonly messages: Message[] = [];
+
+  public readonly vectorTerms = new Array<string>();
+  public completionModel?: string;
+  public completionTemperature?: number;
+  public contextAvailable?: ContextResponse;
+
+  addContextItem(contextItem: ContextItem) {
+    // const items = this.contextItems.get(contextItem.type);
+    // assert(items);
+    // items.push(contextItem.content);
+    this.messages.push({ content: contextItem.content, role: 'user' });
+  }
+}

--- a/packages/navie/src/interaction-state.ts
+++ b/packages/navie/src/interaction-state.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-underscore-dangle */
 import { ContextItem, ContextResponse } from './context';
 import Message from './message';
 

--- a/packages/navie/src/message.ts
+++ b/packages/navie/src/message.ts
@@ -1,0 +1,6 @@
+export const CHARACTERS_PER_TOKEN = 3;
+
+export default interface Message {
+  content: string;
+  role: 'user' | 'system';
+}

--- a/packages/navie/src/project-info.ts
+++ b/packages/navie/src/project-info.ts
@@ -1,10 +1,10 @@
-export type ProjectInfoRequest = {};
+export type ProjectInfoRequest = { [key: string]: unknown };
 
 export type AppMapConfig = {
   name: string;
   language: string;
   appmap_dir: string;
-  packages: any;
+  packages: unknown;
 };
 
 export type AppMapStats = {

--- a/packages/navie/src/project-info.ts
+++ b/packages/navie/src/project-info.ts
@@ -1,0 +1,24 @@
+export type ProjectInfoRequest = {};
+
+export type AppMapConfig = {
+  name: string;
+  language: string;
+  appmap_dir: string;
+  packages: any;
+};
+
+export type AppMapStats = {
+  packages: string[];
+  routes: string[];
+  tables: string[];
+  numAppMaps: number;
+};
+
+export type ProjectInfoResponse = {
+  appmapConfig: AppMapConfig;
+  appmapStats: AppMapStats;
+};
+
+export type ProjectInfoProvider = (
+  request: ProjectInfoRequest
+) => Promise<ProjectInfoResponse | undefined>;

--- a/packages/navie/src/prompt.ts
+++ b/packages/navie/src/prompt.ts
@@ -1,0 +1,119 @@
+export enum PromptType {
+  Question = 'question',
+  CodeSelection = 'codeSelection',
+  AppMapConfig = 'appmapConfig',
+  AppMapStats = 'appmapStats',
+  SequenceDiagram = 'sequenceDiagrams',
+  CodeSnippet = 'codeSnippets',
+  DataRequest = 'dataRequest',
+}
+
+export type Prompt = {
+  content: string;
+  prefix: string;
+  multiple?: boolean;
+};
+
+export const PROMPTS: Record<PromptType, Prompt> = {
+  [PromptType.CodeSelection]: {
+    content: `**The user's code selection**
+
+The user is asking about specific lines of code that they have selected in their code editor.`,
+    prefix: 'Code selection',
+  },
+  [PromptType.Question]: {
+    content: `**The user's question**
+
+This is the primary question that the user wants you to answer. Your response should be
+focused primarily on answering this question.
+
+When the user is asking about creating or using diagrams, focus your answer on AppMap.
+Avoid recommending other diagram tools such as Lucidchart, Draw.io, PlantUML, or Mermaid,
+except as supplemental resources to AppMap.
+`,
+    prefix: 'Question',
+  },
+  [PromptType.AppMapConfig]: {
+    content: `**AppMap configuration**
+
+You're provided with the AppMap configuration of the user's project. The project information is
+provided as the YAML file \`appmap.yml\`. This file contains the configuration of the AppMap agent,
+including:
+
+- **name** - The name of the project.
+- **language** - The programming language of the project.
+- **appmap_dir** - The directory where the AppMap files are stored. Note that this property should generally
+  always be set to \`tmp/appmap\`. Don't advise the user to change this unless there are specific instructions to do so.
+- **packages** - A list of code packages that should be recorded when the AppMap agent is running.
+
+Because the project already contains an \`appmap.yml\` file, you don't need to describe how to install the AppMap language
+library / agent. You may, however, advise the user on how to optimize this configuration for their specific needs.`,
+    prefix: 'appmap.yml',
+  },
+  [PromptType.AppMapStats]: {
+    content: `**AppMap statistics**
+
+You're provided with information about the AppMaps that have been recorded and are available in the user's project.
+This information includes the following information about data that's in the AppMaps:
+
+- **packages** - A list of code packages.
+- **routes** - A list of HTTP routes.
+- **tables** - A list of database tables.
+- **numAppMaps** - The number of AppMaps that are available in the project.`,
+    prefix: 'AppMap statistics',
+  },
+  [PromptType.SequenceDiagram]: {
+    content: `**Sequence diagrams**
+
+You're provided with sequence diagrams that are relevant to the user's question.
+Each sequence diagram represents the actual flow of code that was recorded by the AppMap language library
+which is integrated into the project.
+`,
+    prefix: 'Sequence diagram',
+    multiple: true,
+  },
+  [PromptType.CodeSnippet]: {
+    content: `**Code snippets**
+
+You're provided with code snippets that are relevant to the user's question. Each code snippet represents
+a piece of code that was recorded by the AppMap language library which is integrated into the project.
+
+Sequence diagrams, if available, provide more context about how each code snippet is used in the overall program.
+
+Each code snippet begins with the file name and line number where the code is located,
+followed by the code itself.
+`,
+    prefix: 'Code snippet',
+    multiple: true,
+  },
+  [PromptType.DataRequest]: {
+    content: `**Data requests**
+
+You're provided with data requests that are relevant to the user's question. A data request
+is an outbound request to a database, API, or other data source that was made by the program.
+Each data request was recorded by the AppMap language library which is integrated into the project.
+
+Sequence diagrams, if available, provide more context about how each data request is used in the overall program.`,
+    prefix: 'Data request',
+    multiple: true,
+  },
+};
+
+export function buildPromptDescriptor(promptType: PromptType): string {
+  const prompt = PROMPTS[promptType];
+  const content = [prompt.content];
+  if (prompt.multiple) {
+    content.push(
+      `Multiple data examples of this type will be provided. Each one will be prefixed with "[${prompt.prefix}]"`
+    );
+  } else {
+    content.push(`The data example will be prefixed with "[${prompt.prefix}]"`);
+  }
+
+  return content.join('\n\n');
+}
+
+export function buildPromptValue(promptType: PromptType, value: string): string {
+  const prompt = PROMPTS[promptType];
+  return `[${prompt.prefix}] ${value}`;
+}

--- a/packages/navie/src/services/apply-context-service.ts
+++ b/packages/navie/src/services/apply-context-service.ts
@@ -1,0 +1,163 @@
+/* eslint-disable no-plusplus */
+import { log } from 'console';
+import assert from 'assert';
+
+import { ContextItem, ContextResponse } from '../context';
+import InteractionHistory, {
+  ContextItemEvent,
+  PromptInteractionEvent,
+} from '../interaction-history';
+import { PROMPTS, PromptType, buildPromptDescriptor } from '../prompt';
+
+type ContextItemWithFile = ContextItem & { file?: string };
+
+type Selector = () => boolean;
+
+export default class ApplyContextService {
+  constructor(public readonly interactionHistory: InteractionHistory) {}
+
+  applyContext(context: ContextResponse | undefined, characterLimit: number) {
+    if (!context) {
+      this.interactionHistory.addEvent(
+        new PromptInteractionEvent(
+          'contextLookup',
+          'system',
+          'No matching context information was found'
+        )
+      );
+      return;
+    }
+
+    const { sequenceDiagrams, codeSnippets, codeObjects } = context;
+
+    const availableContent = new Array<ContextItemWithFile | undefined>();
+    const availableDiagrams = [...sequenceDiagrams];
+    const availableCodeSnippets: [string, string][] = Object.keys(codeSnippets).map((key) => [
+      key,
+      codeSnippets[key],
+    ]);
+    const availableDataRequests = [...codeObjects];
+
+    const availableItemCount = () =>
+      [availableDiagrams.length, availableCodeSnippets.length, availableDataRequests.length].reduce(
+        (a, b) => a + b,
+        0
+      );
+
+    // Select items in a round-robin fashion, to ensure a mix of content types. Heuristically, we
+    // want to see one sequence diagram, 5 code snippets, and 2 data request. If we run out of
+    // one type of content type, we'll continue adding the other types.
+    const roundSize = 1 + 5 + 2;
+    let index = 0;
+    while (availableItemCount() > 0) {
+      const itemType = index % roundSize;
+      index += 1;
+
+      let item: [string, string] | undefined;
+      let name: string | undefined;
+      let content: string | undefined;
+      let file: string | undefined;
+
+      const selectDiagram = (): boolean => {
+        if (availableDiagrams.length === 0) return false;
+
+        name = PROMPTS[PromptType.SequenceDiagram].prefix;
+        content = availableDiagrams.shift();
+        return true;
+      };
+
+      const selectCodeSnippet = (): boolean => {
+        if (availableCodeSnippets.length === 0) return false;
+
+        name = PROMPTS[PromptType.CodeSnippet].prefix;
+        item = availableCodeSnippets.shift();
+        assert(item);
+        [file, content] = item;
+        return true;
+      };
+
+      const selectDataRequest = (): boolean => {
+        if (availableDataRequests.length === 0) return false;
+
+        name = PROMPTS[PromptType.DataRequest].prefix;
+        content = availableDataRequests.shift();
+        return true;
+      };
+
+      let selectionMade: boolean;
+      if (itemType === 0) {
+        selectionMade = selectDiagram() || selectCodeSnippet() || selectDataRequest();
+      } else if (itemType >= 1 && itemType <= 5) {
+        selectionMade = selectCodeSnippet() || selectDataRequest();
+      } else {
+        selectionMade = selectDataRequest() || selectCodeSnippet();
+      }
+
+      if (selectionMade) {
+        assert(name && content);
+        availableContent.push({ name, content, file });
+      }
+    }
+
+    let charsRemaining = characterLimit;
+    log(`Remaining characters before context: ${charsRemaining}`);
+
+    const messages = new Array<ContextItem>();
+    const addContextItem = (contextItem: ContextItemWithFile | undefined): boolean => {
+      if (!contextItem) return false;
+
+      // TODO: If the first content item is bigger than charsRemaining, no context can be added.
+      // This can happen if the "micro" AppMap is still too big.
+      if (charsRemaining - contextItem.content.length < 0) return false;
+
+      charsRemaining -= contextItem.content.length;
+      this.interactionHistory.addEvent(
+        new ContextItemEvent(
+          { name: contextItem.name, content: contextItem.content },
+          contextItem.file
+        )
+      );
+      messages.push(contextItem);
+      return true;
+    };
+
+    // The sequence diagram may be too big to fit; in that case, continue with code snippets.
+    addContextItem(availableContent.shift());
+    for (const contextItem of availableContent) {
+      if (!addContextItem(contextItem)) break;
+    }
+
+    this.interactionHistory.log(`Remaining characters after context: ${charsRemaining}`);
+  }
+
+  addSystemPrompts(context: ContextResponse) {
+    const { sequenceDiagrams, codeSnippets, codeObjects } = context;
+
+    if (sequenceDiagrams.length > 0)
+      this.interactionHistory.addEvent(
+        new PromptInteractionEvent(
+          PromptType.SequenceDiagram,
+          'system',
+          buildPromptDescriptor(PromptType.SequenceDiagram)
+        )
+      );
+
+    if (Object.keys(codeSnippets).length > 0)
+      this.interactionHistory.addEvent(
+        new PromptInteractionEvent(
+          PromptType.CodeSnippet,
+          'system',
+          buildPromptDescriptor(PromptType.CodeSnippet)
+        )
+      );
+
+    if (codeObjects.length > 0)
+      this.interactionHistory.addEvent(
+        new PromptInteractionEvent(
+          PromptType.DataRequest,
+          'system',
+          buildPromptDescriptor(PromptType.DataRequest)
+        )
+      );
+  }
+}

--- a/packages/navie/src/services/apply-context-service.ts
+++ b/packages/navie/src/services/apply-context-service.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-plusplus */
 import { log } from 'console';
 import assert from 'assert';
 
@@ -10,8 +9,6 @@ import InteractionHistory, {
 import { PROMPTS, PromptType, buildPromptDescriptor } from '../prompt';
 
 type ContextItemWithFile = ContextItem & { file?: string };
-
-type Selector = () => boolean;
 
 export default class ApplyContextService {
   constructor(public readonly interactionHistory: InteractionHistory) {}

--- a/packages/navie/src/services/code-selection-service.ts
+++ b/packages/navie/src/services/code-selection-service.ts
@@ -1,0 +1,26 @@
+import InteractionHistory, { PromptInteractionEvent } from '../interaction-history';
+import { PromptType, buildPromptDescriptor, buildPromptValue } from '../prompt';
+
+export default class CodeSelectionService {
+  constructor(public interactionHistory: InteractionHistory) {}
+
+  addSystemPrompt() {
+    this.interactionHistory.addEvent(
+      new PromptInteractionEvent(
+        PromptType.CodeSelection,
+        'system',
+        buildPromptDescriptor(PromptType.CodeSelection)
+      )
+    );
+  }
+
+  applyCodeSelection(codeSelection: string) {
+    this.interactionHistory.addEvent(
+      new PromptInteractionEvent(
+        PromptType.CodeSelection,
+        'user',
+        buildPromptValue(PromptType.CodeSelection, codeSelection)
+      )
+    );
+  }
+}

--- a/packages/navie/src/services/completion-service.ts
+++ b/packages/navie/src/services/completion-service.ts
@@ -1,0 +1,39 @@
+import buildChatOpenAI from '../chat-openai';
+import InteractionHistory, { CompletionEvent } from '../interaction-history';
+
+export type Completion = AsyncIterable<string>;
+
+export default interface CompletionService {
+  complete: () => Completion;
+}
+
+export class OpenAICompletionService implements CompletionService {
+  constructor(
+    public readonly interactionHistory: InteractionHistory,
+    public readonly modelName: string,
+    public readonly temperature: number
+  ) {}
+
+  async *complete(): Completion {
+    const { messages } = this.interactionHistory.buildState();
+
+    const chatAI = buildChatOpenAI({
+      modelName: this.modelName,
+      temperature: this.temperature,
+      streaming: true,
+    });
+
+    this.interactionHistory.addEvent(new CompletionEvent(this.modelName, this.temperature));
+
+    const response = await chatAI.completionWithRetry({
+      messages,
+      model: this.modelName,
+      stream: true,
+    });
+
+    for await (const token of response) {
+      const content = token.choices.map((choice) => choice.delta.content).join('');
+      yield content;
+    }
+  }
+}

--- a/packages/navie/src/services/lookup-context-service.ts
+++ b/packages/navie/src/services/lookup-context-service.ts
@@ -1,0 +1,25 @@
+import { log } from 'console';
+import InteractionHistory, { ContextLookupEvent } from '../interaction-history';
+import { ContextRequest, ContextResponse } from '../context';
+
+export default class LookupContextService {
+  constructor(
+    public readonly interactionHistory: InteractionHistory,
+    public readonly contextFn: (data: ContextRequest) => Promise<ContextResponse>
+  ) {}
+
+  async lookupContext(request: ContextRequest): Promise<ContextResponse | undefined> {
+    const searchContext = await this.contextFn(request);
+    const { sequenceDiagrams } = searchContext;
+
+    if (!sequenceDiagrams || sequenceDiagrams.length === 0) {
+      log('No sequence diagrams found');
+      this.interactionHistory.addEvent(new ContextLookupEvent(undefined));
+      return undefined;
+    }
+
+    this.interactionHistory.addEvent(new ContextLookupEvent(searchContext));
+
+    return searchContext;
+  }
+}

--- a/packages/navie/src/services/memory-service.ts
+++ b/packages/navie/src/services/memory-service.ts
@@ -1,0 +1,37 @@
+import { ConversationSummaryMemory } from 'langchain/memory';
+import { AIMessage, HumanMessage } from '@langchain/core/messages';
+
+import buildChatOpenAI from '../chat-openai';
+import Message from '../message';
+import InteractionHistory, { PromptInteractionEvent } from '../interaction-history';
+
+export default class MemoryService {
+  constructor(
+    public readonly interactionHistory: InteractionHistory,
+    public readonly modelName: string,
+    public readonly temperature: number
+  ) {}
+
+  async predictSummary(messages: Message[]) {
+    const predictAI = buildChatOpenAI({
+      modelName: this.modelName,
+      temperature: this.temperature,
+    });
+
+    const memory = new ConversationSummaryMemory({
+      memoryKey: 'chat_history',
+      llm: predictAI,
+    });
+
+    // eslint-disable-next-line arrow-body-style
+    const lcMessages = messages.map((message) => {
+      return message.role === 'user'
+        ? new HumanMessage({ content: message.content })
+        : new AIMessage({ content: message.content });
+    });
+
+    // TODO: We never have an existing summary, so the second argument is always empty.
+    const summary = await memory.predictNewSummary(lcMessages, '');
+    this.interactionHistory.addEvent(new PromptInteractionEvent('summary', 'user', summary));
+  }
+}

--- a/packages/navie/src/services/project-info-service.ts
+++ b/packages/navie/src/services/project-info-service.ts
@@ -1,0 +1,60 @@
+import { ProjectInfoProvider, ProjectInfoResponse } from '../project-info';
+import InteractionHistory, { PromptInteractionEvent } from '../interaction-history';
+import { PromptType, buildPromptDescriptor, buildPromptValue } from '../prompt';
+
+type Test = () => boolean;
+
+type EmptyMap = Record<string, never>;
+
+export default class ProjectInfoService {
+  constructor(
+    public interactionHistory: InteractionHistory,
+    public projectInfoProvider: ProjectInfoProvider
+  ) {}
+
+  async lookupProjectInfo(): Promise<ProjectInfoResponse | EmptyMap> {
+    const projectInfo = await this.projectInfoProvider({ type: 'projectInfo' });
+    if (!projectInfo) {
+      this.interactionHistory.log('No project info found');
+      return {};
+    }
+
+    this.interactionHistory.log('Project info obtained');
+    const projectInfoKeys: [PromptType, keyof ProjectInfoResponse, Test, string][] = [
+      [
+        PromptType.AppMapConfig,
+        'appmapConfig',
+        () => !!projectInfo.appmapConfig?.appmap_dir,
+        `The user's project does not contain an AppMap config file (appmap.yml).`,
+      ],
+      [
+        PromptType.AppMapStats,
+        'appmapStats',
+        () => projectInfo.appmapStats?.numAppMaps > 0,
+        `The user's project does not contain any AppMaps.`,
+      ],
+    ];
+    projectInfoKeys.forEach(([promptType, projectInfoKey, isPresent, missingInfoMessage]) => {
+      if (!isPresent()) {
+        this.interactionHistory.addEvent(
+          new PromptInteractionEvent(promptType, 'system', missingInfoMessage)
+        );
+        return;
+      }
+
+      const promptValue = projectInfo[projectInfoKey];
+      this.interactionHistory.addEvent(
+        new PromptInteractionEvent(promptType, 'system', buildPromptDescriptor(promptType))
+      );
+      this.interactionHistory.addEvent(
+        new PromptInteractionEvent(
+          promptType,
+          'user',
+          buildPromptValue(promptType, JSON.stringify(promptValue))
+        )
+      );
+    });
+
+    return projectInfo;
+  }
+}

--- a/packages/navie/src/services/question-service.ts
+++ b/packages/navie/src/services/question-service.ts
@@ -1,0 +1,26 @@
+import InteractionHistory, { PromptInteractionEvent } from '../interaction-history';
+import { PromptType, buildPromptDescriptor, buildPromptValue } from '../prompt';
+
+export default class QuestionService {
+  constructor(public interactionHistory: InteractionHistory) {}
+
+  addSystemPrompt() {
+    this.interactionHistory.addEvent(
+      new PromptInteractionEvent(
+        PromptType.Question,
+        'system',
+        buildPromptDescriptor(PromptType.Question)
+      )
+    );
+  }
+
+  applyQuestion(question: string) {
+    this.interactionHistory.addEvent(
+      new PromptInteractionEvent(
+        PromptType.Question,
+        'user',
+        buildPromptValue(PromptType.Question, question)
+      )
+    );
+  }
+}

--- a/packages/navie/src/services/vector-terms-service.ts
+++ b/packages/navie/src/services/vector-terms-service.ts
@@ -45,7 +45,7 @@ export default class VectorTermsService {
       },
     ];
 
-    let searchTermsObject: any;
+    let searchTermsObject: Record<string, unknown> | string | string[] | undefined;
     let attemptNumber = 3;
     // eslint-disable-next-line no-plusplus
     while (!searchTermsObject && attemptNumber-- > 0) {
@@ -76,25 +76,21 @@ export default class VectorTermsService {
     warn(`searchTermsObject: ${JSON.stringify(searchTermsObject)}`);
 
     const terms = new Set<string>();
-    if (
-      !searchTermsObject ||
-      JSON.stringify(searchTermsObject) === '[]' ||
-      JSON.stringify(searchTermsObject) === '{}'
-    ) {
+    if (!searchTermsObject || !Object.keys(searchTermsObject).length) {
       warn(`Unable to obtain search terms from AI. Will use the raw user search.`);
       const words = question.split(/\s/);
       for (const word of words) terms.add(word);
     } else {
-      const collectTerms = (obj: any) => {
+      const collectTerms = (obj: unknown) => {
+        if (!obj) return;
+
         if (typeof obj === 'string') {
           for (const term of obj.split(/[._-]/)) terms.add(term);
         } else if (Array.isArray(obj)) {
           for (const term of obj) collectTerms(term);
         } else if (typeof obj === 'object') {
-          // eslint-disable-next-line guard-for-in
-          for (const key in obj) {
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-            collectTerms(obj[key]);
+          for (const term of Object.values(obj)) {
+            collectTerms(term);
           }
         }
       };

--- a/packages/navie/src/services/vector-terms-service.ts
+++ b/packages/navie/src/services/vector-terms-service.ts
@@ -1,0 +1,115 @@
+import OpenAI from 'openai';
+import { warn } from 'console';
+import { ChatOpenAI } from '@langchain/openai';
+
+import buildChatOpenAI from '../chat-openai';
+import InteractionHistory, { VectorTermsInteractionEvent } from '../interaction-history';
+
+const SYSTEM_PROMPT = `You are assisting a developer to search a code base.
+
+The developer asks a question using natural language. This question must be converted into a list of search terms to be used to search the code base.
+
+**Procedure**
+
+1) Analyze the user's question and determine which words in the user's question are likely to match code functions, variables, and parameter names.
+2) Convert all search terms to under_score_separated_words.
+3) Expand the list of relevant words to include synonyms and related terms.
+4) Return the list of search terms and their synonyms. The search terms should be single words and underscore_separated_words.
+
+**Response**
+
+Respond with a JSON list.
+`;
+
+export default class VectorTermsService {
+  constructor(
+    public readonly interactionHistory: InteractionHistory,
+    public modelName: string,
+    public temperature: number
+  ) {}
+
+  async suggestTerms(question: string): Promise<string[]> {
+    const openAI: ChatOpenAI = buildChatOpenAI({
+      modelName: this.modelName,
+      temperature: this.temperature,
+    });
+
+    const messages: OpenAI.ChatCompletionMessageParam[] = [
+      {
+        content: SYSTEM_PROMPT,
+        role: 'system',
+      },
+      {
+        content: question,
+        role: 'user',
+      },
+    ];
+
+    let searchTermsObject: any;
+    let attemptNumber = 3;
+    // eslint-disable-next-line no-plusplus
+    while (!searchTermsObject && attemptNumber-- > 0) {
+      // eslint-disable-next-line no-await-in-loop
+      const response = await openAI.completionWithRetry({
+        messages,
+        model: 'gpt-4-0125-preview',
+        stream: true,
+      });
+      const tokens = Array<string>();
+      // eslint-disable-next-line no-await-in-loop
+      for await (const token of response) {
+        tokens.push(token.choices.map((choice) => choice.delta.content).join(''));
+      }
+      const rawTerms = tokens.join('');
+
+      const sanitizedTerms = rawTerms.replace(/```json/g, '').replace(/```/g, '');
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        searchTermsObject = JSON.parse(sanitizedTerms);
+      } catch (err) {
+        // Retry on JSON parse error
+        warn(sanitizedTerms);
+        warn(`Non-JSON response from AI; will retry...`);
+      }
+    }
+
+    warn(`searchTermsObject: ${JSON.stringify(searchTermsObject)}`);
+
+    const terms = new Set<string>();
+    if (
+      !searchTermsObject ||
+      JSON.stringify(searchTermsObject) === '[]' ||
+      JSON.stringify(searchTermsObject) === '{}'
+    ) {
+      warn(`Unable to obtain search terms from AI. Will use the raw user search.`);
+      const words = question.split(/\s/);
+      for (const word of words) terms.add(word);
+    } else {
+      const collectTerms = (obj: any) => {
+        if (typeof obj === 'string') {
+          for (const term of obj.split(/[._-]/)) terms.add(term);
+        } else if (Array.isArray(obj)) {
+          for (const term of obj) collectTerms(term);
+        } else if (typeof obj === 'object') {
+          // eslint-disable-next-line guard-for-in
+          for (const key in obj) {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+            collectTerms(obj[key]);
+          }
+        }
+      };
+      collectTerms(searchTermsObject);
+    }
+
+    const wordList = [...terms]
+      .map((word) => word.trim())
+      .filter((word) => word.length > 2)
+      .map((word) => word.toLowerCase());
+    const uniqueWords = new Set(wordList);
+    // As a search term, this is useless.
+    uniqueWords.delete('code');
+    const result = [...uniqueWords];
+    this.interactionHistory.addEvent(new VectorTermsInteractionEvent(result));
+    return result;
+  }
+}

--- a/packages/navie/test/code-explainer-service.spec.ts
+++ b/packages/navie/test/code-explainer-service.spec.ts
@@ -1,0 +1,265 @@
+import { ChatHistory, ClientRequest, CodeExplainerService, ExplainOptions } from '../src/explain';
+import CompletionService from '../src/services/completion-service';
+import MemoryService from '../src/services/memory-service';
+import VectorTermsService from '../src/services/vector-terms-service';
+import { ContextProvider, ContextRequest, ContextResponse } from '../src/context';
+import Message from '../src/message';
+import InteractionHistory from '../src/interaction-history';
+import LookupContextService from '../src/services/lookup-context-service';
+import ApplyContextService from '../src/services/apply-context-service';
+import CodeSelectionService from '../src/services/code-selection-service';
+import QuestionService from '../src/services/question-service';
+import ProjectInfoService from '../src/services/project-info-service';
+import { ProjectInfoProvider } from '../src/project-info';
+
+const SEQUENCE_DIAGRAMS = [`diagram-1`, `diagram-2`];
+const CODE_SNIPPETS = {
+  'app/user.rb': `class User < ApplicationRecord; end`,
+  'app/post.rb': `class Post < ApplicationRecord; end`,
+};
+const CODE_OBJECTS = [
+  `SELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT 1`,
+  `SELECT "posts".* FROM "posts" WHERE "posts"."user_id" = $1`,
+];
+
+const SEARCH_CONTEXT = {
+  sequenceDiagrams: SEQUENCE_DIAGRAMS,
+  codeSnippets: CODE_SNIPPETS,
+  codeObjects: CODE_OBJECTS,
+};
+
+const TOKEN_STREAM: AsyncIterable<string> = {
+  [Symbol.asyncIterator]: async function* () {
+    yield 'The user management system is a system ';
+    yield 'that allows users to create and manage their own accounts.';
+  },
+};
+
+const EXPLAIN_OPTIONS: ExplainOptions = {
+  modelName: 'gpt-3.5-turbo',
+  responseTokens: 1000,
+  tokenLimit: 5000,
+  temperature: 0.5,
+};
+
+describe('CodeExplainerService', () => {
+  let interactionHistory: InteractionHistory;
+  let requestContext: (request: ContextRequest) => Promise<ContextResponse>;
+  let vectorTermsService: VectorTermsService;
+  let completionService: CompletionService;
+  let questionService: QuestionService;
+  let codeSelectionService: CodeSelectionService;
+  let projectInfoService: ProjectInfoService;
+  let memoryService: MemoryService;
+  let lookupContextService: LookupContextService;
+  let applyContextService: ApplyContextService;
+  let codeExplainerService: CodeExplainerService;
+  let tokenCount: number;
+  const question = 'How does user management work?';
+  let codeSelection: string | undefined = undefined;
+
+  beforeEach(async () => {
+    interactionHistory = new InteractionHistory();
+    completionService = {
+      complete: () => TOKEN_STREAM,
+    };
+    questionService = new QuestionService(interactionHistory);
+    codeSelectionService = new CodeSelectionService(interactionHistory);
+    vectorTermsService = new VectorTermsService(interactionHistory, 'gpt-4', 0.5);
+    jest.spyOn(vectorTermsService, 'suggestTerms').mockImplementation((query: string) => {
+      const expectedAggregateQuestion = [question, codeSelection].filter(Boolean).join('\n\n');
+      expect(query).toEqual(expectedAggregateQuestion);
+      return Promise.resolve(['user', 'management']);
+    });
+    applyContextService = new ApplyContextService(interactionHistory);
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  async function explain(
+    clientRequest: ClientRequest,
+    options: ExplainOptions,
+    history: ChatHistory = []
+  ): Promise<string[]> {
+    const result = codeExplainerService.execute(clientRequest, options, history);
+    const resultArray = new Array<string>();
+    for await (const item of result) {
+      resultArray.push(item);
+    }
+    return resultArray;
+  }
+
+  describe('without chat history', () => {
+    beforeEach(() => {
+      tokenCount = 2242;
+      const lookupProvider: ContextProvider = jest
+        .fn()
+        .mockImplementation((request: ContextRequest) => {
+          expect(request.vectorTerms).toEqual(['user', 'management']);
+          expect(request.tokenCount).toEqual(tokenCount);
+          return Promise.resolve(SEARCH_CONTEXT);
+        });
+      lookupContextService = new LookupContextService(interactionHistory, lookupProvider);
+
+      const projectInfoProvider: ProjectInfoProvider = jest.fn().mockResolvedValue({
+        appmapConfig: {
+          name: 'mock-project',
+          language: 'ruby',
+          appmap_dir: 'tmp/appmap',
+          packages: ['lib'],
+        },
+        appmapStats: {
+          classes: 7,
+          methods: 10,
+          packages: 3,
+          numAppMaps: 5,
+        },
+      });
+      projectInfoService = new ProjectInfoService(interactionHistory, projectInfoProvider);
+
+      memoryService = new MemoryService(interactionHistory, 'gpt-4', 0.5);
+      jest
+        .spyOn(memoryService, 'predictSummary')
+        .mockRejectedValue('predictSummary should not be called for the initial question');
+
+      codeExplainerService = new CodeExplainerService(
+        interactionHistory,
+        completionService,
+        questionService,
+        codeSelectionService,
+        projectInfoService,
+        vectorTermsService,
+        lookupContextService,
+        applyContextService,
+        memoryService
+      );
+    });
+
+    it('produces an explanation', async () => {
+      const result = await explain(
+        {
+          question,
+        },
+        EXPLAIN_OPTIONS,
+        []
+      );
+
+      expect(
+        interactionHistory
+          .buildState()
+          .messages.filter((msg) => msg.role === 'system')
+          .map((msg) => msg.content.split('\n')[0])
+      ).toEqual([
+        '**Task: Explaining Code, Analyzing Code, Generating Code**',
+        `**The user's question**`,
+        `**AppMap configuration**`,
+        `**AppMap statistics**`,
+        `**Sequence diagrams**`,
+        `**Code snippets**`,
+        `**Data requests**`,
+      ]);
+
+      expect(result).toEqual([
+        'The user management system is a system ',
+        'that allows users to create and manage their own accounts.',
+      ]);
+    });
+
+    describe('with code selection', () => {
+      beforeEach(() => {
+        tokenCount = 2163;
+        codeSelection = `class UserController { create() { } }`;
+      });
+
+      it('includes the code selection in the prompt', async () => {
+        const result = await explain(
+          {
+            question,
+            codeSelection,
+          },
+          EXPLAIN_OPTIONS,
+          []
+        );
+        expect(
+          interactionHistory
+            .buildState()
+            .messages.filter((msg) => msg.role === 'system')
+            .map((msg) => msg.content.split('\n')[0])
+        ).toEqual([
+          '**Task: Explaining Code, Analyzing Code, Generating Code**',
+          `**The user's question**`,
+          `**The user's code selection**`,
+          `**AppMap configuration**`,
+          `**AppMap statistics**`,
+          `**Sequence diagrams**`,
+          `**Code snippets**`,
+          `**Data requests**`,
+        ]);
+
+        expect(result).toEqual([
+          'The user management system is a system ',
+          'that allows users to create and manage their own accounts.',
+        ]);
+      });
+    });
+  });
+
+  describe('with chat history', () => {
+    const userMessage = {
+      id: '1',
+      isUser: true,
+      text: 'What is user management?',
+    };
+    const aiMessage = {
+      id: '2',
+      isUser: false,
+      text: 'The user management system is a system that allows users to create and manage their own accounts.',
+    };
+
+    const history: ChatHistory = [userMessage, aiMessage].map((msg) => ({
+      content: msg.text,
+      role: msg.isUser ? 'user' : 'system',
+    }));
+
+    beforeEach(() => {
+      requestContext = jest
+        .fn()
+        .mockRejectedValue('requestContext should not be called for follow-up questions');
+
+      memoryService = new MemoryService(interactionHistory, 'gpt-4', 0.5);
+      memoryService.predictSummary = jest.fn().mockImplementation((messages: Message[]) => {
+        expect(messages.map((msg) => msg.content)).toEqual([userMessage.text, aiMessage.text]);
+        return Promise.resolve(
+          'The user asked about user management. The AI responded with a description of the user management subsystem.'
+        );
+      });
+
+      codeExplainerService = new CodeExplainerService(
+        interactionHistory,
+        completionService,
+        questionService,
+        codeSelectionService,
+        projectInfoService,
+        vectorTermsService,
+        lookupContextService,
+        applyContextService,
+        memoryService
+      );
+    });
+
+    it('summarizes the chat history in the messages', async () => {
+      const result = await explain({ question }, EXPLAIN_OPTIONS, history);
+      expect(result).toEqual([
+        'The user management system is a system ',
+        'that allows users to create and manage their own accounts.',
+      ]);
+      expect(memoryService.predictSummary).toHaveBeenCalledWith(history);
+    });
+
+    it('does not request context from the client', async () => {
+      await explain({ question }, EXPLAIN_OPTIONS, history);
+
+      expect(requestContext).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/navie/test/services/apply-context-service.spec.ts
+++ b/packages/navie/test/services/apply-context-service.spec.ts
@@ -1,0 +1,113 @@
+import InteractionHistory from '../../src/interaction-history';
+import ApplyContextService from '../../src/services/apply-context-service';
+
+const SEQUENCE_DIAGRAMS = [`diagram-1`, `diagram-2`];
+const CODE_SNIPPETS = {
+  'app/user.rb': `class User < ApplicationRecord; end`,
+  'app/post.rb': `class Post < ApplicationRecord; end`,
+};
+const CODE_OBJECTS = [
+  `SELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT 1`,
+  `SELECT "posts".* FROM "posts" WHERE "posts"."user_id" = $1`,
+];
+
+describe('collectContext', () => {
+  let interactionHistory: InteractionHistory;
+  let applyContextService: ApplyContextService;
+
+  beforeEach(() => {
+    interactionHistory = new InteractionHistory();
+    applyContextService = new ApplyContextService(interactionHistory);
+  });
+  afterEach(() => jest.resetAllMocks());
+
+  const collect = (characterLimit: number) =>
+    applyContextService.applyContext(
+      {
+        sequenceDiagrams: SEQUENCE_DIAGRAMS,
+        codeSnippets: CODE_SNIPPETS,
+        codeObjects: CODE_OBJECTS,
+      },
+      characterLimit
+    );
+
+  it('collects samples of context into the output', () => {
+    collect(1000 * 1000);
+    expect(
+      interactionHistory.events.filter((e) => e.name === 'contextItem').map((e) => ({ ...e }))
+    ).toEqual([
+      {
+        name: 'contextItem',
+        contextItem: {
+          content: `diagram-1`,
+          name: 'Sequence diagram',
+        },
+        file: undefined,
+      },
+      {
+        name: 'contextItem',
+        contextItem: {
+          content: `class User < ApplicationRecord; end`,
+          name: 'Code snippet',
+        },
+        file: 'app/user.rb',
+      },
+      {
+        name: 'contextItem',
+        contextItem: {
+          content: `class Post < ApplicationRecord; end`,
+          name: 'Code snippet',
+        },
+        file: 'app/post.rb',
+      },
+      {
+        name: 'contextItem',
+        contextItem: {
+          content: `SELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT 1`,
+          name: 'Data request',
+        },
+        file: undefined,
+      },
+      {
+        name: 'contextItem',
+        contextItem: {
+          content: `SELECT "posts".* FROM "posts" WHERE "posts"."user_id" = $1`,
+          name: 'Data request',
+        },
+        file: undefined,
+      },
+      {
+        name: 'contextItem',
+        contextItem: {
+          content: `diagram-2`,
+          name: 'Sequence diagram',
+        },
+        file: undefined,
+      },
+    ]);
+  });
+
+  it('limits the output to the character limit', () => {
+    collect(75);
+    expect(
+      interactionHistory.events.filter((e) => e.name === 'contextItem').map((e) => ({ ...e }))
+    ).toEqual([
+      {
+        name: 'contextItem',
+        contextItem: {
+          content: `diagram-1`,
+          name: 'Sequence diagram',
+        },
+        file: undefined,
+      },
+      {
+        name: 'contextItem',
+        contextItem: {
+          content: `class User < ApplicationRecord; end`,
+          name: 'Code snippet',
+        },
+        file: 'app/user.rb',
+      },
+    ]);
+  });
+});

--- a/packages/navie/test/services/vector-terms-service.spec.ts
+++ b/packages/navie/test/services/vector-terms-service.spec.ts
@@ -1,0 +1,123 @@
+/* eslint-disable @typescript-eslint/no-unsafe-return */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+
+import { ChatOpenAI, OpenAIChatInput } from '@langchain/openai';
+import assert from 'assert';
+
+import VectorTermsService from '../../src/services/vector-terms-service';
+import buildChatOpenAI from '../../src/chat-openai';
+import InteractionHistory from '../../src/interaction-history';
+
+jest.mock('../../src/chat-openai');
+
+describe('DefaultVectorTermsService', () => {
+  let interactionHistory: InteractionHistory;
+  let service: VectorTermsService;
+  let completionWithRetry: jest.Mock;
+
+  beforeEach(() => {
+    completionWithRetry = jest.fn();
+    const predictAI = {
+      completionWithRetry,
+    } as unknown as ChatOpenAI;
+
+    jest.mocked(buildChatOpenAI).mockImplementation((params: Partial<OpenAIChatInput>) => {
+      assert(!params.streaming);
+      return predictAI;
+    });
+    interactionHistory = new InteractionHistory();
+    interactionHistory.on('event', (event) => console.log(event.message));
+    service = new VectorTermsService(interactionHistory, 'gpt-4', 0.5);
+  });
+  afterEach(() => jest.resetAllMocks());
+
+  function mockAIResponse(responses: string[]): void {
+    const choices = responses.map((response, index) => ({
+      delta: {
+        content: response,
+      },
+      index,
+      finish_reason: 'stop',
+    }));
+    completionWithRetry.mockResolvedValueOnce([
+      {
+        id: 'cmpl-3Z5z9J5Z5Z5Z5Z5Z5Z5Z5Z5Z5Z5',
+        choices,
+        created: 1635989729,
+        model: 'gpt-3.5',
+        object: 'chat.completion.chunk',
+      },
+    ]);
+  }
+
+  describe('when LLM suggested terms', () => {
+    describe('is a valid JSON object', () => {
+      it('is recorded in the interaction history', async () => {
+        mockAIResponse([`{"terms": ["user", "management"]}`]);
+        const terms = await service.suggestTerms('user management');
+        expect(interactionHistory.events.map((e) => ({ ...e }))).toEqual([
+          {
+            name: 'vectorTerms',
+            terms: ['user', 'management'],
+          },
+        ]);
+      });
+      it('should return the terms', async () => {
+        mockAIResponse([`{"terms": ["user", "management"]}`]);
+        const terms = await service.suggestTerms('user management');
+        expect(terms).toEqual(['user', 'management']);
+        expect(completionWithRetry).toHaveBeenCalledTimes(1);
+      });
+      it('removes very short terms', async () => {
+        mockAIResponse([`["user", "management", "a"]`]);
+        const terms = await service.suggestTerms('user management');
+        expect(terms).toEqual(['user', 'management']);
+        expect(completionWithRetry).toHaveBeenCalledTimes(1);
+      });
+      it('converts underscore_words to distinct words', async () => {
+        mockAIResponse([`["user_management"]`]);
+        const terms = await service.suggestTerms('user management');
+        expect(terms).toEqual(['user', 'management']);
+        expect(completionWithRetry).toHaveBeenCalledTimes(1);
+      });
+    });
+    describe('are a valid JSON list', () => {
+      it('should return the terms', async () => {
+        mockAIResponse(['["user", "management"]']);
+        const terms = await service.suggestTerms('user management');
+        expect(terms).toEqual(['user', 'management']);
+      });
+    });
+    describe('are valid JSON wrapped in fences', () => {
+      it('should return the terms', async () => {
+        mockAIResponse(['```json', '["user", "management"]', '```']);
+        const terms = await service.suggestTerms('user management');
+        expect(terms).toEqual(['user', 'management']);
+      });
+    });
+
+    describe('are invalid JSON', () => {
+      it('retries', async () => {
+        mockAIResponse(['invalid json']);
+        mockAIResponse(['["user", "management"]']);
+        const terms = await service.suggestTerms('user management');
+        expect(terms).toEqual(['user', 'management']);
+        expect(completionWithRetry).toHaveBeenCalledTimes(2);
+      });
+      it('retries three times and then uses the raw search terms', async () => {
+        mockAIResponse(['invalid json']);
+        mockAIResponse(['invalid json']);
+        mockAIResponse(['invalid json']);
+        const terms = await service.suggestTerms('managing a user');
+        expect(terms).toEqual(['managing', 'user']);
+        expect(completionWithRetry).toHaveBeenCalledTimes(3);
+        expect(interactionHistory.events.map((e) => ({ ...e }))).toEqual([
+          {
+            terms: ['managing', 'user'],
+            name: 'vectorTerms',
+          },
+        ]);
+      });
+    });
+  });
+});

--- a/packages/navie/tsconfig.json
+++ b/packages/navie/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "types": ["node", "jest"],
+    "declaration": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": true
+  },
+  "include": ["src"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -462,7 +462,7 @@ __metadata:
     ts-jest: ^29.0.5
     ts-node: ^10.4.0
     tsc: ^2.0.3
-    typescript: ^4.5.4
+    typescript: ^4.9.5
   languageName: unknown
   linkType: soft
 
@@ -6908,251 +6908,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@langchain/community@npm:~0.0.3":
-  version: 0.0.3
-  resolution: "@langchain/community@npm:0.0.3"
-  dependencies:
-    "@langchain/core": ~0.1.0
-    "@langchain/openai": ~0.0.5
-    flat: ^5.0.2
-    langsmith: ~0.0.48
-    uuid: ^9.0.0
-    zod: ^3.22.3
-  peerDependencies:
-    "@aws-crypto/sha256-js": ^5.0.0
-    "@aws-sdk/client-bedrock-runtime": ^3.422.0
-    "@aws-sdk/client-dynamodb": ^3.310.0
-    "@aws-sdk/client-kendra": ^3.352.0
-    "@aws-sdk/client-lambda": ^3.310.0
-    "@aws-sdk/client-sagemaker-runtime": ^3.310.0
-    "@aws-sdk/client-sfn": ^3.310.0
-    "@aws-sdk/credential-provider-node": ^3.388.0
-    "@clickhouse/client": ^0.2.5
-    "@cloudflare/ai": ^1.0.12
-    "@elastic/elasticsearch": ^8.4.0
-    "@getmetal/metal-sdk": "*"
-    "@getzep/zep-js": ^0.9.0
-    "@gomomento/sdk": ^1.51.1
-    "@gomomento/sdk-core": ^1.51.1
-    "@google-ai/generativelanguage": ^0.2.1
-    "@gradientai/nodejs-sdk": ^1.2.0
-    "@huggingface/inference": ^2.6.4
-    "@mozilla/readability": "*"
-    "@opensearch-project/opensearch": "*"
-    "@pinecone-database/pinecone": ^1.1.0
-    "@planetscale/database": ^1.8.0
-    "@qdrant/js-client-rest": ^1.2.0
-    "@raycast/api": ^1.55.2
-    "@rockset/client": ^0.9.1
-    "@smithy/eventstream-codec": ^2.0.5
-    "@smithy/protocol-http": ^3.0.6
-    "@smithy/signature-v4": ^2.0.10
-    "@smithy/util-utf8": ^2.0.0
-    "@supabase/postgrest-js": ^1.1.1
-    "@supabase/supabase-js": ^2.10.0
-    "@tensorflow-models/universal-sentence-encoder": "*"
-    "@tensorflow/tfjs-converter": "*"
-    "@tensorflow/tfjs-core": "*"
-    "@upstash/redis": ^1.20.6
-    "@vercel/kv": ^0.2.3
-    "@vercel/postgres": ^0.5.0
-    "@writerai/writer-sdk": ^0.40.2
-    "@xata.io/client": ^0.28.0
-    "@xenova/transformers": ^2.5.4
-    "@zilliz/milvus2-sdk-node": ">=2.2.7"
-    cassandra-driver: ^4.7.2
-    chromadb: "*"
-    closevector-common: 0.1.0-alpha.1
-    closevector-node: 0.1.0-alpha.10
-    closevector-web: 0.1.0-alpha.16
-    cohere-ai: ">=6.0.0"
-    convex: ^1.3.1
-    faiss-node: ^0.5.1
-    firebase-admin: ^11.9.0
-    google-auth-library: ^8.9.0
-    googleapis: ^126.0.1
-    hnswlib-node: ^1.4.2
-    html-to-text: ^9.0.5
-    ioredis: ^5.3.2
-    jsdom: "*"
-    llmonitor: ^0.5.9
-    lodash: ^4.17.21
-    mongodb: ^5.2.0
-    mysql2: ^3.3.3
-    neo4j-driver: "*"
-    node-llama-cpp: "*"
-    pg: ^8.11.0
-    pg-copy-streams: ^6.0.5
-    pickleparser: ^0.2.1
-    portkey-ai: ^0.1.11
-    redis: ^4.6.4
-    replicate: ^0.18.0
-    typeorm: ^0.3.12
-    typesense: ^1.5.3
-    usearch: ^1.1.1
-    vectordb: ^0.1.4
-    voy-search: 0.6.2
-    weaviate-ts-client: ^1.4.0
-    web-auth-library: ^1.0.3
-    ws: ^8.14.2
-  peerDependenciesMeta:
-    "@aws-crypto/sha256-js":
-      optional: true
-    "@aws-sdk/client-bedrock-runtime":
-      optional: true
-    "@aws-sdk/client-dynamodb":
-      optional: true
-    "@aws-sdk/client-kendra":
-      optional: true
-    "@aws-sdk/client-lambda":
-      optional: true
-    "@aws-sdk/client-sagemaker-runtime":
-      optional: true
-    "@aws-sdk/client-sfn":
-      optional: true
-    "@aws-sdk/credential-provider-node":
-      optional: true
-    "@clickhouse/client":
-      optional: true
-    "@cloudflare/ai":
-      optional: true
-    "@elastic/elasticsearch":
-      optional: true
-    "@getmetal/metal-sdk":
-      optional: true
-    "@getzep/zep-js":
-      optional: true
-    "@gomomento/sdk":
-      optional: true
-    "@gomomento/sdk-core":
-      optional: true
-    "@google-ai/generativelanguage":
-      optional: true
-    "@gradientai/nodejs-sdk":
-      optional: true
-    "@huggingface/inference":
-      optional: true
-    "@mozilla/readability":
-      optional: true
-    "@opensearch-project/opensearch":
-      optional: true
-    "@pinecone-database/pinecone":
-      optional: true
-    "@planetscale/database":
-      optional: true
-    "@qdrant/js-client-rest":
-      optional: true
-    "@raycast/api":
-      optional: true
-    "@rockset/client":
-      optional: true
-    "@smithy/eventstream-codec":
-      optional: true
-    "@smithy/protocol-http":
-      optional: true
-    "@smithy/signature-v4":
-      optional: true
-    "@smithy/util-utf8":
-      optional: true
-    "@supabase/postgrest-js":
-      optional: true
-    "@supabase/supabase-js":
-      optional: true
-    "@tensorflow-models/universal-sentence-encoder":
-      optional: true
-    "@tensorflow/tfjs-converter":
-      optional: true
-    "@tensorflow/tfjs-core":
-      optional: true
-    "@upstash/redis":
-      optional: true
-    "@vercel/kv":
-      optional: true
-    "@vercel/postgres":
-      optional: true
-    "@writerai/writer-sdk":
-      optional: true
-    "@xata.io/client":
-      optional: true
-    "@xenova/transformers":
-      optional: true
-    "@zilliz/milvus2-sdk-node":
-      optional: true
-    cassandra-driver:
-      optional: true
-    chromadb:
-      optional: true
-    closevector-common:
-      optional: true
-    closevector-node:
-      optional: true
-    closevector-web:
-      optional: true
-    cohere-ai:
-      optional: true
-    convex:
-      optional: true
-    faiss-node:
-      optional: true
-    firebase-admin:
-      optional: true
-    google-auth-library:
-      optional: true
-    googleapis:
-      optional: true
-    hnswlib-node:
-      optional: true
-    html-to-text:
-      optional: true
-    ioredis:
-      optional: true
-    jsdom:
-      optional: true
-    llmonitor:
-      optional: true
-    lodash:
-      optional: true
-    mongodb:
-      optional: true
-    mysql2:
-      optional: true
-    neo4j-driver:
-      optional: true
-    node-llama-cpp:
-      optional: true
-    pg:
-      optional: true
-    pg-copy-streams:
-      optional: true
-    pickleparser:
-      optional: true
-    portkey-ai:
-      optional: true
-    redis:
-      optional: true
-    replicate:
-      optional: true
-    typeorm:
-      optional: true
-    typesense:
-      optional: true
-    usearch:
-      optional: true
-    vectordb:
-      optional: true
-    voy-search:
-      optional: true
-    weaviate-ts-client:
-      optional: true
-    web-auth-library:
-      optional: true
-    ws:
-      optional: true
-  checksum: fdd5f81b693a4f90a7035202170c17a50916d80000da91e39642ff70bb96f9224b1e837d8f0f45ec0a0103398a8e7db0b3f345ca374703d714d87d465daa24be
-  languageName: node
-  linkType: hard
-
-"@langchain/community@npm:~0.0.33":
+"@langchain/community@npm:~0.0.3, @langchain/community@npm:~0.0.33":
   version: 0.0.34
   resolution: "@langchain/community@npm:0.0.34"
   dependencies:
@@ -7457,7 +7213,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@langchain/openai@npm:^0.0.15, @langchain/openai@npm:~0.0.14":
+"@langchain/openai@npm:^0.0.15, @langchain/openai@npm:~0.0.14, @langchain/openai@npm:~0.0.5":
   version: 0.0.15
   resolution: "@langchain/openai@npm:0.0.15"
   dependencies:
@@ -7467,19 +7223,6 @@ __metadata:
     zod: ^3.22.4
     zod-to-json-schema: ^3.22.3
   checksum: ec186df8d39ffaa8082b3b44669da88e1280c1d961891cab4c7d961e753056a1ddb9aec00aa58dacc65daaa1f7f2948da2b03cc73bfadc58bba624f911a89b3b
-  languageName: node
-  linkType: hard
-
-"@langchain/openai@npm:~0.0.5":
-  version: 0.0.5
-  resolution: "@langchain/openai@npm:0.0.5"
-  dependencies:
-    "@langchain/core": ~0.1.0
-    js-tiktoken: ^1.0.7
-    openai: ^4.19.0
-    zod: ^3.22.3
-    zod-to-json-schema: 3.20.3
-  checksum: c1889e9bf0bf8aa07ff23d17fea2b9876e841a35a314002e642741a30b82f09cd597352e373810a3a54c44f6e9d5c67830bf9f664ff45206bde9d0299c7a2b4f
   languageName: node
   linkType: hard
 
@@ -29084,14 +28827,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"langchainhub@npm:~0.0.6":
-  version: 0.0.6
-  resolution: "langchainhub@npm:0.0.6"
-  checksum: f771e5375b7ae9cc6fc59d5e2b1fd35c29e5759f4595617e3a235142bc2ca12c4135aa1631d85ee4e25c89968696242dd6380f6b90e87ffbc9006efc3cdc53c4
-  languageName: node
-  linkType: hard
-
-"langchainhub@npm:~0.0.8":
+"langchainhub@npm:~0.0.6, langchainhub@npm:~0.0.8":
   version: 0.0.8
   resolution: "langchainhub@npm:0.0.8"
   checksum: b46316adbbd5f1971892b423e6a7e9c7681f4c44e4ac3c3b79c6beef96a28fc9582a4ee14affb617fd887f3dac8cae55368e1b7c4a41bb43f86f17c5d63031e3
@@ -29099,8 +28835,8 @@ __metadata:
   linkType: hard
 
 "langsmith@npm:~0.0.48":
-  version: 0.0.49
-  resolution: "langsmith@npm:0.0.49"
+  version: 0.0.70
+  resolution: "langsmith@npm:0.0.70"
   dependencies:
     "@types/uuid": ^9.0.1
     commander: ^10.0.1
@@ -29109,7 +28845,7 @@ __metadata:
     uuid: ^9.0.0
   bin:
     langsmith: dist/cli/main.cjs
-  checksum: 9976d9fe1e4d4ace5041af08d3271dff61d7a87fbd88523b52274817704d282c46a48187cc73af0f7e440dbe4db5da1d221966d1136a71cbfa6115e5159242a8
+  checksum: a3e4d750e139af725230affb80dfc03100f3ee18d73391d056df2d1faf4bb8964b112dbfd740ef8bd30779dfef61989cfa3fd82f97dbfc29a84dc7f95294a25e
   languageName: node
   linkType: hard
 
@@ -32228,25 +31964,6 @@ __metadata:
     is-docker: ^2.1.1
     is-wsl: ^2.2.0
   checksum: e9545bec64cdbf30a0c35c1bdc310344adf8428a117f7d8df3c0af0a0a24c513b304916a6d9b11db0190ff7225c2d578885080b761ed46a3d5f6f1eebb98b63c
-  languageName: node
-  linkType: hard
-
-"openai@npm:^4.19.0":
-  version: 4.20.1
-  resolution: "openai@npm:4.20.1"
-  dependencies:
-    "@types/node": ^18.11.18
-    "@types/node-fetch": ^2.6.4
-    abort-controller: ^3.0.0
-    agentkeepalive: ^4.2.1
-    digest-fetch: ^1.3.0
-    form-data-encoder: 1.7.2
-    formdata-node: ^4.3.2
-    node-fetch: ^2.6.7
-    web-streams-polyfill: ^3.2.1
-  bin:
-    openai: bin/cli
-  checksum: 01d2aeaf9c1a0e93159cd49207d86188edf43a6276aeb1a4aab8614727f64591452bbe19baa344f799d0a94314ff386e39c019b62f305543952606759a3927f1
   languageName: node
   linkType: hard
 
@@ -39577,12 +39294,12 @@ typescript@^4.5.4:
   linkType: hard
 
 "typescript@npm:^5.3.2":
-  version: 5.3.2
-  resolution: "typescript@npm:5.3.2"
+  version: 5.3.3
+  resolution: "typescript@npm:5.3.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: d92534dda639eb825db013203404c1fabca8ac630564283c9e7dc9e64fd9c9346c2de95ecebdf3e6e8c1c32941bca1cfe0da37877611feb9daf8feeaea58d230
+  checksum: 2007ccb6e51bbbf6fde0a78099efe04dc1c3dfbdff04ca3b6a8bc717991862b39fd6126c0c3ebf2d2d98ac5e960bcaa873826bb2bb241f14277034148f41f6a2
   languageName: node
   linkType: hard
 
@@ -39617,12 +39334,12 @@ typescript@^4.5.4:
   linkType: hard
 
 "typescript@patch:typescript@^5.3.2#~builtin<compat/typescript>":
-  version: 5.3.2
-  resolution: "typescript@patch:typescript@npm%3A5.3.2#~builtin<compat/typescript>::version=5.3.2&hash=7ad353"
+  version: 5.3.3
+  resolution: "typescript@patch:typescript@npm%3A5.3.3#~builtin<compat/typescript>::version=5.3.3&hash=7ad353"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: c034461079fbfde3cb584ddee52afccb15b6e32a0ce186d0b2719968786f7ca73e1b07f71fac4163088790b16811c6ccf79680de190664ef66ff0ba9c1fe4a23
+  checksum: f61375590b3162599f0f0d5b8737877ac0a7bc52761dbb585d67e7b8753a3a4c42d9a554c4cc929f591ffcf3a2b0602f65ae3ce74714fd5652623a816862b610
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -436,6 +436,36 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@appland/navie@workspace:packages/navie":
+  version: 0.0.0-use.local
+  resolution: "@appland/navie@workspace:packages/navie"
+  dependencies:
+    "@langchain/core": ^0.1.32
+    "@langchain/openai": ^0.0.15
+    "@types/jest": ^29.4.1
+    "@types/node": ^17.0.2
+    "@typescript-eslint/eslint-plugin": ^5.51.0
+    "@typescript-eslint/parser": ^5.7.0
+    eslint: ^8.4.1
+    eslint-config-airbnb-base: ^15.0.0
+    eslint-config-airbnb-typescript: ^17.0.0
+    eslint-config-prettier: ^8.3.0
+    eslint-formatter-pretty: ^4.1.0
+    eslint-plugin-eslint-comments: ^3.2.0
+    eslint-plugin-import: ^2.25.3
+    eslint-plugin-jest: ^25.3.0
+    eslint-plugin-promise: ^6.0.1
+    eslint-plugin-unicorn: ^39.0.0
+    jest: ^29.5.0
+    langchain: ^0.1.25
+    openai: ^4.28.0
+    ts-jest: ^29.0.5
+    ts-node: ^10.4.0
+    tsc: ^2.0.3
+    typescript: ^4.5.4
+  languageName: unknown
+  linkType: soft
+
 "@appland/openapi@workspace:^1.7.0, @appland/openapi@workspace:^1.8.0, @appland/openapi@workspace:packages/openapi":
   version: 0.0.0-use.local
   resolution: "@appland/openapi@workspace:packages/openapi"
@@ -7122,6 +7152,293 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@langchain/community@npm:~0.0.33":
+  version: 0.0.34
+  resolution: "@langchain/community@npm:0.0.34"
+  dependencies:
+    "@langchain/core": ~0.1.36
+    "@langchain/openai": ~0.0.14
+    flat: ^5.0.2
+    langsmith: ~0.1.1
+    uuid: ^9.0.0
+    zod: ^3.22.3
+  peerDependencies:
+    "@aws-crypto/sha256-js": ^5.0.0
+    "@aws-sdk/client-bedrock-agent-runtime": ^3.485.0
+    "@aws-sdk/client-bedrock-runtime": ^3.422.0
+    "@aws-sdk/client-dynamodb": ^3.310.0
+    "@aws-sdk/client-kendra": ^3.352.0
+    "@aws-sdk/client-lambda": ^3.310.0
+    "@aws-sdk/client-sagemaker-runtime": ^3.310.0
+    "@aws-sdk/client-sfn": ^3.310.0
+    "@aws-sdk/credential-provider-node": ^3.388.0
+    "@azure/search-documents": ^12.0.0
+    "@clickhouse/client": ^0.2.5
+    "@cloudflare/ai": "*"
+    "@datastax/astra-db-ts": ^0.1.4
+    "@elastic/elasticsearch": ^8.4.0
+    "@getmetal/metal-sdk": "*"
+    "@getzep/zep-js": ^0.9.0
+    "@gomomento/sdk": ^1.51.1
+    "@gomomento/sdk-core": ^1.51.1
+    "@google-ai/generativelanguage": ^0.2.1
+    "@gradientai/nodejs-sdk": ^1.2.0
+    "@huggingface/inference": ^2.6.4
+    "@mozilla/readability": "*"
+    "@opensearch-project/opensearch": "*"
+    "@pinecone-database/pinecone": "*"
+    "@planetscale/database": ^1.8.0
+    "@qdrant/js-client-rest": ^1.2.0
+    "@raycast/api": ^1.55.2
+    "@rockset/client": ^0.9.1
+    "@smithy/eventstream-codec": ^2.0.5
+    "@smithy/protocol-http": ^3.0.6
+    "@smithy/signature-v4": ^2.0.10
+    "@smithy/util-utf8": ^2.0.0
+    "@supabase/postgrest-js": ^1.1.1
+    "@supabase/supabase-js": ^2.10.0
+    "@tensorflow-models/universal-sentence-encoder": "*"
+    "@tensorflow/tfjs-converter": "*"
+    "@tensorflow/tfjs-core": "*"
+    "@upstash/redis": ^1.20.6
+    "@upstash/vector": ^1.0.2
+    "@vercel/kv": ^0.2.3
+    "@vercel/postgres": ^0.5.0
+    "@writerai/writer-sdk": ^0.40.2
+    "@xata.io/client": ^0.28.0
+    "@xenova/transformers": ^2.5.4
+    "@zilliz/milvus2-sdk-node": ">=2.2.7"
+    better-sqlite3: ^9.4.0
+    cassandra-driver: ^4.7.2
+    chromadb: "*"
+    closevector-common: 0.1.3
+    closevector-node: 0.1.6
+    closevector-web: 0.1.6
+    cohere-ai: "*"
+    convex: ^1.3.1
+    discord.js: ^14.14.1
+    dria: ^0.0.3
+    faiss-node: ^0.5.1
+    firebase-admin: ^11.9.0 || ^12.0.0
+    google-auth-library: ^8.9.0
+    googleapis: ^126.0.1
+    hnswlib-node: ^1.4.2
+    html-to-text: ^9.0.5
+    ioredis: ^5.3.2
+    jsdom: "*"
+    llmonitor: ^0.5.9
+    lodash: ^4.17.21
+    lunary: ^0.6.11
+    mongodb: ">=5.2.0"
+    mysql2: ^3.3.3
+    neo4j-driver: "*"
+    node-llama-cpp: "*"
+    pg: ^8.11.0
+    pg-copy-streams: ^6.0.5
+    pickleparser: ^0.2.1
+    portkey-ai: ^0.1.11
+    redis: "*"
+    replicate: ^0.18.0
+    typeorm: ^0.3.12
+    typesense: ^1.5.3
+    usearch: ^1.1.1
+    vectordb: ^0.1.4
+    voy-search: 0.6.2
+    weaviate-ts-client: "*"
+    web-auth-library: ^1.0.3
+    ws: ^8.14.2
+  peerDependenciesMeta:
+    "@aws-crypto/sha256-js":
+      optional: true
+    "@aws-sdk/client-bedrock-agent-runtime":
+      optional: true
+    "@aws-sdk/client-bedrock-runtime":
+      optional: true
+    "@aws-sdk/client-dynamodb":
+      optional: true
+    "@aws-sdk/client-kendra":
+      optional: true
+    "@aws-sdk/client-lambda":
+      optional: true
+    "@aws-sdk/client-sagemaker-runtime":
+      optional: true
+    "@aws-sdk/client-sfn":
+      optional: true
+    "@aws-sdk/credential-provider-node":
+      optional: true
+    "@azure/search-documents":
+      optional: true
+    "@clickhouse/client":
+      optional: true
+    "@cloudflare/ai":
+      optional: true
+    "@datastax/astra-db-ts":
+      optional: true
+    "@elastic/elasticsearch":
+      optional: true
+    "@getmetal/metal-sdk":
+      optional: true
+    "@getzep/zep-js":
+      optional: true
+    "@gomomento/sdk":
+      optional: true
+    "@gomomento/sdk-core":
+      optional: true
+    "@google-ai/generativelanguage":
+      optional: true
+    "@gradientai/nodejs-sdk":
+      optional: true
+    "@huggingface/inference":
+      optional: true
+    "@mozilla/readability":
+      optional: true
+    "@opensearch-project/opensearch":
+      optional: true
+    "@pinecone-database/pinecone":
+      optional: true
+    "@planetscale/database":
+      optional: true
+    "@qdrant/js-client-rest":
+      optional: true
+    "@raycast/api":
+      optional: true
+    "@rockset/client":
+      optional: true
+    "@smithy/eventstream-codec":
+      optional: true
+    "@smithy/protocol-http":
+      optional: true
+    "@smithy/signature-v4":
+      optional: true
+    "@smithy/util-utf8":
+      optional: true
+    "@supabase/postgrest-js":
+      optional: true
+    "@supabase/supabase-js":
+      optional: true
+    "@tensorflow-models/universal-sentence-encoder":
+      optional: true
+    "@tensorflow/tfjs-converter":
+      optional: true
+    "@tensorflow/tfjs-core":
+      optional: true
+    "@upstash/redis":
+      optional: true
+    "@upstash/vector":
+      optional: true
+    "@vercel/kv":
+      optional: true
+    "@vercel/postgres":
+      optional: true
+    "@writerai/writer-sdk":
+      optional: true
+    "@xata.io/client":
+      optional: true
+    "@xenova/transformers":
+      optional: true
+    "@zilliz/milvus2-sdk-node":
+      optional: true
+    better-sqlite3:
+      optional: true
+    cassandra-driver:
+      optional: true
+    chromadb:
+      optional: true
+    closevector-common:
+      optional: true
+    closevector-node:
+      optional: true
+    closevector-web:
+      optional: true
+    cohere-ai:
+      optional: true
+    convex:
+      optional: true
+    discord.js:
+      optional: true
+    dria:
+      optional: true
+    faiss-node:
+      optional: true
+    firebase-admin:
+      optional: true
+    google-auth-library:
+      optional: true
+    googleapis:
+      optional: true
+    hnswlib-node:
+      optional: true
+    html-to-text:
+      optional: true
+    ioredis:
+      optional: true
+    jsdom:
+      optional: true
+    llmonitor:
+      optional: true
+    lodash:
+      optional: true
+    lunary:
+      optional: true
+    mongodb:
+      optional: true
+    mysql2:
+      optional: true
+    neo4j-driver:
+      optional: true
+    node-llama-cpp:
+      optional: true
+    pg:
+      optional: true
+    pg-copy-streams:
+      optional: true
+    pickleparser:
+      optional: true
+    portkey-ai:
+      optional: true
+    redis:
+      optional: true
+    replicate:
+      optional: true
+    typeorm:
+      optional: true
+    typesense:
+      optional: true
+    usearch:
+      optional: true
+    vectordb:
+      optional: true
+    voy-search:
+      optional: true
+    weaviate-ts-client:
+      optional: true
+    web-auth-library:
+      optional: true
+    ws:
+      optional: true
+  checksum: caf56c76fd3a6fa8c827a14a5226e36d9733c6aa37740f1840fc45deb246119f1c6da6551214f5a4bd42e8af2038122401b63c40f1a37f358757933bab2c48dc
+  languageName: node
+  linkType: hard
+
+"@langchain/core@npm:^0.1.32, @langchain/core@npm:~0.1.36, @langchain/core@npm:~0.1.39":
+  version: 0.1.40
+  resolution: "@langchain/core@npm:0.1.40"
+  dependencies:
+    ansi-styles: ^5.0.0
+    camelcase: 6
+    decamelize: 1.2.0
+    js-tiktoken: ^1.0.8
+    langsmith: ~0.1.7
+    ml-distance: ^4.0.0
+    p-queue: ^6.6.2
+    p-retry: 4
+    uuid: ^9.0.0
+    zod: ^3.22.4
+    zod-to-json-schema: ^3.22.3
+  checksum: dc3c1a20d3ba8f1e60cadc7d73d011245f35c473e8a30cf0355ec79e9c52069c9d894882220f14eed91f354d53b6c30f61b8bfb35aeceaaeb951fddced8d0037
+  languageName: node
+  linkType: hard
+
 "@langchain/core@npm:~0.1.0":
   version: 0.1.0
   resolution: "@langchain/core@npm:0.1.0"
@@ -7137,6 +7454,19 @@ __metadata:
     uuid: ^9.0.0
     zod: ^3.22.3
   checksum: 8027f2cc0c554d9da0a01c05a2c8e416abf147db77b2c8e6be49f012ac013b4d9bab5d5c664e69c1d91498e1527689253a4d865814e163d090370fcb5cd60767
+  languageName: node
+  linkType: hard
+
+"@langchain/openai@npm:^0.0.15, @langchain/openai@npm:~0.0.14":
+  version: 0.0.15
+  resolution: "@langchain/openai@npm:0.0.15"
+  dependencies:
+    "@langchain/core": ~0.1.39
+    js-tiktoken: ^1.0.7
+    openai: ^4.26.0
+    zod: ^3.22.4
+    zod-to-json-schema: ^3.22.3
+  checksum: ec186df8d39ffaa8082b3b44669da88e1280c1d961891cab4c7d961e753056a1ddb9aec00aa58dacc65daaa1f7f2948da2b03cc73bfadc58bba624f911a89b3b
   languageName: node
   linkType: hard
 
@@ -28574,10 +28904,197 @@ __metadata:
   languageName: node
   linkType: hard
 
+"langchain@npm:^0.1.25":
+  version: 0.1.25
+  resolution: "langchain@npm:0.1.25"
+  dependencies:
+    "@anthropic-ai/sdk": ^0.9.1
+    "@langchain/community": ~0.0.33
+    "@langchain/core": ~0.1.36
+    "@langchain/openai": ~0.0.14
+    binary-extensions: ^2.2.0
+    expr-eval: ^2.0.2
+    js-tiktoken: ^1.0.7
+    js-yaml: ^4.1.0
+    jsonpointer: ^5.0.1
+    langchainhub: ~0.0.8
+    langsmith: ~0.1.7
+    ml-distance: ^4.0.0
+    openapi-types: ^12.1.3
+    p-retry: 4
+    uuid: ^9.0.0
+    yaml: ^2.2.1
+    zod: ^3.22.4
+    zod-to-json-schema: ^3.22.3
+  peerDependencies:
+    "@aws-sdk/client-s3": ^3.310.0
+    "@aws-sdk/client-sagemaker-runtime": ^3.310.0
+    "@aws-sdk/client-sfn": ^3.310.0
+    "@aws-sdk/credential-provider-node": ^3.388.0
+    "@azure/storage-blob": ^12.15.0
+    "@gomomento/sdk": ^1.51.1
+    "@gomomento/sdk-core": ^1.51.1
+    "@gomomento/sdk-web": ^1.51.1
+    "@google-ai/generativelanguage": ^0.2.1
+    "@google-cloud/storage": ^6.10.1 || ^7.7.0
+    "@notionhq/client": ^2.2.10
+    "@pinecone-database/pinecone": "*"
+    "@supabase/supabase-js": ^2.10.0
+    "@vercel/kv": ^0.2.3
+    "@xata.io/client": ^0.28.0
+    apify-client: ^2.7.1
+    assemblyai: ^4.0.0
+    axios: "*"
+    cheerio: ^1.0.0-rc.12
+    chromadb: "*"
+    convex: ^1.3.1
+    couchbase: ^4.2.10
+    d3-dsv: ^2.0.0
+    epub2: ^3.0.1
+    fast-xml-parser: ^4.2.7
+    google-auth-library: ^8.9.0
+    handlebars: ^4.7.8
+    html-to-text: ^9.0.5
+    ignore: ^5.2.0
+    ioredis: ^5.3.2
+    jsdom: "*"
+    mammoth: ^1.6.0
+    mongodb: ">=5.2.0"
+    node-llama-cpp: "*"
+    notion-to-md: ^3.1.0
+    officeparser: ^4.0.4
+    pdf-parse: 1.1.1
+    peggy: ^3.0.2
+    playwright: ^1.32.1
+    puppeteer: ^19.7.2
+    pyodide: ^0.24.1
+    redis: ^4.6.4
+    sonix-speech-recognition: ^2.1.1
+    srt-parser-2: ^1.2.3
+    typeorm: ^0.3.12
+    weaviate-ts-client: "*"
+    web-auth-library: ^1.0.3
+    ws: ^8.14.2
+    youtube-transcript: ^1.0.6
+    youtubei.js: ^9.1.0
+  peerDependenciesMeta:
+    "@aws-sdk/client-s3":
+      optional: true
+    "@aws-sdk/client-sagemaker-runtime":
+      optional: true
+    "@aws-sdk/client-sfn":
+      optional: true
+    "@aws-sdk/credential-provider-node":
+      optional: true
+    "@azure/storage-blob":
+      optional: true
+    "@gomomento/sdk":
+      optional: true
+    "@gomomento/sdk-core":
+      optional: true
+    "@gomomento/sdk-web":
+      optional: true
+    "@google-ai/generativelanguage":
+      optional: true
+    "@google-cloud/storage":
+      optional: true
+    "@notionhq/client":
+      optional: true
+    "@pinecone-database/pinecone":
+      optional: true
+    "@supabase/supabase-js":
+      optional: true
+    "@vercel/kv":
+      optional: true
+    "@xata.io/client":
+      optional: true
+    apify-client:
+      optional: true
+    assemblyai:
+      optional: true
+    axios:
+      optional: true
+    cheerio:
+      optional: true
+    chromadb:
+      optional: true
+    convex:
+      optional: true
+    couchbase:
+      optional: true
+    d3-dsv:
+      optional: true
+    epub2:
+      optional: true
+    faiss-node:
+      optional: true
+    fast-xml-parser:
+      optional: true
+    google-auth-library:
+      optional: true
+    handlebars:
+      optional: true
+    html-to-text:
+      optional: true
+    ignore:
+      optional: true
+    ioredis:
+      optional: true
+    jsdom:
+      optional: true
+    mammoth:
+      optional: true
+    mongodb:
+      optional: true
+    node-llama-cpp:
+      optional: true
+    notion-to-md:
+      optional: true
+    officeparser:
+      optional: true
+    pdf-parse:
+      optional: true
+    peggy:
+      optional: true
+    playwright:
+      optional: true
+    puppeteer:
+      optional: true
+    pyodide:
+      optional: true
+    redis:
+      optional: true
+    sonix-speech-recognition:
+      optional: true
+    srt-parser-2:
+      optional: true
+    typeorm:
+      optional: true
+    weaviate-ts-client:
+      optional: true
+    web-auth-library:
+      optional: true
+    ws:
+      optional: true
+    youtube-transcript:
+      optional: true
+    youtubei.js:
+      optional: true
+  checksum: 50a85c3f31fc1b566fbabc7aaa19edb7a92daec982f0dae6882b28b92492cc1fcdd8877484df1ef67293acc66a2d6495bc145afe4e21be182a9a1cd580f56c26
+  languageName: node
+  linkType: hard
+
 "langchainhub@npm:~0.0.6":
   version: 0.0.6
   resolution: "langchainhub@npm:0.0.6"
   checksum: f771e5375b7ae9cc6fc59d5e2b1fd35c29e5759f4595617e3a235142bc2ca12c4135aa1631d85ee4e25c89968696242dd6380f6b90e87ffbc9006efc3cdc53c4
+  languageName: node
+  linkType: hard
+
+"langchainhub@npm:~0.0.8":
+  version: 0.0.8
+  resolution: "langchainhub@npm:0.0.8"
+  checksum: b46316adbbd5f1971892b423e6a7e9c7681f4c44e4ac3c3b79c6beef96a28fc9582a4ee14affb617fd887f3dac8cae55368e1b7c4a41bb43f86f17c5d63031e3
   languageName: node
   linkType: hard
 
@@ -28593,6 +29110,21 @@ __metadata:
   bin:
     langsmith: dist/cli/main.cjs
   checksum: 9976d9fe1e4d4ace5041af08d3271dff61d7a87fbd88523b52274817704d282c46a48187cc73af0f7e440dbe4db5da1d221966d1136a71cbfa6115e5159242a8
+  languageName: node
+  linkType: hard
+
+"langsmith@npm:~0.1.1, langsmith@npm:~0.1.7":
+  version: 0.1.8
+  resolution: "langsmith@npm:0.1.8"
+  dependencies:
+    "@types/uuid": ^9.0.1
+    commander: ^10.0.1
+    p-queue: ^6.6.2
+    p-retry: 4
+    uuid: ^9.0.0
+  bin:
+    langsmith: dist/cli/main.cjs
+  checksum: cfa211ebfbf0b723efe8fa3c85cb2bdb434396256ca210545b4629d06cde6aec92187073d0aaa709955ae79d66aa154469744401975ae324c96d4c6f594c798e
   languageName: node
   linkType: hard
 
@@ -31715,6 +32247,25 @@ __metadata:
   bin:
     openai: bin/cli
   checksum: 01d2aeaf9c1a0e93159cd49207d86188edf43a6276aeb1a4aab8614727f64591452bbe19baa344f799d0a94314ff386e39c019b62f305543952606759a3927f1
+  languageName: node
+  linkType: hard
+
+"openai@npm:^4.26.0, openai@npm:^4.28.0":
+  version: 4.28.4
+  resolution: "openai@npm:4.28.4"
+  dependencies:
+    "@types/node": ^18.11.18
+    "@types/node-fetch": ^2.6.4
+    abort-controller: ^3.0.0
+    agentkeepalive: ^4.2.1
+    digest-fetch: ^1.3.0
+    form-data-encoder: 1.7.2
+    formdata-node: ^4.3.2
+    node-fetch: ^2.6.7
+    web-streams-polyfill: ^3.2.1
+  bin:
+    openai: bin/cli
+  checksum: 1eeb392bfb495a8ddc44622950de25d7782a3cc00f748919ec3bfca0775bef6653e32b0edb11cee028f140c352e1a123acad4996d7cfdcf8eec078f20e5e63d0
   languageName: node
   linkType: hard
 
@@ -41275,7 +41826,16 @@ typescript@~4.4.3:
   languageName: node
   linkType: hard
 
-"zod@npm:^3.22.3":
+"zod-to-json-schema@npm:^3.22.3":
+  version: 3.22.4
+  resolution: "zod-to-json-schema@npm:3.22.4"
+  peerDependencies:
+    zod: ^3.22.4
+  checksum: 22f89d505cc3d93020de38e4471362fbecd73a8df58017553ad57fb14e69b6f2f88bcdfe9f84b291442ed0654f97344d517af291d23848e43e6e208ee23dac2b
+  languageName: node
+  linkType: hard
+
+"zod@npm:^3.22.3, zod@npm:^3.22.4":
   version: 3.22.4
   resolution: "zod@npm:3.22.4"
   checksum: 80bfd7f8039b24fddeb0718a2ec7c02aa9856e4838d6aa4864335a047b6b37a3273b191ef335bf0b2002e5c514ef261ffcda5a589fb084a48c336ffc4cdbab7f


### PR DESCRIPTION
Migrate Navie logic from api-services into new package `@appland/navie`.

In addition, the following enhancements:

**Logging**

[InteractionHistory](https://github.com/getappmap/appmap-js/pull/1615/files#diff-ed85c6d6714ad90002f856d93a39906e6cbd3135d24e1b4bb445c8360a9df27cR127) provides much better logging and details about what's going on inside the Explain component.

**Project info**

In addition to AppMap context, Navie requests [Project Info](https://github.com/getappmap/appmap-js/pull/1615/files#diff-d451839854fdfc13d9f2da27758ef473b81e4b5b29d901364d8ac7eaca0d693bR3), which is basically the appmap.yml file and appmap stats. With this information, Navie knows definitively:

* The programming language
* Whether AppMaps have been made.

**Prompt** 

Prompt is [built very dynamically](https://github.com/getappmap/appmap-js/pull/1615/files#diff-bddf41bf154086666e887ec469e3804e08d84cae93a4474e51f004ead4500a9eR102) based on the context and project info that Navie is able to obtain.

