### PR TITLE
feat: Help Agent

### DIFF
--- a/packages/cli/bin/build-doc
+++ b/packages/cli/bin/build-doc
@@ -1,4 +1,0 @@
-#!/bin/bash
-set -ex
-
-rsync -av --delete ../../docs built/

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -19,7 +19,7 @@
     "pre-commit": "lint-staged",
     "test": "jest --filter=./tests/testFilter.js",
     "test:binary": "jest -c tests/binary/jest.config.js",
-    "build": "tsc && yarn build:html",
+    "build": "tsc && yarn build:html && yarn build:doc",
     "watch": "tsc --watch",
     "build:html": "ts-node esbuild.html.ts",
     "build:doc": "rsync -av --delete ../../docs built/",

--- a/packages/cli/src/cmds/index/index.ts
+++ b/packages/cli/src/cmds/index/index.ts
@@ -21,7 +21,7 @@ import { loadConfiguration } from '@appland/client';
 import { appmapStatsV1, appmapStatsV2 } from '../../rpc/appmap/stats';
 import LocalNavie from '../../rpc/explain/navie/navie-local';
 import RemoteNavie from '../../rpc/explain/navie/navie-remote';
-import { Context, ProjectInfo } from '@appland/navie';
+import { Context, Help, ProjectInfo } from '@appland/navie';
 import { InteractionEvent } from '@appland/navie/dist/interaction-history';
 
 const AI_KEY_ENV_VARS = ['OPENAI_API_KEY'];
