### PR TITLE
feat: Consider labels when providing the context

### DIFF
--- a/packages/cli/src/rpc/configuration.ts
+++ b/packages/cli/src/rpc/configuration.ts
@@ -22,7 +22,7 @@ export class Configuration {
   }
 
   static async buildFromRpcParams(params: ConfigurationRpc.V2.Set.Params): Promise<Configuration> {
-    return new Configuration(params.projectDirectories, params.appmapConfigFiles);
+    return new Configuration(params.projectDirectories || [], params.appmapConfigFiles || []);
   }
 }
 

--- a/packages/navie/src/agent.ts
+++ b/packages/navie/src/agent.ts
@@ -1,3 +1,4 @@
+import { ContextV2 } from './context';
 import { ProjectInfo } from './project-info';
 
 export enum AgentMode {
@@ -12,7 +13,8 @@ export class AgentOptions {
     public aggregateQuestion: string,
     public chatHistory: string[],
     public projectInfo: ProjectInfo[],
-    public codeSelection?: string
+    public codeSelection?: string,
+    public contextLabels?: ContextV2.ContextLabel[]
   ) {}
 
   get hasAppMaps() {

--- a/packages/navie/src/agents/explain-agent.ts
+++ b/packages/navie/src/agents/explain-agent.ts
@@ -38,11 +38,32 @@ Do NOT emit a "Considerations" section in your response, describing the importan
 engineering concepts. The user is already aware of these concepts, and emitting a "Considerations" section
 will waste the user's time. The user wants direct answers to their questions.
 
+**Making AppMap data**
+
+You may encourage the user to make AppMap data if the context that you receive seems incomplete, and
+you believe that you could provide a better answer if you had access to sequence diagrams,
+HTTP server and client requests, exceptions, log messages, and database queries.
+
+Observe the following guidelines when encouraging the user to make AppMap data:
+
+1) For Node.js, recommend the user to run \`npx appmap-node <command>\` to generate AppMap data.
+  Do not recommend appmap-agent-js, as this Node.js library is deprecated.
+2) For Ruby, do not instruct the user to set \`APPMAP=true\`, because
+  these languages already generate AppMap data automatically based on the Rails environment.
+3) Do not instruct the user to install the NPM package or CLI binary package \`@appland/appmap\` for the purpose of
+  making AppMap data, beacuse this package is not needed for that purpose.
+
 **Teach the user about the @help prefix**
 
-If it seems like the user might be asking about how to use AppMap, rather than about the contents of their AppMaps,
-you should teach the user about the "@help" prefix. You can inform the user that they can begin their question with
-the "@help" prefix to get help with using AppMap. 
+If it seems like the user is probably asking about how to record AppMap data for their project,
+you should teach the user about the "@help" prefix. You can inform the user that they can begin
+their question with the "@help" prefix to get help with using AppMap.
+
+**Teach the user about the @generate prefix**
+
+If it seems like the user is probably asking about how to generate code for their project,
+you should teach the user about the "@generate" prefix. You can inform the user that they can begin
+their question with the "@generate" prefix to get an answer that is directed towards code generation.
 `;
 
 export default class ExplainAgent implements Agent {

--- a/packages/navie/src/agents/explain-agent.ts
+++ b/packages/navie/src/agents/explain-agent.ts
@@ -70,7 +70,11 @@ export default class ExplainAgent implements Agent {
     const tokenCount = tokensAvailable();
     const vectorTerms = await this.vectorTermsService.suggestTerms(options.aggregateQuestion);
 
-    const context = await this.lookupContextService.lookupContext(vectorTerms, tokenCount);
+    const context = await this.lookupContextService.lookupContext(
+      vectorTerms,
+      tokenCount,
+      options.contextLabels
+    );
     const help = await this.lookupContextService.lookupHelp(languages, vectorTerms, tokenCount);
 
     LookupContextService.applyContext(context, help, this.applyContextService, tokenCount);

--- a/packages/navie/src/agents/generate-agent.ts
+++ b/packages/navie/src/agents/generate-agent.ts
@@ -22,16 +22,17 @@ You do not need to explain the importance of programming concepts like planning 
 
 **Response Format**
 
-Your solution must be provided as a series of code files and/or patches that implement the desired functionality within the project 
+Your solution must be provided as a series of code files and snippets that implement the desired functionality within the project 
 code. Do not propose wrapping the project with other code, running the project in a different environment, wrapping the project with
 shell commands, or other workarounds. Your solution must be suitable for use as a pull request to the project.
 
-* Your response should be provided as series of code files and/or patches that implement the desired functionality.
+* Your response should be provided as series of code files and/or snippets that implement the desired functionality.
 * You should emit code that is designed to solve the problem described by the user.
-* To modify existing code, emit a patch that can be applied to the existing codebase.
-* To create new code, emit a new file that can be added to the existing codebase.
+* To modify existing code, emit a code snippet that augments or replaces code in an existing file.
+  Tell the user which file they need to modify.
+* To create new code, emit a new file that can be added to the existing codebase. Tell the user where to add the new file.
 * At the beginning of every patch file or code file you emit, you must print the path to the code file within the workspace.
-
+* Limit the amount of text explanation you emit to the minimum necessary. The user is primarily interested in the code itself.
 `;
 export class GenerateAgent implements Agent {
   constructor(

--- a/packages/navie/src/agents/help-agent.ts
+++ b/packages/navie/src/agents/help-agent.ts
@@ -58,6 +58,11 @@ When helping the user make AppMaps for JavaScript, Node.js and/or TypeScript, yo
 use "appmap-node", which is the new AppMap agent for JavaScript, Node.js and TypeScript. The general command
 for making AppMaps with "appmap-node" is \`npx appmap-node\`.
 
+Do not recommend appmap-agent-js, as this Node.js library is deprecated.
+
+Do not instruct the user to install the NPM package or CLI binary package \`@appland/appmap\` for the purpose of
+making AppMap data, beacuse this package is not needed for that purpose.
+
 Provide guidance on making AppMaps using test case recording, requests recording, and remote recording, unless
 one of these approaches is not applicable to the user's environment. 
 

--- a/packages/navie/src/context.ts
+++ b/packages/navie/src/context.ts
@@ -57,6 +57,29 @@ export namespace ContextV2 {
     score?: number;
   };
 
+  export enum ContextLabelName {
+    HelpWithAppMap = 'help-with-appmap',
+    Architecture = 'architecture',
+    Feature = 'feature',
+    Overview = 'overview',
+    Troubleshoot = 'troubleshoot',
+    Explain = 'explain',
+    Generate = 'generate',
+  }
+
+  export enum ContextLabelWeight {
+    // The label is very relevant to the request.
+    High = 'high',
+    // The label is somewhat relevant to the request.
+    Medium = 'medium',
+  }
+
+  // A label that describes the nature of the user's request.
+  export type ContextLabel = {
+    name: ContextLabelName | string;
+    weight: ContextLabelWeight | string;
+  };
+
   // Request a set of context items from the context provider.
   export type ContextRequest = ContextV1.ContextRequest & {
     // Boost recent context items. For example, if the user is asking about an event that has recently occurred, such
@@ -69,11 +92,8 @@ export namespace ContextV2 {
     locations?: string[];
     // When specified, only return context items of these types.
     itemTypes?: ContextItemType[];
-    // Weight the importance of the context items. The sum of the weights should be 1.
-    // Item types not specified will be omitted from the response, along with item types whose weight is 0 or less.
-    // If the user's question is directed most specifically to a certain type of context item, the weights should be
-    // set to emphasize that type of context item. If the user's question is more general, the weights can be omitted.
-    weights?: Record<ContextItemType, number>;
+    // Emphasize context items that are relevant to the classification of the user's request.
+    labels?: ContextLabel[];
   };
 
   export type ContextResponse = ContextItem[];

--- a/packages/navie/src/services/agent-selection-service.ts
+++ b/packages/navie/src/services/agent-selection-service.ts
@@ -32,7 +32,7 @@ export default class AgentSelectionService {
   selectAgent(
     question: string,
     options: ExplainOptions,
-    projectInfo: ProjectInfo[]
+    _projectInfo: ProjectInfo[]
   ): AgentModeResult {
     let modifiedQuestion = question;
 

--- a/packages/navie/src/services/classification-service.ts
+++ b/packages/navie/src/services/classification-service.ts
@@ -1,6 +1,7 @@
 import { ChatOpenAI } from '@langchain/openai';
 import OpenAI from 'openai';
 import InteractionHistory from '../interaction-history';
+import { ContextV2 } from '../context';
 
 const SYSTEM_PROMPT = `**Question classifier**
 
@@ -9,51 +10,80 @@ There are several types of questions that the developer may be asking.
 
 Your task is to assign a likelihood to each of the following question types:
 
-- **Help with AppMap**: The developer is asking for help using the AppMap product.
-- **Project architecture**: The developer is asking about the high level architecture of their project.
-- **Explaining code**: The developer is asking for an explanation of how a specific feature of their project works.
-- **Generating code**: The developer is asking for code to be generated for a specific task.
+- **help-with-appmap**: The developer is asking for help using the AppMap product.
+- **architecture**: The developer is asking about the architecture of the project.
+- **feature**: The developer is asking for an explanation of how a specific feature of the project works.
+- **overview**: The developer is asking a high-level question about the structure, purpose,
+  functionality or intent of the project.
+- **troubleshoot**: The developer is asking for help troubleshooting an issue.
+- **explain**: The developer is asking for an explanation of a specific piece of code or functionality.
+- **generate**: The developer is asking for code to be generated for a specific task.
 
 **Classification scores**
 
 Each question type is assigned one of the following likelihoods:
 
-- **High**: The question is very likely to be of this type.
-- **Medium**: The question is somewhat likely to be of this type.
-- **Low**: The question is unlikely to be of this type.
+- **high**: The question is very likely to be of this type.
+- **medium**: The question is somewhat likely to be of this type.
+- **low**: The question is unlikely to be of this type.
 
 **Response**
 
-Respond with a list of question types and their likelihoods. The question types should be one of the following: 'Help with AppMap', 
-'Project architecture', 'Explaining code', 'Generating code'. The likelihoods should be one of the following: 'High', 'Medium', 'Low'.
+Respond with the likelihood of each question type. Question types with "low" likelihood may
+be omitted.
 
-**Example**
+**Examples**
 
 Some examples of questions and their classifications are:
 
 \`\`\`
-Question: How do I install?
-Classification: Help with AppMap (High)
-Classification: Project architecture (Low)
-Classification: Explaining code (Low)
-Classification: Generating code (Low)
+question: How do I record AppMap data of my Spring app?
+classification:
+  - help-with-appmap: high
+  - architecture: low
+  - feature: low
+  - overview: low
+  - troubleshoot: low
+  - explain: low
+  - generate: low
 \`\`\`
 
 \`\`\`
-Question: How does the project work?
-Classification: Help with AppMap (Low)
-Classification: Project architecture (High)
-Classification: Explaining code (Low)
-Classification: Generating code (Low)
+question: How does the project work?
+classification:
+  - help-with-appmap: low
+  - architecture: high
+  - feature: low
+  - overview: high
+  - troubleshoot: low
+  - explain: low
+  - generate: low
 \`\`\`
 
 \`\`\`
-Question: Generate a new user
-Classification: Help with AppMap (Low)
-Classification: Project architecture (Low)
-Classification: Explaining code (Low)
-Classification: Generating code (High)
+question: Generate a form and controller to update the user profile
+classification:
+  - help-with-appmap: low
+  - architecture: medium
+  - feature: high
+  - overview: low
+  - explain: low
+  - generate: high
 \`\`\`
+
+\`\`\`
+question: Why am I getting a 500 error?
+classification:
+  - help-with-appmap: low
+  - architecture: low
+  - feature: low
+  - overview: low
+  - troubleshoot: high
+  - explain: medium
+  - generate: low
+\`\`\`
+
+
 `;
 
 export default class ClassificationService {
@@ -63,7 +93,7 @@ export default class ClassificationService {
     public temperature: number
   ) {}
 
-  async classifyQuestion(question: string): Promise<string> {
+  async classifyQuestion(question: string): Promise<ContextV2.ContextLabel[]> {
     const openAI: ChatOpenAI = new ChatOpenAI({
       modelName: this.modelName,
       temperature: this.temperature,
@@ -92,6 +122,22 @@ export default class ClassificationService {
       tokens.push(token.choices.map((choice) => choice.delta.content).join(''));
     }
     const rawTerms = tokens.join('');
-    return rawTerms;
+
+    const lines = rawTerms.split('\n');
+    const classification: (ContextV2.ContextLabel | null)[] = lines
+      .map((line) => {
+        if (!line.trim()) return null;
+
+        const match = line.match(/([\w-]+)\s*:\s*(\w+)/);
+        if (!match) return null;
+
+        return {
+          name: match[1],
+          weight: match[2],
+        };
+      })
+      .filter((item) => item);
+
+    return classification as ContextV2.ContextLabel[];
   }
 }

--- a/packages/navie/src/services/lookup-context-service.ts
+++ b/packages/navie/src/services/lookup-context-service.ts
@@ -14,13 +14,18 @@ export default class LookupContextService {
     public readonly helpFn: (data: HelpRequest) => Promise<HelpResponse>
   ) {}
 
-  async lookupContext(keywords: string[], tokenCount: number): Promise<ContextV2.ContextResponse> {
+  async lookupContext(
+    keywords: string[],
+    tokenCount: number,
+    contextLabels?: ContextV2.ContextLabel[]
+  ): Promise<ContextV2.ContextResponse> {
     const contextRequestPayload: ContextV2.ContextRequest & { version: 2; type: 'search' } = {
       version: 2,
       type: 'search',
       vectorTerms: keywords,
       tokenCount,
     };
+    if (contextLabels) contextRequestPayload.labels = contextLabels;
 
     const context = await this.contextFn(contextRequestPayload);
 
@@ -28,7 +33,7 @@ export default class LookupContextService {
     if (contextFound) {
       this.interactionHistory.addEvent(new ContextLookupEvent(context));
     } else {
-      log('No sequence diagrams found');
+      log('No context found');
       this.interactionHistory.addEvent(new ContextLookupEvent(undefined));
     }
 

--- a/packages/navie/test/agents/explain-agent.spec.ts
+++ b/packages/navie/test/agents/explain-agent.spec.ts
@@ -81,7 +81,8 @@ describe('@explain agent', () => {
 
       expect(lookupContextService.lookupContext).toHaveBeenCalledWith(
         ['user', 'management'],
-        tokensAvailable
+        tokensAvailable,
+        undefined
       );
       expect(lookupContextService.lookupHelp).toHaveBeenCalledWith(
         ['ruby'],

--- a/packages/navie/test/explain.spec.ts
+++ b/packages/navie/test/explain.spec.ts
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import { Agent, AgentMode, AgentOptions } from '../src/agent';
+import { Agent, AgentMode } from '../src/agent';
 import { ChatHistory, ClientRequest, CodeExplainerService, ExplainOptions } from '../src/explain';
 import InteractionHistory from '../src/interaction-history';
 import Message from '../src/message';
@@ -110,7 +110,7 @@ describe('CodeExplainerService', () => {
       complete: () => TOKEN_STREAM,
     };
     classificationService = {
-      classifyQuestion: jest.fn().mockResolvedValue(undefined),
+      classifyQuestion: jest.fn().mockResolvedValue([]),
     } as unknown as ClassificationService;
     codeSelection = undefined;
     codeSelectionService = new CodeSelectionService(interactionHistory);
@@ -140,6 +140,7 @@ describe('CodeExplainerService', () => {
           aggregateQuestion: userMessage1,
           chatHistory: [],
           codeSelection: undefined,
+          contextLabels: [],
           projectInfo: [
             {
               appmapConfig: APPMAP_CONFIG,
@@ -189,6 +190,7 @@ describe('CodeExplainerService', () => {
           aggregateQuestion: [userMessage1, userMessage2].join('\n\n'),
           chatHistory: [userMessage1, assistantMessage1],
           codeSelection: undefined,
+          contextLabels: [],
           projectInfo: [
             {
               appmapConfig: APPMAP_CONFIG,

--- a/packages/navie/test/services/classification-service.spec.ts
+++ b/packages/navie/test/services/classification-service.spec.ts
@@ -20,9 +20,23 @@ describe('ClassificationService', () => {
 
   describe('when LLM responds', () => {
     it('returns the response', async () => {
-      mockAIResponse(completionWithRetry, [`Classification: user management`]);
+      const classification = `
+architecture: high
+- troubleshooting: low
+`;
+
+      mockAIResponse(completionWithRetry, [classification]);
       const response = await service.classifyQuestion('user management');
-      expect(response).toEqual(`Classification: user management`);
+      expect(response).toEqual([
+        {
+          name: 'architecture',
+          weight: 'high',
+        },
+        {
+          name: 'troubleshooting',
+          weight: 'low',
+        },
+      ]);
       expect(completionWithRetry).toHaveBeenCalledTimes(1);
     });
   });

--- a/packages/navie/test/services/vector-terms-service.spec.ts
+++ b/packages/navie/test/services/vector-terms-service.spec.ts
@@ -52,6 +52,7 @@ describe('VectorTermsService', () => {
         expect(completionWithRetry).toHaveBeenCalledTimes(1);
       });
     });
+
     describe('are a valid JSON list', () => {
       it('should return the terms', async () => {
         mockAIResponse(completionWithRetry, ['["user", "management"]']);
@@ -59,6 +60,7 @@ describe('VectorTermsService', () => {
         expect(terms).toEqual(['user', 'management']);
       });
     });
+
     describe('are valid JSON wrapped in fences', () => {
       it('should return the terms', async () => {
         mockAIResponse(completionWithRetry, ['```json', '["user", "management"]', '```']);
@@ -67,7 +69,24 @@ describe('VectorTermsService', () => {
       });
     });
 
-    describe('are invalid JSON', () => {
+    describe('is YAML', () => {
+      it('parses the terms', async () => {
+        mockAIResponse(completionWithRetry, ['response_key:', '  - user', '  - management']);
+        const terms = await service.suggestTerms('user management');
+        expect(terms).toEqual(['response', 'key', 'user', 'management']);
+      });
+    });
+
+    describe('is prefixed by "Terms:"', () => {
+      it('is accepted and processed', async () => {
+        mockAIResponse(completionWithRetry, ['Terms: ["user", "management"]']);
+        const terms = await service.suggestTerms('user management');
+        expect(terms).toEqual(['user', 'management']);
+        expect(completionWithRetry).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('is list-ish ', () => {
       it('is accepted and processed', async () => {
         mockAIResponse(completionWithRetry, ['-user -mgmt']);
         const terms = await service.suggestTerms('user management');

--- a/packages/rpc/src/explain.ts
+++ b/packages/rpc/src/explain.ts
@@ -44,11 +44,17 @@ export namespace ExplainRpc {
     score?: number;
   };
 
+  export type ContextLabel = {
+    name: string;
+    weight: string;
+  };
+
   export type ExplainStatusResponse = {
     step: Step;
     threadId?: string;
     err?: Error | RpcError;
     vectorTerms?: string[];
+    labels?: ContextLabel[];
     searchResponse?: SearchRpc.SearchResponse;
     contextResponse?: ContextItem[];
     explanation?: string[];


### PR DESCRIPTION
When providing the explain context, consider the labels that have been applied to the question by the AI classifier.

Initially, the behavior is this:

```typescript
    if (
      labels.find((label) => label.name === 'architecture') ||
      labels.find((label) => label.name === 'overview')
    ) {
      keywords.push('architecture');
      keywords.push('design');
      keywords.push('readme');
      keywords.push('about');
      keywords.push('overview');
      for (const dir of this.projectDirectories) {
        keywords.push(basename(dir));
      }
    }
```

This is an effort to focus on high-level documentation and content that contains the name of the project itself.

In my ad-hoc testing, the classifier has done a good job of applying the "architecture" and "overview" labels. We should reflect these labels back to the user in the context view also (RHS of the Navie UI).