### PR TITLE
feat: Update @appland/navie

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -84,11 +84,11 @@
     "vuex"
   ],
   "dependencies": {
-    "@appland/client": "workspace:^1.15.0",
-    "@appland/components": "workspace:^4.0.0",
+    "@appland/client": "workspace:^1.16.0",
+    "@appland/components": "workspace:^4.12.0",
     "@appland/diagrams": "workspace:^1.8.0",
-    "@appland/models": "workspace:^2.10.0",
-    "@appland/navie": "workspace:^1.2.0",
+    "@appland/models": "workspace:^2.10.1",
+    "@appland/navie": "workspace:^1.5.0",
     "@appland/openapi": "workspace:^1.8.0",
     "@appland/rpc": "workspace:^1.6.0",
     "@appland/scanner": "workspace:^1.86.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -139,11 +139,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@appland/appmap@workspace:packages/cli"
   dependencies:
-    "@appland/client": "workspace:^1.15.0"
-    "@appland/components": "workspace:^4.0.0"
+    "@appland/client": "workspace:^1.16.0"
+    "@appland/components": "workspace:^4.12.0"
     "@appland/diagrams": "workspace:^1.8.0"
-    "@appland/models": "workspace:^2.10.0"
-    "@appland/navie": "workspace:^1.2.0"
+    "@appland/models": "workspace:^2.10.1"
+    "@appland/navie": "workspace:^1.5.0"
     "@appland/openapi": "workspace:^1.8.0"
     "@appland/rpc": "workspace:^1.6.0"
     "@appland/scanner": "workspace:^1.86.0"
@@ -247,7 +247,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@appland/client@^1.12.0, @appland/client@workspace:^1.12.0, @appland/client@workspace:^1.15.0, @appland/client@workspace:packages/client":
+"@appland/client@^1.12.0, @appland/client@workspace:^1.12.0, @appland/client@workspace:^1.16.0, @appland/client@workspace:packages/client":
   version: 0.0.0-use.local
   resolution: "@appland/client@workspace:packages/client"
   dependencies:
@@ -284,7 +284,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@appland/components@workspace:^4.0.0, @appland/components@workspace:packages/components":
+"@appland/components@workspace:^4.12.0, @appland/components@workspace:packages/components":
   version: 0.0.0-use.local
   resolution: "@appland/components@workspace:packages/components"
   dependencies:
@@ -413,7 +413,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@appland/models@workspace:^2.10.0, @appland/models@workspace:packages/models":
+"@appland/models@workspace:^2.10.0, @appland/models@workspace:^2.10.1, @appland/models@workspace:packages/models":
   version: 0.0.0-use.local
   resolution: "@appland/models@workspace:packages/models"
   dependencies:
@@ -437,7 +437,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@appland/navie@workspace:^1.2.0, @appland/navie@workspace:packages/navie":
+"@appland/navie@workspace:^1.5.0, @appland/navie@workspace:packages/navie":
   version: 0.0.0-use.local
   resolution: "@appland/navie@workspace:packages/navie"
   dependencies:


### PR DESCRIPTION
Pick up the new RAG-based @help agent.

Though it looks like this may have happened automatically - https://github.com/getappmap/appmap-js/releases/tag/%40appland/appmap-v3.134.0