### PR TITLE
Introduce dynamic prompt suggestions

### DIFF
--- a/packages/cli/src/cmds/index/rpc.ts
+++ b/packages/cli/src/cmds/index/rpc.ts
@@ -20,6 +20,7 @@ import { configureRpcDirectories } from '../../lib/handleWorkingDirectory';
 import { loadConfiguration } from '@appland/client';
 import { getConfigurationV1, setConfigurationV1 } from '../../rpc/configuration';
 import { Agents } from '@appland/navie';
+import promptSuggestionsV1 from '../../rpc/prompt';
 
 const AI_KEY_ENV_VARS = ['OPENAI_API_KEY', 'AZURE_OPENAI_API_KEY'];
 
@@ -175,6 +176,7 @@ export const handler = async (argv) => {
     explainStatusHandler(),
     setConfigurationV1(),
     getConfigurationV1(),
+    promptSuggestionsV1(),
   ];
   const rpcServer = new RPCServer(port, rpcMethods);
   rpcServer.start();

--- a/packages/cli/src/rpc/appmap/stats.ts
+++ b/packages/cli/src/rpc/appmap/stats.ts
@@ -5,7 +5,7 @@ import { readFile } from 'fs/promises';
 import configuration, { AppMapConfigWithDirectory } from '../configuration';
 import { join } from 'path';
 
