### PR TITLE
Update @appland/navie to include code editor

### DIFF
--- a/packages/navie/src/project-info.ts
+++ b/packages/navie/src/project-info.ts
@@ -14,9 +14,14 @@ export type AppMapStats = {
   numAppMaps: number;
 };
 
+export type CodeEditorInfo = {
+  name: string;
+};
+
 export type ProjectInfo = {
   appmapConfig?: AppMapConfig;
   appmapStats: AppMapStats;
+  codeEditor?: CodeEditorInfo;
 };
 
 export type ProjectInfoResponse = ProjectInfo | Array<ProjectInfo>;

--- a/packages/navie/src/prompt.ts
+++ b/packages/navie/src/prompt.ts
@@ -8,6 +8,7 @@ export enum PromptType {
   CodeSnippet = 'codeSnippets',
   DataRequest = 'dataRequest',
   HelpDoc = 'helpDoc',
+  CodeEditor = 'codeEditor',
 }
 
 const PROMPT_NAMES: Record<PromptType, { singular: string; plural: string }> = {
@@ -20,6 +21,7 @@ const PROMPT_NAMES: Record<PromptType, { singular: string; plural: string }> = {
   [PromptType.CodeSnippet]: { singular: 'code snippet', plural: 'code snippets' },
   [PromptType.DataRequest]: { singular: 'data request', plural: 'data requests' },
   [PromptType.HelpDoc]: { singular: 'help document', plural: 'help documents' },
+  [PromptType.CodeEditor]: { singular: 'code editor', plural: 'code editors' },
 };
 
 export type Prompt = {
@@ -128,6 +130,12 @@ You're provided with relevant snippets of AppMap documentation. Each documentati
 information about installing, configuring, and using AppMap.`,
     prefix: 'Help document',
     multiple: true,
+  },
+  [PromptType.CodeEditor]: {
+    content: `**Code editor**
+
+You're provided with information about the user's code editor. This information includes the code editor's name.`,
+    prefix: 'Code editor',
   },
 };
 

--- a/packages/navie/src/services/project-info-service.ts
+++ b/packages/navie/src/services/project-info-service.ts
@@ -33,6 +33,12 @@ export default class ProjectInfoService {
         () => projectInfo.some(({ appmapStats }) => appmapStats.numAppMaps > 0),
         `The project does not contain any AppMaps.`,
       ],
+      [
+        PromptType.CodeEditor,
+        PromptType.CodeEditor,
+        () => projectInfo.some(({ codeEditor }) => Boolean(codeEditor)),
+        `The project does not contain any code editor information.`,
+      ],
     ];
     projectInfoKeys.forEach(([promptType, projectInfoKey, isPresent, missingInfoMessage]) => {
       if (!isPresent()) {
@@ -45,7 +51,7 @@ export default class ProjectInfoService {
       const promptValue = projectInfo.map((info) => {
         let value: Record<string, unknown> | undefined = info[projectInfoKey];
         const hasName = 'name' in info;
-        if (!hasName && info.appmapConfig?.name) {
+        if (!hasName && info.appmapConfig?.name && promptType !== PromptType.CodeEditor) {
           value = { ...value, name: info.appmapConfig.name };
         }
         return value;


### PR DESCRIPTION
This is part of [this PR](https://github.com/getappmap/appmap-js/pull/1706), but I want to release a new version of `@appland/navie` first, so that `@appland/cli` can bump it's dependencies using the new `@appland/navie` version.