### PR TITLE
Update filter menu and increase contrast

### DIFF
--- a/packages/components/src/components/Container.vue
+++ b/packages/components/src/components/Container.vue
@@ -104,11 +104,11 @@ export default {
     border-radius: 0.5rem;
     padding: 0.25rem 0.5rem;
     appearance: none;
-    background: $gray2;
-    color: #808b98;
+    background: lighten($gray2, 10%);
+    color: $gray5;
     font-weight: bold;
     cursor: pointer;
-    opacity: 0.8;
+    opacity: 0.9;
 
     &:hover {
       opacity: 1;
@@ -130,8 +130,8 @@ export default {
       bottom: -3px;
       margin-left: -3px;
       width: 6px;
-      background: $gray2;
-      opacity: 0.8;
+      background: lighten($gray2, 10%);
+      opacity: 0.9;
     }
   }
 
@@ -141,7 +141,7 @@ export default {
     left: 0;
     width: 100%;
     height: 6px;
-    background: $gray4;
+    background: $gray5;
     cursor: grab;
   }
 }

--- a/packages/components/src/components/FilterMenu.vue
+++ b/packages/components/src/components/FilterMenu.vue
@@ -537,7 +537,7 @@ export default {
     border-bottom: 1px solid $gray2;
     display: flex;
     justify-content: flex-start;
-    align-items: center;
+    align-items: baseline;
 
     svg {
       width: 1em;
@@ -588,12 +588,6 @@ export default {
       margin-left: 2rem;
       svg {
         fill: white;
-      }
-    }
-
-    @media (min-width: 900px) {
-      &-close {
-        display: none;
       }
     }
   }

--- a/packages/components/src/components/FilterMenu.vue
+++ b/packages/components/src/components/FilterMenu.vue
@@ -85,14 +85,16 @@
               :suggestions="hideNamesSuggestions"
               suggestions-placement="top"
             />
-            <div class="filters__hide" v-if="hiddenNames.length">
-              <div class="filters__hide-item" v-for="(name, index) in hiddenNames" :key="name">
-                {{ name }}
-                <CloseThinIcon
-                  class="filters__hide-item-icon"
-                  @click.stop="removeHiddenName(index)"
-                />
-              </div>
+          </div>
+        </div>
+        <div class="filters__block-row">
+          <div class="filters__hide" v-if="hiddenNames.length">
+            <div class="filters__hide-item" v-for="(name, index) in hiddenNames" :key="name">
+              {{ name }}
+              <CloseThinIcon
+                class="filters__hide-item-icon"
+                @click.stop="removeHiddenName(index)"
+              />
             </div>
           </div>
         </div>
@@ -740,7 +742,7 @@ export default {
     margin-top: 0.75rem;
     width: 100%;
     display: flex;
-    flex-wrap: wrap;
+    flex-direction: column;
     justify-content: flex-start;
     align-items: flex-start;
     gap: 0.5rem;
@@ -751,6 +753,8 @@ export default {
       justify-content: flex-start;
       align-items: center;
       padding: 5px 10px;
+      overflow-wrap: break-word;
+      max-width: 310px;
       background: $light-purple;
       color: $gray6;
       line-height: 1;

--- a/packages/components/src/components/Slider.vue
+++ b/packages/components/src/components/Slider.vue
@@ -83,7 +83,7 @@ export default {
 };
 </script>
 
-<style scoped lang="css">
+<style lang="scss" scoped>
 .slider {
   height: fit-content;
   width: fit-content;
@@ -95,11 +95,11 @@ export default {
   border-radius: 0.5rem;
   padding: 0.25rem 0.5rem;
   appearance: none;
-  background: #242c41;
-  color: #808b98;
+  background: lighten($gray2, 10%);
+  color: $gray5;
   font-weight: bold;
   cursor: pointer;
-  opacity: 0.8;
+  opacity: 0.9;
 }
 
 .handle {
@@ -114,8 +114,8 @@ export default {
   width: 6px;
   height: 100%;
   margin: auto;
-  background: #242c41;
-  opacity: 0.8;
+  background: lighten($gray2, 10%);
+  opacity: 0.9;
 }
 
 .grab {
@@ -124,7 +124,7 @@ export default {
   position: absolute;
   transform: translateY(3px);
   border-radius: 3px;
-  background: #808b98;
+  background: $gray5;
   cursor: grab;
   z-index: 10;
 }

--- a/packages/components/src/pages/VsCodeExtension.vue
+++ b/packages/components/src/pages/VsCodeExtension.vue
@@ -1904,7 +1904,7 @@ code {
   height: 0px;
 }
 ::-webkit-scrollbar-thumb {
-  background: $gray2;
+  background: $gray4;
   border: 0;
   border-radius: 50px;
 }


### PR DESCRIPTION
* Make scrollbars a lighter shade of grey so it has better contrast.
* Make the zoom sliders have better contrast.
* Always show the "X" close icon for the filter menu.
* When hiding a code object with a long name, don't extend the width of the filter menu.

## Before

![image](https://github.com/getappmap/appmap-js/assets/45714532/6bf68add-2314-4dff-a5de-4abe35deb695)

## After

![image](https://github.com/getappmap/appmap-js/assets/45714532/f3ef0411-2e4b-4e04-9759-589b83a824d2)
