### PR TITLE
Lint TypeScript in packages/cli

### DIFF
--- a/packages/cli/.eslintrc.cjs
+++ b/packages/cli/.eslintrc.cjs
@@ -51,7 +51,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['**/__tests__/*.{j,t}s?(x)', '**/tests/unit/**/*.spec.{j,t}s?(x)'],
+      files: ['**/__tests__/*.{j,t}s?(x)', '**/tests/**/*.spec.{j,t}s?(x)'],
       env: {
         jest: true,
       },

--- a/packages/cli/.eslintrc.cjs
+++ b/packages/cli/.eslintrc.cjs
@@ -1,37 +1,62 @@
+const FIXME = [
+  '@typescript-eslint/no-unsafe-member-access',
+  '@typescript-eslint/no-unsafe-call',
+  '@typescript-eslint/no-unsafe-assignment',
+  '@typescript-eslint/no-unsafe-return',
+  '@typescript-eslint/no-unsafe-argument',
+  '@typescript-eslint/no-explicit-any',
+  '@typescript-eslint/no-unused-vars',
+  '@typescript-eslint/require-await',
+  '@typescript-eslint/no-var-requires',
+  '@typescript-eslint/prefer-nullish-coalescing',
+  '@typescript-eslint/no-misused-promises',
+  '@typescript-eslint/restrict-template-expressions',
+  '@typescript-eslint/no-floating-promises',
+  '@typescript-eslint/no-empty-function',
+  '@typescript-eslint/class-literal-property-style',
+  'no-param-reassign',
+  'prefer-const',
+  '@typescript-eslint/dot-notation',
+];
+
 module.exports = {
   root: true,
+  ignorePatterns: [
+    'src/telemetry.ts', // symlink to a separate "package"
+  ],
   env: {
     browser: true,
     es2020: true,
+    node: true,
   },
-  extends: ['airbnb-base', 'prettier', 'plugin:import/typescript'],
-  plugins: ['prettier'],
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended-type-checked',
+    'plugin:@typescript-eslint/stylistic-type-checked',
+    'prettier',
+  ],
   parserOptions: {
-    parser: 'babel-eslint',
-    ecmaVersion: 11,
+    project: 'tsconfig.lint.json',
+    tsconfigRootDir: __dirname,
   },
   rules: {
     'no-param-reassign': ['error', { props: false }],
     'no-underscore-dangle': ['error', { allowAfterThis: true }],
     'no-console': process.env.NODE_ENV === 'production' ? 'warn' : 'off',
     'no-debugger': process.env.NODE_ENV === 'production' ? 'warn' : 'off',
-    'prettier/prettier': ['error'],
-    'import/extensions': [
-      'error',
-      'ignorePackages',
-      {
-        js: 'never',
-        jsx: 'never',
-        ts: 'never',
-        tsx: 'never',
-      },
-    ],
+    '@typescript-eslint/no-redundant-type-constituents': 'off', // we use these for doc purposes
+    '@typescript-eslint/consistent-type-definitions': 'off',
+
+    ...Object.fromEntries(FIXME.map((rule) => [rule, 'warn'])),
   },
   overrides: [
     {
       files: ['**/__tests__/*.{j,t}s?(x)', '**/tests/unit/**/*.spec.{j,t}s?(x)'],
       env: {
         jest: true,
+      },
+      rules: {
+        '@typescript-eslint/unbound-method': 'off', // this is commonly used when setting up mocks
       },
     },
   ],

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -14,8 +14,8 @@
     "resources"
   ],
   "scripts": {
-    "lint": "eslint 'src/**/*.js' 'tests/**/*.js'",
-    "lint:fix": "eslint 'src/**/*.js' 'tests/**/*.js' --fix",
+    "lint": "eslint src tests",
+    "lint:fix": "eslint src tests --fix",
     "pre-commit": "lint-staged",
     "test": "jest --filter=./tests/testFilter.js",
     "test:binary": "jest -c tests/binary/jest.config.js",
@@ -35,6 +35,7 @@
   "license": "Commons Clause + MIT",
   "devDependencies": {
     "@craftamap/esbuild-plugin-html": "^0.4.0",
+    "@eslint/js": "~8.57.0",
     "@octokit/types": "^11.1.0",
     "@swc/core": "^1.3.76",
     "@types/better-sqlite3": "^7.6.9",
@@ -55,11 +56,9 @@
     "@types/yargs": "^17.0.2",
     "appmap-node": "^2.20.0",
     "esbuild": "0.19.8",
-    "eslint": "^7.25.0",
-    "eslint-config-airbnb-base": "^14.2.1",
+    "eslint": "^8.56.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-import": "^2.22.1",
-    "eslint-plugin-prettier": "^3.4.0",
     "http-browserify": "^1.7.0",
     "https-browserify": "^1.0.0",
     "jest": "^29.7.0",
@@ -77,7 +76,8 @@
     "ts-sinon": "^2.0.2",
     "tsc": "^2.0.3",
     "type-fest": "^3.1.0",
-    "typescript": "^4.9.5"
+    "typescript": "^4.9.5",
+    "typescript-eslint": "^7.7.0"
   },
   "bundledDependencies": [
     "@appland/components",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -52,6 +52,7 @@
     "@types/tmp": "^0.2.3",
     "@types/validator": "^13.7.10",
     "@types/w3c-xmlserializer": "^2.0.2",
+    "@types/yargs": "^17.0.2",
     "appmap-node": "^2.20.0",
     "esbuild": "0.19.8",
     "eslint": "^7.25.0",

--- a/packages/cli/src/cmds/agentInstaller/commandRunner.ts
+++ b/packages/cli/src/cmds/agentInstaller/commandRunner.ts
@@ -6,7 +6,7 @@ import { verbose } from '../../utils';
 import { ChildProcessError } from '../errors';
 
 export class ProcessLog {
-  public static buffer: string = '';
+  public static buffer = '';
 
   public static log(command: string, childProcess: ChildProcess) {
     this.buffer = this.buffer.concat(`\n\nRunning command: \`${command}\`\n\n`);

--- a/packages/cli/src/cmds/agentInstaller/gradleParser.ts
+++ b/packages/cli/src/cmds/agentInstaller/gradleParser.ts
@@ -1,10 +1,10 @@
 import moo from 'moo';
 
 class SourceOffsets {
-  braceIdx: number = 1;
+  braceIdx = 1;
   // A syntactically correct build file will always have an rbrace to match the
   // lbrace.
-  rbrace: number = -1;
+  rbrace = -1;
   constructor(readonly blockName: string, readonly lbrace: number) {}
 }
 
@@ -45,7 +45,7 @@ export type GradleParseResult = {
 } & { [k in keyof Keywords]?: SourceOffsets };
 
 export class GradleParser {
-  public debug: number = 0;
+  public debug = 0;
 
   /**
    * Parse the given gradle source, returning a GradleParseResult describing what we found.

--- a/packages/cli/src/cmds/agentInstaller/gradleParser.ts
+++ b/packages/cli/src/cmds/agentInstaller/gradleParser.ts
@@ -100,7 +100,7 @@ export class GradleParser {
       }
 
       const ignored = ['comment', 'multicomment', 'other', 'space'];
-      if (ignored.includes(t.type!)) {
+      if (ignored.includes(t.type)) {
         continue;
       }
       if (this.debug === 1) {

--- a/packages/cli/src/cmds/agentInstaller/install-agent.ts
+++ b/packages/cli/src/cmds/agentInstaller/install-agent.ts
@@ -113,8 +113,7 @@ const _handler = async (
     const projects = await getProjects(ui, installers, directory, true, projectType);
 
     const noopsInvoked = new Set<string>();
-    for (let i = 0; i < projects.length; i++) {
-      const project = projects[i];
+    for (const project of projects) {
       if (project.selectedInstaller?.isNoop) {
         // make sure we're not duplicating messages
         if (noopsInvoked.has(project.selectedInstaller.name)) continue;

--- a/packages/cli/src/cmds/agentInstaller/install-agent.ts
+++ b/packages/cli/src/cmds/agentInstaller/install-agent.ts
@@ -125,7 +125,7 @@ const _handler = async (
       }
 
       const installProcedure = new AgentInstallerProcedure(
-        project.selectedInstaller as AgentInstaller,
+        project.selectedInstaller!,
         project.path
       );
 

--- a/packages/cli/src/cmds/agentInstaller/install-agent.ts
+++ b/packages/cli/src/cmds/agentInstaller/install-agent.ts
@@ -89,7 +89,7 @@ class InstallerError extends Error {
   }
 }
 
-const _handler = async (
+const handler = async (
   args: InstallCommandOptions
 ): Promise<{ exitCode: number; err: Error | null }> => {
   const {
@@ -227,7 +227,7 @@ export default {
   },
 
   async handler(args: InstallCommandOptions): Promise<void> {
-    const { exitCode, err } = await _handler(args);
+    const { exitCode, err } = await handler(args);
 
     Telemetry.flush(() => {
       Yargs.exit(exitCode, err as any);

--- a/packages/cli/src/cmds/agentInstaller/javaBuildToolInstaller.ts
+++ b/packages/cli/src/cmds/agentInstaller/javaBuildToolInstaller.ts
@@ -67,7 +67,7 @@ export default abstract class JavaBuildToolInstaller extends AgentInstaller {
         .split('=')[1];
     }
 
-    return this._agentJar!.trim();
+    return this._agentJar.trim();
   }
 
   async environment(): Promise<Record<string, string>> {

--- a/packages/cli/src/cmds/agentInstaller/pythonAgentInstaller.ts
+++ b/packages/cli/src/cmds/agentInstaller/pythonAgentInstaller.ts
@@ -152,7 +152,7 @@ export class PipenvInstaller extends PythonInstaller {
 
 export class PipInstaller extends PythonInstaller {
   static identifier = 'pip';
-  private _buildFile: string = 'requirements.txt';
+  private _buildFile = 'requirements.txt';
 
   constructor(path: string) {
     super(PipInstaller.identifier, path);

--- a/packages/cli/src/cmds/agentInstaller/status.ts
+++ b/packages/cli/src/cmds/agentInstaller/status.ts
@@ -53,7 +53,7 @@ export default {
       const [project] = await getProjects(ui, installers, directory, false, projectType);
 
       const statusProcedure = new AgentStatusProcedure(
-        project.selectedInstaller as AgentInstaller,
+        project.selectedInstaller!,
         directory
       );
 

--- a/packages/cli/src/cmds/archive/archiveStore.ts
+++ b/packages/cli/src/cmds/archive/archiveStore.ts
@@ -38,8 +38,9 @@ export class FileArchiveStore implements ArchiveStore {
       // Example archive path: .appmap/archive/full/2c51afaae3cc355e4bac499e9b68ea1d3dc1b36a.tar
       // Extract archive type and revision from the path
       const archiveTokens = path.split('/');
-      const revision = archiveTokens.pop()?.split('.')[0]!;
-      const type = archiveTokens.pop()!;
+      const revision = archiveTokens.pop()?.split('.')[0];
+      const type = archiveTokens.pop();
+      assert(type && revision);
       return { id: path, type, revision };
     };
 

--- a/packages/cli/src/cmds/archive/archiveStore.ts
+++ b/packages/cli/src/cmds/archive/archiveStore.ts
@@ -88,7 +88,7 @@ export class GitHubArchiveStore implements ArchiveStore {
       full: new Map<ArchiveId, ArchiveEntry>(),
       incremental: new Map<ArchiveId, ArchiveEntry>(),
     };
-    for (let page = 1; true; page++) {
+    for (let page = 1; ; page++) {
       const response = (
         await this.octokit.rest.actions.listArtifactsForRepo({
           owner,

--- a/packages/cli/src/cmds/compare-report/ChangeReport.ts
+++ b/packages/cli/src/cmds/compare-report/ChangeReport.ts
@@ -86,8 +86,8 @@ export class TestFailure {
           .split('\n')
           .map(
             (line, index) =>
-              `${(index + testSnippet!.startLine).toString() === lineno ? '> ' : '  '} ${
-                index + testSnippet!.startLine
+              `${(index + testSnippet.startLine).toString() === lineno ? '> ' : '  '} ${
+                index + testSnippet.startLine
               }: ${line}`
           )
           .join('\n');

--- a/packages/cli/src/cmds/compare-report/Preprocessor.ts
+++ b/packages/cli/src/cmds/compare-report/Preprocessor.ts
@@ -110,7 +110,7 @@ export function filterFindings(findings: FindingChange[], section: Section | Exp
   return findings.filter(
     (finding) =>
       (!includeDomains || includeDomains.includes(finding.finding.impactDomain || 'Stability')) &&
-      (!excludeDomains || !excludeDomains.includes(finding.finding.impactDomain || 'Stability'))
+      (!excludeDomains?.includes(finding.finding.impactDomain || 'Stability'))
   );
 }
 

--- a/packages/cli/src/cmds/compare-report/ReportSection.ts
+++ b/packages/cli/src/cmds/compare-report/ReportSection.ts
@@ -136,7 +136,7 @@ export default class ReportSection {
     return context;
   }
 
-  static helpers(): { [name: string]: Function } | undefined {
+  static helpers() {
     type RecorderGroup = {
       recorderName: string;
       count: number;

--- a/packages/cli/src/cmds/compare/ReportFieldCalculator.ts
+++ b/packages/cli/src/cmds/compare/ReportFieldCalculator.ts
@@ -58,6 +58,18 @@ export default class ReportFieldCalculator {
 
           // Build a text snippet for each top level context.
           const allActions = [...diagramDiff.rootActions];
+          /* FIXME: this loop probably doesn't do what's intended —
+           * it's equivalent to:
+           *
+           *   diagramDiff.rootActions = [diagramDiff.rootActions[0]];
+           *   const snippet = format(FormatType.Text, diagramDiff, 'diff');
+           *   sequenceDiagramDiff.set(snippet.diagram, [appmap]);
+           *   diagramDiff.rootActions = allActions;
+           *
+           * but it's not clear what the intended behavior is since it's verified
+           * by tests to be this. — divide
+           */
+          // eslint-disable-next-line @typescript-eslint/prefer-for-of
           for (let actionIndex = 0; actionIndex < diagramDiff.rootActions.length; actionIndex++) {
             const action = diagramDiff.rootActions[actionIndex];
             diagramDiff.rootActions = [action];

--- a/packages/cli/src/cmds/compare/reportChanges.ts
+++ b/packages/cli/src/cmds/compare/reportChanges.ts
@@ -50,7 +50,7 @@ export default async function reportChanges(
   for (const revisionName of [RevisionName.Base, RevisionName.Head]) {
     const metadataByPath = appMapMetadata[revisionName];
     for (const appmap of metadataByPath.keys()) {
-      if (!(await sequenceDiagramExists(revisionName as RevisionName, appmap))) {
+      if (!(await sequenceDiagramExists(revisionName, appmap))) {
         warn(`No sequence diagram found for ${revisionName} AppMap ${appmap}`);
         metadataByPath.delete(appmap);
       }

--- a/packages/cli/src/cmds/inventory-report/Reporter.ts
+++ b/packages/cli/src/cmds/inventory-report/Reporter.ts
@@ -32,8 +32,7 @@ export default function buildReporter(
       report = new WelcomeReporter(appmapURL, sourceURL);
       break;
     case TemplateName.Summary:
-      const summaryReport = new SummaryReporter(appmapURL, sourceURL);
-      report = summaryReport;
+      report = new SummaryReporter(appmapURL, sourceURL);
       break;
   }
   return report;

--- a/packages/cli/src/cmds/inventory-report/SummaryReporter.ts
+++ b/packages/cli/src/cmds/inventory-report/SummaryReporter.ts
@@ -91,7 +91,7 @@ export default class SummaryReporter implements Reporter {
     return template.generateMarkdown(report);
   }
 
-  static helpers(): Record<string, Function> {
+  static helpers() {
     const rule_url = (rule: string) => {
       return new SafeString(`[${rule}](https://appmap.io/docs/reference/rules/${rule})`);
     };

--- a/packages/cli/src/cmds/inventory-report/WelcomeReporter.ts
+++ b/packages/cli/src/cmds/inventory-report/WelcomeReporter.ts
@@ -48,7 +48,7 @@ export default class WelcomeReporter implements Reporter {
     return template.generateMarkdown(data);
   }
 
-  static helpers(): { [name: string]: Function } | undefined {
+  static helpers() {
     const agent_reference_name = (language: string) => {
       if (language === 'javascript') return 'agent-js';
       else return language;

--- a/packages/cli/src/cmds/navie/help.ts
+++ b/packages/cli/src/cmds/navie/help.ts
@@ -89,12 +89,12 @@ export class HelpIndex {
       const splitter = new MarkdownTextSplitter();
       // TODO: Utilize the front matter
       const chunks = await splitter.createDocuments([text]);
-      for (let i = 0; i < chunks.length; i++) {
-        const { from, to } = chunks[i].metadata.loc.lines;
+      for (const chunk of chunks) {
+        const { from, to } = chunk.metadata.loc.lines;
         const id = packRef(filePath, from, to);
-        contentByRef.set(id, chunks[i].pageContent);
+        contentByRef.set(id, chunk.pageContent);
         const pageName = frontMatter?.name || frontMatter?.title;
-        documents.push({ id, pageName, content: chunks[i].pageContent });
+        documents.push({ id, pageName, content: chunk.pageContent });
       }
     };
 

--- a/packages/cli/src/cmds/navie/projectInfo.ts
+++ b/packages/cli/src/cmds/navie/projectInfo.ts
@@ -3,7 +3,7 @@ import { collectStats } from '../../rpc/appmap/stats';
 import configuration from '../../rpc/configuration';
 
 export default async function collectProjectInfos(): Promise<ProjectInfo.ProjectInfo[]> {
-  const projectInfoByPath: { [key: string]: ProjectInfo.ProjectInfo } = {};
+  const projectInfoByPath: Record<string, ProjectInfo.ProjectInfo> = {};
   const appmapDirectories = await configuration().appmapDirectories();
   const appmapStats = await collectStats(appmapDirectories);
   appmapStats.forEach((stats) => {

--- a/packages/cli/src/cmds/open/showAppMap.ts
+++ b/packages/cli/src/cmds/open/showAppMap.ts
@@ -9,7 +9,9 @@ export default async function showAppMap(appMapFile: string) {
       try {
         spawn('code', [abspath(appMapFile)]);
         return;
-      } catch {} // fallthrough
+      } catch {
+        // fallthrough
+      }
     return openInBrowser(appMapFile, false);
   }
 

--- a/packages/cli/src/cmds/prune/prune.ts
+++ b/packages/cli/src/cmds/prune/prune.ts
@@ -47,7 +47,7 @@ function parseSize(size: string) {
 }
 
 function generateConsoleMessage(filters: any): string {
-  let exclusions = [] as Array<any>;
+  let exclusions = [] as any[];
 
   if ('hideUnlabeled' in filters) exclusions.push('All unlabeled functions');
   if ('hideMediaRequests' in filters) exclusions.push('All media requests');

--- a/packages/cli/src/cmds/record/action/startTestCases.ts
+++ b/packages/cli/src/cmds/record/action/startTestCases.ts
@@ -4,7 +4,7 @@ import RecordContext from '../recordContext';
 
 export default async function startTestCases(context: RecordContext) {
   const { configuration } = context;
-  if (Boolean(process.stdout.isTTY)) {
+  if (process.stdout.isTTY) {
     const defaultMaxTime = configuration.setting('test_recording.max_time', 30);
     let maxTime: number | undefined;
     do {

--- a/packages/cli/src/cmds/record/configuration.ts
+++ b/packages/cli/src/cmds/record/configuration.ts
@@ -14,7 +14,7 @@ export type RemoteRecordingConfig = {
 export class TestCommand {
   constructor(public command: string, public env: Record<string, string> = {}) {}
 
-  static toString(cmd: TestCommand): string {
+  static toString(this: void, cmd: TestCommand): string {
     return `${TestCaseRecording.envString(cmd.env)}${cmd.command}`;
   }
 }

--- a/packages/cli/src/cmds/record/configuration.ts
+++ b/packages/cli/src/cmds/record/configuration.ts
@@ -36,9 +36,7 @@ interface Setting {
 
 export type AppMapSettings = {
   max_time?: number;
-} & {
-  [key: string]: Setting;
-};
+} & Record<string, Setting>;
 
 export default class Configuration {
   constructor(appMapFile?: string, settingsFile?: string) {

--- a/packages/cli/src/cmds/record/record.ts
+++ b/packages/cli/src/cmds/record/record.ts
@@ -108,7 +108,7 @@ export default {
       }
 
       if (typeof state === 'string') {
-        await showAppMap(state as FileName);
+        await showAppMap(state);
       }
 
       await StatsCommand.handler(argv, 'from_record');

--- a/packages/cli/src/cmds/record/recordContext.ts
+++ b/packages/cli/src/cmds/record/recordContext.ts
@@ -123,7 +123,7 @@ export default class RecordContext {
   get failures(): number {
     if (!this.results) throw new Error('Internal Error, no results yet');
 
-    return this.exitCodes!.reduce((acc, c) => acc + (c !== 0 ? 1 : 0), 0);
+    return this.exitCodes.reduce((acc, c) => acc + (c !== 0 ? 1 : 0), 0);
   }
 
   get output(): string[] {

--- a/packages/cli/src/cmds/record/state/agentNotAvailable.ts
+++ b/packages/cli/src/cmds/record/state/agentNotAvailable.ts
@@ -62,13 +62,14 @@ For case (3), you should contact AppMap support for help with troubleshooting.
     case NextStepChoices.RELAUNCH.value:
       await UI.continue('Press enter when the server has been restarted');
       break;
-    case NextStepChoices.SUPPORT.value:
+    case NextStepChoices.SUPPORT.value: {
       const details = recordContext.remoteError?.toString() || '';
 
       await openTicket(details, DEFAULT_HELP_MSG, false);
 
       return abort; // We're done
       break;
+    }
   }
 
   return initial;

--- a/packages/cli/src/cmds/sequenceDiagram.ts
+++ b/packages/cli/src/cmds/sequenceDiagram.ts
@@ -150,8 +150,7 @@ export const handler = async (argv: any) => {
     }
   };
 
-  for (let i = 0; i < argv.appmap.length; i++) {
-    const appmapFile = argv.appmap[i];
+  for (const appmapFile of argv.appmap) {
     await generateDiagram(appmapFile);
   }
 

--- a/packages/cli/src/cmds/sequenceDiagram/readDiagramFile.ts
+++ b/packages/cli/src/cmds/sequenceDiagram/readDiagramFile.ts
@@ -2,6 +2,6 @@ import { readFile } from 'fs/promises';
 import { Diagram, unparseDiagram } from '@appland/sequence-diagram';
 
 export async function readDiagramFile(fileName: string): Promise<Diagram> {
-  const jsonData = JSON.parse(await readFile(fileName, 'utf-8')) as any;
+  const jsonData = JSON.parse(await readFile(fileName, 'utf-8'));
   return unparseDiagram(jsonData);
 }

--- a/packages/cli/src/cmds/sequenceDiagramDiff.ts
+++ b/packages/cli/src/cmds/sequenceDiagramDiff.ts
@@ -110,10 +110,10 @@ export const handler = async (argv: any) => {
   const compareFiles = async (): Promise<void> => {
     if (argv.validate) {
       const baseValidation = await validateDiagram(
-        JSON.parse(await readFile(baseDiagramFile, 'utf-8')) as any
+        JSON.parse(await readFile(baseDiagramFile, 'utf-8'))
       );
       const headValidation = await validateDiagram(
-        JSON.parse(await readFile(headDiagramFile, 'utf-8')) as any
+        JSON.parse(await readFile(headDiagramFile, 'utf-8'))
       );
 
       if (baseValidation !== ValidationResult.Valid || headValidation !== ValidationResult.Valid) {

--- a/packages/cli/src/cmds/sequenceDiagramDiff.ts
+++ b/packages/cli/src/cmds/sequenceDiagramDiff.ts
@@ -167,7 +167,7 @@ export const handler = async (argv: any) => {
   };
 
   const compareDirectories = async (): Promise<void> => {
-    const diagramData: Map<string, { diagrams: Map<string, Diagram> }> = new Map();
+    const diagramData = new Map<string, { diagrams: Map<string, Diagram> }>();
     diagramData.set(baseDiagramFile, {
       diagrams: new Map<string, Diagram>(),
     });

--- a/packages/cli/src/cmds/stats/accumulateEvents.ts
+++ b/packages/cli/src/cmds/stats/accumulateEvents.ts
@@ -30,7 +30,7 @@ async function parseClassMap(mapPath: string): Promise<ClassMap> {
   });
 }
 
-export async function accumulateEvents(mapPath: string): Promise<Array<EventInfo>> {
+export async function accumulateEvents(mapPath: string): Promise<EventInfo[]> {
   const classMap = await parseClassMap(mapPath);
   const events = {};
 

--- a/packages/cli/src/cmds/stats/stats.ts
+++ b/packages/cli/src/cmds/stats/stats.ts
@@ -76,7 +76,7 @@ export const builder = (args: yargs.Argv) => {
 export async function handler(
   argv: any,
   handlerCaller = 'from_stats'
-): Promise<Array<EventInfo> | Promise<[SortedAppMapSize[], SlowestExecutionTime[]]> | undefined> {
+): Promise<EventInfo[] | Promise<[SortedAppMapSize[], SlowestExecutionTime[]]> | undefined> {
   verbose(argv.verbose);
   handleWorkingDirectory(argv.directory);
 

--- a/packages/cli/src/cmds/stats/stats.ts
+++ b/packages/cli/src/cmds/stats/stats.ts
@@ -75,7 +75,7 @@ export const builder = (args: yargs.Argv) => {
 
 export async function handler(
   argv: any,
-  handlerCaller: string = 'from_stats'
+  handlerCaller = 'from_stats'
 ): Promise<Array<EventInfo> | Promise<[SortedAppMapSize[], SlowestExecutionTime[]]> | undefined> {
   verbose(argv.verbose);
   handleWorkingDirectory(argv.directory);

--- a/packages/cli/src/cmds/stats/statsForDirectory.ts
+++ b/packages/cli/src/cmds/stats/statsForDirectory.ts
@@ -18,7 +18,7 @@ export async function statsForDirectory(
   appMapDir: string,
   format: string,
   limit: number,
-  handlerCaller: string = 'from_stats'
+  handlerCaller = 'from_stats'
 ): Promise<[SortedAppMapSize[], SlowestExecutionTime[]]> {
   async function calculateAppMapSizes(appMapDir: string): Promise<AppMapSizeTable> {
     const appMapSizes: AppMapSizeTable = {};

--- a/packages/cli/src/cmds/stats/statsForDirectory.ts
+++ b/packages/cli/src/cmds/stats/statsForDirectory.ts
@@ -91,8 +91,8 @@ export async function statsForDirectory(
           if (
             event.definedClass &&
             event.path &&
-            (event.path[0] == '/' ||
-              event.path[0] == '<' ||
+            (event.path.startsWith('/') ||
+              event.path.startsWith('<') ||
               event.path.includes('::') ||
               event.path.startsWith('Kernel'))
           ) {

--- a/packages/cli/src/cmds/stats/statsForMap.ts
+++ b/packages/cli/src/cmds/stats/statsForMap.ts
@@ -29,7 +29,7 @@ export async function statsForMap(
   format: string,
   limit: number,
   mapPath: string
-): Promise<Array<EventInfo>> {
+): Promise<EventInfo[]> {
   const eventsStats = (await accumulateEvents(mapPath)).slice(0, limit);
 
   if (format === 'json') {

--- a/packages/cli/src/cmds/stats/types/appMapSize.ts
+++ b/packages/cli/src/cmds/stats/types/appMapSize.ts
@@ -3,9 +3,7 @@ export type AppMapSize = {
   size: number;
 };
 
-export type AppMapSizeTable = {
-  [key: string]: AppMapSize;
-};
+export type AppMapSizeTable = Record<string, AppMapSize>;
 
 export type SortedAppMapSize = {
   path: string;

--- a/packages/cli/src/cmds/upload.ts
+++ b/packages/cli/src/cmds/upload.ts
@@ -27,7 +27,7 @@ type Metadata = {
 
 export const MAX_APPMAP_SIZE = 2 * 1024 * 1024;
 
-function applyOrCheck(data: { [x: string]: string | undefined }, key: string, input?: string) {
+function applyOrCheck(data: Record<string, string | undefined>, key: string, input?: string) {
   if (!input) return;
 
   const existing = data[key];

--- a/packages/cli/src/cmds/upload.ts
+++ b/packages/cli/src/cmds/upload.ts
@@ -96,7 +96,7 @@ export async function handler(argv: Arguments): Promise<void> {
   if (paths.length === 0) throw new Error(`No AppMaps found in directory '${appmapDir}'`);
 
   let total = paths.length;
-  const { baseURL } = await loadConfiguration();
+  const { baseURL } = loadConfiguration();
   UI.progress(`Uploading ${total} AppMaps for ${app} to ${baseURL}...`);
 
   const uuids: string[] = [];

--- a/packages/cli/src/cmds/upload.ts
+++ b/packages/cli/src/cmds/upload.ts
@@ -123,7 +123,7 @@ export async function handler(argv: Arguments): Promise<void> {
   UI.success(`Created mapset ${url} with ${total} AppMaps`);
 }
 
-const command: CommandModule<{}, Arguments> = {
+const command: CommandModule<never, Arguments> = {
   command: 'upload',
   builder: {
     directory: {

--- a/packages/cli/src/depends.js
+++ b/packages/cli/src/depends.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/unbound-method
 const { dirname } = require('path');
 const { verbose, processNamedFiles } = require('./utils');
 const { default: UpToDate } = require('./lib/UpToDate');

--- a/packages/cli/src/diffArchive/ChangeAnalysis.ts
+++ b/packages/cli/src/diffArchive/ChangeAnalysis.ts
@@ -245,7 +245,7 @@ export class ChangeAnalysisImpl {
     for (const revisionName of [RevisionName.Base, RevisionName.Head]) {
       const metadataByPath = appMapMetadata[revisionName];
       for (const appmap of metadataByPath.keys()) {
-        if (!(await sequenceDiagramExists(revisionName as RevisionName, appmap))) {
+        if (!(await sequenceDiagramExists(revisionName, appmap))) {
           warn(`No sequence diagram found for ${revisionName} AppMap ${appmap}`);
           metadataByPath.delete(appmap);
         }

--- a/packages/cli/src/fingerprint/algorithms.js
+++ b/packages/cli/src/fingerprint/algorithms.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/prefer-default-export
 function notNull(event) {
   return event !== null && event !== undefined;
 }

--- a/packages/cli/src/fingerprint/algorithms.js
+++ b/packages/cli/src/fingerprint/algorithms.js
@@ -55,7 +55,7 @@ function buildTree(events) {
   });
 
   const commands = rootEvents.filter(
-    (e) => e.kind === 'http_server_request' || (e.labels && e.labels.includes('command'))
+    (e) => e.kind === 'http_server_request' || (e.labels?.includes('command'))
   );
   if (commands.length > 0) {
     return commands;

--- a/packages/cli/src/fingerprint/canonicalize/classDependencies.js
+++ b/packages/cli/src/fingerprint/canonicalize/classDependencies.js
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/unbound-method */
 /* eslint-disable class-methods-use-this */
 const { CodeObject } = require('@appland/models');
 const Unique = require('./unique');

--- a/packages/cli/src/fingerprint/canonicalize/packageDependencies.js
+++ b/packages/cli/src/fingerprint/canonicalize/packageDependencies.js
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/unbound-method */
 /* eslint-disable class-methods-use-this */
 const { CodeObject } = require('@appland/models');
 const Unique = require('./unique');

--- a/packages/cli/src/fingerprint/fingerprintDirectoryCommand.ts
+++ b/packages/cli/src/fingerprint/fingerprintDirectoryCommand.ts
@@ -4,8 +4,8 @@ import FingerprintQueue from './fingerprintQueue';
 import emitUsage from '../lib/emitUsage';
 
 class FingerprintDirectoryCommand {
-  private appmaps: number = 0;
-  private events: number = 0;
+  private appmaps = 0;
+  private events = 0;
   private metadata?: Metadata;
 
   constructor(private readonly directory: string) {}

--- a/packages/cli/src/fingerprint/fingerprinter.ts
+++ b/packages/cli/src/fingerprint/fingerprinter.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unsafe-declaration-merging */
 import { join as joinPath, basename, resolve } from 'path';
 import gracefulFs from 'graceful-fs';
 import { promisify } from 'util';

--- a/packages/cli/src/fingerprint/globber.ts
+++ b/packages/cli/src/fingerprint/globber.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unsafe-declaration-merging */
 import { assert } from 'console';
 import { default as defaultfs } from 'fs';
 import { Stats } from 'fs-extra';

--- a/packages/cli/src/fulltext/AppMapIndex.ts
+++ b/packages/cli/src/fulltext/AppMapIndex.ts
@@ -277,7 +277,7 @@ export function reportMatches(
     type: 'appmap',
     results: searchResults,
     stats: [...scoreStats.keys()].reduce((acc, key) => {
-      acc[key] = scoreStats.get(key as ScoreStats)!;
+      acc[key] = scoreStats.get(key)!;
       return acc;
     }, {}) as SearchStats,
     numResults,

--- a/packages/cli/src/fulltext/FindEvents.ts
+++ b/packages/cli/src/fulltext/FindEvents.ts
@@ -103,6 +103,7 @@ export default class FindEvents {
     filteredAppMap.rootEvents().forEach((event) => indexEvent(event));
 
     this.filteredAppMap = filteredAppMap;
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
     const self = this;
     this.idx = lunr(function () {
       this.ref('fqid');

--- a/packages/cli/src/functionStats.js
+++ b/packages/cli/src/functionStats.js
@@ -1,4 +1,3 @@
-// @ts-nocheck
 const { analyzeSQL, normalizeSQL } = require('@appland/models');
 const { formatValue, formatHttpServerRequest } = require('./utils');
 

--- a/packages/cli/src/inspect/filter.js
+++ b/packages/cli/src/inspect/filter.js
@@ -46,7 +46,7 @@ const filter = (rl, context, home) => {
         filter(rl, context, home);
       }
 
-      if (!filterField || !filterField.filterName) {
+      if (!filterField?.filterName) {
         return retry();
       }
 

--- a/packages/cli/src/inspect/home.js
+++ b/packages/cli/src/inspect/home.js
@@ -1,4 +1,3 @@
-// @ts-ignore
 const { Table } = require('console-table-printer');
 const Fields = require('./fields');
 

--- a/packages/cli/src/inspect/print.js
+++ b/packages/cli/src/inspect/print.js
@@ -1,4 +1,3 @@
-// @ts-ignore
 const { Table } = require('console-table-printer');
 const Fields = require('./fields');
 

--- a/packages/cli/src/lib/git.ts
+++ b/packages/cli/src/lib/git.ts
@@ -41,7 +41,7 @@ class SanitizedUri {
 }
 
 function hasUrl(remote: unknown): remote is { url: string } {
-  return remote && remote['url'];
+  return remote?.['url'];
 }
 
 async function findAndSanitizeRepository(dir: string): Promise<SanitizedUri | void> {

--- a/packages/cli/src/lib/loadAppMapConfig.ts
+++ b/packages/cli/src/lib/loadAppMapConfig.ts
@@ -14,10 +14,10 @@ export type HideOption =
 // fields that are likely to be used for creating a canonical sequence diagram.
 export type CompareFilter = {
   hide_external?: boolean;
-  dependency_folders?: Array<string>;
-  hide_name?: Array<string>;
-  hide?: Array<HideOption>;
-  reveal?: Array<HideOption>;
+  dependency_folders?: string[];
+  hide_name?: string[];
+  hide?: HideOption[];
+  reveal?: HideOption[];
 };
 
 export interface CompareConfig {

--- a/packages/cli/src/lib/locateAppMapConfigFile.ts
+++ b/packages/cli/src/lib/locateAppMapConfigFile.ts
@@ -3,7 +3,7 @@ import { exists } from '../utils';
 
 export async function locateAppMapConfigFile(appmapDir: string): Promise<string | undefined> {
   let dir: string = appmapDir;
-  while (true) {
+  for (;;) {
     const appmapFile = join(dir, 'appmap.yml');
     if (await exists(appmapFile)) return appmapFile;
 

--- a/packages/cli/src/lib/processAppMapDir.ts
+++ b/packages/cli/src/lib/processAppMapDir.ts
@@ -20,8 +20,8 @@ export type TaskResultHandler<V> = (appmapFile: string, result: V) => void | Pro
 
 export type ProcessResult = {
   oversized: Set<string>;
-  errors: Array<Error>;
-  unhandledErrors: Array<Error>;
+  errors: Error[];
+  unhandledErrors: Error[];
   numProcessed: number;
 };
 

--- a/packages/cli/src/lib/serveAndOpen.ts
+++ b/packages/cli/src/lib/serveAndOpen.ts
@@ -80,7 +80,7 @@ export default async function serveAndOpen(
     }
   })
     .listen(0, '127.0.0.1', () => {
-      const port = (server!.address() as AddressInfo).port;
+      const port = (server.address() as AddressInfo).port;
 
       const params = new URLSearchParams();
       for (const [key, value] of Object.entries(resources)) {

--- a/packages/cli/src/lib/serveAndOpen.ts
+++ b/packages/cli/src/lib/serveAndOpen.ts
@@ -66,7 +66,7 @@ export default async function serveAndOpen(
       const pathname = requestUrl.pathname;
       if (pathname === '/') {
         return serveStaticFile(baseDir, file, 'text/html');
-      } else if (pathname && pathname.startsWith('/resource')) {
+      } else if (pathname?.startsWith('/resource')) {
         const pathname = requestUrl.query;
         if (pathname) serveStaticFile(process.cwd(), decodeURIComponent(pathname));
         else send404();

--- a/packages/cli/src/lib/sqlErrorLog.ts
+++ b/packages/cli/src/lib/sqlErrorLog.ts
@@ -9,7 +9,7 @@ async function writeErrorToFile(error: ParseError) {
   const flags = SqlParseErrorFileOpened ? 'a' : 'w';
   SqlParseErrorFileOpened = true;
   open(SqlParseErrorFileName, flags).then((handle) => {
-    handle.write([error.toString(), ''].join('\n')).finally(handle.close.bind(handle));
+    handle.write([String(error), ''].join('\n')).finally(handle.close.bind(handle));
   });
 }
 

--- a/packages/cli/src/lib/ticket/openTicket.ts
+++ b/packages/cli/src/lib/ticket/openTicket.ts
@@ -9,7 +9,7 @@ import { isValidEmail, isValidName } from './validation';
 export default async function openTicket(
   errors: string | string[],
   helpMsg: string = DEFAULT_HELP_MSG,
-  prompt: boolean = true
+  prompt = true
 ): Promise<void> {
   errors = !Array.isArray(errors) ? [errors] : errors;
 

--- a/packages/cli/src/lib/ticket/zendesk.ts
+++ b/packages/cli/src/lib/ticket/zendesk.ts
@@ -62,7 +62,7 @@ ${errors.map((e) => `===\n${stripAnsi(e)}\n===`).join('\n')}`,
     // for ZENDESK_AUTHZ is {email_address}msg, {ken:{api_token}.
     const zendeskAuthz = process.env.ZENDESK_AUTHZ;
     if (zendeskAuthz) {
-      body: headers['Authorization'] = `Basic ${Buffer.from(zendeskAuthz).toString('base64')}`;
+      headers['Authorization'] = `Basic ${Buffer.from(zendeskAuthz).toString('base64')}`;
     }
 
     const { data: res } = await axios

--- a/packages/cli/src/lib/workerPool.ts
+++ b/packages/cli/src/lib/workerPool.ts
@@ -40,7 +40,7 @@ export default class WorkerPool extends EventEmitter {
   workers: Worker[] = [];
   freeWorkers: Worker[] = [];
   tasks: Task[] = [];
-  workerInfoByThreadId: Map<number, WorkerInfo> = new Map();
+  workerInfoByThreadId = new Map<number, WorkerInfo>();
 
   addWorkerInterval?: NodeJS.Timeout | undefined;
 

--- a/packages/cli/src/report/ReportTemplate.ts
+++ b/packages/cli/src/report/ReportTemplate.ts
@@ -1,6 +1,7 @@
 export class ReportTemplate {
   constructor(
     public template: HandlebarsTemplateDelegate,
+    // eslint-disable-next-line @typescript-eslint/ban-types
     public helpers: Record<string, Function>
   ) {}
 

--- a/packages/cli/src/report/helpers.ts
+++ b/packages/cli/src/report/helpers.ts
@@ -6,7 +6,7 @@ const inspect = (value: any) => {
 };
 
 const length = (...list: any[]): number => {
-  const _fn = list.pop();
+  /* const _fn = */ list.pop();
   let result = 0;
   for (const item of list) {
     if (item === undefined || item === null) {
@@ -23,7 +23,7 @@ const length = (...list: any[]): number => {
 };
 
 const coalesce = (...list: any[]): number => {
-  const _fn = list.pop();
+  /* const _fn = */ list.pop();
   return list.find((item) => item !== undefined && item !== null && item !== '');
 };
 
@@ -33,13 +33,13 @@ const extractArrayValue = (args: any[]): any[] => (Array.isArray(args[0]) ? args
 
 const every = (...args: any[]): boolean => {
   args = [...args];
-  const _fn = args.pop();
+  /* const _fn = */ args.pop();
   return args.every((value) => !!value);
 };
 
 const eq = (...args: any[]): boolean => {
   args = [...args];
-  const _fn = args.pop();
+  /* const _fn = */ args.pop();
   if (args.length === 0) return false;
   const first = args[0];
   return args.every((value) => value === first);
@@ -61,21 +61,21 @@ const format_as_yaml = (value: any): SafeString => new Handlebars.SafeString(dum
 
 const sum = (...args: any[]) => {
   args = [...args];
-  const _fn = args.pop();
+  /* const _fn = */ args.pop();
   const values = extractArrayValue(args);
   return values.reduce((a, b) => a + (b || 0), 0);
 };
 
 const subtract = (...args: any[]) => {
   args = [...args];
-  const _fn = args.pop();
+  /* const _fn = */ args.pop();
   const initial = args.shift() || 0;
   return args.reduce((a, b) => a - (b || 0), initial);
 };
 
 const divide = (...args: any[]) => {
   args = [...args];
-  const _fn = args.pop();
+  /* const _fn = */ args.pop();
   const values = extractArrayValue(args);
   const initial = values.shift() || 0;
   return values.reduce((a, b) => a / (b || 1), initial);

--- a/packages/cli/src/rpc/explain/buildContext.ts
+++ b/packages/cli/src/rpc/explain/buildContext.ts
@@ -36,7 +36,7 @@ export default async function buildContext(
   const appmapLocation = (appmap: string, event?: SearchRpc.EventMatch) => {
     const appmapFile = [appmap, 'appmap.json'].join('.');
     const tokens = [appmapFile];
-    if (event && event.eventIds.length) tokens.push(String(event.eventIds[0]));
+    if (event?.eventIds.length) tokens.push(String(event.eventIds[0]));
     return tokens.join(':');
   };
 

--- a/packages/cli/src/rpc/explain/collectContext.ts
+++ b/packages/cli/src/rpc/explain/collectContext.ts
@@ -170,7 +170,7 @@ export class ContextCollector {
     let charCount = 0;
     let maxEventsPerDiagram = 5;
     log(`Requested char limit: ${this.charLimit}`);
-    while (true) {
+    for (;;) {
       log(`Collecting context with ${maxEventsPerDiagram} events per diagram.`);
 
       contextCandidate = await eventsCollector.collectEvents(maxEventsPerDiagram);

--- a/packages/cli/src/rpc/explain/explain.ts
+++ b/packages/cli/src/rpc/explain/explain.ts
@@ -44,8 +44,6 @@ export class Explain extends EventEmitter {
   }
 
   async explain(navie: INavie): Promise<void> {
-    const self = this;
-
     navie.on('ack', (userMessageId, threadId) => {
       this.status.threadId = threadId;
       this.emit('ack', userMessageId, threadId);

--- a/packages/cli/src/rpc/explain/explain.ts
+++ b/packages/cli/src/rpc/explain/explain.ts
@@ -25,7 +25,7 @@ export type SearchContextOptions = {
 
 export type SearchContextResponse = {
   sequenceDiagrams: string[];
-  codeSnippets: { [key: string]: string };
+  codeSnippets: Record<string, string>;
   codeObjects: string[];
 };
 

--- a/packages/cli/src/rpc/explain/navie/navie-local.ts
+++ b/packages/cli/src/rpc/explain/navie/navie-local.ts
@@ -131,7 +131,7 @@ export default class LocalNavie extends EventEmitter implements INavie {
     this.emit('complete');
   }
 
-  #skipTelemetry: boolean = !Telemetry.enabled;
+  #skipTelemetry = !Telemetry.enabled;
 
   #reportConfigTelemetry() {
     if (this.#skipTelemetry) return;

--- a/packages/cli/src/rpc/explain/navie/navie-local.ts
+++ b/packages/cli/src/rpc/explain/navie/navie-local.ts
@@ -54,10 +54,10 @@ const OPTION_SETTERS: Record<
   (explainOptions: Explain.ExplainOptions, value: string | number) => void
 > = {
   tokenLimit: (explainOptions, value) => {
-    explainOptions.tokenLimit = typeof value === 'string' ? parseInt(value as string, 10) : value;
+    explainOptions.tokenLimit = typeof value === 'string' ? parseInt(value, 10) : value;
   },
   temperature: (explainOptions, value) => {
-    explainOptions.temperature = typeof value === 'string' ? parseFloat(value as string) : value;
+    explainOptions.temperature = typeof value === 'string' ? parseFloat(value) : value;
   },
   modelName: (explainOptions, value) => {
     explainOptions.modelName = String(value);

--- a/packages/cli/src/rpc/explain/navie/navie-remote.ts
+++ b/packages/cli/src/rpc/explain/navie/navie-remote.ts
@@ -83,7 +83,7 @@ export default class RemoteNavie extends EventEmitter implements INavie {
               return {};
             }
           } catch (e) {
-            warn(`Explain context function ${data} threw an error: ${e}`);
+            warn(`Explain context function ${JSON.stringify(data)} threw an error: ${e}`);
             // TODO: Report an error object instead?
             return {};
           }

--- a/packages/cli/src/rpc/rpc.ts
+++ b/packages/cli/src/rpc/rpc.ts
@@ -12,7 +12,7 @@ export class RpcError extends Error implements jayson.JSONRPCError {
     let rpcError: jayson.JSONRPCError;
     warn(`Handling exception: ${inspect(err)}`);
     if (err.stack) warn(`Stack trace: ${err.stack}`);
-    if (err.cause) warn(`Cause: ${err.cause}`);
+    if (err.cause) warn(`Cause: ${String(err.cause)}`);
     if (isRpcError(err)) {
       rpcError = { code: err.code, message: err.message };
       const data: Record<string, any> = {};

--- a/packages/cli/src/rpc/rpc.ts
+++ b/packages/cli/src/rpc/rpc.ts
@@ -20,12 +20,16 @@ export class RpcError extends Error implements jayson.JSONRPCError {
         warn(`Data: ${err.data}`);
         try {
           data.data = JSON.parse(JSON.stringify(err.data));
-        } catch {}
+        } catch {
+          // fallthrough
+        }
       }
       if (err.cause) {
         try {
           data.cause = JSON.parse(JSON.stringify(err.cause));
-        } catch {}
+        } catch {
+          // fallthrough
+        }
       }
       if (err.stack) data.stack = err.stack;
 

--- a/packages/cli/src/search/findCodeObjects.ts
+++ b/packages/cli/src/search/findCodeObjects.ts
@@ -186,7 +186,7 @@ export default class FindCodeObjects {
       }
 
       let appmapName = indexDir;
-      if (indexDir.indexOf(process.cwd()) === 0) {
+      if (indexDir.startsWith(process.cwd())) {
         appmapName = indexDir.substring(process.cwd().length + 1);
       }
 

--- a/packages/cli/src/search/types.d.ts
+++ b/packages/cli/src/search/types.d.ts
@@ -86,7 +86,7 @@ export interface EventMatch {
 }
 
 export interface CodeObjectMatchSpec {
-  tokens: Array<(codeObject: CodeObject) => boolean>;
+  tokens: ((codeObject: CodeObject) => boolean)[];
 }
 
 export interface Filter {

--- a/packages/cli/src/sequenceDiagram/analyzeAppMaps.ts
+++ b/packages/cli/src/sequenceDiagram/analyzeAppMaps.ts
@@ -18,7 +18,7 @@ export default async function analyzeAppMaps(
   const includedCodeObjectIds = new Set<CodeObjectId>();
 
   const interpretCodeObjectPattern = (pattern: string) => {
-    if (pattern.charAt(0) === '+') {
+    if (pattern.startsWith('+')) {
       pattern = pattern.slice(1);
       requiredPatterns.add(pattern);
     }

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -261,7 +261,7 @@ export function formatValue(value: ReturnValueObject) {
     return 'Null';
   }
 
-  const valueStr = value.value.indexOf('#<') === 0 ? null : value.value;
+  const valueStr = value.value.startsWith('#<') ? null : value.value;
 
   return [value.class, valueStr].filter((e) => e).join(' ');
 }

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -56,7 +56,7 @@ export async function mtime(filePath: PathLike): Promise<number | undefined> {
   // as temp files).
 
   const fileStat = await statFile(filePath);
-  if (!fileStat || !fileStat.isFile()) {
+  if (!fileStat?.isFile()) {
     return;
   }
   return fileStat.mtimeMs;
@@ -64,7 +64,7 @@ export async function mtime(filePath: PathLike): Promise<number | undefined> {
 
 export async function isFile(filePath: PathLike): Promise<boolean> {
   const fileStat = await statFile(filePath);
-  return !!(fileStat && fileStat.isFile());
+  return !!fileStat?.isFile();
 }
 
 /**
@@ -147,7 +147,7 @@ export async function processNamedFiles(
     // If the directory contains the target fileName, add it to the process queue and return.
     const targetFileName = join(dir, fileName);
     const target = await stats(targetFileName);
-    if (target && target.isFile()) {
+    if (target?.isFile()) {
       matchCount += 1;
       q.push(targetFileName);
       return;
@@ -162,7 +162,7 @@ export async function processNamedFiles(
     }
     for (const childName of children) {
       const child = await stats(join(dir, childName));
-      if (child && child.isDirectory()) {
+      if (child?.isDirectory()) {
         await processDir(join(dir, childName));
       }
     }
@@ -256,8 +256,8 @@ export function prefixLines(str: string, prefix: string): string {
   return str.replace(/^/gm, prefix);
 }
 
-export function formatValue(value: ReturnValueObject) {
-  if (value === null || value === undefined || value.value === null || value.value === undefined) {
+export function formatValue(value?: ReturnValueObject) {
+  if (value?.value === null || value?.value === undefined) {
     return 'Null';
   }
 

--- a/packages/cli/tests/integration/rpc.explain.spec.ts
+++ b/packages/cli/tests/integration/rpc.explain.spec.ts
@@ -149,10 +149,10 @@ describe('RPC', () => {
               const foundType = contextItemTypes.find((itemType) => itemTypes.includes(itemType));
               assert(foundType, `Expected one of ${itemTypes.join(', ')}, got none`);
 
-              this.callbacks.onToken!(answer, userMessageId);
+              this.callbacks.onToken(answer, userMessageId);
 
               setTimeout(() => {
-                this.callbacks.onComplete!();
+                this.callbacks.onComplete();
               }, 0);
             }
           }
@@ -230,7 +230,7 @@ describe('RPC', () => {
             constructor(public callbacks: AICallbacks) {}
 
             async inputPrompt(): Promise<void> {
-              this.callbacks.onComplete!();
+              this.callbacks.onComplete();
             }
           }
 

--- a/packages/cli/tests/integration/rpc.explain.spec.ts
+++ b/packages/cli/tests/integration/rpc.explain.spec.ts
@@ -187,7 +187,7 @@ describe('RPC', () => {
 
           const statusResult: ExplainRpc.ExplainStatusResponse = await queryStatus();
           const sequenceDiagrams = statusResult.contextResponse
-            ?.filter((item) => item.type === ContextV2.ContextItemType.SequenceDiagram)
+            ?.filter((item) => item.type === 'sequence-diagram')
             .map((item) => item.content);
           expect(sequenceDiagrams?.join('\n')).toContain('@startuml');
           expect(Object.keys(statusResult)).toContain('contextResponse');

--- a/packages/cli/tests/unit/agentInstall/agentInstaller.spec.ts
+++ b/packages/cli/tests/unit/agentInstall/agentInstaller.spec.ts
@@ -3,8 +3,8 @@ import AgentInstaller from '../../../src/cmds/agentInstaller/agentInstaller';
 import commandStruct from '../../../src/cmds/agentInstaller/commandStruct';
 
 class FakeInstaller extends AgentInstaller {
-  public buildFile: string = 'bf';
-  public documentation: string = 'http://www.example.com';
+  public buildFile = 'bf';
+  public documentation = 'http://www.example.com';
   constructor(path: string) {
     super('Fake', path);
   }

--- a/packages/cli/tests/unit/agentInstall/gradleInstaller.spec.ts
+++ b/packages/cli/tests/unit/agentInstall/gradleInstaller.spec.ts
@@ -34,6 +34,7 @@ describe('GradleInstaller', () => {
         // By default, we'll run all test. This is here to make it easy to skip
         // them by name: change true to false, and check for the test name of
         // interest.
+        // eslint-disable-next-line no-constant-condition
         const testFn = true || test === 'extra-repo-block' ? it : xit;
 
         const actualFile = `${test}${testExt}`;

--- a/packages/cli/tests/unit/agentInstall/installCommand.spec.ts
+++ b/packages/cli/tests/unit/agentInstall/installCommand.spec.ts
@@ -36,6 +36,7 @@ const invokeCommand = (
     if (err) throw err;
   }
 ) => {
+  // eslint-disable-next-line @typescript-eslint/no-inferrable-types
   const debugSwitch: string = ''; // to debug, set debugSwitch to -v
 
   if (debugSwitch !== '-v') {

--- a/packages/cli/tests/unit/agentInstall/mavenInstaller.spec.ts
+++ b/packages/cli/tests/unit/agentInstall/mavenInstaller.spec.ts
@@ -33,8 +33,7 @@ describe('MavenInstaller', () => {
       const tests = files.map((file) => path.basename(file, expectedExt));
       const efWrite = sinon.stub(EncodedFile.prototype, 'write');
 
-      for (let i = 0; i < tests.length; ++i) {
-        const test = tests[i];
+      for (const test of tests) {
         sinon.stub(maven, 'buildFilePath').value(path.join(dataDir, `${test}.actual.xml`));
 
         const expected = (await fs.readFile(path.join(dataDir, `${test}${expectedExt}`)))

--- a/packages/cli/tests/unit/agentInstall/statusCommand.spec.ts
+++ b/packages/cli/tests/unit/agentInstall/statusCommand.spec.ts
@@ -64,7 +64,7 @@ describe('status sub-command', () => {
   });
 
   it('chooses an installer when there are multiple options', async () => {
-    const installers: Array<AgentInstaller> = [];
+    const installers: AgentInstaller[] = [];
     installers[0] = stubInterface<AgentInstaller>();
     installers[1] = stubInterface<AgentInstaller>();
 

--- a/packages/cli/tests/unit/agentInstall/statusCommand.spec.ts
+++ b/packages/cli/tests/unit/agentInstall/statusCommand.spec.ts
@@ -15,7 +15,7 @@ const invokeCommand = (
   projectDir: string,
   evalResults: (err: Error | undefined, argv: any, output: string) => void
 ) => {
-  return yargs
+  return yargs([])
     .command(require('../../../src/cmds/agentInstaller/status').default)
     .parse(`status ${projectDir}`, {}, (err, argv, output) => {
       evalResults(err, argv, output);

--- a/packages/cli/tests/unit/compareReport/findings.spec.ts
+++ b/packages/cli/tests/unit/compareReport/findings.spec.ts
@@ -78,7 +78,7 @@ describe('findings', () => {
           } as unknown as ChangeReport,
           reportOptions
         );
-        expect(report).toEqual(`<h2 id=\"performance-problems\">Performance problems</h2>
+        expect(report).toEqual(`<h2 id="performance-problems">Performance problems</h2>
 
 ### :tada: Problems resolved (1)
 

--- a/packages/cli/tests/unit/compareReport/newAppMaps.spec.ts
+++ b/packages/cli/tests/unit/compareReport/newAppMaps.spec.ts
@@ -58,7 +58,7 @@ describe('newAppMaps', () => {
           } as unknown as ChangeReport,
           reportOptions
         );
-        expect(report).toEqual(`<h2 id=\"new-appmaps\">⭐ New AppMaps</h2>
+        expect(report).toEqual(`<h2 id="new-appmaps">⭐ New AppMaps</h2>
 
 
 [[rspec] Users controller test](https://getappmap.com/?path=head%2Fminitest%2Fusers_controller_test.appmap.json) from [\`spec/controllers/users_controller_test.rb:10\`](spec/controllers/users_controller_test.rb#L10)
@@ -102,7 +102,7 @@ describe('newAppMaps', () => {
           } as unknown as ChangeReport,
           { ...reportOptions, ...{ maxElements: 2 } }
         );
-        expect(report).toEqual(`<h2 id=\"new-appmaps\">⭐ New AppMaps</h2>
+        expect(report).toEqual(`<h2 id="new-appmaps">⭐ New AppMaps</h2>
 
 
 [[rspec] Users controller test](https://getappmap.com/?path=head%2Fminitest%2Fusers_controller_test.appmap.json) from [\`spec/controllers/users_controller_test.rb:10\`](spec/controllers/users_controller_test.rb#L10)

--- a/packages/cli/tests/unit/compareReport/removedAppMaps.spec.ts
+++ b/packages/cli/tests/unit/compareReport/removedAppMaps.spec.ts
@@ -61,7 +61,7 @@ describe('removedAppMaps', () => {
           } as unknown as ChangeReport,
           reportOptions
         );
-        expect(report).toEqual(`<h2 id=\"removed-appmaps\">✖️ Removed AppMaps</h2>
+        expect(report).toEqual(`<h2 id="removed-appmaps">✖️ Removed AppMaps</h2>
 
 [[rspec] Users controller test](https://getappmap.com/?path=base%2Fminitest%2Fusers_controller_test.appmap.json)
 `);
@@ -104,7 +104,7 @@ describe('removedAppMaps', () => {
           } as unknown as ChangeReport,
           { ...reportOptions, ...{ maxElements: 2 } }
         );
-        expect(report).toEqual(`<h2 id=\"removed-appmaps\">✖️ Removed AppMaps</h2>
+        expect(report).toEqual(`<h2 id="removed-appmaps">✖️ Removed AppMaps</h2>
 
 [[rspec] Users controller test](https://getappmap.com/?path=base%2Fminitest%2Fusers_controller_test.appmap.json)
 

--- a/packages/cli/tests/unit/lib/emitUsage.spec.ts
+++ b/packages/cli/tests/unit/lib/emitUsage.spec.ts
@@ -53,7 +53,7 @@ describe('emitUsage', () => {
       const resultPath = await emitUsage(process.cwd(), numEvents, numAppMaps, metadata as any);
       expect(resultPath).toBeDefined();
 
-      const dto = JSON.parse(await readFile(resultPath as string, 'utf-8')) as UsageUpdateDto;
+      const dto = JSON.parse(await readFile(resultPath!, 'utf-8')) as UsageUpdateDto;
       expect(dto).toMatchObject({
         events: numEvents,
         appmaps: numAppMaps,

--- a/packages/cli/tests/unit/lib/openTicket.spec.ts
+++ b/packages/cli/tests/unit/lib/openTicket.spec.ts
@@ -18,7 +18,7 @@ const getNthCallArgs = (stub, nth) => (stub as sinon.SinonStub).getCall(nth).arg
 
 class TestErrorResponse implements HttpErrorResponse {
   headers: Record<string, string> = {};
-  body: string = '';
+  body = '';
   toString(): string {
     return `${JSON.stringify(this)}`;
   }

--- a/packages/cli/tests/unit/lib/quotePath.spec.ts
+++ b/packages/cli/tests/unit/lib/quotePath.spec.ts
@@ -13,5 +13,5 @@ describe(quotePath, () => {
     [['/tmp/app\\map.json', true], '"/tmp/app\\\\map.json"'],
     [['/tmp/ap"p\nmap\0/ma\\p1.json'], '"/tmp/ap\\"p\\nmap\\0/ma\\\\p1.json"'],
     [['/tmp/ap"p\nmap\0/ma\\p1.json', true], '"/tmp/ap\\"p\\nmap\\0/ma\\\\p1.json"'],
-  ])('with %o', (args, expected) => expect(quotePath.apply(undefined, args)).toEqual(expected));
+  ])('with %o', (args, expected) => expect(quotePath(...args)).toEqual(expected));
 });

--- a/packages/cli/tests/unit/lib/workerPool.spec.ts
+++ b/packages/cli/tests/unit/lib/workerPool.spec.ts
@@ -15,7 +15,7 @@ describe('WorkerPool', () => {
 
   const initializeWorkerPool = () => (workerPool = new WorkerPool(jobFile, numThreads));
 
-  const runTasks = async <T>(tasks: Array<T>): Promise<TaskResult> => {
+  const runTasks = async <T>(tasks: T[]): Promise<TaskResult> => {
     const processTasks = async (cb: (err: Error | null, result: any) => void) => {
       await Promise.all(
         tasks.map((task) => {

--- a/packages/cli/tests/unit/record/record.remote.spec.ts
+++ b/packages/cli/tests/unit/record/record.remote.spec.ts
@@ -130,7 +130,7 @@ describe('record remote', () => {
 
           const appMapName = 'myAppMap';
           sinon.stub(nameAppMap, 'default').resolves(appMapName);
-          sinon.stub(saveAppMap, 'default').resolves(`${nameAppMap}.appmap.json`);
+          sinon.stub(saveAppMap, 'default').resolves(`${appMapName}.appmap.json`);
         });
 
         const EXAMPLES = [

--- a/packages/cli/tests/unit/record/record.test.spec.ts
+++ b/packages/cli/tests/unit/record/record.test.spec.ts
@@ -178,7 +178,6 @@ describe('record test', () => {
       });
       expect(recordContext.properties()).toEqual({
         exitCodes: '0',
-        // eslint-disable-next-line prettier/prettier
         log: `
 ===
 
@@ -208,7 +207,6 @@ describe('record test', () => {
       });
       expect(recordContext.properties()).toEqual({
         exitCodes: '1',
-        // eslint-disable-next-line prettier/prettier
         log: `
 ===
 

--- a/packages/cli/tests/unit/rpc/explain/buildContext.spec.ts
+++ b/packages/cli/tests/unit/rpc/explain/buildContext.spec.ts
@@ -1,5 +1,7 @@
-import buildContext from '../../../../src/rpc/explain/buildContext';
+import { ContextV2 } from '@appland/navie';
+
 import { handler as sequenceDiagramHandler } from '../../../../src/rpc/appmap/sequenceDiagram';
+import buildContext from '../../../../src/rpc/explain/buildContext';
 import lookupSourceCode from '../../../../src/rpc/explain/lookupSourceCode';
 
 jest.mock('../../../../src/rpc/appmap/sequenceDiagram');
@@ -45,7 +47,9 @@ describe('buildContext', () => {
           ],
         },
       ]);
-      expect(context.filter((item) => item.type !== 'sequence-diagram')).toEqual([
+      expect(
+        context.filter((item) => item.type !== ContextV2.ContextItemType.SequenceDiagram)
+      ).toEqual([
         {
           location: 'app/models/user.rb',
           type: 'code-snippet',
@@ -66,7 +70,9 @@ describe('buildContext', () => {
           events: [{ fqid: 'query:SELECT * FROM users', score: 1, eventIds: [1, 2] }],
         },
       ]);
-      expect(context.filter((item) => item.type !== 'sequence-diagram')).toEqual([
+      expect(
+        context.filter((item) => item.type !== ContextV2.ContextItemType.SequenceDiagram)
+      ).toEqual([
         {
           location: 'appmap1.appmap.json:1',
           type: 'data-request',

--- a/packages/cli/tests/unit/util.ts
+++ b/packages/cli/tests/unit/util.ts
@@ -44,7 +44,7 @@ async function executeWorkspaceOSCommand(cmd: string, workingDirectory: string):
 }
 
 export async function cleanProject(workingDirectory: string) {
-  const commands = [`git checkout HEAD .`, `git clean -f -d .`];
+  const commands = [`git checkout HEAD .`, `git clean -fdx .`];
   for (const command of commands) {
     try {
       await executeWorkspaceOSCommand(command, workingDirectory);

--- a/packages/cli/tsconfig.lint.json
+++ b/packages/cli/tsconfig.lint.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "extends": "./tsconfig.json",
+  "include": ["."],
+  "exclude": ["dist", "build", "node_modules"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,6 +5,13 @@ __metadata:
   version: 6
   cacheKey: 8
 
+"@aashutoshrathi/word-wrap@npm:^1.2.3":
+  version: 1.2.6
+  resolution: "@aashutoshrathi/word-wrap@npm:1.2.6"
+  checksum: ada901b9e7c680d190f1d012c84217ce0063d8f5c5a7725bb91ec3c5ed99bb7572680eb2d2938a531ccbaec39a95422fcd8a6b4a13110c7d98dd75402f66a0cd
+  languageName: node
+  linkType: hard
+
 "@ampproject/remapping@npm:^2.0.0":
   version: 2.1.1
   resolution: "@ampproject/remapping@npm:2.1.1"
@@ -149,6 +156,7 @@ __metadata:
     "@appland/scanner": "workspace:^1.86.0"
     "@appland/sequence-diagram": "workspace:^1.12.0"
     "@craftamap/esbuild-plugin-html": ^0.4.0
+    "@eslint/js": ~8.57.0
     "@octokit/rest": ^20.0.1
     "@octokit/types": ^11.1.0
     "@sidvind/better-ajv-errors": ^0.9.1
@@ -189,11 +197,9 @@ __metadata:
     detect-indent: ^6.1.0
     diff: ^5.1.0
     esbuild: 0.19.8
-    eslint: ^7.25.0
-    eslint-config-airbnb-base: ^14.2.1
+    eslint: ^8.56.0
     eslint-config-prettier: ^8.3.0
     eslint-plugin-import: ^2.22.1
-    eslint-plugin-prettier: ^3.4.0
     fs-extra: ^10.1.0
     gitconfiglocal: ^2.1.0
     glob: ^7.2.3
@@ -239,6 +245,7 @@ __metadata:
     tsc: ^2.0.3
     type-fest: ^3.1.0
     typescript: ^4.9.5
+    typescript-eslint: ^7.7.0
     validator: ^13.7.0
     w3c-xmlserializer: ^2.0.0
     yargs: ^17.1.1
@@ -5671,7 +5678,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint-community/eslint-utils@npm:^4.2.0":
+"@eslint-community/eslint-utils@npm:^4.2.0, @eslint-community/eslint-utils@npm:^4.4.0":
   version: 4.4.0
   resolution: "@eslint-community/eslint-utils@npm:4.4.0"
   dependencies:
@@ -5679,6 +5686,13 @@ __metadata:
   peerDependencies:
     eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
   checksum: cdfe3ae42b4f572cbfb46d20edafe6f36fc5fb52bf2d90875c58aefe226892b9677fef60820e2832caf864a326fe4fc225714c46e8389ccca04d5f9288aabd22
+  languageName: node
+  linkType: hard
+
+"@eslint-community/regexpp@npm:^4.10.0, @eslint-community/regexpp@npm:^4.6.1":
+  version: 4.10.0
+  resolution: "@eslint-community/regexpp@npm:4.10.0"
+  checksum: 2a6e345429ea8382aaaf3a61f865cae16ed44d31ca917910033c02dc00d505d939f10b81e079fa14d43b51499c640138e153b7e40743c4c094d9df97d4e56f7b
   languageName: node
   linkType: hard
 
@@ -5713,6 +5727,30 @@ __metadata:
     minimatch: ^3.0.4
     strip-json-comments: ^3.1.1
   checksum: 784aa2157e2808b52bbbaf1d1cfca9a6ba0b2faaa3696eb7a1229d4b357400fbd8a6aa09a16e7ae0868ea075d3a8f365cf5928b6d05a1df47f40a1167423a4fa
+  languageName: node
+  linkType: hard
+
+"@eslint/eslintrc@npm:^2.1.4":
+  version: 2.1.4
+  resolution: "@eslint/eslintrc@npm:2.1.4"
+  dependencies:
+    ajv: ^6.12.4
+    debug: ^4.3.2
+    espree: ^9.6.0
+    globals: ^13.19.0
+    ignore: ^5.2.0
+    import-fresh: ^3.2.1
+    js-yaml: ^4.1.0
+    minimatch: ^3.1.2
+    strip-json-comments: ^3.1.1
+  checksum: 10957c7592b20ca0089262d8c2a8accbad14b4f6507e35416c32ee6b4dbf9cad67dfb77096bbd405405e9ada2b107f3797fe94362e1c55e0b09d6e90dd149127
+  languageName: node
+  linkType: hard
+
+"@eslint/js@npm:8.57.0, @eslint/js@npm:~8.57.0":
+  version: 8.57.0
+  resolution: "@eslint/js@npm:8.57.0"
+  checksum: 315dc65b0e9893e2bff139bddace7ea601ad77ed47b4550e73da8c9c2d2766c7a575c3cddf17ef85b8fd6a36ff34f91729d0dcca56e73ca887c10df91a41b0bb
   languageName: node
   linkType: hard
 
@@ -5844,6 +5882,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@humanwhocodes/config-array@npm:^0.11.14":
+  version: 0.11.14
+  resolution: "@humanwhocodes/config-array@npm:0.11.14"
+  dependencies:
+    "@humanwhocodes/object-schema": ^2.0.2
+    debug: ^4.3.1
+    minimatch: ^3.0.5
+  checksum: 861ccce9eaea5de19546653bccf75bf09fe878bc39c3aab00aeee2d2a0e654516adad38dd1098aab5e3af0145bbcbf3f309bdf4d964f8dab9dcd5834ae4c02f2
+  languageName: node
+  linkType: hard
+
 "@humanwhocodes/config-array@npm:^0.5.0":
   version: 0.5.0
   resolution: "@humanwhocodes/config-array@npm:0.5.0"
@@ -5866,10 +5915,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@humanwhocodes/module-importer@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@humanwhocodes/module-importer@npm:1.0.1"
+  checksum: 0fd22007db8034a2cdf2c764b140d37d9020bbfce8a49d3ec5c05290e77d4b0263b1b972b752df8c89e5eaa94073408f2b7d977aed131faf6cf396ebb5d7fb61
+  languageName: node
+  linkType: hard
+
 "@humanwhocodes/object-schema@npm:^1.2.0, @humanwhocodes/object-schema@npm:^1.2.1":
   version: 1.2.1
   resolution: "@humanwhocodes/object-schema@npm:1.2.1"
   checksum: a824a1ec31591231e4bad5787641f59e9633827d0a2eaae131a288d33c9ef0290bd16fda8da6f7c0fcb014147865d12118df10db57f27f41e20da92369fcb3f1
+  languageName: node
+  linkType: hard
+
+"@humanwhocodes/object-schema@npm:^2.0.2":
+  version: 2.0.3
+  resolution: "@humanwhocodes/object-schema@npm:2.0.3"
+  checksum: d3b78f6c5831888c6ecc899df0d03bcc25d46f3ad26a11d7ea52944dc36a35ef543fad965322174238d677a43d5c694434f6607532cff7077062513ad7022631
   languageName: node
   linkType: hard
 
@@ -7270,7 +7333,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nodelib/fs.walk@npm:^1.2.3":
+"@nodelib/fs.walk@npm:^1.2.3, @nodelib/fs.walk@npm:^1.2.8":
   version: 1.2.8
   resolution: "@nodelib/fs.walk@npm:1.2.8"
   dependencies:
@@ -11288,6 +11351,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/json-schema@npm:^7.0.15":
+  version: 7.0.15
+  resolution: "@types/json-schema@npm:7.0.15"
+  checksum: 97ed0cb44d4070aecea772b7b2e2ed971e10c81ec87dd4ecc160322ffa55ff330dace1793489540e3e318d90942064bb697cc0f8989391797792d919737b3b98
+  languageName: node
+  linkType: hard
+
 "@types/json-schema@npm:^7.0.6, @types/json-schema@npm:^7.0.7":
   version: 7.0.11
   resolution: "@types/json-schema@npm:7.0.11"
@@ -11583,6 +11653,13 @@ __metadata:
   version: 7.5.6
   resolution: "@types/semver@npm:7.5.6"
   checksum: 563a0120ec0efcc326567db2ed920d5d98346f3638b6324ea6b50222b96f02a8add3c51a916b6897b51523aad8ac227d21d3dcf8913559f1bfc6c15b14d23037
+  languageName: node
+  linkType: hard
+
+"@types/semver@npm:^7.5.8":
+  version: 7.5.8
+  resolution: "@types/semver@npm:7.5.8"
+  checksum: ea6f5276f5b84c55921785a3a27a3cd37afee0111dfe2bcb3e03c31819c197c782598f17f0b150a69d453c9584cd14c4c4d7b9a55d2c5e6cacd4d66fdb3b3663
   languageName: node
   linkType: hard
 
@@ -11899,6 +11976,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/eslint-plugin@npm:7.7.0":
+  version: 7.7.0
+  resolution: "@typescript-eslint/eslint-plugin@npm:7.7.0"
+  dependencies:
+    "@eslint-community/regexpp": ^4.10.0
+    "@typescript-eslint/scope-manager": 7.7.0
+    "@typescript-eslint/type-utils": 7.7.0
+    "@typescript-eslint/utils": 7.7.0
+    "@typescript-eslint/visitor-keys": 7.7.0
+    debug: ^4.3.4
+    graphemer: ^1.4.0
+    ignore: ^5.3.1
+    natural-compare: ^1.4.0
+    semver: ^7.6.0
+    ts-api-utils: ^1.3.0
+  peerDependencies:
+    "@typescript-eslint/parser": ^7.0.0
+    eslint: ^8.56.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: f97348425d114282407f4f524cdc618199d0d6d86e4e556709063b07611192068872cbd7f612cbd670617d958ee4519b25eeca0bccbac1b08433ce41511d3825
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/eslint-plugin@npm:^4.30.0":
   version: 4.33.0
   resolution: "@typescript-eslint/eslint-plugin@npm:4.33.0"
@@ -12015,6 +12117,24 @@ __metadata:
   peerDependencies:
     eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
   checksum: aa74dab82946132cf2fc0b620e200e31a02021ba2459eafaba404c9be7f50b576fb09b359f5e45836ac6bbb85cc11fcafe3682bc92e1d1af38cf28e461066cc6
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/parser@npm:7.7.0":
+  version: 7.7.0
+  resolution: "@typescript-eslint/parser@npm:7.7.0"
+  dependencies:
+    "@typescript-eslint/scope-manager": 7.7.0
+    "@typescript-eslint/types": 7.7.0
+    "@typescript-eslint/typescript-estree": 7.7.0
+    "@typescript-eslint/visitor-keys": 7.7.0
+    debug: ^4.3.4
+  peerDependencies:
+    eslint: ^8.56.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 44dc88eae2fafd3ae92338683d70d077d0c4342dcd4949dc05ffa7686de2753b8565c643eedb3bf1c6b6c1b4a2f0849000474b8e70572184ebe366b0b1dbb1ee
   languageName: node
   linkType: hard
 
@@ -12136,6 +12256,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/scope-manager@npm:7.7.0":
+  version: 7.7.0
+  resolution: "@typescript-eslint/scope-manager@npm:7.7.0"
+  dependencies:
+    "@typescript-eslint/types": 7.7.0
+    "@typescript-eslint/visitor-keys": 7.7.0
+  checksum: cb280d4aa64cdefee362ef97b6fde3ae86a376fccff7f012e4e635ffe544dd90be37b340c7099784d0fbebb37b925aab6b53195825b41cee38e2382d0b552871
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/type-utils@npm:5.11.0":
   version: 5.11.0
   resolution: "@typescript-eslint/type-utils@npm:5.11.0"
@@ -12186,6 +12316,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/type-utils@npm:7.7.0":
+  version: 7.7.0
+  resolution: "@typescript-eslint/type-utils@npm:7.7.0"
+  dependencies:
+    "@typescript-eslint/typescript-estree": 7.7.0
+    "@typescript-eslint/utils": 7.7.0
+    debug: ^4.3.4
+    ts-api-utils: ^1.3.0
+  peerDependencies:
+    eslint: ^8.56.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 74c07e4fcc8e6ee7870a161596d25ecfa22624947d94ca9af7147590caa13b6388f0e55101961ab02f77e7e6cffdaf19895575d7329dda50fa18fc71bf15f6b7
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/types@npm:4.33.0":
   version: 4.33.0
   resolution: "@typescript-eslint/types@npm:4.33.0"
@@ -12218,6 +12365,13 @@ __metadata:
   version: 5.62.0
   resolution: "@typescript-eslint/types@npm:5.62.0"
   checksum: 48c87117383d1864766486f24de34086155532b070f6264e09d0e6139449270f8a9559cfef3c56d16e3bcfb52d83d42105d61b36743626399c7c2b5e0ac3b670
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/types@npm:7.7.0":
+  version: 7.7.0
+  resolution: "@typescript-eslint/types@npm:7.7.0"
+  checksum: c47aae2c1474b85fab012e0518c57685c595f11775b615b6a6749f943aa7a98554d9eb7054114850679f46699578049998408a492e0c1abd3bded2aee8e261a5
   languageName: node
   linkType: hard
 
@@ -12311,6 +12465,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/typescript-estree@npm:7.7.0":
+  version: 7.7.0
+  resolution: "@typescript-eslint/typescript-estree@npm:7.7.0"
+  dependencies:
+    "@typescript-eslint/types": 7.7.0
+    "@typescript-eslint/visitor-keys": 7.7.0
+    debug: ^4.3.4
+    globby: ^11.1.0
+    is-glob: ^4.0.3
+    minimatch: ^9.0.4
+    semver: ^7.6.0
+    ts-api-utils: ^1.3.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 54d16b2a083bff3c6d38fbee56465403bbcba411bf25e94f2d8bbbbd8b4b35c151c7845997e5141224f8dba5bc1f34964762713035d49113700efd7381246d02
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/utils@npm:5.11.0":
   version: 5.11.0
   resolution: "@typescript-eslint/utils@npm:5.11.0"
@@ -12360,6 +12533,23 @@ __metadata:
   peerDependencies:
     eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
   checksum: c6e28c942fbac5500f0e8ed67ef304b484ba296486e55306f78fb090dc9d5bb1f25a0bedc065e14680041eadce5e95fa10aab618cb0c316599ec987e6ea72442
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/utils@npm:7.7.0":
+  version: 7.7.0
+  resolution: "@typescript-eslint/utils@npm:7.7.0"
+  dependencies:
+    "@eslint-community/eslint-utils": ^4.4.0
+    "@types/json-schema": ^7.0.15
+    "@types/semver": ^7.5.8
+    "@typescript-eslint/scope-manager": 7.7.0
+    "@typescript-eslint/types": 7.7.0
+    "@typescript-eslint/typescript-estree": 7.7.0
+    semver: ^7.6.0
+  peerDependencies:
+    eslint: ^8.56.0
+  checksum: 830ff3af96538083d7513c211e39f07375b7e973c135a2b9bbae1ad7509bd4dce33a144a22d896a2ff4c18e9fcccd423535b6f9bb8adafe36e800f16bc53378c
   languageName: node
   linkType: hard
 
@@ -12428,6 +12618,23 @@ __metadata:
     "@typescript-eslint/types": 5.62.0
     eslint-visitor-keys: ^3.3.0
   checksum: 976b05d103fe8335bef5c93ad3f76d781e3ce50329c0243ee0f00c0fcfb186c81df50e64bfdd34970148113f8ade90887f53e3c4938183afba830b4ba8e30a35
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/visitor-keys@npm:7.7.0":
+  version: 7.7.0
+  resolution: "@typescript-eslint/visitor-keys@npm:7.7.0"
+  dependencies:
+    "@typescript-eslint/types": 7.7.0
+    eslint-visitor-keys: ^3.4.3
+  checksum: 16d0b63b9d98ea1d3d20bd6f9dc3cbd2674055845ad493d98118669d54792b1c167f57ae25beaae2c1107ed07012ac3c3093cca978b2ab49833dc491bc302b33
+  languageName: node
+  linkType: hard
+
+"@ungap/structured-clone@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "@ungap/structured-clone@npm:1.2.0"
+  checksum: 4f656b7b4672f2ce6e272f2427d8b0824ed11546a601d8d5412b9d7704e83db38a8d9f402ecdf2b9063fc164af842ad0ec4a55819f621ed7e7ea4d1efcc74524
   languageName: node
   linkType: hard
 
@@ -13669,7 +13876,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn-jsx@npm:^5.3.1":
+"acorn-jsx@npm:^5.3.1, acorn-jsx@npm:^5.3.2":
   version: 5.3.2
   resolution: "acorn-jsx@npm:5.3.2"
   peerDependencies:
@@ -13775,6 +13982,15 @@ __metadata:
   bin:
     acorn: bin/acorn
   checksum: f790b99a1bf63ef160c967e23c46feea7787e531292bb827126334612c234ed489a0dc2c7ba33156416f0ffa8d25bf2b0fdb7f35c2ba60eb3e960572bece4001
+  languageName: node
+  linkType: hard
+
+"acorn@npm:^8.9.0":
+  version: 8.11.3
+  resolution: "acorn@npm:8.11.3"
+  bin:
+    acorn: bin/acorn
+  checksum: 76d8e7d559512566b43ab4aadc374f11f563f0a9e21626dd59cb2888444e9445923ae9f3699972767f18af61df89cd89f5eaaf772d1327b055b45cb829b4a88c
   languageName: node
   linkType: hard
 
@@ -21317,6 +21533,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-scope@npm:^7.2.2":
+  version: 7.2.2
+  resolution: "eslint-scope@npm:7.2.2"
+  dependencies:
+    esrecurse: ^4.3.0
+    estraverse: ^5.2.0
+  checksum: ec97dbf5fb04b94e8f4c5a91a7f0a6dd3c55e46bfc7bbcd0e3138c3a76977570e02ed89a1810c778dcd72072ff0e9621ba1379b4babe53921d71e2e4486fda3e
+  languageName: node
+  linkType: hard
+
 "eslint-template-visitor@npm:^2.3.2":
   version: 2.3.2
   resolution: "eslint-template-visitor@npm:2.3.2"
@@ -21370,6 +21596,13 @@ __metadata:
   version: 3.3.0
   resolution: "eslint-visitor-keys@npm:3.3.0"
   checksum: d59e68a7c5a6d0146526b0eec16ce87fbf97fe46b8281e0d41384224375c4e52f5ffb9e16d48f4ea50785cde93f766b0c898e31ab89978d88b0e1720fbfb7808
+  languageName: node
+  linkType: hard
+
+"eslint-visitor-keys@npm:^3.4.1, eslint-visitor-keys@npm:^3.4.3":
+  version: 3.4.3
+  resolution: "eslint-visitor-keys@npm:3.4.3"
+  checksum: 36e9ef87fca698b6fd7ca5ca35d7b2b6eeaaf106572e2f7fd31c12d3bfdaccdb587bba6d3621067e5aece31c8c3a348b93922ab8f7b2cbc6aaab5e1d89040c60
   languageName: node
   linkType: hard
 
@@ -21468,6 +21701,54 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint@npm:^8.56.0":
+  version: 8.57.0
+  resolution: "eslint@npm:8.57.0"
+  dependencies:
+    "@eslint-community/eslint-utils": ^4.2.0
+    "@eslint-community/regexpp": ^4.6.1
+    "@eslint/eslintrc": ^2.1.4
+    "@eslint/js": 8.57.0
+    "@humanwhocodes/config-array": ^0.11.14
+    "@humanwhocodes/module-importer": ^1.0.1
+    "@nodelib/fs.walk": ^1.2.8
+    "@ungap/structured-clone": ^1.2.0
+    ajv: ^6.12.4
+    chalk: ^4.0.0
+    cross-spawn: ^7.0.2
+    debug: ^4.3.2
+    doctrine: ^3.0.0
+    escape-string-regexp: ^4.0.0
+    eslint-scope: ^7.2.2
+    eslint-visitor-keys: ^3.4.3
+    espree: ^9.6.1
+    esquery: ^1.4.2
+    esutils: ^2.0.2
+    fast-deep-equal: ^3.1.3
+    file-entry-cache: ^6.0.1
+    find-up: ^5.0.0
+    glob-parent: ^6.0.2
+    globals: ^13.19.0
+    graphemer: ^1.4.0
+    ignore: ^5.2.0
+    imurmurhash: ^0.1.4
+    is-glob: ^4.0.0
+    is-path-inside: ^3.0.3
+    js-yaml: ^4.1.0
+    json-stable-stringify-without-jsonify: ^1.0.1
+    levn: ^0.4.1
+    lodash.merge: ^4.6.2
+    minimatch: ^3.1.2
+    natural-compare: ^1.4.0
+    optionator: ^0.9.3
+    strip-ansi: ^6.0.1
+    text-table: ^0.2.0
+  bin:
+    eslint: bin/eslint.js
+  checksum: 3a48d7ff85ab420a8447e9810d8087aea5b1df9ef68c9151732b478de698389ee656fd895635b5f2871c89ee5a2652b3f343d11e9db6f8486880374ebc74a2d9
+  languageName: node
+  linkType: hard
+
 "espree@npm:^7.3.0, espree@npm:^7.3.1":
   version: 7.3.1
   resolution: "espree@npm:7.3.1"
@@ -21490,6 +21771,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"espree@npm:^9.6.0, espree@npm:^9.6.1":
+  version: 9.6.1
+  resolution: "espree@npm:9.6.1"
+  dependencies:
+    acorn: ^8.9.0
+    acorn-jsx: ^5.3.2
+    eslint-visitor-keys: ^3.4.1
+  checksum: eb8c149c7a2a77b3f33a5af80c10875c3abd65450f60b8af6db1bfcfa8f101e21c1e56a561c6dc13b848e18148d43469e7cd208506238554fb5395a9ea5a1ab9
+  languageName: node
+  linkType: hard
+
 "esprima@npm:^4.0.0, esprima@npm:^4.0.1, esprima@npm:~4.0.0":
   version: 4.0.1
   resolution: "esprima@npm:4.0.1"
@@ -21506,6 +21798,15 @@ __metadata:
   dependencies:
     estraverse: ^5.1.0
   checksum: a0807e17abd7fbe5fbd4fab673038d6d8a50675cdae6b04fbaa520c34581be0c5fa24582990e8acd8854f671dd291c78bb2efb9e0ed5b62f33bac4f9cf820210
+  languageName: node
+  linkType: hard
+
+"esquery@npm:^1.4.2":
+  version: 1.5.0
+  resolution: "esquery@npm:1.5.0"
+  dependencies:
+    estraverse: ^5.1.0
+  checksum: aefb0d2596c230118656cd4ec7532d447333a410a48834d80ea648b1e7b5c9bc9ed8b5e33a89cb04e487b60d622f44cf5713bf4abed7c97343edefdc84a35900
   languageName: node
   linkType: hard
 
@@ -23286,7 +23587,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob-parent@npm:^6.0.1":
+"glob-parent@npm:^6.0.1, glob-parent@npm:^6.0.2":
   version: 6.0.2
   resolution: "glob-parent@npm:6.0.2"
   dependencies:
@@ -23457,6 +23758,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"globals@npm:^13.19.0":
+  version: 13.24.0
+  resolution: "globals@npm:13.24.0"
+  dependencies:
+    type-fest: ^0.20.2
+  checksum: 56066ef058f6867c04ff203b8a44c15b038346a62efbc3060052a1016be9f56f4cf0b2cd45b74b22b81e521a889fc7786c73691b0549c2f3a6e825b3d394f43c
+  languageName: node
+  linkType: hard
+
 "globals@npm:^13.6.0, globals@npm:^13.9.0":
   version: 13.12.1
   resolution: "globals@npm:13.12.1"
@@ -23582,6 +23892,13 @@ __metadata:
   version: 1.0.4
   resolution: "grapheme-splitter@npm:1.0.4"
   checksum: 0c22ec54dee1b05cd480f78cf14f732cb5b108edc073572c4ec205df4cd63f30f8db8025afc5debc8835a8ddeacf648a1c7992fe3dcd6ad38f9a476d84906620
+  languageName: node
+  linkType: hard
+
+"graphemer@npm:^1.4.0":
+  version: 1.4.0
+  resolution: "graphemer@npm:1.4.0"
+  checksum: bab8f0be9b568857c7bec9fda95a89f87b783546d02951c40c33f84d05bb7da3fd10f863a9beb901463669b6583173a8c8cc6d6b306ea2b9b9d5d3d943c3a673
   languageName: node
   linkType: hard
 
@@ -24489,6 +24806,13 @@ __metadata:
   version: 5.2.0
   resolution: "ignore@npm:5.2.0"
   checksum: 6b1f926792d614f64c6c83da3a1f9c83f6196c2839aa41e1e32dd7b8d174cef2e329d75caabb62cb61ce9dc432f75e67d07d122a037312db7caa73166a1bdb77
+  languageName: node
+  linkType: hard
+
+"ignore@npm:^5.3.1":
+  version: 5.3.1
+  resolution: "ignore@npm:5.3.1"
+  checksum: 71d7bb4c1dbe020f915fd881108cbe85a0db3d636a0ea3ba911393c53946711d13a9b1143c7e70db06d571a5822c0a324a6bcde5c9904e7ca5047f01f1bf8cd3
   languageName: node
   linkType: hard
 
@@ -25437,7 +25761,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-path-inside@npm:^3.0.2":
+"is-path-inside@npm:^3.0.2, is-path-inside@npm:^3.0.3":
   version: 3.0.3
   resolution: "is-path-inside@npm:3.0.3"
   checksum: abd50f06186a052b349c15e55b182326f1936c89a78bf6c8f2b707412517c097ce04bc49a0ca221787bc44e1049f51f09a2ffb63d22899051988d3a618ba13e9
@@ -30282,7 +30606,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^3.1.1, minimatch@npm:^3.1.2":
+"minimatch@npm:^3.0.5, minimatch@npm:^3.1.1, minimatch@npm:^3.1.2":
   version: 3.1.2
   resolution: "minimatch@npm:3.1.2"
   dependencies:
@@ -30333,6 +30657,15 @@ __metadata:
   dependencies:
     brace-expansion: ^2.0.1
   checksum: 253487976bf485b612f16bf57463520a14f512662e592e95c571afdab1442a6a6864b6c88f248ce6fc4ff0b6de04ac7aa6c8bb51e868e99d1d65eb0658a708b5
+  languageName: node
+  linkType: hard
+
+"minimatch@npm:^9.0.4":
+  version: 9.0.4
+  resolution: "minimatch@npm:9.0.4"
+  dependencies:
+    brace-expansion: ^2.0.1
+  checksum: cf717f597ec3eed7dabc33153482a2e8d49f4fd3c26e58fd9c71a94c5029a0838728841b93f46bf1263b65a8010e2ee800d0dc9b004ab8ba8b6d1ec07cc115b5
   languageName: node
   linkType: hard
 
@@ -32143,6 +32476,20 @@ __metadata:
     type-check: ^0.4.0
     word-wrap: ^1.2.3
   checksum: dbc6fa065604b24ea57d734261914e697bd73b69eff7f18e967e8912aa2a40a19a9f599a507fa805be6c13c24c4eae8c71306c239d517d42d4c041c942f508a0
+  languageName: node
+  linkType: hard
+
+"optionator@npm:^0.9.3":
+  version: 0.9.3
+  resolution: "optionator@npm:0.9.3"
+  dependencies:
+    "@aashutoshrathi/word-wrap": ^1.2.3
+    deep-is: ^0.1.3
+    fast-levenshtein: ^2.0.6
+    levn: ^0.4.1
+    prelude-ls: ^1.2.1
+    type-check: ^0.4.0
+  checksum: 09281999441f2fe9c33a5eeab76700795365a061563d66b098923eb719251a42bdbe432790d35064d0816ead9296dbeb1ad51a733edf4167c96bd5d0882e428a
   languageName: node
   linkType: hard
 
@@ -36483,6 +36830,17 @@ resolve@1.1.7:
   languageName: node
   linkType: hard
 
+"semver@npm:^7.6.0":
+  version: 7.6.0
+  resolution: "semver@npm:7.6.0"
+  dependencies:
+    lru-cache: ^6.0.0
+  bin:
+    semver: bin/semver.js
+  checksum: 7427f05b70786c696640edc29fdd4bc33b2acf3bbe1740b955029044f80575fc664e1a512e4113c3af21e767154a94b4aa214bf6cd6e42a1f6dba5914e0b208c
+  languageName: node
+  linkType: hard
+
 "send@npm:0.17.2":
   version: 0.17.2
   resolution: "send@npm:0.17.2"
@@ -38833,6 +39191,15 @@ resolve@1.1.7:
   languageName: node
   linkType: hard
 
+"ts-api-utils@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "ts-api-utils@npm:1.3.0"
+  peerDependencies:
+    typescript: ">=4.2.0"
+  checksum: c746ddabfdffbf16cb0b0db32bb287236a19e583057f8649ee7c49995bb776e1d3ef384685181c11a1a480369e022ca97512cb08c517b2d2bd82c83754c97012
+  languageName: node
+  linkType: hard
+
 "ts-dedent@npm:^2.0.0, ts-dedent@npm:^2.2.0":
   version: 2.2.0
   resolution: "ts-dedent@npm:2.2.0"
@@ -39412,6 +39779,22 @@ resolve@1.1.7:
   version: 0.0.6
   resolution: "typedarray@npm:0.0.6"
   checksum: 33b39f3d0e8463985eeaeeacc3cb2e28bc3dfaf2a5ed219628c0b629d5d7b810b0eb2165f9f607c34871d5daa92ba1dc69f49051cf7d578b4cbd26c340b9d1b1
+  languageName: node
+  linkType: hard
+
+"typescript-eslint@npm:^7.7.0":
+  version: 7.7.0
+  resolution: "typescript-eslint@npm:7.7.0"
+  dependencies:
+    "@typescript-eslint/eslint-plugin": 7.7.0
+    "@typescript-eslint/parser": 7.7.0
+    "@typescript-eslint/utils": 7.7.0
+  peerDependencies:
+    eslint: ^8.56.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 86d09a765263b7dad0e6055894fb720bd9310713bfd68cdc302c614598110b20d4ca97a99b1739c883152d470842822cd798a3be479b3de13fe982d8e8b6672b
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -168,6 +168,7 @@ __metadata:
     "@types/tmp": ^0.2.3
     "@types/validator": ^13.7.10
     "@types/w3c-xmlserializer": ^2.0.2
+    "@types/yargs": ^17.0.2
     JSONStream: ^1.3.5
     ajv: ^8.6.3
     applicationinsights: ^2.1.4


### PR DESCRIPTION
I noticed that we weren't linting .ts files in the CLI package.

I added the right configuration to enable this; also, removed the (quite obsolete) airbnb preset and replaced it with currently recommended ones.

I've fixed a couple low hanging lint problems and turned all the ones that are widespread in the package into warnings so they don't break the builds. We should strive to whittle down the list slowly.