### PR TITLE
feat: Migrate ChatSearch to v2 stats API

### DIFF
--- a/packages/cli/src/cmds/index/index.ts
+++ b/packages/cli/src/cmds/index/index.ts
@@ -18,7 +18,7 @@ import { explainHandler, explainStatusHandler } from '../../rpc/explain/explain'
 import RPCServer from './rpcServer';
 import appmapData from '../../rpc/appmap/data';
 import { loadConfiguration } from '@appland/client';
-import { appmapStatsV1 } from '../../rpc/appmap/stats';
+import { appmapStatsV1, appmapStatsV2 } from '../../rpc/appmap/stats';
 import LocalNavie from '../../rpc/explain/navie/navie-local';
 import RemoteNavie from '../../rpc/explain/navie/navie-remote';
 import { Context, ProjectInfo } from '@appland/navie';
@@ -145,6 +145,7 @@ export const handler = async (argv) => {
         numProcessed(cmd),
         search(),
         appmapStatsV1(),
+        appmapStatsV2(), // Forwards compatibility for @appland/components v4.11.0 and onwards
         appmapFilter(),
         appmapData(),
         metadata(),

--- a/packages/components/src/components/chat-search/ContextStatus.vue
+++ b/packages/components/src/components/chat-search/ContextStatus.vue
@@ -1,8 +1,8 @@
 <template>
-  <v-status-bar v-if="appmapStats && appmapStats.numAppMaps" level="success">
+  <v-status-bar v-if="numAppMaps" level="success">
     <template v-slot:header>
       <div class="context__header">
-        {{ appmapStats.numAppMaps }} AppMap{{ appmapStats.numAppMaps === 1 ? '' : 's' }} available
+        {{ numAppMaps }} AppMap{{ numAppMaps === 1 ? '' : 's' }} available
       </div>
     </template>
     <template v-slot:body>
@@ -47,11 +47,7 @@
           You can still ask Navie questions, but Navie only has partial information about your
           project.
         </p>
-        <p
-          v-if="appmapStats && appmapStats.numAppMaps === 0"
-          class="mt-0 mb-0"
-          data-cy="status-no-data"
-        >
+        <p v-if="appmapStats && numAppMaps === 0" class="mt-0 mb-0" data-cy="status-no-data">
           You need to
           <a href="#" @click.prevent="openRecordInstructions" data-cy="record-guide">
             record runtime data
@@ -68,15 +64,7 @@ import Vue, { PropType } from 'vue';
 import VStatusBar from '@/components/chat-search/StatusBar.vue';
 import VFailIcon from '@/assets/close.svg';
 import VSuccessIcon from '@/assets/success-checkmark.svg';
-
-type AppmapStats = {
-  numAppMaps: number;
-  packages: string[];
-  classes: string[];
-  routes: string[];
-  tables: string[];
-  appmaps: any[];
-};
+import { AppMapRpc } from '@appland/rpc';
 
 export default Vue.extend({
   name: 'v-context-status',
@@ -94,7 +82,13 @@ export default Vue.extend({
   },
 
   props: {
-    appmapStats: Object as PropType<AppmapStats>,
+    appmapStats: Array as PropType<AppMapRpc.Stats.V2.Response | undefined>,
+  },
+
+  computed: {
+    numAppMaps(): number {
+      return (this.appmapStats || []).reduce((acc, { numAppMaps }) => acc + numAppMaps, 0);
+    },
   },
 
   methods: {

--- a/packages/components/src/components/chat-search/MatchInstructions.vue
+++ b/packages/components/src/components/chat-search/MatchInstructions.vue
@@ -2,7 +2,7 @@
   <div class="match-instructions" data-cy="match-instructions">
     <div class="content">
       <div class="content__header">
-        <p>{{ appmapStats.numAppMaps }} AppMaps available</p>
+        <p>{{ numAppMaps }} AppMaps available</p>
         <div class="divider">|</div>
         <v-button
           data-cy="create-more-appmaps-btn"
@@ -34,12 +34,18 @@ export default {
 
   props: {
     appmapStats: {
-      type: Object,
-      required: true,
+      type: Array,
+      required: false,
     },
     searchResponse: {
       type: Object,
       required: true,
+    },
+  },
+
+  computed: {
+    numAppMaps() {
+      return (this.appmapStats || []).reduce((acc, { numAppMaps }) => acc + numAppMaps, 0);
     },
   },
 

--- a/packages/components/src/components/chat-search/NoMatchInstructions.vue
+++ b/packages/components/src/components/chat-search/NoMatchInstructions.vue
@@ -4,7 +4,7 @@
       <h2>No relevant AppMaps found</h2>
       <div class="content">
         <p>
-          Of the <strong>{{ appmapStats.numAppMaps }}</strong> AppMaps available in your project,
+          Of the <strong>{{ numAppMaps }}</strong> AppMaps available in your project,
           <strong>None</strong> of them seem to be relevant enough to your question.
         </p>
         <p>
@@ -22,9 +22,14 @@ export default {
 
   props: {
     appmapStats: {
-      type: Object,
-      required: true,
-      default: () => ({ numAppMaps: 0 }),
+      type: Array,
+      required: false,
+    },
+  },
+
+  computed: {
+    numAppMaps() {
+      return (this.appmapStats || []).reduce((acc, { numAppMaps }) => acc + numAppMaps, 0);
     },
   },
 

--- a/packages/components/src/lib/AppMapRPC.ts
+++ b/packages/components/src/lib/AppMapRPC.ts
@@ -1,3 +1,4 @@
+import { AppMapRpc } from '@appland/rpc';
 import { browserClient, reportError } from './RPC';
 
 import { EventEmitter } from 'events';
@@ -117,11 +118,15 @@ export default class AppMapRPC {
 
   appmapStats(): Promise<any> {
     return new Promise((resolve, reject) => {
-      this.client.request('appmap.stats', {}, function (err: any, error: any, result: any) {
-        if (err || error) return reportError(reject, err, error);
+      this.client.request(
+        AppMapRpc.Stats.V2.Method,
+        {},
+        function (err: any, error: any, result: any) {
+          if (err || error) return reportError(reject, err, error);
 
-        resolve(result);
-      });
+          resolve(result);
+        }
+      );
     });
   }
 

--- a/packages/components/src/pages/ChatSearch.vue
+++ b/packages/components/src/pages/ChatSearch.vue
@@ -15,7 +15,10 @@
         :question="question"
         @isChatting="setIsChatting"
       >
-        <v-context-status v-if="!hasAppMaps || !isChatting" :appmap-stats="appmapStats" />
+        <v-context-status
+          v-if="appmapStats && (!hasAppMaps || !isChatting)"
+          :appmap-stats="appmapStats"
+        />
       </v-chat>
     </div>
     <div
@@ -195,7 +198,7 @@ export default {
         },
         () => {
           // 1000ms or 5ms per appmap, whichever is greater
-          return Math.max(1000, this.appmapStats?.numAppMaps ?? 0 * 5);
+          return Math.max(1000, (this.appmapStats?.numAppMaps ?? 0) * 5);
         }
       ),
     };
@@ -272,7 +275,7 @@ export default {
       );
     },
     hasAppMaps() {
-      return this.appmapStats?.numAppMaps > 0;
+      return this.appmapStats?.some(({ numAppMaps }) => numAppMaps > 0) ?? false;
     },
   },
   methods: {

--- a/packages/components/src/stories/ChatSearch.stories.js
+++ b/packages/components/src/stories/ChatSearch.stories.js
@@ -37,13 +37,16 @@ const mostRecentAppMaps = [orderData, petclinicData, longPackageData].map((appma
   path: `tmp/appmap/${i}.appmap.json`,
 }));
 
-const appmapStats = {
-  numAppMaps: appmaps.length,
-  packages: Array.from({ length: 4 }, (_, i) => `app/controllers/${i}`),
-  classes: Array.from({ length: 6 }, (_, i) => `Model${i}`),
-  routes: Array.from({ length: 8 }, (_, i) => `GET /users/${i}`),
-  tables: Array.from({ length: 7 }, (_, i) => `table_${i}`),
-};
+const appmapStats = [
+  {
+    name: 'example',
+    numAppMaps: mostRecentAppMaps.length,
+    packages: Array.from({ length: 4 }, (_, i) => `app/controllers/${i}`),
+    classes: Array.from({ length: 6 }, (_, i) => `Model${i}`),
+    routes: Array.from({ length: 8 }, (_, i) => `GET /users/${i}`),
+    tables: Array.from({ length: 7 }, (_, i) => `table_${i}`),
+  },
+];
 
 export default {
   title: 'Pages/ChatSearch',
@@ -89,7 +92,10 @@ export const ChatSearchWithAppMaps = (args, { argTypes }) => ({
 export const ChatSearchMock = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
   components: { VChatSearch },
-  template: `<v-chat-search v-bind="$props"></v-chat-search>`,
+  template: `<v-chat-search v-bind="$props" ref="chatSearch"></v-chat-search>`,
+  mounted() {
+    this.$refs.chatSearch.setAppMapStats(appmapStats);
+  },
 });
 
 export const ChatSearchMockWithCodeSelection = (args, { argTypes }) => ({
@@ -110,13 +116,19 @@ export const ChatSearchMockWithFilters = (args, { argTypes }) => ({
 export const ChatSearchMockSearchPrepopulated = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
   components: { VChatSearch },
-  template: `<v-chat-search v-bind="$props"></v-chat-search>`,
+  template: `<v-chat-search v-bind="$props" ref="chatSearch"></v-chat-search>`,
+  mounted() {
+    this.$refs.chatSearch.setAppMapStats(appmapStats);
+  },
 });
 
 export const ChatSearchMockSearchPrepopulatedEmptyResults = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
   components: { VChatSearch },
-  template: `<v-chat-search v-bind="$props"></v-chat-search>`,
+  template: `<v-chat-search v-bind="$props" ref="chatSearch"></v-chat-search>`,
+  mounted() {
+    this.$refs.chatSearch.setAppMapStats([{ numAppMaps: 0 }]);
+  },
 });
 
 const MOCK_EXPLANATION =

--- a/packages/components/src/stories/ChatSearchNoMatchInstructions.stories.js
+++ b/packages/components/src/stories/ChatSearchNoMatchInstructions.stories.js
@@ -6,9 +6,12 @@ export default {
   argTypes: {},
 };
 
-const appmapStats = {
-  numAppMaps: 100,
-};
+const appmapStats = [
+  {
+    name: 'project',
+    numAppMaps: 100,
+  },
+];
 
 const Template = (args, { argTypes }) => ({
   props: Object.keys(argTypes),


### PR DESCRIPTION
This PR modifies the ChatSearch frontend to request stats from `v2.appmap.stats` instead of the v1 method. It aggregates the response to fit within the current frontend.