### PR TITLE
De-emphasize "No AppMaps" status in Navie

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -10,7 +10,7 @@
     "build": "tsc",
     "watch": "tsc --watch",
     "lint": "eslint",
-    "test": "appmap-agent-js"
+    "test": "appmap-node jest"
   },
   "publishConfig": {
     "access": "public"
@@ -26,13 +26,13 @@
     "socket.io-client": "^4.7.2"
   },
   "devDependencies": {
-    "@appland/appmap-agent-js": "^13.9.0",
     "@types/jest": "^29.4.1",
     "@types/js-yaml": "^4.0.5",
     "@types/nock": "^11.1.0",
     "@types/node": "^17.0.2",
     "@typescript-eslint/eslint-plugin": "^5.51.0",
     "@typescript-eslint/parser": "^5.7.0",
+    "appmap-node": "^2.19.3",
     "eslint": "^8.4.1",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-config-airbnb-typescript": "^17.0.0",

--- a/packages/components/src/assets/info-circle.svg
+++ b/packages/components/src/assets/info-circle.svg
@@ -1,0 +1,7 @@
+<!--
+  Font Awesome Free 5.2.0 by @fontawesome - https://fontawesome.com
+  License - https://fontawesome.com/license (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License)
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <path d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"/>
+</svg>

--- a/packages/components/src/components/chat-search/ContextStatus.vue
+++ b/packages/components/src/components/chat-search/ContextStatus.vue
@@ -2,7 +2,7 @@
   <v-status-bar v-if="numAppMaps" level="success">
     <template v-slot:header>
       <div class="context__header">
-        {{ numAppMaps }} AppMap{{ numAppMaps === 1 ? '' : 's' }} available
+        {{ numAppMaps }} AppMap recording{{ numAppMaps === 1 ? '' : 's' }} available
       </div>
     </template>
     <template v-slot:body>
@@ -23,9 +23,9 @@
     </template>
   </v-status-bar>
 
-  <v-status-bar v-else level="error">
+  <v-status-bar v-else level="info">
     <template v-slot:header>
-      <div class="context__header">No AppMaps available</div>
+      <div class="context__header">No AppMap data available</div>
     </template>
     <template v-slot:body>
       <div class="context__sub-header">

--- a/packages/components/src/components/chat-search/StatusBar.vue
+++ b/packages/components/src/components/chat-search/StatusBar.vue
@@ -4,6 +4,7 @@
       <span class="status-bar__header__title">
         <v-warning-icon class="warning-icon" v-if="level === 'warning' || level === 'error'" />
         <v-success-icon class="success-icon" v-if="level === 'success'" />
+        <v-info-icon class="info-icon" v-if="level === 'info'" />
         <slot name="header" />
       </span>
       <v-chevron-down-icon :class="['toggle-icon', showBody ? 'up' : 'down']" />
@@ -19,6 +20,7 @@ import Vue, { PropType } from 'vue';
 import VChevronDownIcon from '@/assets/fa-solid_chevron-down.svg';
 import VWarningIcon from '@/assets/exclamation-circle.svg';
 import VSuccessIcon from '@/assets/success-checkmark.svg';
+import VInfoIcon from '@/assets/info-circle.svg';
 
 export default Vue.extend({
   name: 'v-status-bar',
@@ -27,6 +29,7 @@ export default Vue.extend({
     VChevronDownIcon,
     VWarningIcon,
     VSuccessIcon,
+    VInfoIcon,
   },
 
   data() {
@@ -37,9 +40,9 @@ export default Vue.extend({
 
   props: {
     level: {
-      type: String as PropType<'success' | 'warning' | 'error'>,
+      type: String as PropType<'info' | 'success' | 'warning' | 'error'>,
       default: 'success',
-      validator: (value: string) => ['success', 'warning', 'error'].includes(value),
+      validator: (value: string) => ['info', 'success', 'warning', 'error'].includes(value),
     },
   },
 
@@ -77,7 +80,8 @@ $fg: #ececec;
       gap: 0.5rem;
 
       .warning-icon,
-      .success-icon {
+      .success-icon,
+      .info-icon {
         fill: $fg;
         width: 20px;
 
@@ -124,7 +128,8 @@ $fg: #ececec;
     }
   }
 
-  &--success {
+  &--success,
+  &--info {
     background-color: rgba(128, 128, 255, 0.1);
   }
 

--- a/packages/components/src/pages/ChatSearch.vue
+++ b/packages/components/src/pages/ChatSearch.vue
@@ -303,7 +303,7 @@ export default {
   },
   computed: {
     showStatus() {
-      return !this.targetAppmap && this.appmapStats && (!this.hasAppMaps || !this.isChatting);
+      return !this.targetAppmap && this.appmapStats && !this.isChatting;
     },
     targetAppmapName() {
       return this.targetAppmap?.metadata?.name;

--- a/packages/components/tests/e2e/specs/chat/chatSearch.spec.js
+++ b/packages/components/tests/e2e/specs/chat/chatSearch.spec.js
@@ -98,11 +98,10 @@ context('Chat search', () => {
       cy.viewport(1280, 720);
     });
 
-    it('shows the context status when AppMaps are not available and the user is chatting', () => {
+    it('does not show the context status when AppMaps are not available and the user is chatting', () => {
       cy.get('[data-cy="status-bar"]').should('be.visible');
       cy.get('[data-cy="chat-input"]', { timeout: 25000 }).type('Hello world{enter}');
-      cy.get('.button-panel').should('be.visible');
-      cy.get('[data-cy="status-bar"]').should('be.visible');
+      cy.get('[data-cy="status-bar"]').should('not.exist');
     });
   });
 });

--- a/packages/models/package.json
+++ b/packages/models/package.json
@@ -13,7 +13,7 @@
     "lint": "eslint 'src/**/*.[jt]s' 'tests/**/*.[jt]s'",
     "lint:fix": "eslint 'src/**/*.[jt]s' 'tests/**/*.[jt]s' --fix",
     "pre-commit": "lint-staged",
-    "test": "appmap-agent-js",
+    "test": "appmap-node jest",
     "watch": "tsup --watch"
   },
   "lint-staged": {
@@ -29,10 +29,10 @@
   "author": "",
   "license": "Commons Clause + MIT",
   "devDependencies": {
-    "@appland/appmap-agent-js": "^13.9.0",
     "@types/crypto-js": "^4.1.1",
     "@typescript-eslint/eslint-plugin": "^5.43.0",
     "@typescript-eslint/parser": "^5.43.0",
+    "appmap-node": "^2.19.3",
     "eslint": "^7.25.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-import": "^2.22.1",

--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -9,17 +9,17 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "test": "appmap-agent-js",
+    "test": "appmap-node jest",
     "build": "tsc -p tsconfig.build.json",
     "watch": "tsc -p tsconfig.build.json --watch",
     "lint": "eslint src"
   },
   "devDependencies": {
-    "@appland/appmap-agent-js": "^13.9.0",
     "@types/jest": "^29.4.1",
     "@types/js-yaml": "^4.0.5",
     "@typescript-eslint/eslint-plugin": "^5.7.0",
     "@typescript-eslint/parser": "^5.7.0",
+    "appmap-node": "^2.19.3",
     "eslint": "^8.4.1",
     "jest": "^29.5.0",
     "openapi-types": "^12.1.0",

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "license": "MIT",
   "scripts": {
-    "test": "appmap-agent-js",
+    "test": "appmap-node jest",
     "lint": "eslint telemetry.ts",
     "pre-commit": "lint-staged"
   },
@@ -17,10 +17,10 @@
     "read-pkg-up": "^7.0.1"
   },
   "devDependencies": {
-    "@appland/appmap-agent-js": "^13.9.0",
     "@types/jest": "^29.4.1",
     "@typescript-eslint/eslint-plugin": "^5.7.0",
     "@typescript-eslint/parser": "^5.7.0",
+    "appmap-node": "^2.19.3",
     "eslint": "^8.4.1",
     "eslint-config-prettier": "^8.3.0",
     "jest": "^29.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -251,7 +251,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@appland/client@workspace:packages/client"
   dependencies:
-    "@appland/appmap-agent-js": ^13.9.0
     "@appland/models": "workspace:^2.10.0"
     "@types/form-data": ^2.5.0
     "@types/jest": ^29.4.1
@@ -260,6 +259,7 @@ __metadata:
     "@types/node": ^17.0.2
     "@typescript-eslint/eslint-plugin": ^5.51.0
     "@typescript-eslint/parser": ^5.7.0
+    appmap-node: ^2.19.3
     eslint: ^8.4.1
     eslint-config-airbnb-base: ^15.0.0
     eslint-config-airbnb-typescript: ^17.0.0
@@ -417,11 +417,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@appland/models@workspace:packages/models"
   dependencies:
-    "@appland/appmap-agent-js": ^13.9.0
     "@appland/sql-parser": ^1.5.0
     "@types/crypto-js": ^4.1.1
     "@typescript-eslint/eslint-plugin": ^5.43.0
     "@typescript-eslint/parser": ^5.43.0
+    appmap-node: ^2.19.3
     crypto-js: ^4.0.0
     eslint: ^7.25.0
     eslint-config-prettier: ^8.3.0
@@ -472,12 +472,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@appland/openapi@workspace:packages/openapi"
   dependencies:
-    "@appland/appmap-agent-js": ^13.9.0
     "@appland/models": "workspace:^2.10.0"
     "@types/jest": ^29.4.1
     "@types/js-yaml": ^4.0.5
     "@typescript-eslint/eslint-plugin": ^5.7.0
     "@typescript-eslint/parser": ^5.7.0
+    appmap-node: ^2.19.3
     eslint: ^8.4.1
     jest: ^29.5.0
     js-yaml: ^4.1.0
@@ -606,11 +606,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@appland/telemetry@workspace:packages/telemetry"
   dependencies:
-    "@appland/appmap-agent-js": ^13.9.0
     "@types/jest": ^29.4.1
     "@typescript-eslint/eslint-plugin": ^5.7.0
     "@typescript-eslint/parser": ^5.7.0
     applicationinsights: ^2.1.4
+    appmap-node: ^2.19.3
     conf: <11
     eslint: ^8.4.1
     eslint-config-prettier: ^8.3.0
@@ -14160,6 +14160,23 @@ __metadata:
   bin:
     appmap-node: bin/appmap-node.js
   checksum: 897f5ea6fb840731588003c85e2c91092ffb6c6068e6b19d2e7f2ebd5a5f1ebecf0d9cc7cb1bb13320d68db9726e5b8a8cda0c4a7ebd1c5813adaf42090b62b2
+  languageName: node
+  linkType: hard
+
+"appmap-node@npm:^2.19.3":
+  version: 2.19.3
+  resolution: "appmap-node@npm:2.19.3"
+  dependencies:
+    acorn-walk: ^8.2.0
+    astring: ^1.8.6
+    chalk: <5
+    json5: ^2.2.3
+    meriyah: ^4.3.7
+    source-map-js: ^1.0.2
+    yaml: ^2.3.4
+  bin:
+    appmap-node: bin/appmap-node.js
+  checksum: ffb964654004f859ab082d826ffb831725bf8b1e32c7f18f62692a3077e1b938b9568e63cea29db3940f5c1b953db14b822742dc7db17f0c9893c463fa3a26b2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
* Changes the "No AppMaps" status bar from red to blue to de-emphasize it. 
* Changes the warning/error exclamation point icon to an info icon.
* Makes it so that the "No AppMaps" status bar does not stay on the page while the user is chatting.
* Changed `No AppMaps available` to `No AppMap data available`.
* Changed `33 AppMaps available` to `33 AppMap recordings available` (where 33 is an example number).

## Before

![image](https://github.com/getappmap/appmap-js/assets/45714532/279d3cc2-6c65-40fa-a18a-ae37fbcca0c8)

## After

![image](https://github.com/getappmap/appmap-js/assets/45714532/aefc309c-53c0-4e1b-be47-af9c9d326002)