### PR TITLE
fix: Request context serially

### DIFF
--- a/packages/navie/src/agents/explain-agent.ts
+++ b/packages/navie/src/agents/explain-agent.ts
@@ -70,10 +70,8 @@ export default class ExplainAgent implements Agent {
     const tokenCount = tokensAvailable();
     const vectorTerms = await this.vectorTermsService.suggestTerms(options.aggregateQuestion);
 
-    const contextRequest = this.lookupContextService.lookupContext(vectorTerms, tokenCount);
-    const helpRequest = this.lookupContextService.lookupHelp(languages, vectorTerms, tokenCount);
-    const context = await contextRequest;
-    const help = await helpRequest;
+    const context = await this.lookupContextService.lookupContext(vectorTerms, tokenCount);
+    const help = await this.lookupContextService.lookupHelp(languages, vectorTerms, tokenCount);
 
     LookupContextService.applyContext(context, help, this.applyContextService, tokenCount);
   }


### PR DESCRIPTION
This fixes the server-side issue where one context response maps to both search and help retrievals. 