### PR TITLE
Include code editor in context

### DIFF
--- a/packages/cli/src/cmds/index/index.ts
+++ b/packages/cli/src/cmds/index/index.ts
@@ -152,7 +152,7 @@ export const handler = async (argv) => {
         appmapData(),
         metadata(),
         sequenceDiagram(),
-        explainHandler(navieProvider),
+        explainHandler(navieProvider, argv.codeEditor),
         explainStatusHandler(),
       ];
       const rpcServer = new RPCServer(port, rpcMethods);

--- a/packages/cli/src/cmds/index/rpc.ts
+++ b/packages/cli/src/cmds/index/rpc.ts
@@ -65,6 +65,12 @@ export const builder = (args: yargs.Argv) => {
     choices: Object.values(Agents).map((agent) => agent.toLowerCase()),
   });
 
+  args.option('code-editor', {
+    describe: 'Which code editor spawned the process',
+    type: 'string',
+    choices: ['vscode', 'jetbrains'],
+  });
+
   return args.strict();
 };
 
@@ -175,7 +181,7 @@ export const handler = async (argv) => {
     appmapData(),
     metadata(),
     sequenceDiagram(),
-    explainHandler(navieProvider),
+    explainHandler(navieProvider, argv.codeEditor),
     explainStatusHandler(),
     setConfigurationV1(),
     getConfigurationV1(),

--- a/packages/cli/src/cmds/navie/projectInfo.ts
+++ b/packages/cli/src/cmds/navie/projectInfo.ts
@@ -2,9 +2,22 @@ import { ProjectInfo } from '@appland/navie';
 import { collectStats } from '../../rpc/appmap/stats';
 import configuration from '../../rpc/configuration';
 
-export default async function collectProjectInfos(): Promise<ProjectInfo.ProjectInfo[]> {
-  const projectInfoByPath: Record<string, ProjectInfo.ProjectInfo> = {};
+export default async function collectProjectInfos(
+  codeEditor?: string
+): Promise<ProjectInfo.ProjectInfo[]> {
+  const projectInfoByPath = new Map<string, ProjectInfo.ProjectInfo>();
+
+  const projectInfo = (directory: string): ProjectInfo.ProjectInfo => {
+    const info = projectInfoByPath.get(directory);
+    if (info) return info;
+
+    const result = { directory };
+    projectInfoByPath.set(directory, result);
+    return result;
+  };
+
   const appmapDirectories = await configuration().appmapDirectories();
+
   const appmapStats = await collectStats(appmapDirectories);
   appmapStats.forEach((stats) => {
     const { directory } = stats;
@@ -13,11 +26,11 @@ export default async function collectProjectInfos(): Promise<ProjectInfo.Project
     delete (stats as Record<string, unknown>).classes;
     delete (stats as Record<string, unknown>).path;
 
-    projectInfoByPath[directory] = { appmapConfig: undefined, appmapStats: stats };
+    projectInfo(directory).appmapStats = stats;
   });
 
   appmapDirectories.forEach((dir) => {
-    projectInfoByPath[dir.directory].appmapConfig = {
+    projectInfo(dir.directory).appmapConfig = {
       name: dir.appmapConfig.name,
       language: dir.appmapConfig.language ?? 'unknown',
       appmap_dir: dir.appmapConfig.appmap_dir ?? 'tmp/appmap',
@@ -25,8 +38,11 @@ export default async function collectProjectInfos(): Promise<ProjectInfo.Project
     };
   });
 
-  // It's good when results are stable.
-  return Object.values(projectInfoByPath).sort((a, b) =>
-    (a.appmapConfig?.name || '').localeCompare(b.appmapConfig?.name || '')
-  );
+  const { projectDirectories } = configuration();
+  if (codeEditor) {
+    projectDirectories.forEach((dir) => {
+      projectInfo(dir).codeEditor = { name: codeEditor };
+    });
+  }
+  return [...projectInfoByPath.values()].sort((a, b) => a.directory.localeCompare(b.directory));
 }

--- a/packages/cli/src/lib/detectCodeEditor.ts
+++ b/packages/cli/src/lib/detectCodeEditor.ts
@@ -1,0 +1,15 @@
+export enum CodeEditor {
+  VSCode = 'vscode',
+  JetBrains = 'jetbrains',
+}
+
+export default function detectCodeEditor(): string | undefined {
+  const editor = process.env.APPMAP_CODE_EDITOR;
+  if (editor) return editor;
+
+  const termProgram = process.env.TERM_PROGRAM;
+  if (termProgram === 'vscode') return CodeEditor.VSCode;
+
+  const terminalEmulator = process.env.TERMINAL_EMULATOR;
+  if (terminalEmulator?.toLowerCase().includes('jetbrains')) return CodeEditor.JetBrains;
+}

--- a/packages/cli/src/rpc/explain/buildContext.ts
+++ b/packages/cli/src/rpc/explain/buildContext.ts
@@ -26,9 +26,9 @@ import { ContextV2 } from '@appland/navie';
 export default async function buildContext(
   searchResults: SearchRpc.SearchResult[]
 ): Promise<ContextV2.ContextResponse> {
-  const sequenceDiagrams = new Array<ContextV2.ContextItem>();
-  const codeSnippets = new Array<ContextV2.ContextItem>();
-  const dataRequests = new Array<ContextV2.ContextItem>();
+  const sequenceDiagrams = new Array<ContextV2.FileContextItem>();
+  const codeSnippets = new Array<ContextV2.FileContextItem>();
+  const dataRequests = new Array<ContextV2.FileContextItem>();
 
   const codeSnippetLocations = new Set<string>();
   const dataRequestContent = new Set<string>();
@@ -54,6 +54,7 @@ export default async function buildContext(
     });
     assert(typeof plantUML === 'string');
     sequenceDiagrams.push({
+      directory: result.directory,
       location: appmapLocation(result.appmap),
       type: ContextV2.ContextItemType.SequenceDiagram,
       content: plantUML,
@@ -74,6 +75,7 @@ export default async function buildContext(
         if (!dataRequestContent.has(event.fqid)) {
           dataRequestContent.add(event.fqid);
           dataRequests.push({
+            directory: result.directory,
             location: appmapLocation(result.appmap, event),
             type: ContextV2.ContextItemType.DataRequest,
             content: event.fqid,
@@ -94,6 +96,7 @@ export default async function buildContext(
       const snippets = await lookupSourceCode(result.directory, event.location);
       if (snippets) {
         codeSnippets.push({
+          directory: result.directory,
           type: ContextV2.ContextItemType.CodeSnippet,
           location: event.location,
           content: snippets.join('\n'),

--- a/packages/cli/src/rpc/explain/collectContext.ts
+++ b/packages/cli/src/rpc/explain/collectContext.ts
@@ -88,11 +88,11 @@ export class SourceCollector {
     );
 
     const buildLocation = (doc: SourceIndexMatch) => {
-      const filePath = join(doc.directory, doc.fileName);
-      return `${filePath}:${doc.from}-${doc.to}`;
+      return `${doc.fileName}:${doc.from}-${doc.to}`;
     };
 
     return sourceIndexDocuments.map((doc: SourceIndexMatch) => ({
+      directory: doc.directory,
       type: ContextV2.ContextItemType.CodeSnippet,
       content: doc.content,
       location: buildLocation(doc),

--- a/packages/cli/src/rpc/explain/explain.ts
+++ b/packages/cli/src/rpc/explain/explain.ts
@@ -38,7 +38,8 @@ export class Explain extends EventEmitter {
     public question: string,
     public codeSelection: string | undefined,
     public appmaps: string[] | undefined,
-    public status: ExplainRpc.ExplainStatusResponse
+    public status: ExplainRpc.ExplainStatusResponse,
+    public codeEditor: string | undefined
   ) {
     super();
   }
@@ -126,8 +127,8 @@ export class Explain extends EventEmitter {
     return searchResult.context;
   }
 
-  projectInfoContext(): Promise<ProjectInfo.ProjectInfoResponse> {
-    return collectProjectInfos();
+  async projectInfoContext(): Promise<ProjectInfo.ProjectInfoResponse> {
+    return await collectProjectInfos(this.codeEditor);
   }
 
   helpContext(data: Help.HelpRequest): Promise<Help.HelpResponse> {
@@ -140,7 +141,8 @@ async function explain(
   question: string,
   codeSelection: string | undefined,
   appmaps: string[] | undefined,
-  threadId: string | undefined
+  threadId: string | undefined,
+  codeEditor: string | undefined
 ): Promise<ExplainRpc.ExplainResponse> {
   const status: ExplainRpc.ExplainStatusResponse = {
     step: ExplainRpc.Step.NEW,
@@ -154,7 +156,8 @@ async function explain(
     question,
     codeSelection,
     appmaps,
-    status
+    status,
+    codeEditor
   );
 
   const invokeContextFunction = async (data: any) => {
@@ -223,9 +226,11 @@ async function explain(
 }
 
 const explainHandler: (
-  navieProvider: INavieProvider
+  navieProvider: INavieProvider,
+  codeEditor: string | undefined
 ) => RpcHandler<ExplainRpc.ExplainOptions, ExplainRpc.ExplainResponse> = (
-  navieProvider: INavieProvider
+  navieProvider: INavieProvider,
+  codeEditor: string | undefined
 ) => {
   return {
     name: ExplainRpc.ExplainFunctionName,
@@ -235,7 +240,8 @@ const explainHandler: (
         options.question,
         options.codeSelection,
         options.appmaps,
-        options.threadId
+        options.threadId,
+        codeEditor
       ),
   };
 };

--- a/packages/cli/src/rpc/explain/navie/navie-remote.ts
+++ b/packages/cli/src/rpc/explain/navie/navie-remote.ts
@@ -5,6 +5,7 @@ import { ContextV1, ContextV2, Help, ProjectInfo } from '@appland/navie';
 
 import { verbose } from '../../../utils';
 import { default as INavie } from './inavie';
+import assert from 'assert';
 
 export default class RemoteNavie extends EventEmitter implements INavie {
   constructor(
@@ -56,7 +57,10 @@ export default class RemoteNavie extends EventEmitter implements INavie {
                   codeSnippets: responseV2
                     .filter((item) => item.type === ContextV2.ContextItemType.CodeSnippet)
                     .reduce((acc, item) => {
-                      acc[item.location || ''] = item.content;
+                      assert(item.type === ContextV2.ContextItemType.CodeSnippet);
+                      if (ContextV2.isFileContextItem(item)) {
+                        acc[item.location] = item.content;
+                      }
                       return acc;
                     }, {} as Record<string, string>),
                   codeObjects: responseV2

--- a/packages/cli/tests/integration/buildRPC.ts
+++ b/packages/cli/tests/integration/buildRPC.ts
@@ -29,7 +29,10 @@ export type RPC = {
 // mocked as needed.
 //
 // Returns an RPC client that can be used to make requests to the server.
-export async function buildRPC(navieProvider: INavieProvider): Promise<RPC> {
+export async function buildRPC(
+  navieProvider: INavieProvider,
+  codeEditor?: string | undefined
+): Promise<RPC> {
   const fingerprintWatchCommand = {
     numProcessed: 0,
   } as FingerprintWatchCommand;
@@ -42,7 +45,7 @@ export async function buildRPC(navieProvider: INavieProvider): Promise<RPC> {
     appmapData(),
     metadata(),
     sequenceDiagram(),
-    explainHandler(navieProvider),
+    explainHandler(navieProvider, codeEditor),
     explainStatusHandler(),
     setConfigurationV1(),
     getConfigurationV1(),

--- a/packages/cli/tests/unit/rpc/explain/buildContext.spec.ts
+++ b/packages/cli/tests/unit/rpc/explain/buildContext.spec.ts
@@ -23,6 +23,7 @@ describe('buildContext', () => {
       ]);
       expect(context).toEqual([
         {
+          directory: 'a',
           location: 'appmap1.appmap.json',
           type: 'sequence-diagram',
           content: 'the diagram',
@@ -51,6 +52,7 @@ describe('buildContext', () => {
         context.filter((item) => item.type !== ContextV2.ContextItemType.SequenceDiagram)
       ).toEqual([
         {
+          directory: 'a',
           location: 'app/models/user.rb',
           type: 'code-snippet',
           score: 1,
@@ -74,6 +76,7 @@ describe('buildContext', () => {
         context.filter((item) => item.type !== ContextV2.ContextItemType.SequenceDiagram)
       ).toEqual([
         {
+          directory: 'a',
           location: 'appmap1.appmap.json:1',
           type: 'data-request',
           score: 1,

--- a/packages/navie/package.json
+++ b/packages/navie/package.json
@@ -43,6 +43,7 @@
   "dependencies": {
     "@langchain/core": "^0.1.32",
     "@langchain/openai": "^0.0.15",
+    "js-yaml": "^4.1.0",
     "langchain": "^0.1.25",
     "openai": "^4.28.0"
   }

--- a/packages/navie/src/agent.ts
+++ b/packages/navie/src/agent.ts
@@ -18,7 +18,7 @@ export class AgentOptions {
   ) {}
 
   get hasAppMaps() {
-    return this.projectInfo.some((info) => info.appmapStats.numAppMaps > 0);
+    return this.projectInfo.some((info) => info.appmapStats && info.appmapStats?.numAppMaps > 0);
   }
 }
 

--- a/packages/navie/src/context.ts
+++ b/packages/navie/src/context.ts
@@ -45,9 +45,6 @@ export namespace ContextV2 {
 
   // A specific context item that is returned in the response.
   export type ContextItem = {
-    // Identifies the location in the code base from which the context was obtained.
-    // For example, a file path with an optional line number or range in the format "path/to/file.rb:1-2".
-    location?: string;
     // The type of context item.
     type: ContextItemType;
     // The content of the context item. The content is specific to the type of context item.
@@ -56,6 +53,29 @@ export namespace ContextV2 {
     // only when the context item was obtained by searching for keywords (terms).
     score?: number;
   };
+
+  export type FileContextItem = ContextItem & {
+    type:
+      | ContextItemType.CodeSnippet
+      | ContextItemType.SequenceDiagram
+      | ContextItemType.DataRequest;
+    // The directory in which the context item is located.
+    directory: string;
+    // Identifies the location in the project directory from which the context was obtained.
+    // For example, a file path with an optional line number or range in the format "path/to/file.rb:1-2".
+    // In some cases, the AppMap agent may not be able to determine the location of the context item,
+    // so this field may be a best guess. In the code editor, perform a search for the file name to locate the file.
+    // This will always be a relative path from the indicated directory.
+    location: string;
+  };
+
+  export function isFileContextItem(contextItem: ContextItem): contextItem is FileContextItem {
+    return (
+      contextItem.type === ContextItemType.CodeSnippet ||
+      contextItem.type === ContextItemType.SequenceDiagram ||
+      contextItem.type === ContextItemType.DataRequest
+    );
+  }
 
   export enum ContextLabelName {
     HelpWithAppMap = 'help-with-appmap',

--- a/packages/navie/src/context.ts
+++ b/packages/navie/src/context.ts
@@ -116,7 +116,7 @@ export namespace ContextV2 {
     labels?: ContextLabel[];
   };
 
-  export type ContextResponse = ContextItem[];
+  export type ContextResponse = Array<ContextItem | FileContextItem>;
 
   export type ContextProvider = (
     request: ContextRequest & { version: 2; type: 'search' }

--- a/packages/navie/src/interaction-history.ts
+++ b/packages/navie/src/interaction-history.ts
@@ -165,7 +165,11 @@ export class HelpLookupEvent extends InteractionEvent {
 }
 
 export class ContextItemEvent extends InteractionEvent {
-  constructor(public promptType: PromptType, public content: string, public location?: string) {
+  constructor(
+    public promptType: PromptType,
+    public content: string,
+    public location?: string | undefined
+  ) {
     super('contextItem');
   }
 

--- a/packages/navie/src/interaction-history.ts
+++ b/packages/navie/src/interaction-history.ts
@@ -170,7 +170,7 @@ export class ContextItemEvent extends InteractionEvent {
   }
 
   get promptPrefix() {
-    return PROMPTS[this.promptType].prefix;
+    return PROMPTS[this.promptType].tagName;
   }
 
   get metadata() {

--- a/packages/navie/src/lib/apply-context.ts
+++ b/packages/navie/src/lib/apply-context.ts
@@ -66,7 +66,9 @@ export default function applyContext(
   const appliedContext = new Array<ContextV2.ContextItem>();
 
   const itemDescription = (contextItem: ContextV2.ContextItem): string =>
-    [contextItem.type, contextItem.location].filter(Boolean).join(' ');
+    [contextItem.type, ContextV2.isFileContextItem(contextItem) ? contextItem.location : undefined]
+       .filter(Boolean)
+      .join(' ');
 
   const addContextItem = (contextItem: ContextV2.ContextItem): ContextItemStatus => {
     // Don't consume too much of the character limit on a single item.

--- a/packages/navie/src/project-info.ts
+++ b/packages/navie/src/project-info.ts
@@ -14,9 +14,15 @@ export type AppMapStats = {
   numAppMaps: number;
 };
 
+export type CodeEditorInfo = {
+  name: string;
+};
+
 export type ProjectInfo = {
+  directory: string;
   appmapConfig?: AppMapConfig;
-  appmapStats: AppMapStats;
+  appmapStats?: AppMapStats;
+  codeEditor?: CodeEditorInfo;
 };
 
 export type ProjectInfoResponse = ProjectInfo | Array<ProjectInfo>;

--- a/packages/navie/src/prompt.ts
+++ b/packages/navie/src/prompt.ts
@@ -8,6 +8,7 @@ export enum PromptType {
   CodeSnippet = 'codeSnippets',
   DataRequest = 'dataRequest',
   HelpDoc = 'helpDoc',
+  CodeEditor = 'codeEditor',
 }
 
 const PROMPT_NAMES: Record<PromptType, { singular: string; plural: string }> = {
@@ -20,11 +21,12 @@ const PROMPT_NAMES: Record<PromptType, { singular: string; plural: string }> = {
   [PromptType.CodeSnippet]: { singular: 'code snippet', plural: 'code snippets' },
   [PromptType.DataRequest]: { singular: 'data request', plural: 'data requests' },
   [PromptType.HelpDoc]: { singular: 'help document', plural: 'help documents' },
+  [PromptType.CodeEditor]: { singular: 'code editor', plural: 'code editors' },
 };
 
 export type Prompt = {
   content: string;
-  prefix: string;
+  tagName: string;
   multiple?: boolean;
 };
 
@@ -33,7 +35,7 @@ export const PROMPTS: Record<PromptType, Prompt> = {
     content: `**The user's code selection**
 
 The user is asking about specific lines of code that they have selected in their code editor.`,
-    prefix: 'Code selection',
+    tagName: 'code-selection',
   },
   [PromptType.Question]: {
     content: `**The user's question**
@@ -47,7 +49,7 @@ well as you can from the context you have.
 Avoid recommending other diagram tools such as Lucidchart, Draw.io, PlantUML, or Mermaid,
 except as supplemental resources to AppMap.
 `,
-    prefix: 'Question',
+    tagName: 'question',
   },
   [PromptType.IssueDescription]: {
     content: `**The code generation task**
@@ -55,7 +57,7 @@ except as supplemental resources to AppMap.
 This is a description of a code enhancement that the user wants you to help them with. Your response should be
 focused primarily on solving this issue via code generation.
 `,
-    prefix: 'Question',
+    tagName: 'issue-description',
   },
   [PromptType.AppMapConfig]: {
     content: `**AppMap configuration**
@@ -72,7 +74,7 @@ of each element contain the configuration of the AppMap agent, including:
 
 Because the workspace already contains an \`appmap.yml\` file, you don't need to describe how to install the AppMap language
 library / agent. You may, however, advise the user on how to optimize this configuration for their specific needs.`,
-    prefix: 'AppMap configurations',
+    tagName: 'appmap-config',
   },
   [PromptType.AppMapStats]: {
     content: `**AppMap statistics**
@@ -86,7 +88,7 @@ each project:
 - **routes** - A list of HTTP routes.
 - **tables** - A list of database tables.
 - **numAppMaps** - The number of AppMaps that are available in the project.`,
-    prefix: 'AppMap statistics',
+    tagName: 'appmap-stats',
   },
   [PromptType.SequenceDiagram]: {
     content: `**Sequence diagrams**
@@ -95,7 +97,7 @@ You're provided with sequence diagrams that are relevant to the task.
 Each sequence diagram represents the actual flow of code that was recorded by the AppMap language library
 which is integrated into the project.
 `,
-    prefix: 'Sequence diagram',
+    tagName: 'sequence-diagram',
     multiple: true,
   },
   [PromptType.CodeSnippet]: {
@@ -108,7 +110,7 @@ Sequence diagrams, if available, provide more context about how each code snippe
 Each code snippet begins with the file name and line number where the code is located,
 followed by the code itself.
 `,
-    prefix: 'Code snippet',
+    tagName: 'code-snippet',
     multiple: true,
   },
   [PromptType.DataRequest]: {
@@ -119,7 +121,7 @@ is an outbound request to a database, API, or other data source that was made by
 Each data request was recorded by the AppMap language library which is integrated into the project.
 
 Sequence diagrams, if available, provide more context about how each data request is used in the overall program.`,
-    prefix: 'Data request',
+    tagName: 'data-request',
     multiple: true,
   },
   [PromptType.HelpDoc]: {
@@ -127,8 +129,14 @@ Sequence diagrams, if available, provide more context about how each data reques
 
 You're provided with relevant snippets of AppMap documentation. Each documentation snippet provides detailed
 information about installing, configuring, and using AppMap.`,
-    prefix: 'Help document',
+    tagName: 'help-doc',
     multiple: true,
+  },
+  [PromptType.CodeEditor]: {
+    content: `**Code editor**
+
+You're provided with information about the user's code editor. This information includes the code editor's name.`,
+    tagName: 'code-editor',
   },
 };
 
@@ -137,11 +145,11 @@ export function buildPromptDescriptor(promptType: PromptType): string {
   const content = [prompt.content];
   if (prompt.multiple) {
     content.push(
-      `Multiple ${PROMPT_NAMES[promptType].plural} of this type will be provided. Each one will be prefixed with "[${prompt.prefix}]"`
+      `Multiple ${PROMPT_NAMES[promptType].plural} of this type will be provided. Each one will be prefixed with "[${prompt.tagName}]"`
     );
   } else {
     content.push(
-      `The ${PROMPT_NAMES[promptType].singular} will be prefixed with "[${prompt.prefix}]"`
+      `The ${PROMPT_NAMES[promptType].singular} will be prefixed with "[${prompt.tagName}]"`
     );
   }
 
@@ -150,5 +158,5 @@ export function buildPromptDescriptor(promptType: PromptType): string {
 
 export function buildPromptValue(promptType: PromptType, value: string): string {
   const prompt = PROMPTS[promptType];
-  return `[${prompt.prefix}] ${value}`;
+  return [`<${prompt.tagName}>`, value, `</${prompt.tagName}>`].join('\n');
 }

--- a/packages/navie/src/services/apply-context-service.ts
+++ b/packages/navie/src/services/apply-context-service.ts
@@ -60,11 +60,17 @@ export default class ApplyContextService {
           break;
         default:
       }
-      if (promptType)
+      if (promptType) {
         this.interactionHistory.addEvent(
-          new ContextItemEvent(promptType, item.content, item.location)
+          new ContextItemEvent(
+            promptType,
+            item.content,
+            ContextV2.isFileContextItem(item) ? item.location : undefined
+          )
         );
-      else warn(`Unknown context item type: ${item.type} for content: ${item.content}`);
+      } else {
+        warn(`Unknown context item type: ${item.type} for content: ${item.content}`);
+      }
     }
 
     this.interactionHistory.log(`Remaining characters after context: ${charsRemaining}`);

--- a/packages/navie/test/agents/explain-agent.spec.ts
+++ b/packages/navie/test/agents/explain-agent.spec.ts
@@ -49,6 +49,7 @@ describe('@explain agent', () => {
       hasAppMaps: true,
       projectInfo: [
         {
+          directory: 'twitter',
           appmapConfig: { language: 'ruby' } as unknown as any,
           appmapStats: { numAppMaps: 1 } as unknown as any,
         },

--- a/packages/navie/test/agents/help-agent.spec.ts
+++ b/packages/navie/test/agents/help-agent.spec.ts
@@ -45,6 +45,7 @@ describe('HelpAgent', () => {
       [],
       [
         {
+          directory: 'twitter',
           appmapConfig: { language: 'ruby' } as unknown as AppMapConfig,
           appmapStats: { numAppMaps: 0 } as unknown as AppMapStats,
         },
@@ -107,6 +108,7 @@ describe('HelpAgent', () => {
       [],
       [
         {
+          directory: 'shopify',
           appmapConfig: { language: 'ruby' } as unknown as AppMapConfig,
           appmapStats: { numAppMaps: 10 } as unknown as AppMapStats,
         },

--- a/packages/navie/test/interaction-history.spec.ts
+++ b/packages/navie/test/interaction-history.spec.ts
@@ -54,7 +54,7 @@ describe('InteractionHistory', () => {
           );
           const state = interactionHistory.buildState();
           expect(state.messages).toEqual([
-            { content: '[Sequence diagram] diagram-1', role: 'user' },
+            { content: '[sequence-diagram] diagram-1', role: 'user' },
           ]);
         });
       });
@@ -66,7 +66,7 @@ describe('InteractionHistory', () => {
           );
           const state = interactionHistory.buildState();
           expect(state.messages).toEqual([
-            { content: '[Code snippet] file.py: code snippet content', role: 'user' },
+            { content: '[code-snippet] file.py: code snippet content', role: 'user' },
           ]);
         });
       });
@@ -76,7 +76,7 @@ describe('InteractionHistory', () => {
           interactionHistory.addEvent(new ContextItemEvent(PromptType.DataRequest, 'data request'));
           const state = interactionHistory.buildState();
           expect(state.messages).toEqual([
-            { content: '[Data request] data request', role: 'user' },
+            { content: '[data-request] data request', role: 'user' },
           ]);
         });
       });

--- a/packages/navie/test/interaction-history.spec.ts
+++ b/packages/navie/test/interaction-history.spec.ts
@@ -28,9 +28,9 @@ describe('InteractionHistory', () => {
             },
             {
               type: ContextV2.ContextItemType.CodeSnippet,
-              location: 'file.py',
               content: 'code snippet content',
-            },
+              location: 'file.py',
+            } as ContextV2.FileContextItem,
             {
               type: ContextV2.ContextItemType.DataRequest,
               content: 'data request',

--- a/packages/navie/test/services/agent-selection-service.spec.ts
+++ b/packages/navie/test/services/agent-selection-service.spec.ts
@@ -62,6 +62,7 @@ describe('AgentSelectionService', () => {
         new ExplainOptions(),
         [
           {
+            directory: 'appland',
             appmapConfig: { language: 'ruby' } as unknown as AppMapConfig,
             appmapStats: { numAppMaps: 0 } as unknown as AppMapStats,
           },
@@ -78,6 +79,7 @@ describe('AgentSelectionService', () => {
         new ExplainOptions(),
         [
           {
+            directory: 'stripe',
             appmapConfig: { language: 'ruby' } as unknown as AppMapConfig,
             appmapStats: { numAppMaps: 10 } as unknown as AppMapStats,
           },

--- a/packages/navie/test/services/apply-context-service.spec.ts
+++ b/packages/navie/test/services/apply-context-service.spec.ts
@@ -60,7 +60,6 @@ describe('ApplyContextService', () => {
         {
           content: `AppMap Java reference`,
           promptType: 'helpDoc',
-          location: 'appmap-java.md',
           type: 'contextItem',
         },
         {
@@ -222,7 +221,6 @@ describe('ApplyContextService', () => {
           {
             type: 'contextItem',
             promptType: 'helpDoc',
-            location: 'appmap-java.md',
           },
           {
             type: 'contextItem',

--- a/packages/navie/test/services/project-info-service.spec.ts
+++ b/packages/navie/test/services/project-info-service.spec.ts
@@ -1,0 +1,142 @@
+import ProjectInfoService from '../../src/services/project-info-service';
+import InteractionHistory from '../../src/interaction-history';
+import { ProjectInfo, ProjectInfoProvider } from '../../src/project-info';
+import { PromptType } from '../../src/prompt';
+import { jest } from '@jest/globals';
+
+describe('ProjectInfoService', () => {
+  let interactionHistory: InteractionHistory;
+  let projectInfoProviderFn: jest.Mock<ProjectInfoProvider>;
+  let service: ProjectInfoService;
+
+  beforeEach(() => {
+    interactionHistory = new InteractionHistory();
+    interactionHistory.on('event', (event) => console.log(event.message));
+    projectInfoProviderFn = jest.fn();
+
+    service = new ProjectInfoService(
+      interactionHistory,
+      projectInfoProviderFn as ProjectInfoProvider
+    );
+  });
+
+  afterEach(() => jest.resetAllMocks());
+
+  test('no project info found', async () => {
+    projectInfoProviderFn.mockResolvedValueOnce(undefined);
+    const result = await service.lookupProjectInfo();
+    expect(result).toEqual([]);
+    expect(interactionHistory.events).toEqual([]);
+  });
+
+  describe('project info obtained', () => {
+    test('all values missing', async () => {
+      const projectInfo = [
+        {
+          directory: '/some/path',
+        },
+      ];
+      projectInfoProviderFn.mockResolvedValueOnce(projectInfo);
+      const result = await service.lookupProjectInfo();
+      expect(result).toEqual(projectInfo);
+      expect(interactionHistory.events.map((event) => event.metadata)).toEqual([
+        {
+          name: 'appmapConfig',
+          role: 'user',
+          type: 'prompt',
+        },
+        {
+          name: 'appmapStats',
+          role: 'user',
+          type: 'prompt',
+        },
+        {
+          name: 'codeEditor',
+          role: 'user',
+          type: 'prompt',
+        },
+      ]);
+
+      expect(interactionHistory.buildState().messages).toEqual([
+        {
+          content: 'The project does not contain an AppMap config file (appmap.yml).',
+          role: 'user',
+        },
+        {
+          content: 'The project does not contain any AppMaps.',
+          role: 'user',
+        },
+        {
+          content: 'The code editor is not specified.',
+          role: 'user',
+        },
+      ]);
+    });
+
+    test('appmapConfig present', async () => {
+      const projectInfo = [
+        {
+          directory: '/some/path',
+          appmapConfig: {
+            name: 'appmap',
+            language: 'ruby',
+            appmap_dir: 'tmp/appmap',
+            packages: {},
+          },
+        },
+      ];
+      projectInfoProviderFn.mockResolvedValueOnce(projectInfo);
+      await service.lookupProjectInfo();
+      const messages = interactionHistory.buildState().messages;
+      expect(messages).toHaveLength(4);
+      const instructionPrompt = messages[0];
+      const valuePrompt = messages[1];
+      expect(instructionPrompt.content).toContain('**AppMap configuration**');
+      expect(valuePrompt.content).toContain('<appmap-config>');
+      expect(valuePrompt.content).toContain('name: appmap');
+    });
+
+    test('appmapStats present', async () => {
+      const projectInfo = [
+        {
+          directory: '/some/path',
+          appmapStats: {
+            packages: ['appmap'],
+            routes: ['GET /'],
+            tables: ['users'],
+            numAppMaps: 1,
+          },
+        },
+      ];
+      projectInfoProviderFn.mockResolvedValueOnce(projectInfo);
+      await service.lookupProjectInfo();
+      const messages = interactionHistory.buildState().messages;
+      expect(messages).toHaveLength(4);
+      const instructionPrompt = messages[1];
+      const valuePrompt = messages[2];
+      expect(instructionPrompt.content).toContain('**AppMap statistics**');
+      expect(valuePrompt.content).toContain('<appmap-stats>');
+      expect(valuePrompt.content).toContain('numAppMaps: 1');
+    });
+
+    test('codeEditor present', async () => {
+      const projectInfo = [
+        {
+          directory: '/some/path',
+          codeEditor: {
+            name: 'vscode',
+          },
+        },
+      ];
+      projectInfoProviderFn.mockResolvedValueOnce(projectInfo);
+      await service.lookupProjectInfo();
+      const messages = interactionHistory.buildState().messages;
+      expect(messages).toHaveLength(4);
+      const instructionPrompt = messages[2];
+      const valuePrompt = messages[3];
+      expect(instructionPrompt.content).toContain('**Code editor**');
+      expect(valuePrompt.content).toContain('<code-editor>');
+      expect(valuePrompt.content).toContain('name: vscode');
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -469,6 +469,7 @@ __metadata:
     eslint-plugin-promise: ^6.0.1
     eslint-plugin-unicorn: ^39.0.0
     jest: ^29.5.0
+    js-yaml: ^4.1.0
     langchain: ^0.1.25
     openai: ^4.28.0
     ts-jest: ^29.0.5


### PR DESCRIPTION
Fixes getappmap/board#318

The main reason for adding this is to help Navie provide IDE-specific @help.

This adds the `--code-editor` command-line option to the `rpc` command, which will propagate the code editor into the context sent to the LLM to help provide better answers. The code editor can also be detected from the environment, in some cases. Use of `--code-editor` is optional so the CLI will be backwards compatible, but we should change how we launch the rpc in VS Code and JetBrains after this change is released.

APPMAP_CODE_EDITOR can also be set in lieu of using the CLI option (which may not be available if the appmap executable is older). 

## Example

```
node ./built/cli.js rpc --port 0 --code-editor vscode
```

### User

@help generate OpenAPI definitions

### Assistant

To generate OpenAPI definitions in Visual Studio Code (VSCode), you'll need to follow a series of steps after ensuring you have AppMaps recorded for your project. Given your setup, you can generate OpenAPI definitions for your JavaScript projects (such as '@appland/navie') which have recorded AppMaps. Generating OpenAPI definitions from AppMaps is a powerful way to document your application's HTTP API by capturing the runtime behavior of your code.

Here’s how to do it in VSCode:

1. **Ensure You Have AppMaps Recorded**: From the [AppMap statistics](#) provided, it looks like the '@appland/navie' project has 50 AppMaps recorded. This is a good starting point to generate OpenAPI definitions as these AppMaps capture the HTTP API behavior of your application.

2. **Open VSCode Command Palette**: Press `Ctrl+Shift+P` (Windows/Linux) or `Cmd+Shift+P` (macOS) to open the command palette in Visual Studio Code.

3. **Generate OpenAPI Definitions**: Type `AppMap: Generate OpenAPI` into the command palette and then press `Enter`. This action instructs the AppMap extension to analyze the recorded AppMaps and generate an OpenAPI definition document based on the interactions captured within those AppMaps.

4. **Save the OpenAPI Document**: The extension will open a new file with your OpenAPI definition document. You should save this file locally. You can share it with your team or use it with 3rd-party API tools like Postman for further API interaction simulations or for documentation purposes.

5. **Commit the OpenAPI YAML File**: As part of best practices, consider committing the generated `openapi.yaml` file to your source control. This allows your documentation to stay up-to-date with your codebase, and makes it easier for code reviewers to understand API changes in pull requests.

For detailed instructions, refer to the visual guide included in the documentation: ![alt_text](/assets/img/openapi/openapi-1.webp "OpenAPI export to file").

**Helpful Tip**: Consistently updating your OpenAPI definitions by re-generating them after significant changes or additions to your AppMaps ensures your API documentation remains current. This process can be integrated into your CI/CD pipeline for automated updates.

By following these steps, you'll be leveraging AppMap’s capability to auto-generate accurate OpenAPI definitions from your application’s runtime data, simplifying and enhancing your API documentation workflow.
