### PR TITLE
Test the native binary for @appland/appmap

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -166,6 +166,31 @@ jobs:
           # TODO: Run only the appmap-node version of these tests
           # npx appmap-node yarn run test
 
+  test_native:
+    runs-on: ubuntu-latest
+
+    needs: [yarn_install]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Node
+        uses: ./.github/actions/setup-node
+
+      - name: Setup Ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 3.1
+
+      - name: Build
+        run: yarn run build
+
+      - name: Test
+        run: |
+          cd packages/cli
+          yarn test:binary
+
   test_the_rest:
     runs-on: ubuntu-latest
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -18,7 +18,7 @@
     "lint:fix": "eslint 'src/**/*.js' 'tests/**/*.js' --fix",
     "pre-commit": "lint-staged",
     "test": "jest --filter=./tests/testFilter.js",
-    "jest": "jest --filter=./tests/testFilter.js",
+    "test:binary": "jest -c tests/binary/jest.config.js",
     "build": "tsc && yarn build:html",
     "watch": "tsc --watch",
     "build:html": "ts-node esbuild.html.ts",

--- a/packages/cli/tests/binary/helpers/index.ts
+++ b/packages/cli/tests/binary/helpers/index.ts
@@ -1,0 +1,27 @@
+import { ChildProcess, spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { run } from '../../../src/cmds/agentInstaller/commandRunner';
+import CommandStruct, { CommandReturn } from '../../../src/cmds/agentInstaller/commandStruct';
+
+export const BinaryPath = join(__dirname, '..', '..', '..', 'release', 'appmap');
+
+export function runUntilCompletion(args: string[], cwd = process.cwd()): Promise<CommandReturn> {
+  return run(
+    new CommandStruct(BinaryPath, args, cwd, {
+      APPMAP_TELEMETRY_DISABLED: '1',
+    })
+  );
+}
+
+export async function buildRubyProject(): Promise<string> {
+  const projectPath = join(tmpdir(), `test-appmap-project-${Date.now()}`);
+  const srcPath = join(projectPath, 'src');
+  await mkdir(srcPath, { recursive: true });
+  await writeFile(join(projectPath, 'Gemfile'), 'source "https://rubygems.org"\n');
+  await writeFile(join(srcPath, 'main.rb'), 'puts "Hello, world!"');
+  return projectPath;
+}

--- a/packages/cli/tests/binary/helpers/setup.ts
+++ b/packages/cli/tests/binary/helpers/setup.ts
@@ -1,0 +1,63 @@
+import { join, resolve } from 'node:path';
+import { BinaryPath } from '.';
+import { run } from '../../../src/cmds/agentInstaller/commandRunner';
+import CommandStruct from '../../../src/cmds/agentInstaller/commandStruct';
+import { stat } from 'node:fs/promises';
+import { exit } from 'node:process';
+import { log } from 'console';
+import chalk from 'chalk';
+import { platform } from 'node:os';
+
+const packageRoot = join(__dirname, '..', '..', '..');
+const oneDayAgo = Date.now() - 1000 * 60 * 60 * 24;
+
+// jest.setTimeout(1000 * 60 * 5);
+
+export default async function performSetup() {
+  if (process.env.SKIP_BUILD_NATIVE) {
+    return;
+  }
+
+  try {
+    const stats = await stat(BinaryPath);
+    if (stats.mtimeMs > oneDayAgo) {
+      log(chalk.green('The appmap binary has been built within 24h and will not be rebuilt.'));
+      log('To force a rebuild, delete ' + resolve(BinaryPath));
+      return;
+    }
+  } catch {
+    log('Binary not found');
+  }
+
+  log(chalk.yellow('Building native appmap binary. This may take a while.'));
+  log(`To skip this step, set the ${chalk.green('SKIP_BUILD_NATIVE')} environment variable.`);
+
+  const startTime = Date.now();
+  try {
+    await run(
+      new CommandStruct(
+        'yarn',
+        [
+          'pkg',
+          '--config',
+          'package.json',
+          '--compress',
+          'GZip',
+          '-o',
+          'release/appmap',
+          '-t',
+          `node18-${platform()}-x64`,
+          'built/cli.js',
+        ],
+        packageRoot,
+        {}
+      )
+    );
+  } catch (err) {
+    log(chalk.red('Error building binary'));
+    log(err);
+    exit(1);
+  }
+
+  log(`${chalk.green('Binary built')} in ${(Date.now() - startTime) / 1000} seconds`);
+}

--- a/packages/cli/tests/binary/jest.config.js
+++ b/packages/cli/tests/binary/jest.config.js
@@ -1,0 +1,12 @@
+/** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testTimeout: parseInt(process.env.TEST_TIMEOUT, 10) || 30000,
+  silent: true,
+  restoreMocks: true,
+  maxWorkers: 1,
+  testRegex: '.bin-spec.ts$',
+  setupFilesAfterEnv: ['./helpers/setup.ts'],
+  globalSetup: './helpers/setup.ts',
+};

--- a/packages/cli/tests/binary/smoke.bin-spec.ts
+++ b/packages/cli/tests/binary/smoke.bin-spec.ts
@@ -1,0 +1,23 @@
+import { buildRubyProject, runUntilCompletion } from './helpers';
+
+describe('appmap', () => {
+  let projectPath: string;
+
+  it('runs the help command', async () => {
+    const res = await runUntilCompletion(['--help']);
+    expect(res.stdout).toStrictEqual(expect.stringContaining('appmap <command>'));
+  });
+
+  describe('install', () => {
+    beforeEach(async () => {
+      projectPath = await buildRubyProject();
+    });
+
+    it('runs the installer', async () => {
+      const res = await runUntilCompletion(['install', '--interactive=false', projectPath]);
+      expect(res.stdout).toStrictEqual(
+        expect.stringContaining('Success! AppMap has finished installing.')
+      );
+    });
+  });
+});


### PR DESCRIPTION
This isn't as extensive as it used to be, but it's enough to catch and prevent any missing module issues in the future, and lays the groundwork to expand tests via Jest.