### PR TITLE
fix: Tolerate absence of source_location in compare-report

### DIFF
--- a/packages/cli/resources/change-report/failed-tests/details.hbs
+++ b/packages/cli/resources/change-report/failed-tests/details.hbs
@@ -4,13 +4,17 @@
   {{#each testFailures}}
 <details>
 <summary>
-{{ testLocation }}
+{{#if testLocation}}
+    {{ testLocation }}
+{{else}}
+    {{ appmap.metadata.name }}
+{{/if}}
 </summary>
 
 <p/>
 
 <!-- testLocation -->
-{{ source_link testLocation }} failed with error:
+{{#if testLocation}}{{ source_link testLocation }}{{/if}} failed with error:
 
     {{#if failureMessage}}
 <!-- failureMessage -->

--- a/packages/cli/src/report/urlHelpers.ts
+++ b/packages/cli/src/report/urlHelpers.ts
@@ -21,7 +21,12 @@ export default function urlHelpers(options: URLOptions): Record<string, (...args
   let { baseDir } = options;
   if (!baseDir) baseDir = process.cwd();
 
-  const source_url = (location: string, fileLinenoSeparator = '#L') => {
+  const source_url = (location: string | undefined, fileLinenoSeparator = '#L') => {
+    // source_location is optional in AppMap spec. Since this helper
+    // is called directly from Handlebars templates, declaring location
+    // as "location: string" does not guarantee its presence.
+    if (!location) return;
+
     if (typeof fileLinenoSeparator === 'object') {
       fileLinenoSeparator = '#L';
     }

--- a/packages/cli/tests/unit/compareReport/ChangeReporter.spec.ts
+++ b/packages/cli/tests/unit/compareReport/ChangeReporter.spec.ts
@@ -29,4 +29,41 @@ describe('ChangeReporter', () => {
 \`\`\`
 (apiDiff) Validation errors in "head": Swagger schema validation failed.`);
   });
+
+  it('tolerates absence of source_location, which is optional in spec', async () => {
+    const appmapURL = 'https://appmap.example.com';
+    const changeReportData: ChangeReport = {
+      testFailures: [
+        {
+          appmap: "tmp/appmap/jest/test/the_test_that_failed",
+          name: "the test that failed"
+        },
+      ],
+      newAppMaps: [],
+      removedAppMaps: [],
+      changedAppMaps: [],
+      appMapMetadata: {
+        base: {},
+        head: {
+          "tmp/appmap/jest/test/the_test_that_failed": {
+            client: {
+              "name": "appmap-node",
+              "url": "https://github.com/getappmap/appmap-node"
+            },
+            recorder: {
+              name: "jest"
+            },
+            name: "the test that failed",
+            test_status: "failed",
+            // no source_location here
+          }
+        },
+      },
+      sequenceDiagramDiff: {},
+    };
+    const changeReporter = new ChangeReporter(appmapURL);
+    const report = await changeReporter.generateReport(changeReportData);
+    expect(report).toContain("the test that failed");
+
+  })
 });


### PR DESCRIPTION
Fixes #1648.

When there is no `source_location` in an AppMap and a change report is generated with `appmap compare` command, AppMap metadata in resulting `change_report.json` will not contain the `source_location`. This was not tolerated in `appmap compare-report` command leading to the error shown in #1648.

- Helper function [source_url](https://github.com/getappmap/appmap-js/blob/2596f365ff12b89dafcc9868b4607377bcc635e2/packages/cli/src/report/urlHelpers.ts#L24) is changed to handle non-existent location.
- Related Handlebars [template](packages/cli/resources/change-report/failed-tests/details.hbs) is changed to show the test name instead of the test location in the failed test summary when there is no location.
- A unit [test](https://github.com/getappmap/appmap-js/blob/2596f365ff12b89dafcc9868b4607377bcc635e2/packages/cli/tests/unit/compareReport/ChangeReporter.spec.ts#L33) is created for this fix.