### PR TITLE
feat: Update Navie token limit to 12,000

### DIFF
--- a/docs/navie/bring-your-own-llm.md
+++ b/docs/navie/bring-your-own-llm.md
@@ -47,7 +47,7 @@ You can use the following variables to direct Navie to use any LLM with an OpenA
 
 * `OPENAI_BASE_URL` — base URL for OpenAI API.
 * `APPMAP_NAVIE_MODEL` — name of the model to use instead of GPT-4.
-* `APPMAP_NAVIE_TOKEN_LIMIT` — maximum context size in tokens (default 8000).
+* `APPMAP_NAVIE_TOKEN_LIMIT` — maximum context size in tokens (default 12000).
 
 For Azure OpenAI, you need to [create a deployment](https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/create-resource) and use these variables instead:
 

--- a/packages/cli/src/rpc/explain/explain.ts
+++ b/packages/cli/src/rpc/explain/explain.ts
@@ -29,7 +29,7 @@ export type SearchContextResponse = {
   codeObjects: string[];
 };
 
-export const DEFAULT_TOKEN_LIMIT = 8000;
+export const DEFAULT_TOKEN_LIMIT = 12000;
 
 export class Explain extends EventEmitter {
   constructor(

--- a/packages/navie/src/explain.ts
+++ b/packages/navie/src/explain.ts
@@ -19,6 +19,8 @@ import LookupContextService from './services/lookup-context-service';
 import ApplyContextService from './services/apply-context-service';
 import ClassificationService from './services/classification-service';
 
+export const DEFAULT_TOKEN_LIMIT = 12000;
+
 export type ChatHistory = Message[];
 
 export interface ClientRequest {
@@ -29,7 +31,7 @@ export interface ClientRequest {
 export class ExplainOptions {
   agentMode: AgentMode | undefined;
   modelName = process.env.APPMAP_NAVIE_MODEL ?? 'gpt-4-0125-preview';
-  tokenLimit = Number(process.env.APPMAP_NAVIE_TOKEN_LIMIT ?? 8000);
+  tokenLimit = Number(process.env.APPMAP_NAVIE_TOKEN_LIMIT ?? DEFAULT_TOKEN_LIMIT);
   temperature = 0.4;
   responseTokens = 1000;
 }


### PR DESCRIPTION
8,000 seems inadequate for larger projects, in which the system prompts may be larger and the sequence diagrams are larger too.