### PR TITLE
feat: Apply fixes and updates to the apply-context function.

### DIFF
--- a/packages/cli/tests/integration/rpc.explain.spec.ts
+++ b/packages/cli/tests/integration/rpc.explain.spec.ts
@@ -1,6 +1,6 @@
 import assert from 'assert';
 import { ExplainRpc } from '@appland/rpc';
-import { Help, explain } from '@appland/navie';
+import { Help, explain, applyContext } from '@appland/navie';
 import { AI } from '@appland/client';
 import { AIClient, AICallbacks, AIInputPromptOptions, AIUserInput } from '@appland/client';
 import { ContextV2, InteractionHistory, ProjectInfo } from '@appland/navie';
@@ -65,6 +65,9 @@ describe('RPC', () => {
         };
 
         jest.mocked(explain).mockReturnValue(explainImpl);
+        jest
+          .mocked(applyContext)
+          .mockImplementation((context: ContextV2.ContextResponse) => context);
 
         const explainOptions: ExplainRpc.ExplainOptions = {
           question,

--- a/packages/cli/tests/unit/rpc/explain/ContextCollector.spec.ts
+++ b/packages/cli/tests/unit/rpc/explain/ContextCollector.spec.ts
@@ -12,6 +12,7 @@ describe('ContextCollector', () => {
   let contextCollector: ContextCollector;
 
   beforeEach(() => {
+    jest.mocked(navie.applyContext).mockImplementation((context) => context);
     contextCollector = new ContextCollector(['a', 'b'], vectorTerms, charLimit);
   });
   afterEach(() => jest.restoreAllMocks());

--- a/packages/navie/src/context.ts
+++ b/packages/navie/src/context.ts
@@ -39,6 +39,8 @@ export namespace ContextV2 {
     // A data request that was made by the application. This could be a database query,
     // an HTTP client request, or any other type of data request.
     DataRequest = 'data-request',
+    // A help document that is relevant to the user's situation.
+    HelpDoc = 'help-doc',
   }
 
   // A specific context item that is returned in the response.

--- a/packages/navie/src/index.ts
+++ b/packages/navie/src/index.ts
@@ -1,4 +1,5 @@
 /* eslint-disable import/prefer-default-export */
+export { default as applyContext } from './lib/apply-context';
 export { default as Message } from './message';
 export { default as InteractionState } from './interaction-state';
 export { default as explain } from './explain';

--- a/packages/navie/src/lib/apply-context.ts
+++ b/packages/navie/src/lib/apply-context.ts
@@ -1,0 +1,149 @@
+import { log } from 'console';
+
+import { ContextV2 } from '../context';
+
+const VERBOSE = process.env.DEBUG === 'true';
+
+enum ContextItemStatus {
+  OK = 'ok',
+  SIMILAR_CONTENT = 'similar_content',
+  ITEM_UNDEFINED = 'item_undefined',
+  ITEM_TOO_BIG = 'item_too_big',
+}
+
+export const DEFAULT_SELECTION_FREQUENCY: Map<ContextV2.ContextItemType, number> = Object.entries({
+  [ContextV2.ContextItemType.SequenceDiagram]: 1,
+  [ContextV2.ContextItemType.CodeSnippet]: 5,
+  [ContextV2.ContextItemType.DataRequest]: 2,
+  [ContextV2.ContextItemType.HelpDoc]: 1,
+}).reduce((map, [key, value]) => {
+  map.set(key as ContextV2.ContextItemType, value);
+  return map;
+}, new Map<ContextV2.ContextItemType, number>());
+
+export default function applyContext(
+  context: ContextV2.ContextItem[],
+  characterLimit: number,
+  maxContentLength: number = characterLimit / 5,
+  selectionFrequency: Map<ContextV2.ContextItemType, number> = DEFAULT_SELECTION_FREQUENCY,
+  verbose = VERBOSE
+): ContextV2.ContextItem[] {
+  const itemTypeByIndex = Array<ContextV2.ContextItemType>();
+  for (const [itemType, frequency] of selectionFrequency) {
+    for (let i = 0; i < frequency; i += 1) {
+      itemTypeByIndex.push(itemType);
+    }
+  }
+
+  const availableContext: Array<ContextV2.ContextItem | undefined> = [...context];
+  const roundSize = itemTypeByIndex.length;
+
+  // Select items in a round-robin fashion, to ensure a mix of content types. Heuristically, we
+  // want to see one sequence diagram, N code snippets, and M data requests. If we run out of
+  // one type of content type, we'll continue adding the other types.
+  let index = 0;
+  const selectedContext = new Array<ContextV2.ContextItem>();
+  let availableItemCount = availableContext.length;
+  while (availableItemCount > 0) {
+    const itemType = index % roundSize;
+    index += 1;
+
+    let contextItem: ContextV2.ContextItem | undefined;
+    const itemIndex = availableContext.findIndex(
+      (item) => item?.type === itemTypeByIndex[itemType]
+    );
+    if (itemIndex !== -1) {
+      availableItemCount -= 1;
+      contextItem = availableContext[itemIndex];
+      availableContext[itemIndex] = undefined;
+    }
+
+    if (contextItem) selectedContext.push(contextItem);
+  }
+
+  let charsRemaining = characterLimit;
+  log(`Remaining characters before context: ${charsRemaining}`);
+  const appliedContext = new Array<ContextV2.ContextItem>();
+
+  const itemDescription = (contextItem: ContextV2.ContextItem): string =>
+    [contextItem.type, contextItem.location].filter(Boolean).join(' ');
+
+  const addContextItem = (contextItem: ContextV2.ContextItem): ContextItemStatus => {
+    // Don't consume too much of the character limit on a single item.
+    if (contextItem.content.length > maxContentLength) {
+      if (verbose) {
+        log(
+          `Skipping context item ${itemDescription(contextItem)} due to size. ${
+            contextItem.content.length
+          } > ${maxContentLength}`
+        );
+      }
+      return ContextItemStatus.ITEM_TOO_BIG;
+    }
+
+    if (
+      contextItem.type === ContextV2.ContextItemType.SequenceDiagram &&
+      appliedContext[appliedContext.length - 1]?.type === ContextV2.ContextItemType.SequenceDiagram
+    ) {
+      if (verbose)
+        log(
+          `Skipping context item ${itemDescription(
+            contextItem
+          )} because the previous context item is also a sequence diagram.`
+        );
+      return ContextItemStatus.SIMILAR_CONTENT;
+    }
+
+    if (verbose)
+      log(`Adding context item ${itemDescription(contextItem)} (${contextItem.content.length})`);
+
+    charsRemaining -= contextItem.content.length;
+    appliedContext.push(contextItem);
+
+    return ContextItemStatus.OK;
+  };
+
+  let hasSequenceDiagramBeenAdded = false;
+  const onlySequenceDiagramsRemaining = (i: number) =>
+    selectedContext
+      .slice(i)
+      .every((item) => item.type === ContextV2.ContextItemType.SequenceDiagram);
+
+  for (let i = 0; i < selectedContext.length; i += 1) {
+    const contextItem = selectedContext[i];
+    const status = addContextItem(contextItem);
+    if (
+      status === ContextItemStatus.OK &&
+      contextItem.type === ContextV2.ContextItemType.SequenceDiagram
+    ) {
+      hasSequenceDiagramBeenAdded = true;
+    }
+
+    if (verbose) log(`Context item ${itemDescription(contextItem)} status: ${status}`);
+
+    const contextItemsRemaining = selectedContext.length - i - 1;
+    if (
+      hasSequenceDiagramBeenAdded &&
+      contextItemsRemaining > 1 &&
+      onlySequenceDiagramsRemaining(i + 1)
+    ) {
+      log(
+        `Only sequence diagrams remain in the context, and at least one sequence diagram has already been added. No further context will be added.`
+      );
+      break;
+    }
+
+    if (charsRemaining <= 0) {
+      log(`Characterlimit reached.`);
+      break;
+    }
+  }
+
+  log(
+    `Added ${
+      characterLimit - charsRemaining
+    } characters out of a requested limit of ${characterLimit}.`
+  );
+
+  return appliedContext;
+}

--- a/packages/navie/src/services/apply-context-service.ts
+++ b/packages/navie/src/services/apply-context-service.ts
@@ -1,4 +1,4 @@
-import { error, log } from 'console';
+import { warn } from 'console';
 
 import { ContextV2 } from '../context';
 import InteractionHistory, {
@@ -6,9 +6,8 @@ import InteractionHistory, {
   PromptInteractionEvent,
 } from '../interaction-history';
 import { PromptType, buildPromptDescriptor } from '../prompt';
-import { HelpDoc, HelpResponse } from '../help';
-
-type ContextItemWithFile = { type: PromptType; content: string; file?: string };
+import { HelpResponse } from '../help';
+import applyContext from '../lib/apply-context';
 
 export default class ApplyContextService {
   constructor(public readonly interactionHistory: InteractionHistory) {}
@@ -16,7 +15,8 @@ export default class ApplyContextService {
   applyContext(
     context: ContextV2.ContextResponse | undefined,
     help: HelpResponse,
-    characterLimit: number
+    characterLimit: number,
+    maxContentLength: number = characterLimit / 5
   ) {
     if (!context) {
       this.interactionHistory.addEvent(
@@ -29,121 +29,42 @@ export default class ApplyContextService {
       return;
     }
 
-    const sequenceDiagrams = context.filter(
-      (item) => item.type === ContextV2.ContextItemType.SequenceDiagram
-    );
-    const codeSnippets = context.filter(
-      (item) => item.type === ContextV2.ContextItemType.CodeSnippet
-    );
-    const dataRequests = context.filter(
-      (item) => item.type === ContextV2.ContextItemType.DataRequest
-    );
+    const contextItems = [
+      ...context,
+      ...help.map((item) => ({
+        type: ContextV2.ContextItemType.HelpDoc,
+        content: item.content,
+        score: item.score,
+        location: item.filePath,
+      })),
+    ];
 
-    const availableContent = new Array<ContextItemWithFile | undefined>();
-    const availableDiagrams = [...sequenceDiagrams];
-    const availableCodeSnippets = [...codeSnippets];
-    const availableDataRequests = [...dataRequests];
-    const availableHelp = [...help];
+    const appliedContextItems = applyContext(contextItems, characterLimit, maxContentLength);
+    const charsApplied = appliedContextItems.reduce((acc, item) => acc + item.content.length, 0);
+    const charsRemaining = characterLimit - charsApplied;
 
-    const availableItemCount = () =>
-      [
-        availableDiagrams.length,
-        availableCodeSnippets.length,
-        availableDataRequests.length,
-        availableHelp.length,
-      ].reduce((a, b) => a + b, 0);
-
-    // Select items in a round-robin fashion, to ensure a mix of content types. Heuristically, we
-    // want to see one sequence diagram, N code snippets, and M data requests. If we run out of
-    // one type of content type, we'll continue adding the other types.
-    const numDiagrams = 1;
-    const numSnippets = 7;
-    const numDataRequests = 2;
-    const numHelp = 1;
-    const roundSize = numDiagrams + numSnippets + numDataRequests + numHelp;
-    let index = 0;
-    while (availableItemCount() > 0) {
-      const itemType = index % roundSize;
-      index += 1;
-
-      let item: ContextV2.ContextItem | undefined;
-      let helpItem: HelpDoc | undefined;
-
-      const selectDiagram = () => {
-        item = availableDiagrams.shift();
-      };
-
-      const selectCodeSnippet = () => {
-        item = availableCodeSnippets.shift();
-      };
-
-      const selectDataRequest = () => {
-        item = availableDataRequests.shift();
-      };
-
-      const selectHelp = () => {
-        helpItem = availableHelp.shift();
-      };
-
-      if (itemType === 0) {
-        selectDiagram();
-      } else if (itemType >= numDiagrams && itemType < numDiagrams + numSnippets) {
-        selectCodeSnippet();
-      } else if (
-        itemType >= numDiagrams + numSnippets &&
-        itemType < numDiagrams + numSnippets + numDataRequests
-      ) {
-        selectDataRequest();
-      } else {
-        selectHelp();
+    for (const item of appliedContextItems) {
+      let promptType: PromptType | undefined;
+      switch (item.type) {
+        case ContextV2.ContextItemType.SequenceDiagram:
+          promptType = PromptType.SequenceDiagram;
+          break;
+        case ContextV2.ContextItemType.CodeSnippet:
+          promptType = PromptType.CodeSnippet;
+          break;
+        case ContextV2.ContextItemType.DataRequest:
+          promptType = PromptType.DataRequest;
+          break;
+        case ContextV2.ContextItemType.HelpDoc:
+          promptType = PromptType.HelpDoc;
+          break;
+        default:
       }
-
-      if (item) {
-        let promptType: PromptType | undefined;
-        // eslint-disable-next-line default-case
-        switch (item.type) {
-          case ContextV2.ContextItemType.SequenceDiagram:
-            promptType = PromptType.SequenceDiagram;
-            break;
-          case ContextV2.ContextItemType.CodeSnippet:
-            promptType = PromptType.CodeSnippet;
-            break;
-          case ContextV2.ContextItemType.DataRequest:
-            promptType = PromptType.DataRequest;
-            break;
-        }
-        if (promptType)
-          availableContent.push({ type: promptType, content: item.content, file: item.location });
-      } else if (helpItem) {
-        availableContent.push({
-          type: PromptType.HelpDoc,
-          content: helpItem.content,
-          file: helpItem.filePath,
-        });
-      }
-    }
-
-    let charsRemaining = characterLimit;
-    log(`Remaining characters before context: ${charsRemaining}`);
-
-    const addContextItem = (contextItem: ContextItemWithFile | undefined): boolean => {
-      if (!contextItem) return false;
-
-      // TODO: If the first content item is bigger than charsRemaining, no context can be added.
-      // This can happen if the "micro" AppMap is still too big.
-      if (charsRemaining - contextItem.content.length < 0) return false;
-
-      charsRemaining -= contextItem.content.length;
-      this.interactionHistory.addEvent(
-        new ContextItemEvent(contextItem.type, contextItem.content, contextItem.file)
-      );
-      return true;
-    };
-
-    // The sequence diagram may be too big to fit; in that case, continue with code snippets.
-    addContextItem(availableContent.shift());
-    for (const contextItem of availableContent) {
-      if (!addContextItem(contextItem)) break;
+      if (promptType)
+        this.interactionHistory.addEvent(
+          new ContextItemEvent(promptType, item.content, item.location)
+        );
+      else warn(`Unknown context item type: ${item.type} for content: ${item.content}`);
     }
 
     this.interactionHistory.log(`Remaining characters after context: ${charsRemaining}`);

--- a/packages/navie/test/services/apply-context-service.spec.ts
+++ b/packages/navie/test/services/apply-context-service.spec.ts
@@ -20,8 +20,8 @@ describe('ApplyContextService', () => {
     });
     afterEach(() => jest.resetAllMocks());
 
-    const collect = (characterLimit: number) =>
-      applyContextService.applyContext(context, help, characterLimit);
+    const collect = (characterLimit: number, maxContentLength = characterLimit / 5) =>
+      applyContextService.applyContext(context, help, characterLimit, maxContentLength);
 
     it('collects samples of context into the output', () => {
       collect(1000 * 1000);
@@ -72,7 +72,7 @@ describe('ApplyContextService', () => {
     });
 
     it('limits the output to the character limit', () => {
-      collect(75);
+      collect(10, 50);
       expect(
         interactionHistory.events.map((e) => ({
           ...e.metadata,


### PR DESCRIPTION
Apply the context items to the Navie context within the context request. 

This allows the context provider to prioritize among all the context that's available, rather than just sending it all back to Navie to be applied. By being smarter in this way, the context provider can make better decisions about which different types of context to include, when to go deeper on a particular type of context, when to drop very large context items that won't fit into the requested context window (or will take up most of the room and leave little room for other context).

## Examples

Here are some examples to try and make the benefits clear.

### Diagram that dominates the context

 Suppose Navie asks the context provider for 12,000 characters of context (a typical amount). The context provider finds an 8,000 character sequence diagram and many more characters of code snippets, SQL, etc. In the existing implementation, the sequence diagram and 4,000 of other context will be sent to Navie, whereupon it will be sent to the AI. This is not a good solution, because the context is dominated by one large sequence diagram. In this new branch, individual context items are not allowed to dominate the context like that.

### Not enough variety (too many diagrams)

In this scenario, the context provider finds 10 sequence diagrams that are all very similar (maybe they are request recordings of different invocations of the same route). Then it looks for code snippets from those diagrams, and finds, say 4,000 characters of code snippets. So the context provider will now return 8,000 characters of very similar sequence diagrams over and over, plus 4,000 of code snippets. This is not a great context. In the new implementation, the context provider will not "fill out" the context with a bunch of sequence diagrams once it runs out of code snippets and data requests. Instead, it will dig deeper to find more code snippets and data requests that are maybe not as high of a match score, but still add more useful context and variety than a bunch of very similar sequence diagrams.

### Not enough variety (future)

In a coming PR, the context provider will be able to locate code snippets through full-text search; not just via AppMap events. So if AppMaps don't yield a lot of great code snippets, the context provider can broaden the search to go find snippets via full-text search. For example, it will start to pull in frontend files, styles, snippets of test cases and READMEs, whatever matches the user's query. These kind of snippets are not good if they are all that's available to the AI, but they are good for rounding out the context. 

## Recap

The context provider gets a lot more authority over which context is actually sent to the AI, out of all the context that is found via searching (both searching AppMaps and via full-text search of the code repo). 




