### PR TITLE
fix: Tone down architecture pressure

### DIFF
--- a/packages/cli/src/rpc/explain/explain.ts
+++ b/packages/cli/src/rpc/explain/explain.ts
@@ -90,8 +90,8 @@ export class Explain extends EventEmitter {
 
     const keywords = [...vectorTerms];
     if (
-      labels.find((label) => label.name === 'architecture') ||
-      labels.find((label) => label.name === 'overview')
+      labels.find((label) => label.name === 'architecture' && label.weight === 'high') ||
+      labels.find((label) => label.name === 'overview' && label.weight === 'high')
     ) {
       keywords.push('architecture');
       keywords.push('design');


### PR DESCRIPTION
Trigger architecture keywords only when the weight is 'high'