### PR TITLE
Warn users in Navie when they don't have AppMap data

### DIFF
--- a/packages/components/src/components/chat-search/Context.vue
+++ b/packages/components/src/components/chat-search/Context.vue
@@ -16,6 +16,25 @@
       <div>
         <h2>Context</h2>
         <div class="context__body">
+          <div
+            v-if="numAppMaps === 0"
+            class="context__body__no-appmaps"
+            data-cy="create-appmap-data"
+          >
+            <p>
+              You don't have any AppMap data. Adding AppMap data to Navie's context improves Navie's
+              code suggestions and answers.
+            </p>
+            <v-button
+              data-cy="create-appmap-data-btn"
+              class="create-appmap-data"
+              size="small"
+              kind="ghost"
+              @click.native="openInstallInstructions"
+            >
+              Open Instructions
+            </v-button>
+          </div>
           <div v-for="t in Object.keys(contextTypes)" :key="t">
             <div v-if="hasContext(t)">
               <h3>
@@ -41,12 +60,14 @@
 <script lang="ts">
 //@ts-nocheck
 import VContextItem from '@/components/chat-search/ContextItem.vue';
+import VButton from '@/components/Button.vue';
 
 export default {
   name: 'v-context',
 
   components: {
     VContextItem,
+    VButton,
   },
 
   props: {
@@ -66,9 +87,9 @@ export default {
     },
     contextTypes() {
       return {
-        'code-snippet': 'Code Snippets',
         'sequence-diagram': 'Sequence Diagrams',
         'data-request': 'Data Requests',
+        'code-snippet': 'Code Snippets',
       };
     },
     contextTypeKeys() {
@@ -85,6 +106,9 @@ export default {
     },
     contextItemCount(type: string) {
       return this.contextItems(type).length;
+    },
+    openInstallInstructions() {
+      this.$root.$emit('open-install-instructions');
     },
   },
 };
@@ -122,6 +146,11 @@ export default {
   }
 
   &__body {
+    &__no-appmaps {
+      padding: 0 1rem;
+      margin-bottom: 2.5rem;
+    }
+
     &__table {
       display: flex;
       flex-direction: column;

--- a/packages/components/src/components/chat-search/ContextItem.vue
+++ b/packages/components/src/components/chat-search/ContextItem.vue
@@ -3,7 +3,7 @@
     <div class="context__body__table-row__header" @click="openLocation">
       <v-code-icon v-if="isCodeSnippet" class="row-icon" />
       <v-white-appmap-logo v-else class="row-icon" />
-      <div>{{ header }}</div>
+      <div class="row-text">{{ header }}</div>
     </div>
     <div
       class="context__body__table-row__content"
@@ -187,6 +187,12 @@ export default {
     .row-icon {
       margin-right: 0.75rem;
       width: 18px;
+    }
+
+    .row-text {
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
 
     &:hover {

--- a/packages/components/src/stories/ChatSearch.stories.js
+++ b/packages/components/src/stories/ChatSearch.stories.js
@@ -242,7 +242,7 @@ const EmptyAppmapStats = {
   numAppMaps: 0,
 };
 
-function buildMockRpc(searchResponse, explanation, appmapStats = AppmapStats) {
+function buildMockRpc(searchResponse, explanation, appmapStats, navieContext) {
   return (method, params, callback) => {
     if (method === 'explain') {
       statusIndex = 0;
@@ -292,9 +292,21 @@ function buildMockRpc(searchResponse, explanation, appmapStats = AppmapStats) {
   };
 }
 
-const nonEmptyMockRpc = buildMockRpc(NonEmptySearchResponse, MOCK_EXPLANATION);
+const nonEmptyMockRpc = buildMockRpc(
+  NonEmptySearchResponse,
+  MOCK_EXPLANATION,
+  AppmapStats,
+  navieContext
+);
 
-const emptyMockRpc = buildMockRpc(EmptySearchResponse, [], EmptyAppmapStats);
+const noAppMapsContext = navieContext.filter((context) => context.type === 'code-snippet');
+
+const emptyMockRpc = buildMockRpc(
+  EmptySearchResponse,
+  MOCK_EXPLANATION,
+  EmptyAppmapStats,
+  noAppMapsContext
+);
 
 ChatSearchMock.args = {
   appmapRpcFn: nonEmptyMockRpc,


### PR DESCRIPTION
* Adds a message when there is no AppMap data to help the user create AppMap data.
* The `Open Instructions` button opens the installation instructions.
* Re-orders the context data so that AppMap data is above code snippets.
* Clips long AppMap names/paths with an ellipsis in the context view.

![image](https://github.com/getappmap/appmap-js/assets/45714532/9171b419-dce5-4e93-b44e-fbdbd4e70eac)

