### PR TITLE
feat: Switch to gpt-4-turbo-2024-04-09 as default

### DIFF
--- a/packages/navie/src/explain.ts
+++ b/packages/navie/src/explain.ts
@@ -30,7 +30,7 @@ export interface ClientRequest {
 
 export class ExplainOptions {
   agentMode: AgentMode | undefined;
-  modelName = process.env.APPMAP_NAVIE_MODEL ?? 'gpt-4-0125-preview';
+  modelName = process.env.APPMAP_NAVIE_MODEL ?? 'gpt-4-turbo-2024-04-09';
   tokenLimit = Number(process.env.APPMAP_NAVIE_TOKEN_LIMIT ?? DEFAULT_TOKEN_LIMIT);
   temperature = 0.4;
   responseTokens = 1000;


### PR DESCRIPTION
With 128k context, fresher knowledge and the broadest set of capabilities, GPT-4 Turbo is more powerful than GPT-4 and offered at a lower price.