### PR TITLE
ci: Set NPM auth token for native build finalization

### DIFF
--- a/.github/workflows/build-native-scanner.yml
+++ b/.github/workflows/build-native-scanner.yml
@@ -271,3 +271,5 @@ jobs:
         uses: actions/checkout@v3
 
       - run: yarn npm tag add `echo ${{ github.ref_name }} | sed -e s/-v/@/` latest
+        env:
+          YARN_NPM_AUTH_TOKEN: ${{ secrets.YARN_NPM_AUTH_TOKEN }}

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -270,3 +270,5 @@ jobs:
         uses: actions/checkout@v3
 
       - run: yarn npm tag add `echo ${{ github.ref_name }} | sed -e s/-v/@/` latest
+        env:
+          YARN_NPM_AUTH_TOKEN: ${{ secrets.YARN_NPM_AUTH_TOKEN }}


### PR DESCRIPTION
This fixes that CI failure after building native packages.