### PR TITLE
feat: Navie may not always search for AppMaps

### DIFF
--- a/packages/components/src/pages/ChatSearch.vue
+++ b/packages/components/src/pages/ChatSearch.vue
@@ -290,15 +290,24 @@ export default {
         const systemMessage = this.$refs.vchat.addSystemMessage();
         let tool: ITool | undefined;
 
+        const contextToolTitle = 'Analyzing your project';
         if (isNewChat) {
           tool = {
-            title: 'Searching for AppMaps',
+            title: contextToolTitle,
           };
           systemMessage.tools.push(tool);
         }
 
+        const onProjectContextComplete = () => {
+          if (tool && tool.title === contextToolTitle) {
+            tool.title = 'Project analysis complete';
+            tool.complete = true;
+          }
+        };
+
         const onComplete = () => {
           this.searching = false;
+          onProjectContextComplete();
           systemMessage.complete = true;
           resolve();
         };
@@ -316,6 +325,7 @@ export default {
         this.ask.on('token', (token, messageId) => {
           if (!systemMessage.messageId) systemMessage.messageId = messageId;
 
+          onProjectContextComplete();
           this.$refs.vchat.addToken(token, myThreadId, messageId);
         });
         this.ask.on('error', onError);
@@ -328,8 +338,8 @@ export default {
             // Update the tool status to reflect the fact that we've found some AppMaps
             if (tool) {
               const numResults = this.searchResponse.results.length;
-              tool.title = 'Searched for AppMaps';
-              tool.status = `Found ${numResults} relevant recording${numResults === 1 ? '' : 's'}`;
+              tool.title = 'Project analysis complete';
+              tool.status = `Found ${numResults} relevant AppMap${numResults === 1 ? '' : 's'}`;
               tool.complete = true;
             }
           }

--- a/packages/components/src/stories/ChatTools.stories.js
+++ b/packages/components/src/stories/ChatTools.stories.js
@@ -13,7 +13,7 @@ export const Search = (args, { argTypes }) => ({
   template: `<v-tool-status v-bind="$props" />`,
 });
 Search.args = {
-  title: 'Searched for AppMaps',
-  status: 'Found 3 relevant recordings',
+  title: 'Project analysis complete',
+  status: 'Found 3 relevant AppMaps',
   complete: true,
 };

--- a/packages/components/tests/unit/chat/ChatSearch.spec.js
+++ b/packages/components/tests/unit/chat/ChatSearch.spec.js
@@ -298,7 +298,7 @@ describe('pages/ChatSearch.vue', () => {
         const { wrapper } = await performSearch();
 
         expect(wrapper.find('[data-cy="tool-status"]').text()).toContain(
-          'Found 0 relevant recordings'
+          'Found 0 relevant AppMaps'
         );
       });
 
@@ -341,12 +341,12 @@ describe('pages/ChatSearch.vue', () => {
       const messageSent = wrapper.vm.sendMessage('How do I reset my password?');
 
       await wrapper.vm.$nextTick();
-      expect(wrapper.find(title).text()).toBe('Searching for AppMaps');
+      expect(wrapper.find(title).text()).toBe('Analyzing your project');
       expect(wrapper.find(status).text()).toBe('');
 
       await messageSent;
-      expect(wrapper.find(title).text()).toBe('Searched for AppMaps');
-      expect(wrapper.find(status).text()).toBe('Found 1 relevant recording');
+      expect(wrapper.find(title).text()).toBe('Project analysis complete');
+      expect(wrapper.find(status).text()).toBe('Found 1 relevant AppMap');
     });
   });
 


### PR DESCRIPTION
When the project does not contain AppMaps, Navie will not initiate a search. Account for this in the ChatSearch UI.

The progress box language is updated somewhat. 

**Initial message**

<img width="429" alt="Screen Shot 2024-03-04 at 5 05 31 PM" src="https://github.com/getappmap/appmap-js/assets/86395/bc185c19-df99-4b7b-b75b-b7f637f7e256">

**Project was searched for AppMaps**
<img width="378" alt="Screen Shot 2024-03-04 at 5 05 23 PM" src="https://github.com/getappmap/appmap-js/assets/86395/78d90dea-9c2d-41b3-a2bc-9df8ed82a636">

**Project was not searched for AppMaps**
<img width="380" alt="Screen Shot 2024-03-04 at 5 06 42 PM" src="https://github.com/getappmap/appmap-js/assets/86395/4bfbd22f-acf0-4b7a-856c-dc89ff5100cb">
