### PR TITLE
Open Navie from an appmap

### DIFF
--- a/packages/components/src/assets/compass-simpler.svg
+++ b/packages/components/src/assets/compass-simpler.svg
@@ -1,0 +1,11 @@
+<svg viewBox="0 0 86 85" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="43.5" cy="42.5" r="30" stroke="white" stroke-width="3"/>
+  <path d="M43 0L49.0622 42.75H36.9378L43 0Z" fill="white"/>
+  <path d="M43 85L49.0622 42.25H36.9378L43 85Z" fill="white"/>
+  <path d="M86 42L43.25 35.9378V48.0622L86 42Z" fill="white"/>
+  <path d="M0 42L42.75 35.9378V48.0622L0 42Z" fill="white"/>
+  <path d="M25.1116 24.1116L45.6713 39.5645L40.5645 44.6713L25.1116 24.1116Z" fill="white"/>
+  <path d="M60.9137 59.9137L45.4607 39.3539L40.354 44.4607L60.9137 59.9137Z" fill="white"/>
+  <path d="M60.9137 23.6904L40.3539 39.1433L45.4607 44.2501L60.9137 23.6904Z" fill="white"/>
+  <path d="M24.6905 59.9137L40.1434 39.3539L45.2502 44.4607L24.6905 59.9137Z" fill="white"/>
+</svg>