-type Stats = {
+export type Stats = {
   name: string;
   directory: string;
   packages: string[];

--- a/packages/cli/src/rpc/prompt.ts
+++ b/packages/cli/src/rpc/prompt.ts
@@ -1,0 +1,95 @@
+import { PromptRpc } from '@appland/rpc';
+import { RpcHandler } from './rpc';
+import { collectStats, Stats } from './appmap/stats';
+
+export const fallbackPrompts = [
+  {
+    name: 'What is an AppMap recording?',
+    description: 'Learn about the key concepts powering Navie',
+    prompt: '@help What is an AppMap recording?',
+  },
+  {
+    name: 'How do I record my application?',
+    description: 'Learn about how build deeper understanding of your application',
+    prompt: '@help How do I record my application?',
+  },
+] as const;
+
+function scoreRoute(route: string): number {
+  let score = 0;
+  if (route.match(/^(PUT|POST|DELETE)/)) {
+    score += 1;
+  }
+  if (route.match(/\/api\//i)) {
+    score += 1;
+  }
+  return score;
+}
+
+function getPromptsFromStats(stats: ReadonlyArray<Stats>) {
+  const prompts: PromptRpc.V1.Suggestions.Response = [];
+  const hasAppMaps = stats?.some(({ numAppMaps }) => numAppMaps > 0);
+  if (hasAppMaps) {
+    // Pick the route with the best score
+    // Routes score higher if they're PUT/POST/DELETE or contain `/api/` in the path
+    const routes = stats
+      .flatMap(({ routes }) => routes || [])
+      .map((route) => [route, scoreRoute(route)] as [string, number])
+      .sort(([, a], [, b]) => b - a);
+    if (routes.length) {
+      // Pick a random route among the top scoring routes
+      const [, highestScore] = routes[0];
+      const topScoringRoutes = routes
+        .filter(([, score]) => score === highestScore)
+        .map(([route]) => route);
+      const route = topScoringRoutes[Math.floor(topScoringRoutes.length * Math.random())];
+      prompts.push({
+        name: `Explain ${route}`,
+        description: 'Navie can describe the behavior of a route in your application',
+        prompt: `Describe the overall flow of the route "${route}"`,
+      });
+    }
+
+    // Pick a random table
+    const tables: string[] = stats.flatMap(({ tables }) => tables || []);
+    const table: string | undefined = tables[Math.floor(tables.length * Math.random())];
+    if (table) {
+      prompts.push({
+        name: `Describe the ${table} table`,
+        description: 'Navie can describe the usage of a database table in your application',
+        prompt: `Describe the usage of the table "${table}"`,
+      });
+    }
+
+    // Pick a random class
+    const classes: string[] = stats.flatMap(({ classes }) => classes || []);
+    const chosenClass: string | undefined = classes[Math.floor(classes.length * Math.random())];
+    if (chosenClass && prompts.length < 2) {
+      prompts.push({
+        name: `Describe the ${chosenClass} class`,
+        description:
+          'Navie can describe the usage and architecture around classes in your application',
+        prompt: `Describe the behavior and usage of the class "${chosenClass}"`,
+      });
+    }
+  }
+
+  for (let i = 0; prompts.length < 2 && i < fallbackPrompts.length; i++) {
+    prompts.push(fallbackPrompts[i]);
+  }
+
+  return prompts;
+}
+
+export default function promptSuggestionsV1(): RpcHandler<
+  PromptRpc.V1.Suggestions.Params,
+  PromptRpc.V1.Suggestions.Response
+> {
+  return {
+    name: PromptRpc.V1.Suggestions.Method,
+    async handler() {
+      const stats = await collectStats();
+      return getPromptsFromStats(stats);
+    },
+  };
+}

--- a/packages/cli/tests/unit/rpc/prompt.spec.ts
+++ b/packages/cli/tests/unit/rpc/prompt.spec.ts
@@ -1,0 +1,139 @@
+import { join } from 'path';
+import type { Stats } from '../../../src/rpc/appmap/stats';
+import * as statsLib from '../../../src/rpc/appmap/stats';
+import promptSuggestionsV1, { fallbackPrompts } from '../../../src/rpc/prompt';
+
+describe('v1.prompt.suggestions', () => {
+  const { handler } = promptSuggestionsV1();
+
+  function withStats(stats: Partial<Stats> | Partial<Stats>[], randomValue = 0.123) {
+    beforeEach(() => {
+      const statsArray = Array.isArray(stats) ? stats : [stats];
+      jest.spyOn(Math, 'random').mockReturnValue(randomValue);
+      jest.spyOn(statsLib, 'collectStats').mockResolvedValue(
+        statsArray.map((stats, i) => ({
+          routes: [],
+          classes: [],
+          tables: [],
+          packages: [],
+          numAppMaps: 0,
+          name: `test-${i}`,
+          directory: join('/', 'test', i.toString()),
+          ...stats,
+        }))
+      );
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+  }
+
+  describe('when there are no AppMaps', () => {
+    withStats([]);
+
+    it('returns expected prompts', async () => {
+      const prompts = await handler(undefined);
+      expect(prompts).toEqual(fallbackPrompts);
+    });
+  });
+
+  describe('with a single route', () => {
+    withStats([{ routes: ['GET /api/users'], numAppMaps: 1 }]);
+
+    it('returns expected prompts', async () => {
+      const prompts = await handler(undefined);
+      expect(prompts).toEqual([
+        {
+          name: 'Explain GET /api/users',
+          description: expect.stringContaining('describe the behavior of a route'),
+          prompt: expect.stringContaining('Describe the overall flow of the route'),
+        },
+        fallbackPrompts[0],
+      ]);
+    });
+  });
+
+  describe('with many routes', () => {
+    withStats(
+      [
+        {
+          routes: [
+            'DELETE /api/users',
+            'PUT /api/users',
+            'GET /',
+            'GET /index.html',
+            'POST /login',
+            'DELETE /session',
+          ],
+          numAppMaps: 1,
+        },
+      ],
+      0.9999
+    );
+
+    it('choses a random high scoring route', async () => {
+      const prompts = await handler(undefined);
+      expect(prompts).toEqual([
+        {
+          name: 'Explain PUT /api/users',
+          description: expect.stringContaining('describe the behavior of a route'),
+          prompt: expect.stringContaining('Describe the overall flow of the route'),
+        },
+        fallbackPrompts[0],
+      ]);
+    });
+  });
+
+  describe('with a class and a table', () => {
+    withStats([
+      {
+        classes: ['User'],
+        tables: ['users'],
+        numAppMaps: 1,
+      },
+    ]);
+
+    it('returns expected prompts', async () => {
+      const prompts = await handler(undefined);
+      expect(prompts).toEqual([
+        {
+          name: 'Describe the users table',
+          description: expect.stringContaining('usage of a database table in your application'),
+          prompt: 'Describe the usage of the table "users"',
+        },
+        {
+          name: 'Describe the User class',
+          description: expect.stringContaining(
+            'describe the usage and architecture around classes'
+          ),
+          prompt: 'Describe the behavior and usage of the class "User"',
+        },
+      ]);
+    });
+  });
+
+  describe('with multiple tables', () => {
+    withStats(
+      [
+        {
+          tables: ['users', 'posts', 'comments', 'likes', 'tags', 'categories'],
+          numAppMaps: 1,
+        },
+      ],
+      0.8
+    );
+
+    it('returns expected (randomized) prompts', async () => {
+      const prompts = await handler(undefined);
+      expect(prompts).toEqual([
+        {
+          name: 'Describe the tags table',
+          description: expect.stringContaining('usage of a database table in your application'),
+          prompt: 'Describe the usage of the table "tags"',
+        },
+        fallbackPrompts[0],
+      ]);
+    });
+  });
+});

--- a/packages/components/src/components/chat/Chat.vue
+++ b/packages/components/src/components/chat/Chat.vue
@@ -167,13 +167,9 @@ export default {
       type: Array,
       required: false,
     },
-    disableSuggestions: {
-      type: Boolean,
-      default: false,
-    },
     suggestionSpeaker: {
       type: String,
-      default: 'system',
+      default: 'user',
       validator: (v: string) => ['system', 'user'].includes(v),
     },
     inputPlaceholder: {
@@ -195,7 +191,7 @@ export default {
   },
   computed: {
     suggestionsEnabled() {
-      return this.disableSuggestions !== true && !this.isChatting;
+      return this.suggestions && !this.isChatting;
     },
     isChatting(): boolean {
       return this.messages.length > 0;

--- a/packages/components/src/lib/AppMapRPC.ts
+++ b/packages/components/src/lib/AppMapRPC.ts
@@ -1,4 +1,4 @@
-import { AppMapRpc } from '@appland/rpc';
+import { AppMapRpc, PromptRpc } from '@appland/rpc';
 import { browserClient, reportError } from './RPC';
 
 import { EventEmitter } from 'events';
@@ -153,6 +153,20 @@ export default class AppMapRPC {
           if (err || error) return reportError(reject, err, error);
 
           resolve(result as string);
+        }
+      );
+    });
+  }
+
+  promptSuggestions(): Promise<PromptRpc.V1.Suggestions.Response> {
+    return new Promise((resolve, reject) => {
+      this.client.request(
+        PromptRpc.V1.Suggestions.Method,
+        {},
+        function (err: any, error: any, result: PromptRpc.V1.Suggestions.Response) {
+          if (err || error) return reportError(reject, err, error);
+
+          resolve(result);
         }
       );
     });

--- a/packages/components/src/pages/ChatSearch.vue
+++ b/packages/components/src/pages/ChatSearch.vue
@@ -15,6 +15,7 @@
         :question="question"
         @isChatting="setIsChatting"
         :input-placeholder="inputPlaceholder"
+        :suggestions="promptSuggestions"
       >
         <v-context-status v-if="showStatus" :appmap-stats="appmapStats" />
       </v-chat>
@@ -153,7 +154,6 @@ import VButton from '@/components/Button.vue';
 import AppMapRPC from '@/lib/AppMapRPC';
 import authenticatedClient from '@/components/mixins/authenticatedClient';
 import type { ITool, CodeSelection } from '@/components/chat/Chat.vue';
-
 import debounce from '@/lib/debounce';
 
 export default {
@@ -239,6 +239,7 @@ export default {
         }
       ),
       targetAppmap: this.targetAppmapData,
+      promptSuggestions: undefined,
     };
   },
   watch: {
@@ -477,6 +478,18 @@ export default {
     setIsChatting(isChatting: boolean) {
       this.isChatting = isChatting;
     },
+    async loadPromptSuggestions(): Promise<void> {
+      try {
+        const suggestions = await this.rpcClient().promptSuggestions();
+        this.promptSuggestions = suggestions.map(({ name, description, prompt }) => ({
+          title: name,
+          subTitle: description,
+          prompt,
+        }));
+      } catch (e) {
+        console.error('Error loading prompt suggestions', e);
+      }
+    },
   },
   async mounted() {
     if (this.$refs.vappmap && this.targetAppmap && this.targetAppmapFsPath) {
@@ -484,6 +497,7 @@ export default {
       await this.$refs.vappmap.loadData(this.targetAppmap);
     }
     this.loadAppMapStats();
+    this.loadPromptSuggestions();
   },
 };
 </script>

--- a/packages/rpc/src/index.ts
+++ b/packages/rpc/src/index.ts
@@ -10,3 +10,4 @@ export * from './search';
 export * from './appmap';
 export * from './explain';
 export * from './configuration';
+export * from './prompt';

--- a/packages/rpc/src/prompt.ts
+++ b/packages/rpc/src/prompt.ts
@@ -1,0 +1,15 @@
+export namespace PromptRpc {
+  export namespace V1 {
+    export namespace Suggestions {
+      export const Method = 'v1.prompt.suggestions';
+      export type Params = undefined;
+      export type Response = Array<PromptSuggestion>;
+    }
+  }
+
+  export type PromptSuggestion = {
+    name: string;
+    description: string;
+    prompt: string;
+  };
+}


### PR DESCRIPTION
This change introduces a new RPC method, `v1.prompt.suggestions`, which returns an array of prompt suggestions based off the current AppMap stats. It'll include questions about routes, tables or classes, if available. If nothing is available, or less than two prompts can be dynamically generated, it'll fall back to two static help prompts.

The frontend now calls this RPC method to populate prompt suggestions.

TODO
- [x] Automated tests
- [x] Dynamic prompts could use some tweaking and fine tuning