### PR TITLE
Only update search bar when it has text

### DIFF
--- a/packages/components/src/components/SearchBar.vue
+++ b/packages/components/src/components/SearchBar.vue
@@ -222,7 +222,7 @@ export default {
       return this.$refs.input === window?.document?.activeElement;
     },
     onWindowClick(event) {
-      if (!getEventTarget(event.target, this.$refs.form)) {
+      if (!getEventTarget(event.target, this.$refs.form) && this.searchValue) {
         if (this.$refs.input !== window.document.activeElement) this.showSuggestions = false;
 
         if (


### PR DESCRIPTION
I found this bug when doing something else. 

We're unnecessarily causing an update to our UI every time a user clicks outside of the search bar because we were adding a space (` `) to the search bar value, which is a data property, so it causes a re-render.