### PR TITLE
fix: Add missing dynamic import

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -149,7 +149,9 @@
       "node18-macos-arm64"
     ],
     "scripts": [
-      "built/cmds/record/state/record_*.js"
+      "built/cmds/record/state/record_*.js",
+      "node_modules/openai/_shims/auto/runtime-node.js",
+      "../../node_modules/openai/_shims/auto/runtime-node.js"
     ],
     "assets": [
       "package.json",


### PR DESCRIPTION
Resolves the following error in the binary distribution
```
Error: Cannot find module '/snapshot/appmap-js/node_modules/openai/_shims/auto/runtime-node.js'
```