@@ -111,9 +111,10 @@ export const handler = async (argv) => {
       const buildLocalNavie = (
         threadId: string | undefined,
         contextProvider: Context.ContextProvider,
-        projectInfoProvider: ProjectInfo.ProjectInfoProvider
+        projectInfoProvider: ProjectInfo.ProjectInfoProvider,
+        helpProvider: Help.HelpProvider
       ) => {
-        const navie = new LocalNavie(threadId, contextProvider, projectInfoProvider);
+        const navie = new LocalNavie(threadId, contextProvider, projectInfoProvider, helpProvider);
 
         let START: number | undefined;
 
@@ -134,8 +135,9 @@ export const handler = async (argv) => {
       const buildRemoteNavie = (
         threadId: string | undefined,
         contextProvider: Context.ContextProvider,
-        projectInfoProvider: ProjectInfo.ProjectInfoProvider
-      ) => new RemoteNavie(threadId, contextProvider, projectInfoProvider);
+        projectInfoProvider: ProjectInfo.ProjectInfoProvider,
+        helpProvider: Help.HelpProvider
+      ) => new RemoteNavie(threadId, contextProvider, projectInfoProvider, helpProvider);
 
       const navieProvider = useLocalNavie() ? buildLocalNavie : buildRemoteNavie;
 

--- a/packages/cli/src/cmds/index/rpc.ts
+++ b/packages/cli/src/cmds/index/rpc.ts
@@ -1,4 +1,4 @@
-import yargs from 'yargs';
+import yargs, { help } from 'yargs';
 import chalk from 'chalk';
 
 import { verbose } from '../../utils';
@@ -14,7 +14,7 @@ import appmapData from '../../rpc/appmap/data';
 import { appmapStatsV1, appmapStatsV2 } from '../../rpc/appmap/stats';
 import LocalNavie from '../../rpc/explain/navie/navie-local';
 import RemoteNavie from '../../rpc/explain/navie/navie-remote';
-import { Context, ProjectInfo } from '@appland/navie';
+import { Context, Help, ProjectInfo } from '@appland/navie';
 import { InteractionEvent } from '@appland/navie/dist/interaction-history';
 import { configureRpcDirectories } from '../../lib/handleWorkingDirectory';
 import { loadConfiguration } from '@appland/client';
@@ -125,9 +125,10 @@ export const handler = async (argv) => {
   const buildLocalNavie = (
     threadId: string | undefined,
     contextProvider: Context.ContextProvider,
-    projectInfoProvider: ProjectInfo.ProjectInfoProvider
+    projectInfoProvider: ProjectInfo.ProjectInfoProvider,
+    helpProvider: Help.HelpProvider
   ) => {
-    const navie = new LocalNavie(threadId, contextProvider, projectInfoProvider);
+    const navie = new LocalNavie(threadId, contextProvider, projectInfoProvider, helpProvider);
     applyAIOptions(navie);
 
     let START: number | undefined;
@@ -149,10 +150,11 @@ export const handler = async (argv) => {
   const buildRemoteNavie = (
     threadId: string | undefined,
     contextProvider: Context.ContextProvider,
-    projectInfoProvider: ProjectInfo.ProjectInfoProvider
+    projectInfoProvider: ProjectInfo.ProjectInfoProvider,
+    helpProvider: Help.HelpProvider
   ) => {
     loadConfiguration(false);
-    const navie = new RemoteNavie(threadId, contextProvider, projectInfoProvider);
+    const navie = new RemoteNavie(threadId, contextProvider, projectInfoProvider, helpProvider);
     applyAIOptions(navie);
     return navie;
   };

--- a/packages/cli/src/cmds/navie/help.ts
+++ b/packages/cli/src/cmds/navie/help.ts
@@ -1,0 +1,140 @@
+import lunr from 'lunr';
+import { Help } from '@appland/navie';
+import { processFiles, processNamedFiles, verbose } from '../../utils';
+import { log, warn } from 'console';
+import { readFile } from 'fs/promises';
+import { MarkdownTextSplitter } from 'langchain/text_splitter';
+import { join } from 'path';
+import { existsSync } from 'fs';
+import assert from 'assert';
+import { load } from 'js-yaml';
+
+const DOCS_DIR = ['../../docs', '../../../built/docs']
+  .map((dir) => join(__dirname, dir))
+  .find((dir) => existsSync(dir));
+
+export const DEFAULT_MAX_RESULTS = 10;
+
+export function packRef(filePath: string, from: number, to: number) {
+  return [filePath, from, to].join(':');
+}
+
+export function unpackRef(ref: string): [string, number, number] {
+  const [filePath, from, to] = ref.split(':');
+  return [filePath, parseInt(from), parseInt(to)];
+}
+
+type FrontMatter = {
+  title?: string;
+  name?: string;
+};
+
+export class HelpIndex {
+  constructor(
+    private idx: lunr.Index,
+    private _frontMatterByFile: Map<string, FrontMatter>,
+    private contentByRef: Map<string, string>
+  ) {}
+
+  async search(keywords: string[], maxResults = DEFAULT_MAX_RESULTS): Promise<Help.HelpDoc[]> {
+    return (
+      this.idx
+        .search(keywords.join(' '))
+        .map((result) => {
+          const content = this.contentByRef.get(result.ref);
+          const [filePath, from, to] = unpackRef(result.ref);
+          if (!content) {
+            warn(`Could not find content for ${result.ref}`);
+            return;
+          }
+          return {
+            filePath,
+            from,
+            to,
+            content,
+            score: result.score,
+          };
+        })
+        .filter(Boolean) as Help.HelpDoc[]
+    ).slice(0, maxResults);
+  }
+
+  static async buildIndex(directory: string): Promise<HelpIndex> {
+    const documents = new Array<any>();
+
+    if (verbose()) log(`[HelpIndex] Adding help documents to full-text index`);
+    const startTime = Date.now();
+
+    const frontMatterByFile = new Map<string, FrontMatter>();
+    const contentByRef = new Map<string, string>();
+    const buildDocument = async (filePath: string) => {
+      const document = await readFile(filePath, 'utf8');
+
+      let [_, frontMatterStr, text] = document.split('---');
+      if (!frontMatterStr) {
+        frontMatterStr = '';
+        text = document;
+      }
+      let frontMatter: FrontMatter | undefined;
+      if (frontMatterStr) {
+        try {
+          frontMatter = load(frontMatterStr) as FrontMatter;
+        } catch (e) {
+          warn(`Could not parse front matter in ${filePath}`);
+          warn(e);
+        }
+        if (frontMatter) frontMatterByFile.set(filePath, frontMatter);
+      }
+
+      const splitter = new MarkdownTextSplitter();
+      // TODO: Utilize the front matter
+      const chunks = await splitter.createDocuments([text]);
+      for (let i = 0; i < chunks.length; i++) {
+        const { from, to } = chunks[i].metadata.loc.lines;
+        const id = packRef(filePath, from, to);
+        contentByRef.set(id, chunks[i].pageContent);
+        const pageName = frontMatter?.name || frontMatter?.title;
+        documents.push({ id, pageName, content: chunks[i].pageContent });
+      }
+    };
+
+    await processFiles(directory, (filePath: string) => filePath.endsWith('.md'), buildDocument);
+
+    const idx = lunr(function () {
+      this.ref('id');
+      this.field('pageName');
+      this.field('content');
+
+      this.tokenizer.separator = /[\s/-_:#.]+/;
+
+      for (const doc of documents) this.add(doc);
+    });
+
+    const endTime = Date.now();
+    if (verbose())
+      log(
+        `[AppMapIndex] Added ${documents.length} AppMaps to full-text index in ${
+          endTime - startTime
+        }ms`
+      );
+    return new HelpIndex(idx, frontMatterByFile, contentByRef);
+  }
+}
+
+let helpIndex: HelpIndex | undefined;
+
+// TODO: Store the help index JSON in the distribution, so that we don't have to rebuild it when the process loads.
+export function buildHelpIndex(directory: string): Promise<HelpIndex> {
+  return HelpIndex.buildIndex(directory);
+}
+
+export default async function collectHelp(
+  helpRequest: Help.HelpRequest
+): Promise<Help.HelpResponse> {
+  if (!helpIndex) {
+    assert(DOCS_DIR, 'Could not find AppMap docs directory');
+    helpIndex = await buildHelpIndex(DOCS_DIR);
+  }
+
+  return await helpIndex.search(helpRequest.vectorTerms);
+}

--- a/packages/cli/src/rpc/explain/explain.ts
+++ b/packages/cli/src/rpc/explain/explain.ts
@@ -7,9 +7,10 @@ import { warn } from 'console';
 import { RpcError, RpcHandler } from '../rpc';
 import collectContext from './collectContext';
 import INavie, { INavieProvider } from './navie/inavie';
-import { Context, ProjectInfo } from '@appland/navie';
+import { Context, Help, ProjectInfo } from '@appland/navie';
 import configuration from '../configuration';
 import collectProjectInfos from '../../cmds/navie/projectInfo';
+import collectHelp from '../../cmds/navie/help';
 
 const searchStatusByUserMessageId = new Map<string, ExplainRpc.ExplainStatusResponse>();
 
@@ -122,6 +123,10 @@ export class Explain extends EventEmitter {
   projectInfoContext(): Promise<ProjectInfo.ProjectInfoResponse> {
     return collectProjectInfos();
   }
+
+  helpContext(data: Help.HelpRequest): Promise<Help.HelpResponse> {
+    return collectHelp(data);
+  }
 }
 
 async function explain(
@@ -160,8 +165,9 @@ async function explain(
   const contextProvider: Context.ContextProvider = async (data: any) => invokeContextFunction(data);
   const projectInfoProvider: ProjectInfo.ProjectInfoProvider = async (data: any) =>
     invokeContextFunction(data);
+  const helpProvider: Help.HelpProvider = async (data: any) => invokeContextFunction(data);
 
-  const navie = navieProvider(threadId, contextProvider, projectInfoProvider);
+  const navie = navieProvider(threadId, contextProvider, projectInfoProvider, helpProvider);
   return new Promise<ExplainRpc.ExplainResponse>((resolve, reject) => {
     let isFirst = true;
 

--- a/packages/cli/src/rpc/explain/navie/inavie.ts
+++ b/packages/cli/src/rpc/explain/navie/inavie.ts
@@ -1,4 +1,4 @@
-import { Context, ProjectInfo } from '@appland/navie';
+import { Context, Help, ProjectInfo } from '@appland/navie';
 
 export default interface INavie {
   setOption(key: string, value: string | number): void;
@@ -14,5 +14,6 @@ export default interface INavie {
 export type INavieProvider = (
   threadId: string | undefined,
   contextProvider: Context.ContextProvider,
-  projectInfoProvider: ProjectInfo.ProjectInfoProvider
+  projectInfoProvider: ProjectInfo.ProjectInfoProvider,
+  helpProvider: Help.HelpProvider
 ) => INavie;

--- a/packages/cli/src/rpc/explain/navie/navie-local.ts
+++ b/packages/cli/src/rpc/explain/navie/navie-local.ts
@@ -4,7 +4,7 @@ import { mkdir, readFile, readdir, writeFile } from 'fs/promises';
 import { randomUUID } from 'crypto';
 import { join } from 'path';
 import { homedir } from 'os';
-import { Context, Explain, Message, ProjectInfo, explain } from '@appland/navie';
+import { Context, Explain, Help, Message, ProjectInfo, explain } from '@appland/navie';
 
 import INavie from './inavie';
 import { AgentMode } from '@appland/navie/dist/agent';
@@ -73,7 +73,8 @@ export default class LocalNavie extends EventEmitter implements INavie {
   constructor(
     public threadId: string | undefined,
     private readonly contextProvider: Context.ContextProvider,
-    private readonly projectInfoProvider: ProjectInfo.ProjectInfoProvider
+    private readonly projectInfoProvider: ProjectInfo.ProjectInfoProvider,
+    private readonly helpProvider: Help.HelpProvider
   ) {
     super();
 
@@ -114,6 +115,7 @@ export default class LocalNavie extends EventEmitter implements INavie {
       clientRequest,
       this.contextProvider,
       this.projectInfoProvider,
+      this.helpProvider,
       this.explainOptions,
       history
     );

--- a/packages/cli/src/rpc/explain/navie/navie-remote.ts
+++ b/packages/cli/src/rpc/explain/navie/navie-remote.ts
@@ -4,13 +4,14 @@ import EventEmitter from 'events';
 import { AI } from '@appland/client';
 import { verbose } from '../../../utils';
 import { default as INavie } from './inavie';
-import { Context, ProjectInfo } from '@appland/navie';
+import { Context, Help, ProjectInfo } from '@appland/navie';
 
 export default class RemoteNavie extends EventEmitter implements INavie {
   constructor(
     public threadId: string | undefined,
     private contextProvider: Context.ContextProvider,
-    private projectInfoProvider: ProjectInfo.ProjectInfoProvider
+    private projectInfoProvider: ProjectInfo.ProjectInfoProvider,
+    private helpProvider: Help.HelpProvider
   ) {
     super();
   }
@@ -42,6 +43,9 @@ export default class RemoteNavie extends EventEmitter implements INavie {
                   data as unknown as ProjectInfo.ProjectInfoRequest
                 )) || {}
               );
+            }
+            if (data.type === 'help') {
+              return (await self.helpProvider(data as unknown as Help.HelpRequest)) || {};
             } else {
               warn(`Unhandled context request type: ${data.type}`);
               // A response is required from this function.

--- a/packages/cli/tests/integration/rpc.explain.spec.ts
+++ b/packages/cli/tests/integration/rpc.explain.spec.ts
@@ -1,6 +1,6 @@
 import assert from 'assert';
 import { ExplainRpc } from '@appland/rpc';
-import { explain } from '@appland/navie';
+import { Help, explain } from '@appland/navie';
 import { AI } from '@appland/client';
 import { AIClient, AICallbacks, AIInputPromptOptions, AIUserInput } from '@appland/client';
 import { ContextProvider, InteractionHistory, ProjectInfo } from '@appland/navie';
@@ -44,8 +44,9 @@ describe('RPC', () => {
         navieProvider = (
           threadId: string | undefined,
           contextProvider: ContextProvider,
-          projectInfoProvider: ProjectInfo.ProjectInfoProvider
-        ) => new LocalNavie(threadId, contextProvider, projectInfoProvider);
+          projectInfoProvider: ProjectInfo.ProjectInfoProvider,
+          helpProvider: Help.HelpProvider
+        ) => new LocalNavie(threadId, contextProvider, projectInfoProvider, helpProvider);
         rpcTest = new SingleDirectoryRPCTest(DEFAULT_WORKING_DIR, navieProvider);
       });
 
@@ -69,12 +70,12 @@ describe('RPC', () => {
         const explainOptions: ExplainRpc.ExplainOptions = {
           question,
         };
-        const response = (await rpcTest.client.request(
+        const response = await rpcTest.client.request(
           ExplainRpc.ExplainFunctionName,
           explainOptions
-        ));
+        );
         expect(response.error).toBeFalsy();
-        
+
         const explainResponse: ExplainRpc.ExplainResponse = response.result;
         expect(explainResponse.userMessageId).toBeTruthy();
         expect(explainResponse.threadId).toBeTruthy();
@@ -96,8 +97,9 @@ describe('RPC', () => {
         navieProvider = (
           threadId: string | undefined,
           contextProvider: ContextProvider,
-          projectInfoProvider: ProjectInfo.ProjectInfoProvider
-        ) => new RemoteNavie(threadId, contextProvider, projectInfoProvider);
+          projectInfoProvider: ProjectInfo.ProjectInfoProvider,
+          helpProvider: Help.HelpProvider
+        ) => new RemoteNavie(threadId, contextProvider, projectInfoProvider, helpProvider);
         rpcTest = new SingleDirectoryRPCTest(DEFAULT_WORKING_DIR, navieProvider);
       });
 

--- a/packages/cli/tests/unit/help/HelpIndex.spec.ts
+++ b/packages/cli/tests/unit/help/HelpIndex.spec.ts
@@ -1,0 +1,20 @@
+import { join } from 'path';
+import { HelpIndex, buildHelpIndex } from '../../../src/cmds/navie/help';
+
+describe('HelpIndex', () => {
+  let helpIndex: HelpIndex;
+
+  beforeAll(async () => {
+    helpIndex = await buildHelpIndex(join(__dirname, '..', '..', '..', '..', '..', 'docs'));
+  });
+
+  it('searches for help snippets', async () => {
+    expect(helpIndex).toBeDefined();
+
+    const matches = await helpIndex.search(['java', 'maven'], 3);
+    for (const match of matches) {
+      expect(match.content.toLowerCase()).toContain('maven');
+      expect(match.content.toLowerCase()).toContain('java');
+    }
+  });
+});

--- a/packages/cli/tests/unit/rpc/explain/LocalNavie.spec.ts
+++ b/packages/cli/tests/unit/rpc/explain/LocalNavie.spec.ts
@@ -4,8 +4,11 @@ describe('LocalNavie', () => {
   let navie: LocalNavie;
   let contextProvider = jest.fn();
   let projectInfoProvider = jest.fn();
+  let helpProvider = jest.fn();
 
-  beforeEach(() => (navie = new LocalNavie('threadId', contextProvider, projectInfoProvider)));
+  beforeEach(
+    () => (navie = new LocalNavie('threadId', contextProvider, projectInfoProvider, helpProvider))
+  );
 
   describe('setOptions', () => {
     it("should set 'temperature'", () => {

--- a/packages/navie/src/agent.ts
+++ b/packages/navie/src/agent.ts
@@ -3,6 +3,7 @@ import { ProjectInfo } from './project-info';
 export enum AgentMode {
   Explain = 'explain',
   Generate = 'generate',
+  Help = 'help',
 }
 
 export class AgentOptions {

--- a/packages/navie/src/agents/generate-agent.ts
+++ b/packages/navie/src/agents/generate-agent.ts
@@ -53,12 +53,9 @@ export class GenerateAgent implements Agent {
     );
 
     const vectorTerms = await this.vectorTermsService.suggestTerms(options.aggregateQuestion);
-    await LookupContextService.lookupAndApplyContext(
-      this.lookupContextService,
-      this.applyContextService,
-      vectorTerms,
-      tokensAvailable()
-    );
+    const tokenCount = tokensAvailable();
+    const context = await this.lookupContextService.lookupContext(vectorTerms, tokenCount);
+    LookupContextService.applyContext(context, [], this.applyContextService, tokenCount);
   }
 
   applyQuestionPrompt(question: string): void {

--- a/packages/navie/src/agents/help-agent.ts
+++ b/packages/navie/src/agents/help-agent.ts
@@ -1,0 +1,178 @@
+import { warn } from 'console';
+import { Agent, AgentOptions } from '../agent';
+import { HelpProvider } from '../help';
+import InteractionHistory, { PromptInteractionEvent } from '../interaction-history';
+import { PromptType, buildPromptDescriptor, buildPromptValue } from '../prompt';
+import VectorTermsService from '../services/vector-terms-service';
+import { CHARACTERS_PER_TOKEN } from '../message';
+
+export const HELP_AGENT_PROMPT = `**Task: Providing Help with AppMap**
+
+**About you**
+
+Your name is Navie. Your job is to provide help using AppMap. You are an expert user of AppMap, and you have
+access to the AppMap documentation that's relevant to the user's question.
+
+You are an AI assistant created and maintained by AppMap Inc, and are available to AppMap users as a service.
+
+**About the user**
+
+The user is a software developer who is working to understand, maintain and improve a codebase. You can
+expect the user to be proficient in software development.
+
+The user is using AppMap in their code editor. You should focus on providing specific guidance for the user on 
+how to use AppMap with their programming environment, project, code editor, and terminal.
+
+**Providing help with AppMap**
+
+Use the documentation snippets that are provided to you as the primary resource for helping the user.
+If there is no documentation relevant to the user's question, tell the user that you didn't find 
+any relevant documentation, and terminate your response.
+
+The following are the official AppMap documentation references for each supported language:
+
+- **Ruby** - https://appmap.io/docs/reference/appmap-ruby
+- **Python** - https://appmap.io/docs/reference/appmap-python
+- **Java** - https://appmap.io/docs/reference/appmap-java
+- **JavaScript, Node.js and TypeScript** - https://appmap.io/docs/reference/appmap-node
+
+Languages that do not appear in this list are not supported by AppMap at this time.
+
+Don't suggest configuration of production systems unless the user specifically asks
+about that. If the user asks about configuration of AppMap in production, make sure you include an advisory
+about the security and data protection implications of recording AppMaps in production.
+
+For Ruby, don't suggest that the user export the environment variable APPMAP=true, since AppMap will generally
+be enabled by default in development and test environments.
+
+For Python, don't suggest the terminal command "appmap python" to make AppMaps, as this command does not exist.
+
+When advising the user to use "remote recording", you should advise the user to utilize the AppMap extension
+features of their code editor. Remote recordings are not saved to the \`appmap_dir\` location.
+
+Do not suggest that the user upload any AppMaps to any AppMap-hosted service (e.g. "AppMap Cloud"), as no
+such services are offered at this time. If the user wants to upload and share AppMaps, you should suggest
+that they use the AppMap plugin for Atlassian Confluence.
+
+When helping the user make AppMaps for JavaScript, Node.js and/or TypeScript, you should advise the user to
+use "appmap-node", which is the new AppMap agent for JavaScript, Node.js and TypeScript. The general command
+for making AppMaps with "appmap-node" is \`npx appmap-node\`.
+
+Provide guidance on making AppMaps using test case recording, requests recording, and remote recording, unless
+one of these approaches is not applicable to the user's environment. 
+
+**Response Format**
+
+Respond using Markdown, unless told by the user to use a different format.
+
+The user has not provided you the documentation directly, so don't refer to "the provided documentation".
+When you cite documentation, quote the documentation that you are using.
+`;
+
+const MAKE_APPMAPS_PROMPT = `**Making AppMaps**
+
+If the user's question depends on having AppMaps, advise the user to make AppMaps for their project.
+
+Provide best practices for making AppMaps, taking into account the following considerations:
+
+- **Language**: The programming language in use.
+- **Frameworks**: The user's application and testing frameworks.
+- **IDE**: The user's code editor.
+`;
+
+const PREFIX_TIP_PROMPT = `**Tip: Using the @help prefix**
+
+Finish your response by informing the user that, in the future, they can begin any question
+with the prefix '@help' to activate help mode, and get help with using AppMap.
+`;
+
+export class HelpAgent implements Agent {
+  constructor(
+    public history: InteractionHistory,
+    private helpProvider: HelpProvider,
+    private vectorTermsService: VectorTermsService
+  ) {}
+
+  async perform(options: AgentOptions, tokensAvailable: () => number): Promise<void> {
+    this.history.addEvent(new PromptInteractionEvent('agent', 'system', HELP_AGENT_PROMPT));
+
+    this.history.addEvent(
+      new PromptInteractionEvent(
+        PromptType.Question,
+        'system',
+        buildPromptDescriptor(PromptType.Question)
+      )
+    );
+
+    if (!options.hasAppMaps) {
+      this.history.addEvent(
+        new PromptInteractionEvent('makeAppMaps', 'system', MAKE_APPMAPS_PROMPT)
+      );
+      this.history.addEvent(new PromptInteractionEvent('prefixTip', 'system', PREFIX_TIP_PROMPT));
+      this.history.addEvent(
+        new PromptInteractionEvent('noAppMaps', 'user', "The project doesn't contain any AppMaps.")
+      );
+    }
+
+    const collectLanguages = () => {
+      const languages = new Set(
+        options.projectInfo.map((info) => info.appmapConfig?.language).filter(Boolean)
+      );
+      return Array.from(languages).sort() as string[];
+    };
+
+    const vectorTerms = await this.vectorTermsService.suggestTerms(options.aggregateQuestion);
+    const searchTerms = [...collectLanguages(), ...vectorTerms];
+    let context = await this.helpProvider({
+      type: 'help',
+      vectorTerms: searchTerms,
+      tokenCount: tokensAvailable(),
+    });
+    if (context && context.length > 0) {
+      this.history.addEvent(
+        new PromptInteractionEvent(
+          PromptType.HelpDoc,
+          'system',
+          buildPromptDescriptor(PromptType.HelpDoc)
+        )
+      );
+    } else {
+      warn(`Help provider did not return context items`);
+      context = [];
+      this.history.addEvent(
+        new PromptInteractionEvent(
+          'noHelpDoc',
+          'system',
+          'No relevant documentation was found for this question'
+        )
+      );
+    }
+
+    let charsRemaining = tokensAvailable() * CHARACTERS_PER_TOKEN;
+    for (const doc of context) {
+      this.history.addEvent(
+        new PromptInteractionEvent(
+          PromptType.HelpDoc,
+          'system',
+          // TODO: Provide the file path?
+          buildPromptValue(PromptType.HelpDoc, doc.content)
+        )
+      );
+
+      charsRemaining -= doc.content.length;
+      if (charsRemaining < 0) {
+        break;
+      }
+    }
+  }
+
+  applyQuestionPrompt(question: string): void {
+    this.history.addEvent(
+      new PromptInteractionEvent(
+        PromptType.Question,
+        'user',
+        buildPromptValue(PromptType.Question, question)
+      )
+    );
+  }
+}

--- a/packages/navie/src/agents/help-agent.ts
+++ b/packages/navie/src/agents/help-agent.ts
@@ -83,7 +83,7 @@ Provide best practices for making AppMaps, taking into account the following con
 const PREFIX_TIP_PROMPT = `**Tip: Using the @help prefix**
 
 Finish your response by informing the user that, in the future, they can begin any question
-with the prefix '@help' to activate help mode, and get help with using AppMap.
+with the prefix "@help" to activate help mode, and get help with using AppMap.
 `;
 
 export class HelpAgent implements Agent {

--- a/packages/navie/src/explain.ts
+++ b/packages/navie/src/explain.ts
@@ -11,6 +11,7 @@ import ProjectInfoService from './services/project-info-service';
 import { ProjectInfo, ProjectInfoProvider } from './project-info';
 import CodeSelectionService from './services/code-selection-service';
 import { AgentMode, AgentOptions } from './agent';
+import { HelpProvider } from './help';
 import AgentSelectionService from './services/agent-selection-service';
 import LookupContextService from './services/lookup-context-service';
 import ApplyContextService from './services/apply-context-service';
@@ -105,6 +106,7 @@ export default function explain(
   clientRequest: ClientRequest,
   contextProvider: ContextProvider,
   projectInfoProvider: ProjectInfoProvider,
+  helpProvider: HelpProvider,
   options: ExplainOptions,
   chatHistory?: ChatHistory
 ): IExplain {
@@ -126,6 +128,7 @@ export default function explain(
 
   const agentSelectionService = new AgentSelectionService(
     interactionHistory,
+    helpProvider,
     vectorTermsService,
     lookupContextService,
     applyContextService

--- a/packages/navie/src/explain.ts
+++ b/packages/navie/src/explain.ts
@@ -123,7 +123,11 @@ export default function explain(
     options.modelName,
     options.temperature
   );
-  const lookupContextService = new LookupContextService(interactionHistory, contextProvider);
+  const lookupContextService = new LookupContextService(
+    interactionHistory,
+    contextProvider,
+    helpProvider
+  );
   const applyContextService = new ApplyContextService(interactionHistory);
 
   const agentSelectionService = new AgentSelectionService(

--- a/packages/navie/src/help.ts
+++ b/packages/navie/src/help.ts
@@ -1,0 +1,17 @@
+export type HelpRequest = {
+  type: 'help';
+  vectorTerms: string[];
+  tokenCount: number;
+};
+
+export type HelpDoc = {
+  filePath: string;
+  from: number;
+  to: number;
+  content: string;
+  score: number;
+};
+
+export type HelpResponse = HelpDoc[];
+
+export type HelpProvider = (request: HelpRequest) => Promise<HelpResponse>;

--- a/packages/navie/src/index.ts
+++ b/packages/navie/src/index.ts
@@ -6,5 +6,6 @@ export { default as explain } from './explain';
 export { AgentMode as Agents } from './agent';
 export * as Context from './context';
 export * as ProjectInfo from './project-info';
+export * as Help from './help';
 export * as Explain from './explain';
 export * as InteractionHistory from './interaction-history';

--- a/packages/navie/src/interaction-history.ts
+++ b/packages/navie/src/interaction-history.ts
@@ -3,6 +3,7 @@ import InteractionState from './interaction-state';
 import { ContextItem, ContextResponse } from './context';
 import { PromptType } from './prompt';
 import { CHARACTERS_PER_TOKEN } from './message';
+import { HelpDoc } from './help';
 
 const SNIPPET_LENGTH = 800;
 
@@ -129,6 +130,33 @@ export class ContextLookupEvent extends InteractionEvent {
 
   updateState(state: InteractionState) {
     state.contextAvailable = this.context;
+  }
+}
+
+export class HelpLookupEvent extends InteractionEvent {
+  constructor(public help: HelpDoc[] | undefined) {
+    super('helpLookup');
+  }
+
+  get helpAvailable() {
+    return !!this.help;
+  }
+
+  get metadata() {
+    return {
+      type: this.type,
+      helpAvailable: this.helpAvailable,
+    };
+  }
+
+  get message() {
+    if (!this.help) return `[helpLookup] not found`;
+
+    return `[helpLookup] ${this.help.length} items`;
+  }
+
+  updateState(state: InteractionState) {
+    state.helpAvailable = this.help;
   }
 }
 

--- a/packages/navie/src/interaction-state.ts
+++ b/packages/navie/src/interaction-state.ts
@@ -1,4 +1,5 @@
 import { ContextItem, ContextResponse } from './context';
+import { HelpResponse } from './help';
 import Message from './message';
 
 export default class InteractionState {
@@ -8,11 +9,9 @@ export default class InteractionState {
   public completionModel?: string;
   public completionTemperature?: number;
   public contextAvailable?: ContextResponse;
+  public helpAvailable?: HelpResponse;
 
   addContextItem(contextItem: ContextItem) {
-    // const items = this.contextItems.get(contextItem.type);
-    // assert(items);
-    // items.push(contextItem.content);
     this.messages.push({ content: contextItem.content, role: 'user' });
   }
 }

--- a/packages/navie/src/prompt.ts
+++ b/packages/navie/src/prompt.ts
@@ -124,9 +124,8 @@ Sequence diagrams, if available, provide more context about how each data reques
   [PromptType.HelpDoc]: {
     content: `**Help documents**
 
-You're provided with help documents that are relevant to the task. Each help document provides detailed
-information about installing, configuring, and using AppMap. You should refer to these documents when
-providing guidance to the user.`,
+You're provided with relevant snippets of AppMap documentation. Each documentation snippet provides detailed
+information about installing, configuring, and using AppMap.`,
     prefix: 'Help document',
     multiple: true,
   },

--- a/packages/navie/src/prompt.ts
+++ b/packages/navie/src/prompt.ts
@@ -7,6 +7,7 @@ export enum PromptType {
   SequenceDiagram = 'sequenceDiagrams',
   CodeSnippet = 'codeSnippets',
   DataRequest = 'dataRequest',
+  HelpDoc = 'helpDoc',
 }
 
 const PROMPT_NAMES: Record<PromptType, { singular: string; plural: string }> = {
@@ -18,6 +19,7 @@ const PROMPT_NAMES: Record<PromptType, { singular: string; plural: string }> = {
   [PromptType.SequenceDiagram]: { singular: 'sequence diagram', plural: 'sequence diagrams' },
   [PromptType.CodeSnippet]: { singular: 'code snippet', plural: 'code snippets' },
   [PromptType.DataRequest]: { singular: 'data request', plural: 'data requests' },
+  [PromptType.HelpDoc]: { singular: 'help document', plural: 'help documents' },
 };
 
 export type Prompt = {
@@ -117,6 +119,15 @@ Each data request was recorded by the AppMap language library which is integrate
 
 Sequence diagrams, if available, provide more context about how each data request is used in the overall program.`,
     prefix: 'Data request',
+    multiple: true,
+  },
+  [PromptType.HelpDoc]: {
+    content: `**Help documents**
+
+You're provided with help documents that are relevant to the task. Each help document provides detailed
+information about installing, configuring, and using AppMap. You should refer to these documents when
+providing guidance to the user.`,
+    prefix: 'Help document',
     multiple: true,
   },
 };

--- a/packages/navie/src/services/apply-context-service.ts
+++ b/packages/navie/src/services/apply-context-service.ts
@@ -7,13 +7,14 @@ import InteractionHistory, {
   PromptInteractionEvent,
 } from '../interaction-history';
 import { PROMPTS, PromptType, buildPromptDescriptor } from '../prompt';
+import { HelpResponse } from '../help';
 
 type ContextItemWithFile = ContextItem & { file?: string };
 
 export default class ApplyContextService {
   constructor(public readonly interactionHistory: InteractionHistory) {}
 
-  applyContext(context: ContextResponse | undefined, characterLimit: number) {
+  applyContext(context: ContextResponse | undefined, help: HelpResponse, characterLimit: number) {
     if (!context) {
       this.interactionHistory.addEvent(
         new PromptInteractionEvent(
@@ -34,12 +35,15 @@ export default class ApplyContextService {
       codeSnippets[key],
     ]);
     const availableDataRequests = [...codeObjects];
+    const availableHelp = [...help];
 
     const availableItemCount = () =>
-      [availableDiagrams.length, availableCodeSnippets.length, availableDataRequests.length].reduce(
-        (a, b) => a + b,
-        0
-      );
+      [
+        availableDiagrams.length,
+        availableCodeSnippets.length,
+        availableDataRequests.length,
+        availableHelp.length,
+      ].reduce((a, b) => a + b, 0);
 
     // Select items in a round-robin fashion, to ensure a mix of content types. Heuristically, we
     // want to see one sequence diagram, N code snippets, and M data requests. If we run out of
@@ -47,7 +51,8 @@ export default class ApplyContextService {
     const numDiagrams = 1;
     const numSnippets = 7;
     const numDataRequests = 2;
-    const roundSize = numDiagrams + numSnippets + numDataRequests;
+    const numHelp = 1;
+    const roundSize = numDiagrams + numSnippets + numDataRequests + numHelp;
     let index = 0;
     while (availableItemCount() > 0) {
       const itemType = index % roundSize;
@@ -84,13 +89,29 @@ export default class ApplyContextService {
         return true;
       };
 
+      const selectHelp = (): boolean => {
+        if (availableHelp.length === 0) return false;
+
+        const helpItem = availableHelp.shift();
+        if (!helpItem) return false;
+
+        name = PROMPTS[PromptType.HelpDoc].prefix;
+        [file, content] = [helpItem.filePath, helpItem.content];
+        return true;
+      };
+
       let selectionMade: boolean;
       if (itemType === 0) {
-        selectionMade = selectDiagram() || selectCodeSnippet() || selectDataRequest();
-      } else if (itemType >= numDiagrams && itemType <= numSnippets) {
-        selectionMade = selectCodeSnippet() || selectDataRequest();
+        selectionMade = selectDiagram();
+      } else if (itemType >= numDiagrams && itemType < numDiagrams + numSnippets) {
+        selectionMade = selectCodeSnippet();
+      } else if (
+        itemType >= numDiagrams + numSnippets &&
+        itemType < numDiagrams + numSnippets + numDataRequests
+      ) {
+        selectionMade = selectDataRequest();
       } else {
-        selectionMade = selectDataRequest() || selectCodeSnippet();
+        selectionMade = selectHelp();
       }
 
       if (selectionMade) {
@@ -130,7 +151,7 @@ export default class ApplyContextService {
     this.interactionHistory.log(`Remaining characters after context: ${charsRemaining}`);
   }
 
-  addSystemPrompts(context: ContextResponse) {
+  addSystemPrompts(context: ContextResponse, help: HelpResponse) {
     const { sequenceDiagrams, codeSnippets, codeObjects } = context;
 
     if (sequenceDiagrams.length > 0)
@@ -157,6 +178,15 @@ export default class ApplyContextService {
           PromptType.DataRequest,
           'system',
           buildPromptDescriptor(PromptType.DataRequest)
+        )
+      );
+
+    if (help.length > 0)
+      this.interactionHistory.addEvent(
+        new PromptInteractionEvent(
+          PromptType.HelpDoc,
+          'system',
+          buildPromptDescriptor(PromptType.HelpDoc)
         )
       );
   }

--- a/packages/navie/src/services/classification-service.ts
+++ b/packages/navie/src/services/classification-service.ts
@@ -1,0 +1,97 @@
+import { ChatOpenAI } from '@langchain/openai';
+import OpenAI from 'openai';
+import InteractionHistory from '../interaction-history';
+
+const SYSTEM_PROMPT = `**Question classifier**
+
+You are assisting a developer to classify a question. The developer asks a question using natural language. 
+There are several types of questions that the developer may be asking. 
+
+Your task is to assign a likelihood to each of the following question types:
+
+- **Help with AppMap**: The developer is asking for help using the AppMap product.
+- **Project architecture**: The developer is asking about the high level architecture of their project.
+- **Explaining code**: The developer is asking for an explanation of how a specific feature of their project works.
+- **Generating code**: The developer is asking for code to be generated for a specific task.
+
+**Classification scores**
+
+Each question type is assigned one of the following likelihoods:
+
+- **High**: The question is very likely to be of this type.
+- **Medium**: The question is somewhat likely to be of this type.
+- **Low**: The question is unlikely to be of this type.
+
+**Response**
+
+Respond with a list of question types and their likelihoods. The question types should be one of the following: 'Help with AppMap', 
+'Project architecture', 'Explaining code', 'Generating code'. The likelihoods should be one of the following: 'High', 'Medium', 'Low'.
+
+**Example**
+
+Some examples of questions and their classifications are:
+
+\`\`\`
+Question: How do I install?
+Classification: Help with AppMap (High)
+Classification: Project architecture (Low)
+Classification: Explaining code (Low)
+Classification: Generating code (Low)
+\`\`\`
+
+\`\`\`
+Question: How does the project work?
+Classification: Help with AppMap (Low)
+Classification: Project architecture (High)
+Classification: Explaining code (Low)
+Classification: Generating code (Low)
+\`\`\`
+
+\`\`\`
+Question: Generate a new user
+Classification: Help with AppMap (Low)
+Classification: Project architecture (Low)
+Classification: Explaining code (Low)
+Classification: Generating code (High)
+\`\`\`
+`;
+
+export default class ClassificationService {
+  constructor(
+    public readonly interactionHistory: InteractionHistory,
+    public modelName: string,
+    public temperature: number
+  ) {}
+
+  async classifyQuestion(question: string): Promise<string> {
+    const openAI: ChatOpenAI = new ChatOpenAI({
+      modelName: this.modelName,
+      temperature: this.temperature,
+    });
+
+    const messages: OpenAI.ChatCompletionMessageParam[] = [
+      {
+        content: SYSTEM_PROMPT,
+        role: 'system',
+      },
+      {
+        content: question,
+        role: 'user',
+      },
+    ];
+
+    // eslint-disable-next-line no-await-in-loop
+    const response = await openAI.completionWithRetry({
+      messages,
+      model: openAI.modelName,
+      stream: true,
+    });
+    const tokens = Array<string>();
+    // eslint-disable-next-line no-await-in-loop
+    for await (const token of response) {
+      tokens.push(token.choices.map((choice) => choice.delta.content).join(''));
+    }
+    const rawTerms = tokens.join('');
+    return rawTerms;
+  }
+}

--- a/packages/navie/src/services/lookup-context-service.ts
+++ b/packages/navie/src/services/lookup-context-service.ts
@@ -1,44 +1,66 @@
 import { log } from 'console';
-import InteractionHistory, { ContextLookupEvent } from '../interaction-history';
+import InteractionHistory, { ContextLookupEvent, HelpLookupEvent } from '../interaction-history';
 import { ContextRequest, ContextResponse } from '../context';
 import { CHARACTERS_PER_TOKEN } from '../message';
 import ApplyContextService from './apply-context-service';
+import { HelpRequest, HelpResponse } from '../help';
 
 export default class LookupContextService {
   constructor(
     public readonly interactionHistory: InteractionHistory,
-    public readonly contextFn: (data: ContextRequest) => Promise<ContextResponse>
+    public readonly contextFn: (data: ContextRequest) => Promise<ContextResponse>,
+    public readonly helpFn: (data: HelpRequest) => Promise<HelpResponse>
   ) {}
 
-  async lookupContext(request: ContextRequest): Promise<ContextResponse | undefined> {
-    const searchContext = await this.contextFn(request);
+  async lookupContext(vectorTerms: string[], tokenCount: number): Promise<ContextResponse> {
+    const context = await this.contextFn({
+      type: 'search',
+      vectorTerms,
+      tokenCount,
+    });
 
-    const hasProvidedData = searchContext?.sequenceDiagrams?.length > 0;
-    if (!hasProvidedData) {
+    const contextFound = context?.sequenceDiagrams?.length > 0;
+    if (contextFound) {
+      this.interactionHistory.addEvent(new ContextLookupEvent(context));
+    } else {
       log('No sequence diagrams found');
       this.interactionHistory.addEvent(new ContextLookupEvent(undefined));
-      return undefined;
     }
 
-    this.interactionHistory.addEvent(new ContextLookupEvent(searchContext));
-
-    return searchContext;
+    return context;
   }
 
-  static async lookupAndApplyContext(
-    lookupContextService: LookupContextService,
-    applyContextService: ApplyContextService,
+  async lookupHelp(
+    languages: string[],
     vectorTerms: string[],
-    tokensAvailable: number
-  ) {
-    const context = await lookupContextService.lookupContext({
-      vectorTerms,
-      tokenCount: tokensAvailable,
-      type: 'search',
+    tokenCount: number
+  ): Promise<HelpResponse> {
+    const help = await this.helpFn({
+      type: 'help',
+      vectorTerms: [...languages, ...vectorTerms],
+      tokenCount,
     });
-    if (context) {
-      applyContextService.addSystemPrompts(context);
-      applyContextService.applyContext(context, tokensAvailable * CHARACTERS_PER_TOKEN);
+
+    const helpFound = help?.length > 0;
+
+    if (helpFound) {
+      this.interactionHistory.addEvent(new HelpLookupEvent(help));
+    } else {
+      log('No help found');
+      this.interactionHistory.addEvent(new HelpLookupEvent(undefined));
     }
+
+    return help;
+  }
+
+  static applyContext(
+    context: ContextResponse,
+    help: HelpResponse,
+    applyContextService: ApplyContextService,
+    tokenCount: number
+  ) {
+    applyContextService.addSystemPrompts(context, help);
+
+    applyContextService.applyContext(context, help, tokenCount * CHARACTERS_PER_TOKEN);
   }
 }

--- a/packages/navie/test/agents/generate-agent.spec.ts
+++ b/packages/navie/test/agents/generate-agent.spec.ts
@@ -18,10 +18,9 @@ describe('@generate agent', () => {
     interactionHistory = new InteractionHistory();
     lookupContextService = {
       lookupContext: jest.fn(),
-      contextFn: jest.fn(),
+      lookupHelp: jest.fn(),
     } as unknown as LookupContextService;
     vectorTermsService = suggestsVectorTerms('How does user management work?', undefined);
-    LookupContextService.lookupAndApplyContext = jest.fn();
     applyContextService = {
       addSystemPrompts: jest.fn(),
       applyContext: jest.fn(),
@@ -56,15 +55,14 @@ describe('@generate agent', () => {
       );
     });
 
-    it('invokes the lookup context service', async () => {
+    it('looks up context but not help', async () => {
       await buildAgent().perform(initialQuestionOptions, () => tokensAvailable);
 
-      expect(LookupContextService.lookupAndApplyContext).toHaveBeenCalledWith(
-        lookupContextService,
-        applyContextService,
+      expect(lookupContextService.lookupContext).toHaveBeenCalledWith(
         ['user', 'management'],
         tokensAvailable
       );
+      expect(lookupContextService.lookupHelp).not.toHaveBeenCalled();
     });
 
     it('applies the agent and question system prompts', async () => {

--- a/packages/navie/test/agents/help-agent.spec.ts
+++ b/packages/navie/test/agents/help-agent.spec.ts
@@ -1,0 +1,181 @@
+import { AgentOptions } from '../../src/agent';
+import { HelpAgent } from '../../src/agents/help-agent';
+import { HelpProvider, HelpRequest, HelpResponse } from '../../src/help';
+import InteractionHistory from '../../src/interaction-history';
+import { AppMapConfig, AppMapStats } from '../../src/project-info';
+import VectorTermsService from '../../src/services/vector-terms-service';
+import { suggestsVectorTerms } from '../fixture';
+
+describe('HelpAgent', () => {
+  const question = 'How to make a diagram?';
+  let history: InteractionHistory;
+  let helpProvider: HelpProvider;
+  let vectorTermsService: VectorTermsService;
+
+  function receivesHelpDocs(): void {
+    helpProvider = jest.fn().mockImplementation((request: HelpRequest): Promise<HelpResponse> => {
+      expect(request.type).toEqual('help');
+      expect(request.vectorTerms).toEqual(['ruby', 'diagram']);
+      expect(request.tokenCount).toEqual(1000);
+      return Promise.resolve([
+        {
+          filePath: 'ruby-diagram.md',
+          from: 1,
+          to: 2,
+          content: 'steps to make a Ruby appmap diagram',
+          score: 1,
+        },
+      ]);
+    });
+  }
+
+  beforeEach(() => {
+    history = new InteractionHistory();
+    vectorTermsService = suggestsVectorTerms(question, undefined, ['diagram']);
+  });
+
+  function buildAgent(): HelpAgent {
+    return new HelpAgent(history, helpProvider, vectorTermsService);
+  }
+
+  describe('when there are no AppMaps', () => {
+    const options = new AgentOptions(
+      question,
+      question,
+      [],
+      [
+        {
+          appmapConfig: { language: 'ruby' } as unknown as AppMapConfig,
+          appmapStats: { numAppMaps: 0 } as unknown as AppMapStats,
+        },
+      ]
+    );
+
+    beforeEach(receivesHelpDocs);
+
+    it('searches for help docs', async () => {
+      await buildAgent().perform(options, () => 1000);
+
+      expect(helpProvider).toHaveBeenCalled();
+    });
+    it('prompts the user to create AppMaps', async () => {
+      await buildAgent().perform(options, () => 1000);
+
+      expect(history.events.map((event) => event.metadata)).toEqual([
+        {
+          name: 'agent',
+          role: 'system',
+          type: 'prompt',
+        },
+        {
+          name: 'question',
+          role: 'system',
+          type: 'prompt',
+        },
+        {
+          name: 'makeAppMaps',
+          role: 'system',
+          type: 'prompt',
+        },
+        {
+          name: 'prefixTip',
+          role: 'system',
+          type: 'prompt',
+        },
+        {
+          name: 'noAppMaps',
+          role: 'user',
+          type: 'prompt',
+        },
+        {
+          name: 'helpDoc',
+          role: 'system',
+          type: 'prompt',
+        },
+        {
+          name: 'helpDoc',
+          role: 'system',
+          type: 'prompt',
+        },
+      ]);
+    });
+  });
+  describe('when there are AppMaps', () => {
+    const options = new AgentOptions(
+      question,
+      question,
+      [],
+      [
+        {
+          appmapConfig: { language: 'ruby' } as unknown as AppMapConfig,
+          appmapStats: { numAppMaps: 10 } as unknown as AppMapStats,
+        },
+      ]
+    );
+
+    describe('and it receives help docs', () => {
+      beforeEach(receivesHelpDocs);
+
+      it('searches for help docs', async () => {
+        await buildAgent().perform(options, () => 1000);
+
+        expect(helpProvider).toHaveBeenCalled();
+      });
+
+      it('prompts based on the help docs', async () => {
+        await buildAgent().perform(options, () => 1000);
+
+        expect(history.events.map((event) => event.metadata)).toEqual([
+          {
+            name: 'agent',
+            role: 'system',
+            type: 'prompt',
+          },
+          {
+            name: 'question',
+            role: 'system',
+            type: 'prompt',
+          },
+          {
+            name: 'helpDoc',
+            role: 'system',
+            type: 'prompt',
+          },
+          {
+            name: 'helpDoc',
+            role: 'system',
+            type: 'prompt',
+          },
+        ]);
+      });
+    });
+
+    describe('and it does not find matching help', () => {
+      beforeEach(() => {
+        helpProvider = jest.fn().mockImplementation(() => Promise.resolve([]));
+      });
+
+      it('prompts that no help docs were found', async () => {
+        await buildAgent().perform(options, () => 1000);
+
+        expect(history.events.map((event) => event.metadata)).toEqual([
+          {
+            name: 'agent',
+            role: 'system',
+            type: 'prompt',
+          },
+          {
+            name: 'question',
+            role: 'system',
+            type: 'prompt',
+          },
+          {
+            name: 'noHelpDoc',
+            role: 'system',
+            type: 'prompt',
+          },
+        ]);
+      });
+    });
+  });
+});

--- a/packages/navie/test/explain.spec.ts
+++ b/packages/navie/test/explain.spec.ts
@@ -16,18 +16,18 @@ import {
   predictsSummary,
   providesProjectInfo,
 } from './fixture';
+import ClassificationService from '../src/services/classification-service';
 
 describe('CodeExplainerService', () => {
   let interactionHistory: InteractionHistory;
   let completionService: CompletionService;
+  let classificationService: ClassificationService;
   let agentSelectionService: AgentSelectionService;
   let codeSelection: string | undefined;
   let codeSelectionService: CodeSelectionService;
   let memoryService: MemoryService;
   let projectInfoService: ProjectInfoService;
-  let explainOptions: ExplainOptions;
   let agent: Agent;
-  let codeExplainerService: CodeExplainerService;
 
   let userMessage1: string;
   let assistantMessage1: string | undefined;
@@ -37,6 +37,7 @@ describe('CodeExplainerService', () => {
     return new CodeExplainerService(
       interactionHistory,
       completionService,
+      classificationService,
       agentSelectionService,
       codeSelectionService,
       projectInfoService,
@@ -108,6 +109,9 @@ describe('CodeExplainerService', () => {
     completionService = {
       complete: () => TOKEN_STREAM,
     };
+    classificationService = {
+      classifyQuestion: jest.fn().mockResolvedValue(undefined),
+    } as unknown as ClassificationService;
     codeSelection = undefined;
     codeSelectionService = new CodeSelectionService(interactionHistory);
     projectInfoService = {
@@ -120,7 +124,6 @@ describe('CodeExplainerService', () => {
       memoryService = {
         predictSummary: doesNotPredictSummary(),
       } as unknown as MemoryService;
-      explainOptions = defaultExplainOptions();
       agent = mockAgent();
       mockAgentSelectionService(agent);
     });
@@ -170,7 +173,6 @@ describe('CodeExplainerService', () => {
       memoryService = {
         predictSummary: predictsSummary(),
       } as unknown as MemoryService;
-      explainOptions = defaultExplainOptions();
       agent = mockAgent();
       mockAgentSelectionService(agent);
     });

--- a/packages/navie/test/fixture.ts
+++ b/packages/navie/test/fixture.ts
@@ -91,3 +91,22 @@ export function predictsSummary(): (messages: Message[]) => void {
     return Promise.resolve();
   });
 }
+
+export function mockAIResponse(completionWithRetry: jest.Mock, responses: string[]): void {
+  const choices = responses.map((response, index) => ({
+    delta: {
+      content: response,
+    },
+    index,
+    finish_reason: 'stop',
+  }));
+  completionWithRetry.mockResolvedValueOnce([
+    {
+      id: 'cmpl-3Z5z9J5Z5Z5Z5Z5Z5Z5Z5Z5Z5Z5',
+      choices,
+      created: 1635989729,
+      model: 'gpt-3.5',
+      object: 'chat.completion.chunk',
+    },
+  ] as any);
+}

--- a/packages/navie/test/fixture.ts
+++ b/packages/navie/test/fixture.ts
@@ -1,4 +1,5 @@
 import { ContextProvider, ContextRequest } from '../src/context';
+import { HelpProvider } from '../src/help';
 import InteractionHistory from '../src/interaction-history';
 import Message from '../src/message';
 import { ProjectInfoProvider } from '../src/project-info';
@@ -23,6 +24,16 @@ export const SEARCH_CONTEXT = {
   codeObjects: CODE_OBJECTS,
 };
 
+export const HELP_CONTEXT = [
+  {
+    filePath: 'appmap-java.md',
+    content: 'AppMap Java reference',
+    from: 1,
+    to: 10,
+    score: 1,
+  },
+];
+
 export const TOKEN_STREAM: AsyncIterable<string> = {
   [Symbol.asyncIterator]: async function* () {
     yield 'The user management system is a system ';
@@ -42,27 +53,6 @@ export function suggestsVectorTerms(
   return {
     suggestTerms,
   } as unknown as VectorTermsService;
-}
-
-export function providesContext(
-  interactionHistory: InteractionHistory,
-  tokenCount: number
-): LookupContextService {
-  const lookupProvider: ContextProvider = jest
-    .fn()
-    .mockImplementation((request: ContextRequest) => {
-      expect(request.vectorTerms).toEqual(['user', 'management']);
-      expect(request.tokenCount).toEqual(tokenCount);
-      return Promise.resolve(SEARCH_CONTEXT);
-    });
-  return new LookupContextService(interactionHistory, lookupProvider);
-}
-
-export function providesNoContext(interactionHistory: InteractionHistory): LookupContextService {
-  const lookupProvider: ContextProvider = jest
-    .fn()
-    .mockImplementation(() => Promise.resolve(undefined));
-  return new LookupContextService(interactionHistory, lookupProvider);
 }
 
 export const APPMAP_CONFIG = {

--- a/packages/navie/test/services/agent-selection-service.spec.ts
+++ b/packages/navie/test/services/agent-selection-service.spec.ts
@@ -1,5 +1,7 @@
 import ExplainAgent from '../../src/agents/explain-agent';
+import { HelpAgent } from '../../src/agents/help-agent';
 import { ExplainOptions } from '../../src/explain';
+import { HelpProvider } from '../../src/help';
 import InteractionHistory from '../../src/interaction-history';
 import { AppMapConfig, AppMapStats } from '../../src/project-info';
 import AgentSelectionService from '../../src/services/agent-selection-service';
@@ -9,13 +11,17 @@ import VectorTermsService from '../../src/services/vector-terms-service';
 
 describe('AgentSelectionService', () => {
   let interactionHistory: InteractionHistory;
+  let helpProvider: HelpProvider;
   let vectorTermsService: VectorTermsService;
   let lookupContextService: LookupContextService;
   let applyContextService: ApplyContextService;
   let genericQuestion = 'How does user management work?';
+  let helpAgentQueston = '@help How to make a diagram?';
+
   function buildAgentSelectionService() {
     return new AgentSelectionService(
       interactionHistory,
+      helpProvider,
       vectorTermsService,
       lookupContextService,
       applyContextService
@@ -24,11 +30,47 @@ describe('AgentSelectionService', () => {
 
   beforeEach(() => {
     interactionHistory = new InteractionHistory();
+    helpProvider = jest.fn();
     vectorTermsService = {} as VectorTermsService;
     lookupContextService = {} as LookupContextService;
     applyContextService = {} as ApplyContextService;
   });
 
+  describe('when the question specifies an agent', () => {
+    it('creates the specified agent', () => {
+      const { agent } = buildAgentSelectionService().selectAgent(
+        helpAgentQueston,
+        new ExplainOptions(),
+        []
+      );
+      expect(agent).toBeInstanceOf(HelpAgent);
+    });
+    it('removes the prefix', () => {
+      const { question } = buildAgentSelectionService().selectAgent(
+        helpAgentQueston,
+        new ExplainOptions(),
+        []
+      );
+      expect(question).toEqual('How to make a diagram?');
+    });
+  });
+
+  describe('when there are no AppMaps', () => {
+    it('creates a Help agent', () => {
+      const { agent, question } = buildAgentSelectionService().selectAgent(
+        genericQuestion,
+        new ExplainOptions(),
+        [
+          {
+            appmapConfig: { language: 'ruby' } as unknown as AppMapConfig,
+            appmapStats: { numAppMaps: 0 } as unknown as AppMapStats,
+          },
+        ]
+      );
+      expect(agent).toBeInstanceOf(HelpAgent);
+      expect(question).toEqual(question);
+    });
+  });
   describe('when there are AppMaps', () => {
     it('creates an Explain agent', () => {
       const { agent, question } = buildAgentSelectionService().selectAgent(

--- a/packages/navie/test/services/apply-context-service.spec.ts
+++ b/packages/navie/test/services/apply-context-service.spec.ts
@@ -1,34 +1,27 @@
+import { ContextProvider, ContextRequest, ContextResponse } from '../../src/context';
+import { HelpProvider, HelpRequest, HelpResponse } from '../../src/help';
 import InteractionHistory from '../../src/interaction-history';
 import ApplyContextService from '../../src/services/apply-context-service';
 import LookupContextService from '../../src/services/lookup-context-service';
-import {
-  CODE_OBJECTS,
-  CODE_SNIPPETS,
-  SEQUENCE_DIAGRAMS,
-  providesContext,
-  providesNoContext,
-} from '../fixture';
+import { HELP_CONTEXT, SEARCH_CONTEXT } from '../fixture';
 
 describe('ApplyContextService', () => {
-  describe('collectContext', () => {
+  describe('applyContext', () => {
     let interactionHistory: InteractionHistory;
     let applyContextService: ApplyContextService;
+    let context: ContextResponse;
+    let help: HelpResponse;
 
     beforeEach(() => {
       interactionHistory = new InteractionHistory();
       applyContextService = new ApplyContextService(interactionHistory);
+      context = SEARCH_CONTEXT;
+      help = HELP_CONTEXT;
     });
     afterEach(() => jest.resetAllMocks());
 
     const collect = (characterLimit: number) =>
-      applyContextService.applyContext(
-        {
-          sequenceDiagrams: SEQUENCE_DIAGRAMS,
-          codeSnippets: CODE_SNIPPETS,
-          codeObjects: CODE_OBJECTS,
-        },
-        characterLimit
-      );
+      applyContextService.applyContext(context, help, characterLimit);
 
     it('collects samples of context into the output', () => {
       collect(1000 * 1000);
@@ -78,6 +71,14 @@ describe('ApplyContextService', () => {
         {
           type: 'contextItem',
           contextItem: {
+            content: `AppMap Java reference`,
+            name: 'Help document',
+          },
+          file: 'appmap-java.md',
+        },
+        {
+          type: 'contextItem',
+          contextItem: {
             content: `diagram-2`,
             name: 'Sequence diagram',
           },
@@ -111,7 +112,7 @@ describe('ApplyContextService', () => {
     });
   });
 
-  describe('lookupAndApplyContext', () => {
+  describe('lookup and apply context', () => {
     let interactionHistory: InteractionHistory;
     let lookupContextService: LookupContextService;
     let applyContextService: ApplyContextService;
@@ -123,13 +124,35 @@ describe('ApplyContextService', () => {
       applyContextService = new ApplyContextService(interactionHistory);
     });
 
+    function providesContext(
+      interactionHistory: InteractionHistory,
+      tokenCount: number
+    ): LookupContextService {
+      const contextFn: ContextProvider = jest.fn().mockImplementation((request: ContextRequest) => {
+        expect(request.vectorTerms).toEqual(['user', 'management']);
+        expect(request.tokenCount).toEqual(tokenCount);
+        return Promise.resolve(SEARCH_CONTEXT);
+      });
+      const helpFn: HelpProvider = jest.fn().mockImplementation((request: HelpRequest) => {
+        expect(request.vectorTerms).toEqual(['ruby', 'user', 'management']);
+        expect(request.tokenCount).toEqual(tokenCount);
+        return Promise.resolve(HELP_CONTEXT);
+      });
+      return new LookupContextService(interactionHistory, contextFn, helpFn);
+    }
+
+    function providesNoContext(interactionHistory: InteractionHistory): LookupContextService {
+      const contextFn: ContextProvider = jest
+        .fn()
+        .mockResolvedValue({ sequenceDiagrams: [], codeSnippets: {}, codeObjects: [] });
+      const helpFn: HelpProvider = jest.fn().mockResolvedValue([]);
+      return new LookupContextService(interactionHistory, contextFn, helpFn);
+    }
+
     async function lookupAndApplyContext() {
-      return await LookupContextService.lookupAndApplyContext(
-        lookupContextService,
-        applyContextService,
-        vectorTerms,
-        tokensAvailable
-      );
+      const context = await lookupContextService.lookupContext(vectorTerms, tokensAvailable);
+      const help = await lookupContextService.lookupHelp(['ruby'], vectorTerms, tokensAvailable);
+      LookupContextService.applyContext(context, help, applyContextService, tokensAvailable);
     }
 
     describe('when no context is obtained', () => {
@@ -138,14 +161,19 @@ describe('ApplyContextService', () => {
       it('invokes the lookup context service', async () => {
         await lookupAndApplyContext();
         expect(lookupContextService.contextFn).toHaveBeenCalled();
+        expect(lookupContextService.helpFn).toHaveBeenCalled();
       });
 
-      it('applies the agent and question system prompts only', async () => {
+      it('reports no context or help available', async () => {
         await lookupAndApplyContext();
         expect(interactionHistory.events.map((event) => event.metadata)).toEqual([
           {
             type: 'contextLookup',
             contextAvailable: false,
+          },
+          {
+            type: 'helpLookup',
+            helpAvailable: false,
           },
         ]);
       });
@@ -156,7 +184,7 @@ describe('ApplyContextService', () => {
         () => (lookupContextService = providesContext(interactionHistory, tokensAvailable))
       );
 
-      it('applies the agent, question, and data system prompts as well as the context items', async () => {
+      it('applies the agent, question, data and help system prompts as well as the context items', async () => {
         await lookupAndApplyContext();
 
         expect(lookupContextService.contextFn).toHaveBeenCalled();
@@ -164,6 +192,10 @@ describe('ApplyContextService', () => {
           {
             type: 'contextLookup',
             contextAvailable: true,
+          },
+          {
+            type: 'helpLookup',
+            helpAvailable: true,
           },
           {
             type: 'prompt',
@@ -179,6 +211,11 @@ describe('ApplyContextService', () => {
             type: 'prompt',
             role: 'system',
             name: 'dataRequest',
+          },
+          {
+            type: 'prompt',
+            role: 'system',
+            name: 'helpDoc',
           },
           {
             type: 'contextItem',
@@ -201,6 +238,11 @@ describe('ApplyContextService', () => {
           {
             type: 'contextItem',
             name: 'Data request',
+          },
+          {
+            type: 'contextItem',
+            name: 'Help document',
+            file: 'appmap-java.md',
           },
           {
             type: 'contextItem',

--- a/packages/navie/test/services/classification-service.spec.ts
+++ b/packages/navie/test/services/classification-service.spec.ts
@@ -1,0 +1,29 @@
+import { ChatOpenAI } from '@langchain/openai';
+
+import InteractionHistory from '../../src/interaction-history';
+import ClassificationService from '../../src/services/classification-service';
+import { mockAIResponse } from '../fixture';
+
+jest.mock('@langchain/openai');
+const completionWithRetry = jest.mocked(ChatOpenAI.prototype.completionWithRetry);
+
+describe('ClassificationService', () => {
+  let interactionHistory: InteractionHistory;
+  let service: ClassificationService;
+
+  beforeEach(() => {
+    interactionHistory = new InteractionHistory();
+    interactionHistory.on('event', (event) => console.log(event.message));
+    service = new ClassificationService(interactionHistory, 'gpt-4', 0.5);
+  });
+  afterEach(() => jest.resetAllMocks());
+
+  describe('when LLM responds', () => {
+    it('returns the response', async () => {
+      mockAIResponse(completionWithRetry, [`Classification: user management`]);
+      const response = await service.classifyQuestion('user management');
+      expect(response).toEqual(`Classification: user management`);
+      expect(completionWithRetry).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
Implement RAG lookup of AppMap help docs for the purpose of providing Help with AppMap via Navie.

* Add a `@help` agent mode.
* Activate help mode automatically when the user doesn't have AppMaps.
* Lookup help docs for the user's question, and feed them to the AI in order to get a help response that's based on the most up-to-date docs.
* Classify user questions so that we can tune the way that we apply agents and context.

Example of the question classifier:

```
[Question] How is the user's password validated?
Classification: Classification: Help with AppMap (Low)
Classification: Project architecture (Low)
Classification: Explaining code (High)
Classification: Generating code (Low)
```


```
[Question] Does AppMap work with PHP?
Classification: Classification: Help with AppMap (High)
Classification: Project architecture (Low)
Classification: Explaining code (Low)
Classification: Generating code (Low)
```
