### PR TITLE
fix: Upgrade @appland/rpc to v1.9.0

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -30,7 +30,7 @@
     "@appland/client": "workspace:^1.12.0",
     "@appland/diagrams": "workspace:^1.7.0",
     "@appland/models": "workspace:^2.10.0",
-    "@appland/rpc": "workspace:^1.6.0",
+    "@appland/rpc": "workspace:^1.9.0",
     "@appland/sequence-diagram": "workspace:^1.11.0",
     "buffer": "^6.0.3",
     "d3": "^7.8.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -301,7 +301,7 @@ __metadata:
     "@appland/client": "workspace:^1.12.0"
     "@appland/diagrams": "workspace:^1.7.0"
     "@appland/models": "workspace:^2.10.0"
-    "@appland/rpc": "workspace:^1.6.0"
+    "@appland/rpc": "workspace:^1.9.0"
     "@appland/sequence-diagram": "workspace:^1.11.0"
     "@babel/core": ^7.22.5
     "@babel/node": ^7.22.5
@@ -497,7 +497,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@appland/rpc@workspace:^1.6.0, @appland/rpc@workspace:packages/rpc":
+"@appland/rpc@workspace:^1.6.0, @appland/rpc@workspace:^1.9.0, @appland/rpc@workspace:packages/rpc":
   version: 0.0.0-use.local
   resolution: "@appland/rpc@workspace:packages/rpc"
   dependencies:


### PR DESCRIPTION
Without this, the latest live version of components raises an error referencing `ConfigurationRpc.V2.Get.Method`