### PR TITLE
fix: Don't render sequence diagram context content

### DIFF
--- a/packages/components/src/components/chat-search/Context.vue
+++ b/packages/components/src/components/chat-search/Context.vue
@@ -25,9 +25,8 @@
               <div class="context__body__table">
                 <v-context-item
                   v-for="(contextItem, index) in contextItems(t)"
-                  :key="getContextItemKey(contextItem)"
+                  :key="index"
                   :contextItem="contextItem"
-                  :index="index"
                   data-cy="context-item"
                 />
               </div>
@@ -78,9 +77,6 @@ export default {
   },
 
   methods: {
-    getContextItemKey(contextItem) {
-      return `${contextItem.type}-${contextItem.location || contextItem.content}`;
-    },
     hasContext(type: string) {
       return this.contextResponse.some((context) => context.type === type);
     },

--- a/packages/components/src/components/chat-search/ContextItem.vue
+++ b/packages/components/src/components/chat-search/ContextItem.vue
@@ -5,7 +5,11 @@
       <v-white-appmap-logo v-else class="row-icon" />
       <div>{{ header }}</div>
     </div>
-    <div class="context__body__table-row__content">
+    <div
+      class="context__body__table-row__content"
+      v-if="!isSequenceDiagram"
+      data-cy="context-item-content"
+    >
       <span v-html="highlightedContent" />
     </div>
   </div>
@@ -64,15 +68,11 @@ export default {
       type: Object,
       required: true,
     },
-    index: {
-      type: Number,
-      required: true,
-    },
   },
 
   computed: {
     highlightedContent() {
-      return this.getContext();
+      return this.isSequenceDiagram ? '' : this.getContext();
     },
     language() {
       switch (this.contextItem.type) {
@@ -113,6 +113,9 @@ export default {
     },
     isCodeSnippet() {
       return this.contextItem.type === 'code-snippet';
+    },
+    isSequenceDiagram() {
+      return this.contextItem.type === 'sequence-diagram';
     },
   },
 

--- a/packages/components/tests/unit/chat/ContextItem.spec.js
+++ b/packages/components/tests/unit/chat/ContextItem.spec.js
@@ -1,0 +1,32 @@
+import { mount } from '@vue/test-utils';
+import VContextItem from '@/components/chat-search/ContextItem.vue';
+
+describe('ContextItem', () => {
+  it('does not render content for sequence diagrams', () => {
+    const contextItem = {
+      type: 'sequence-diagram',
+      location: 'app/models/user.rb:10',
+      content: '@plantuml',
+    };
+    const wrapper = mount(VContextItem, {
+      propsData: {
+        contextItem,
+      },
+    });
+    expect(wrapper.find('[data-cy="context-item-content"]').exists()).toBe(false);
+  });
+  it('renders content for other types', () => {
+    const content = 'printf("Hello, world!\n");';
+    const contextItem = {
+      type: 'code-snippet',
+      location: 'app/user.c:10',
+      content,
+    };
+    const wrapper = mount(VContextItem, {
+      propsData: {
+        contextItem,
+      },
+    });
+    expect(wrapper.find('[data-cy="context-item-content"]').text()).toContain(content);
+  });
+});


### PR DESCRIPTION
Raw PlantUML is no longer rendered for sequence diagrams. Instead, they're presented as list items.

![image](https://github.com/getappmap/appmap-js/assets/8737782/cd175399-db9e-4dd2-839f-ed4e12a4c862)
