### PR TITLE
feat: Define v2.configuration.get+set

### DIFF
--- a/packages/rpc/src/configuration.ts
+++ b/packages/rpc/src/configuration.ts
@@ -16,4 +16,22 @@ export namespace ConfigurationRpc {
       };
     }
   }
+
+  export namespace V2 {
+    export namespace Set {
+      export const Method = 'v2.configuration.set';
+      export type Params = V1.Set.Params & {
+        projectDirectories: string[];
+      };
+      export type Response = void;
+    }
+
+    export namespace Get {
+      export const Method = 'v2.configuration.get';
+      export type Params = undefined;
+      export type Response = V1.Get.Response & {
+        projectDirectories: string[];
+      };
+    }
+  }
 }


### PR DESCRIPTION
Define the types used by Configuration V2 so that client code (e.g. IDE plugins) can be developed against these types.
