### PR TITLE
Allow configuring LLM with environment variables

### DIFF
--- a/packages/navie/src/chat-openai.ts
+++ b/packages/navie/src/chat-openai.ts
@@ -1,8 +1,0 @@
-import { ChatOpenAI, OpenAIChatInput } from '@langchain/openai';
-
-export default function buildChatOpenAI(chatInput: Partial<OpenAIChatInput>): ChatOpenAI {
-  if (!process.env.OPENAI_API_KEY) throw new Error('OPENAI_API_KEY is not set');
-
-  chatInput.openAIApiKey = process.env.OPENAI_API_KEY;
-  return new ChatOpenAI(chatInput);
-}

--- a/packages/navie/src/explain.ts
+++ b/packages/navie/src/explain.ts
@@ -112,8 +112,8 @@ export interface ClientRequest {
 }
 
 export class ExplainOptions {
-  modelName = 'gpt-4-0125-preview';
-  tokenLimit = 8000;
+  modelName = process.env.APPMAP_NAVIE_MODEL ?? 'gpt-4-0125-preview';
+  tokenLimit = Number(process.env.APPMAP_NAVIE_TOKEN_LIMIT ?? 8000);
   temperature = 0.4;
   responseTokens = 1000;
 }

--- a/packages/navie/src/services/completion-service.ts
+++ b/packages/navie/src/services/completion-service.ts
@@ -1,4 +1,4 @@
-import buildChatOpenAI from '../chat-openai';
+import { ChatOpenAI } from '@langchain/openai';
 import InteractionHistory, { CompletionEvent } from '../interaction-history';
 
 export type Completion = AsyncIterable<string>;
@@ -17,7 +17,7 @@ export class OpenAICompletionService implements CompletionService {
   async *complete(): Completion {
     const { messages } = this.interactionHistory.buildState();
 
-    const chatAI = buildChatOpenAI({
+    const chatAI = new ChatOpenAI({
       modelName: this.modelName,
       temperature: this.temperature,
       streaming: true,

--- a/packages/navie/src/services/completion-service.ts
+++ b/packages/navie/src/services/completion-service.ts
@@ -1,10 +1,25 @@
 import { ChatOpenAI } from '@langchain/openai';
+
 import InteractionHistory, { CompletionEvent } from '../interaction-history';
+import type Message from '../message';
 
 export type Completion = AsyncIterable<string>;
 
 export default interface CompletionService {
   complete: () => Completion;
+}
+
+// Some LLMs only accept a single system message.
+// This functions merges all system messages into a single message
+// at the start of the list.
+function mergeSystemMessages(messages: Message[]): Message[] {
+  const systemMessages = messages.filter((message) => message.role === 'system');
+  const nonSystemMessages = messages.filter((message) => message.role !== 'system');
+  const mergedSystemMessage = {
+    role: 'system',
+    content: systemMessages.map((message) => message.content).join('\n'),
+  } as const;
+  return [mergedSystemMessage, ...nonSystemMessages];
 }
 
 export class OpenAICompletionService implements CompletionService {
@@ -26,7 +41,7 @@ export class OpenAICompletionService implements CompletionService {
     this.interactionHistory.addEvent(new CompletionEvent(this.modelName, this.temperature));
 
     const response = await chatAI.completionWithRetry({
-      messages,
+      messages: mergeSystemMessages(messages),
       model: this.modelName,
       stream: true,
     });

--- a/packages/navie/src/services/memory-service.ts
+++ b/packages/navie/src/services/memory-service.ts
@@ -1,7 +1,7 @@
 import { ConversationSummaryMemory } from 'langchain/memory';
 import { AIMessage, HumanMessage } from '@langchain/core/messages';
+import { ChatOpenAI } from '@langchain/openai';
 
-import buildChatOpenAI from '../chat-openai';
 import Message from '../message';
 import InteractionHistory, { PromptInteractionEvent } from '../interaction-history';
 
@@ -13,7 +13,7 @@ export default class MemoryService {
   ) {}
 
   async predictSummary(messages: Message[]) {
-    const predictAI = buildChatOpenAI({
+    const predictAI = new ChatOpenAI({
       modelName: this.modelName,
       temperature: this.temperature,
     });

--- a/packages/navie/src/services/vector-terms-service.ts
+++ b/packages/navie/src/services/vector-terms-service.ts
@@ -3,7 +3,6 @@ import OpenAI from 'openai';
 import { warn } from 'console';
 import { ChatOpenAI } from '@langchain/openai';
 
-import buildChatOpenAI from '../chat-openai';
 import InteractionHistory, { VectorTermsInteractionEvent } from '../interaction-history';
 
 const SYSTEM_PROMPT = `You are assisting a developer to search a code base.
@@ -33,7 +32,7 @@ export default class VectorTermsService {
   ) {}
 
   async suggestTerms(question: string): Promise<string[]> {
-    const openAI: ChatOpenAI = buildChatOpenAI({
+    const openAI: ChatOpenAI = new ChatOpenAI({
       modelName: this.modelName,
       temperature: this.temperature,
     });
@@ -52,7 +51,7 @@ export default class VectorTermsService {
     // eslint-disable-next-line no-await-in-loop
     const response = await openAI.completionWithRetry({
       messages,
-      model: 'gpt-4-0125-preview',
+      model: openAI.modelName,
       stream: true,
     });
     const tokens = Array<string>();

--- a/packages/navie/test/services/vector-terms-service.spec.ts
+++ b/packages/navie/test/services/vector-terms-service.spec.ts
@@ -1,30 +1,19 @@
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 
-import { ChatOpenAI, OpenAIChatInput } from '@langchain/openai';
-import assert from 'assert';
+import { ChatOpenAI } from '@langchain/openai';
 
 import VectorTermsService from '../../src/services/vector-terms-service';
-import buildChatOpenAI from '../../src/chat-openai';
 import InteractionHistory from '../../src/interaction-history';
 
-jest.mock('../../src/chat-openai');
+jest.mock('@langchain/openai');
+const completionWithRetry = jest.mocked(ChatOpenAI.prototype.completionWithRetry);
 
 describe('DefaultVectorTermsService', () => {
   let interactionHistory: InteractionHistory;
   let service: VectorTermsService;
-  let completionWithRetry: jest.Mock;
 
   beforeEach(() => {
-    completionWithRetry = jest.fn();
-    const predictAI = {
-      completionWithRetry,
-    } as unknown as ChatOpenAI;
-
-    jest.mocked(buildChatOpenAI).mockImplementation((params: Partial<OpenAIChatInput>) => {
-      assert(!params.streaming);
-      return predictAI;
-    });
     interactionHistory = new InteractionHistory();
     interactionHistory.on('event', (event) => console.log(event.message));
     service = new VectorTermsService(interactionHistory, 'gpt-4', 0.5);
@@ -47,7 +36,7 @@ describe('DefaultVectorTermsService', () => {
         model: 'gpt-3.5',
         object: 'chat.completion.chunk',
       },
-    ]);
+    ] as any);
   }
 
   describe('when LLM suggested terms', () => {


### PR DESCRIPTION
This change allows using `APPMAP_NAVIE_MODEL` and `APPMAP_NAVIE_TOKEN_LIMIT` environment variables along with `OPENAI_{API_KEY,BASE_URL}` and `AZURE_OPENAI_API_{KEY,VERSION,INSTANCE_NAME,DEPLOYMENT_NAME` used by `@langchain/openai` to configure target LLM for Navie.