--- a/packages/components/src/components/Button.vue
+++ b/packages/components/src/components/Button.vue
@@ -99,6 +99,12 @@ export default {
   transition: $transition;
   user-select: none;
 
+  &__content {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
   &:disabled {
     background-color: $gray2;
     border-color: $gray2;
@@ -108,6 +114,7 @@ export default {
       border-color: $gray2;
     }
   }
+
   &--timeout {
     position: relative;
 
@@ -139,6 +146,7 @@ export default {
       background-color: rgba(255, 255, 255, 0.65);
     }
   }
+
   &--secondary {
     background-color: darken(desaturate($color: $brightblue, $amount: 75%), 25%);
     color: $white;
@@ -152,6 +160,7 @@ export default {
       background-color: rgba(255, 255, 255, 0.65);
     }
   }
+
   &--ghost {
     background-color: inherit;
     border: 1px solid $gray4;

--- a/packages/components/src/components/DetailsPanel.vue
+++ b/packages/components/src/components/DetailsPanel.vue
@@ -1,7 +1,16 @@
 <template>
   <div class="details-panel">
     <h3 class="details-panel__title">
-      <AppMapLogo width="70" />
+      <div
+        class="details-panel__ask-navie-button"
+        v-if="showAskNavie"
+        data-cy="details-panel-ask-navie-button"
+        @click="() => this.$emit('askNavieAboutMap')"
+      >
+        <CompassIcon class="compass-icon" />
+        <div>Ask Navie</div>
+      </div>
+      <AppMapLogo v-else width="70" />
       <ChevronDownIcon
         class="details-panel__hide-panel-icon"
         @click="() => this.$emit('hideDetailsPanel')"
@@ -41,11 +50,6 @@
       </div>
     </div>
 
-    <div class="details-panel__notification" v-if="!selectedObject">
-      <FeedbackIcon />
-      Help us improve AppMap.
-      <a href="https://appmap.io/product/feedback/general.html">Send your feedback.</a>
-    </div>
     <div
       class="details-panel__source"
       v-if="!selectedObject && !selectedLabel && sourceLocationObject"
@@ -141,6 +145,7 @@ import ScissorsIcon from '@/assets/scissors-icon.svg';
 import NavArrow from '@/assets/nav-arrow.svg';
 import ClearIcon from '@/assets/x-icon.svg';
 import ChevronDownIcon from '@/assets/fa-solid_chevron-down.svg';
+import CompassIcon from '@/assets/compass-simpler.svg';
 import { SELECT_CODE_OBJECT } from '@/store/vsCode';
 
 const MAX_DISPLAY_NAME_LENGTH = 150;
@@ -171,6 +176,7 @@ export default {
     NavArrow,
     ClearIcon,
     ChevronDownIcon,
+    CompassIcon,
   },
   props: {
     subtitle: String,
@@ -196,6 +202,10 @@ export default {
     isGiantAppMap: {
       type: Boolean,
       default: false,
+    },
+    showAskNavie: {
+      type: Boolean,
+      default: true,
     },
   },
 
@@ -300,6 +310,53 @@ export default {
   word-break: break-word;
   border-right: 1px solid $base15;
   overflow: auto;
+
+  &__ask-navie-button {
+    padding: 0.5rem 0.75rem;
+    background-color: $gray2;
+    border-radius: $border-radius;
+    font-size: 0.9rem;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    width: fit-content;
+    color: $gray5;
+    transition: $transition;
+
+    .compass-icon {
+      width: 28px;
+      margin: -0.25rem 0.5rem -0.25rem 0;
+
+      path {
+        transition: $transition;
+        fill: $gray5;
+      }
+
+      circle {
+        transition: $transition;
+        stroke: $gray5;
+      }
+    }
+
+    &:hover {
+      cursor: pointer;
+      background-color: lighten($gray2, 10%);
+      color: $hotpink;
+      transition: $transition;
+
+      .compass-icon {
+        path {
+          transition: $transition;
+          fill: $hotpink;
+        }
+
+        circle {
+          transition: $transition;
+          stroke: $hotpink;
+        }
+      }
+    }
+  }
 
   &__title {
     margin-bottom: 1rem;

--- a/packages/components/src/components/chat/Chat.vue
+++ b/packages/components/src/components/chat/Chat.vue
@@ -176,6 +176,10 @@ export default {
       default: 'system',
       validator: (v: string) => ['system', 'user'].includes(v),
     },
+    inputPlaceholder: {
+      type: String,
+      default: 'How can I help?',
+    },
   },
   data() {
     return {
@@ -190,9 +194,6 @@ export default {
     };
   },
   computed: {
-    inputPlaceholder() {
-      return 'How can I help?';
-    },
     suggestionsEnabled() {
       return this.disableSuggestions !== true && !this.isChatting;
     },
@@ -358,6 +359,9 @@ export default {
     },
     includeAppMap(appmap: string) {
       this.appmaps.push(appmap);
+    },
+    resetAppMaps() {
+      this.appmaps = [];
     },
   },
   watch: {

--- a/packages/components/src/components/chat/ChatInput.vue
+++ b/packages/components/src/components/chat/ChatInput.vue
@@ -172,22 +172,23 @@ $border-color: #7289c5;
 
       &:empty:before {
         content: attr(placeholder);
-        color: white;
+        color: lighten($gray4, 10%);
       }
 
       &:focus-visible {
         outline: none !important;
       }
     }
+
     .popper {
       position: absolute;
       right: 1rem;
       bottom: 0.45rem;
-      // transform: translate(-50%, -50%);
 
       &__text {
         border: none;
       }
+
       .send {
         height: 2rem;
         width: 2rem;
@@ -196,11 +197,13 @@ $border-color: #7289c5;
         border-radius: $border-radius;
         background-color: #6c81ba;
         transition: background-color 0.5s ease-in-out;
+
         svg {
           path {
             fill: #fff;
           }
         }
+
         &:disabled {
           pointer-events: none;
           background-color: rgba($color: #7289c5, $alpha: 0.25);
@@ -211,6 +214,7 @@ $border-color: #7289c5;
             }
           }
         }
+
         &:hover {
           cursor: pointer;
           background-color: $hotpink;

--- a/packages/components/src/pages/VsCodeExtension.vue
+++ b/packages/components/src/pages/VsCodeExtension.vue
@@ -22,6 +22,7 @@
           :findings="findings"
           :wasAutoPruned="wasAutoPruned"
           :isGiantAppMap="isGiantAppMap"
+          :showAskNavie="showAskNavie"
           @onChangeFilter="
             (value) => {
               this.eventFilterText = value;
@@ -34,16 +35,18 @@
           "
           @clearSelections="clearSelection"
           @hideDetailsPanel="hideDetailsPanel"
+          @askNavieAboutMap="askNavie"
           data-cy="sidebar"
         />
       </transition>
       <div v-if="showDetailsPanel" class="main-column--drag" @mousedown="startResizing"></div>
       <div v-if="!showDetailsPanel" class="sidebar-menu" data-cy="sidebar-menu">
-        <HamburgerMenu
-          class="sidebar-menu__icon sidebar-menu__hamburger-menu"
-          width="30"
-          @click="revealDetailsPanel"
-        />
+        <div data-cy="sidebar-hamburger-menu-icon" @click="revealDetailsPanel">
+          <HamburgerMenu class="sidebar-menu__icon sidebar-menu__hamburger-menu" width="30" />
+        </div>
+        <div data-cy="collapsed-sidebar-ask-navie" @click="askNavie" v-if="showAskNavie">
+          <VCompassIcon class="sidebar-menu__icon sidebar-menu__compass" width="37" />
+        </div>
       </div>
     </div>
 
@@ -141,6 +144,18 @@
           />
         </template>
         <template v-slot:controls>
+          <v-popper
+            class="hover-text-popper"
+            text="Ask Navie about this AppMap"
+            placement="left"
+            text-align="left"
+          >
+            <div v-if="!sequenceDiagramDiffMode && showAskNavie" class="ask-navie">
+              <button class="ask-navie" @click="askNavie" data-cy="ask-navie-control-button">
+                <v-compass-icon />
+              </button>
+            </div>
+          </v-popper>
           <v-popper
             class="hover-text-popper"
             text="Collapse actions below this depth"
@@ -422,6 +437,7 @@ import {
 import isPrecomputedSequenceDiagram from '@/lib/isPrecomputedSequenceDiagram';
 import { SAVED_FILTERS_STORAGE_ID } from '../components/FilterMenu.vue';
 import { DEFAULT_SEQ_DIAGRAM_COLLAPSE_DEPTH } from '../components/DiagramSequence.vue';
+import VCompassIcon from '@/assets/compass-simpler.svg';
 
 const browserPrefixes = ['', 'webkit', 'moz'];
 
@@ -461,6 +477,7 @@ export default {
     VNoDataNotice,
     VUnlicensedNotice,
     VConfigurationRequired,
+    VCompassIcon,
   },
   store,
   data() {
@@ -524,6 +541,14 @@ export default {
       default: true,
     },
     autoExpandDetailsPanel: {
+      type: Boolean,
+      default: true,
+    },
+    appmapFsPath: {
+      type: String,
+      default: '',
+    },
+    showAskNavie: {
       type: Boolean,
       default: true,
     },
@@ -1405,6 +1430,9 @@ export default {
         document.mozFullScreenElement;
       this.isFullscreen = fullscreenElement === this.$el;
     },
+    askNavie() {
+      this.$root.$emit('ask-navie-about-map', this.appmapFsPath);
+    },
   },
   mounted() {
     this.$root.$on('makeRoot', (codeObject) => {
@@ -1677,6 +1705,7 @@ code {
       .sidebar-menu {
         display: flex;
         flex-direction: column;
+        align-items: center;
         margin-top: 0.5rem;
         border-right: 1px solid $gray2;
         height: 100%;
@@ -1693,6 +1722,32 @@ code {
             circle,
             path {
               stroke: $blue;
+              transition: $transition;
+            }
+          }
+        }
+
+        &__compass {
+          circle {
+            stroke: darken($gray5, 10%);
+            transition: $transition;
+          }
+
+          path {
+            fill: darken($gray5, 10%);
+            transition: $transition;
+          }
+
+          &:hover {
+            cursor: pointer;
+
+            circle {
+              stroke: $hotpink;
+              transition: $transition;
+            }
+
+            path {
+              fill: $hotpink;
               transition: $transition;
             }
           }
@@ -1784,6 +1839,35 @@ code {
         font-family: $appland-text-font-family;
         font-size: 0.9rem;
         cursor: pointer;
+      }
+
+      .ask-navie {
+        background-color: inherit;
+        border: none;
+
+        &:hover {
+          cursor: pointer;
+
+          svg path {
+            fill: $hotpink;
+          }
+
+          svg circle {
+            stroke: $hotpink;
+          }
+        }
+
+        svg {
+          width: 20px;
+
+          path {
+            fill: $gray4;
+          }
+
+          circle {
+            stroke: $gray4;
+          }
+        }
       }
 
       .depth-button {

--- a/packages/components/src/stories/ChatSearch.stories.js
+++ b/packages/components/src/stories/ChatSearch.stories.js
@@ -89,6 +89,16 @@ export const ChatSearchWithAppMaps = (args, { argTypes }) => ({
   },
 });
 
+export const ChatSearchWithTargetAppMap = (args, { argTypes }) => ({
+  props: Object.keys(argTypes),
+  components: { VChatSearch },
+  template: `<v-chat-search v-bind="$props" ref="chatSearch"></v-chat-search>`,
+});
+ChatSearchWithTargetAppMap.args = {
+  targetAppmapData: petclinicData,
+  targetAppmapFsPath: 'fake/path',
+};
+
 export const ChatSearchMock = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
   components: { VChatSearch },

--- a/packages/components/tests/e2e/specs/chat/chatSearch.spec.js
+++ b/packages/components/tests/e2e/specs/chat/chatSearch.spec.js
@@ -13,14 +13,14 @@ context('Chat search', () => {
       // Ruby AppMap
       cy.get('.tabs .tab-btn').contains('Dependency Map').click();
 
-      cy.get('[data-cy="app"] [data-id="GET /admin"]', {
+      cy.get('[data-cy="appmap"] [data-id="GET /admin"]', {
         timeout: 10000,
       }).should('be.visible');
 
       // Java AppMap
       cy.get('[data-cy="appmap-list"]').select('Create Visit For Pet');
       cy.get('.tabs .tab-btn').contains('Dependency Map').click();
-      cy.get('[data-cy="app"] [data-id="org/springframework/samples/petclinic/owner"]').should(
+      cy.get('[data-cy="appmap"] [data-id="org/springframework/samples/petclinic/owner"]').should(
         'be.visible'
       );
     });
@@ -32,18 +32,18 @@ context('Chat search', () => {
       cy.get('.tabs .tab-btn').contains('Dependency Map').click();
 
       // Initial state
-      cy.get('[data-cy="app"] [data-id="GET /admin"].highlight');
+      cy.get('[data-cy="appmap"] [data-id="GET /admin"].highlight');
 
       // expand the details panel
       cy.get('.sidebar-menu__hamburger-menu').click();
 
       cy.get('[data-cy="select-object"]').select(0);
       cy.get(
-        '[data-cy="app"] [data-id="app/controllers/Spree::Admin::OrdersController"].highlight'
+        '[data-cy="appmap"] [data-id="app/controllers/Spree::Admin::OrdersController"].highlight'
       );
 
       cy.get('[data-cy="select-object"]').select(1);
-      cy.get('[data-cy="app"] [data-id="GET /admin"].highlight');
+      cy.get('[data-cy="appmap"] [data-id="GET /admin"].highlight');
     });
 
     it('new chat button clears the state', () => {
@@ -53,14 +53,14 @@ context('Chat search', () => {
       cy.get('.tabs .tab-btn').contains('Dependency Map').click();
 
       // Ruby AppMap should be visible
-      cy.get('[data-cy="app"] [data-id="GET /admin"]', {
+      cy.get('[data-cy="appmap"] [data-id="GET /admin"]', {
         timeout: 10000,
       }).should('be.visible');
 
       cy.get('[data-cy="new-chat-btn"]').click();
 
       // Ruby AppMap should not be visible
-      cy.get('[data-cy="app"] [data-id="GET /admin"]', {
+      cy.get('[data-cy="appmap"] [data-id="GET /admin"]', {
         timeout: 10000,
       }).should('not.exist');
     });

--- a/packages/components/tests/unit/VsCodeExtension.spec.js
+++ b/packages/components/tests/unit/VsCodeExtension.spec.js
@@ -17,6 +17,7 @@ describe('VsCodeExtension.vue', () => {
   const defaultFilter = new AppMapFilter();
   const serialized = serializeFilter(defaultFilter);
   const base64encoded = base64UrlEncode(JSON.stringify({ filters: serialized }));
+  const appmapFsPath = '/some/fake/path';
 
   const defaultFilterObject = {
     filterName: 'AppMap default',
@@ -35,10 +36,35 @@ describe('VsCodeExtension.vue', () => {
           return false;
         },
       },
+      propsData: {
+        appmapFsPath,
+      },
     });
     rootWrapper = createWrapper(wrapper.vm.$root);
     await wrapper.vm.loadData(data);
     wrapper.vm.$store.commit(RESET_FILTERS);
+  });
+
+  it('emits the "ask-navie-about-map" event when the buttons are clicked', async () => {
+    // Sanity check
+    expect(rootWrapper.emitted()['ask-navie-about-map']).toBeUndefined();
+
+    wrapper.find('[data-cy="ask-navie-control-button"]').trigger('click');
+    expect(rootWrapper.emitted()['ask-navie-about-map']).toEqual([[appmapFsPath]]);
+
+    wrapper.find('[data-cy="collapsed-sidebar-ask-navie"]').trigger('click');
+    expect(rootWrapper.emitted()['ask-navie-about-map']).toEqual([[appmapFsPath], [appmapFsPath]]);
+
+    // Open the details panel
+    wrapper.find('[data-cy="sidebar-hamburger-menu-icon').trigger('click');
+    await Vue.nextTick();
+
+    wrapper.find('[data-cy="details-panel-ask-navie-button"]').trigger('click');
+    expect(rootWrapper.emitted()['ask-navie-about-map']).toEqual([
+      [appmapFsPath],
+      [appmapFsPath],
+      [appmapFsPath],
+    ]);
   });
 
   it('sets the selected object by FQID', () => {

--- a/packages/components/tests/unit/chat/ChatSearch.spec.js
+++ b/packages/components/tests/unit/chat/ChatSearch.spec.js
@@ -1,5 +1,6 @@
 import VChatSearch from '@/pages/ChatSearch.vue';
 import { mount, createWrapper } from '@vue/test-utils';
+import appmapData from '../fixtures/user_page_scenario.appmap.json';
 
 describe('pages/ChatSearch.vue', () => {
   const chatSearchWrapper = (messagesCalled) => {
@@ -77,6 +78,53 @@ describe('pages/ChatSearch.vue', () => {
     const newWidth = Number.parseInt(lhsPanel.element.style.width.replace('px', ''), 10);
 
     expect(newWidth).toBe(initialWidth + resizeBy);
+  });
+
+  describe('when opened with a target Appmap', () => {
+    let wrapper;
+
+    beforeEach(() => {
+      wrapper = chatSearchWrapper({
+        'v2.appmap.stats': appmapStatsNoAppMaps(),
+        propsData: {
+          targetAppmapData: appmapData,
+          targetAppmapFsPath: 'test',
+        },
+      });
+    });
+
+    it('shows the target Appmap without ask navie buttons', async () => {
+      expect(wrapper.find('[data-cy="appmap"]').exists()).toBe(true);
+
+      expect(wrapper.find('[data-cy="ask-navie-control-button"]').exists()).toBe(false);
+      expect(wrapper.find('[data-cy="collapsed-sidebar-ask-navie"]').exists()).toBe(false);
+
+      // Open the details panel
+      wrapper.find('[data-cy="sidebar-hamburger-menu-icon');
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.find('[data-cy="details-panel-ask-navie-button"]').exists()).toBe(false);
+    });
+
+    it('changes the placeholder text', () => {
+      const placeholder = wrapper.find('[data-cy="chat-input"]').attributes('placeholder');
+      expect(placeholder).toBe('What do you want to know about this AppMap?');
+    });
+
+    it('does not show the status bar', () => {
+      expect(wrapper.find('[data-cy="status-bar"]').exists()).toBe(false);
+    });
+
+    it('has a button to switch the context to the full workspace', async () => {
+      const fullWorkspaceContextButton = wrapper.find('[data-cy="full-workspace-context-button"]');
+      expect(fullWorkspaceContextButton.exists()).toBe(true);
+      fullWorkspaceContextButton.trigger('click');
+      await wrapper.vm.$nextTick();
+      expect(wrapper.find('[data-cy="appmap"]').exists()).toBe(false);
+      expect(wrapper.find('[data-cy="status-bar"]').exists()).toBe(true);
+      const placeholder = wrapper.find('[data-cy="chat-input"]').attributes('placeholder');
+      expect(placeholder).toBe('How can I help?');
+    });
   });
 
   describe('when no AppMaps are available', () => {


### PR DESCRIPTION
Fixes getappmap/board#316

This PR and it's [VS Code counterpart](https://github.com/getappmap/vscode-appland/pull/920) allow a user to open Navie from within an AppMap and then chat with Navie using that AppMap as the context.

## Changes to AppMaps

In an AppMap, there are three clickable elements that will open Navie with the AppMap as context:

1. There is a small compass icon in the control bar.
2. When the details panel is collapsed, there is a compass icon.
3. When the details panel is open, there is an `Ask Navie` button.

![image](https://github.com/getappmap/appmap-js/assets/45714532/5ecbea1d-72ff-4ab0-bebe-afcc5ee441d2)

![image](https://github.com/getappmap/appmap-js/assets/45714532/6bb14d82-11de-4f4d-a200-97dba18859cf)


## Changes to Navie

When Navie is opened with a single AppMap as context:

* The AppMap is rendered from the start in the right panel.
* There is text describing that the user is asking Navie about a single AppMap.
* There is a button that allows the user to switch to using the full workspace as context.
* The placeholder is `What do you want to know about this AppMap?`.
* The status bar is not shown.

![image](https://github.com/getappmap/appmap-js/assets/45714532/16602955-d506-41d6-9cb0-9c2e237b578f)

