### PR TITLE
feat: Include static symbol names in file terms

### DIFF
--- a/packages/cli/src/fulltext/listGitProjectFIles.ts
+++ b/packages/cli/src/fulltext/listGitProjectFIles.ts
@@ -1,42 +1,55 @@
-import { basename, join } from 'path';
-import { executeCommand } from '../lib/executeCommand';
-import { verbose, isFile } from '../utils';
+import { verbose } from '../utils';
+import { exec as execCb } from 'node:child_process';
+import { promisify } from 'util';
+
+const exec = promisify(execCb);
 
 // Run git ls-files and git status to get a list of all git-managed files. By doing it this way,
 // we automatically apply any .gitignore rules.
 export default async function listGitProjectFiles(directory: string): Promise<string[]> {
   const lsFiles = async (): Promise<string[]> => {
-    const gitFiles = (
-      await executeCommand('git ls-files', verbose(), verbose(), verbose(), [0], directory)
-    ).split('\n');
-    return gitFiles.filter(Boolean);
-  };
-  const statusFiles = async (): Promise<string[]> => {
-    return (
-      await executeCommand(
-        'git status --porcelain',
-        verbose(),
-        verbose(),
-        verbose(),
-        [0],
-        directory
-      )
-    )
-      .split('\n')
-      .map((line) => {
-        const [, fileName] = line.split(' ');
-        return fileName;
+    try {
+      const { stdout } = await exec('git ls-files', {
+        cwd: directory,
+        maxBuffer: 1024 ** 2 * 20, // 20 MB
       });
+
+      if (verbose()) console.log(stdout);
+
+      return stdout.split('\n').filter(Boolean);
+    } catch (e) {
+      if (verbose()) {
+        console.error('`git ls-files` failed');
+        console.error(e);
+      }
+      return [];
+    }
   };
 
-  const result = new Set<string>();
-  // TODO: Boost new and modified files.
-  for (const file of [...(await lsFiles()), ...(await statusFiles())]) {
-    if (!file) {
-      continue;
-    }
-    result.add(file);
-  }
+  const statusFiles = async (): Promise<string[]> => {
+    try {
+      const { stdout } = await exec('git status --porcelain', {
+        cwd: directory,
+        maxBuffer: 1024 ** 2 * 20, // 20 MB
+      });
 
-  return [...result];
+      if (verbose()) console.log(stdout);
+
+      return stdout
+        .split('\n')
+        .map((line) => {
+          const [, fileName] = line.split(' ');
+          return fileName;
+        })
+        .filter(Boolean);
+    } catch (e) {
+      if (verbose()) {
+        console.error('`git status --porcelain` failed');
+        console.error(e);
+      }
+      return [];
+    }
+  };
+
+  return Array.from(new Set([...(await lsFiles()), ...(await statusFiles())]));
 }

--- a/packages/cli/src/fulltext/queryKeywords.ts
+++ b/packages/cli/src/fulltext/queryKeywords.ts
@@ -37,7 +37,7 @@ export default function queryKeywords(words: undefined | string | string[]): str
     .map((word) => sanitizeKeyword(word || ''))
     .flat()
     .filter(Boolean)
-    .map((word) => splitCamelized(word).split(/[\s]+/g))
+    .map((word) => splitCamelized(word).split(/[\s_]+/g))
     .flat()
     .map((str) => str.trim())
     .filter(Boolean)

--- a/packages/cli/src/fulltext/querySymbols.ts
+++ b/packages/cli/src/fulltext/querySymbols.ts
@@ -1,0 +1,61 @@
+import { readFileSync } from 'fs';
+
+export const SymbolRegexes: Record<string, RegExp> = {
+  cs: /(((interface|class|enum|struct)\s+(?<symbol1>\w+))|((\s|^)(?!using|try|catch|if|while|do|for|switch)(?<!#define\s+?)(?<symbol2>[\w~$]+)\s*?\([^;)]*?\)[\w\s\d<>[\].:\n]*?{))/g,
+  cpp: /(((struct|enum|union|class)\s+(?<symbol1>\w+)\s*?\{)|(}\s*?(?<symbol2>\w+)\s*?;)|((\s|^)(?!try|catch|if|while|do|for|switch)(?<!#define\s+?)(?<symbol3>[\w~$]+)\s*?\([^;)]*?\)[\w\s\d<>[\].:\n]*?{))/g,
+  rs: /(struct|enum|union|trait|type|fn)\s+(?<symbol1>[\w\p{L}]+)/gu,
+  go: /((type\s+(?<symbol1>[\w\p{L}]+))|(func\s+?(\(.*?\)\s*?)?(?<symbol2>[\w\p{L}]+)\s*?\())/gu,
+  rb: /(((class|module)\s+(?<symbol1>\w+))|(def\s+?(?<symbol2>\w+)))/g,
+  py: /(class|def)\s+(?<symbol1>\w+)/g,
+  java: /(((class|@?interface|enum)\s+(?<symbol1>[\w$]+))|((\s|^)(?!try|catch|if|while|do|for|switch)(?<symbol2>[\w$]+)\s*?\([^;)]*?\)[\w\s\d<>[\].:\n]*?{))/g,
+  ts: /(((class|interface|enum|type|function)\s+(?<symbol1>[#$\w\p{L}]+))|((\s|^)(?!using|try|catch|if|while|do|for|switch)(?<symbol2>[#$\w\p{L}]+)\s*?\([^;)]*?\)[\w\s<>[\].:\n]*?\{)|((?<symbol3>[#$\w\p{L}]+)\s*?(=|:)\s*?\(.*?\)\s*?=>))/gu,
+  kt: /(((class|typealias)\s+(?<symbol1>[\w_]+))|(fun\s+?(<.+?>\s+)?(.*?\.)?(?<symbol2>\w+)))/g,
+  php: /(class|trait|function)\s+(?<symbol1>[\w_$]+)/g,
+};
+
+const genericSymbolRegex =
+  /(((^|\s)(?!using|try|catch|if|while|do|for|switch)(?<symbol1>[#$\w\p{L}~]+)\s*?\(([^;)])*?\)[\w\s<>[\].:\n]*?\{)|(^(?!.*?(?:#|\/\/|"|')).*?(interface|class|enum|struct|union|trait|type(alias|def)?|fu?nc?(tion)?|module|def)\s+?(?<symbol2>[#$\w\p{L}]+))|((?<symbol3>[#$\w\p{L}~]+)\s*?=\s*?[\w\s<>[\].:\n]*?\{))/gmu;
+
+// Define aliases for common file extensions
+['js', 'jsx', 'ts', 'tsx', 'vue', 'svelte'].forEach((ext) => {
+  SymbolRegexes[ext] = SymbolRegexes.ts;
+});
+
+['c', 'cc', 'cxx', 'h', 'hpp', 'cpp', 'hxx'].forEach((ext) => {
+  SymbolRegexes[ext] = SymbolRegexes.cpp;
+});
+
+function getMatches(source: string, regex: RegExp): string[] {
+  const results: string[] = [];
+  const matches = source.matchAll(regex);
+
+  for (const match of matches) {
+    const { groups } = match;
+    const symbol = groups?.symbol1 ?? groups?.symbol2 ?? groups?.symbol3;
+    if (symbol) results.push(symbol);
+  }
+
+  return results;
+}
+
+export default function querySymbols(path: string, allowGeneric = true): string[] {
+  const fileExtension = path.split('.').pop()?.toLowerCase();
+
+  let regex = allowGeneric ? genericSymbolRegex : undefined;
+  if (fileExtension && fileExtension in SymbolRegexes) {
+    regex = SymbolRegexes[fileExtension];
+  }
+
+  if (regex) {
+    try {
+      // readFileSync performs 2x faster than its async counterpart in this case.
+      const content = readFileSync(path, 'utf-8');
+      return getMatches(content, regex);
+    } catch (error) {
+      console.warn(`Error reading file ${path}`);
+      console.warn(error);
+    }
+  }
+
+  return [];
+}

--- a/packages/cli/tests/integration/rpc.explain.spec.ts
+++ b/packages/cli/tests/integration/rpc.explain.spec.ts
@@ -11,7 +11,7 @@ import RemoteNavie from '../../src/rpc/explain/navie/navie-remote';
 import LocalNavie from '../../src/rpc/explain/navie/navie-local';
 import { INavieProvider } from '../../src/rpc/explain/navie/inavie';
 
-import Telemetry from '../../src/telemetry';
+import Telemetry, { Git } from '../../src/telemetry';
 
 jest.mock('@appland/navie');
 
@@ -348,6 +348,7 @@ describe('RPC', () => {
 
 jest.mock('../../src/telemetry');
 Object.defineProperty(Telemetry, 'enabled', { get: jest.fn(), configurable: true });
+jest.mocked(Git.state).mockResolvedValue(0);
 jest.mocked(Explain.ExplainOptions).mockReturnValue({
   modelName: 'test-model',
   responseTokens: 42,

--- a/packages/cli/tests/unit/fixtures/source/sample.c
+++ b/packages/cli/tests/unit/fixtures/source/sample.c
@@ -1,0 +1,30 @@
+#define MODE_DEFAULT 0
+#define MODE_NONE    (MODE_DEFAULT - 1)
+#define MODE_SUPER   (MODE_DEFAULT + 1)
+
+typedef struct {
+  int a;
+  int b;
+} Point;
+
+struct MyStruct {
+  int a;
+  int b;
+};
+
+struct MyOtherStruct
+{
+};
+
+void foo()
+{
+
+}
+
+int main() {
+  Point p;
+  foo();
+  p.a = 1;
+  p.b = 2;
+  return p.a + p.b;
+}

--- a/packages/cli/tests/unit/fixtures/source/sample.cs
+++ b/packages/cli/tests/unit/fixtures/source/sample.cs
@@ -1,0 +1,75 @@
+public class ClassOne { }
+
+public class ClassTwo : IInterface { }
+
+public partial class ClassThree<T> { }
+
+class ClassFour
+{
+
+}
+
+public struct StructOne<T> { }
+
+struct StructTwo
+{
+}
+
+readonly public struct StructThree : IInterface { }
+
+interface IOne { }
+
+public interface ITwo : ISomethingElse
+{
+
+};
+
+private interface IThree<T> { }
+
+namespace MyNamespace
+{
+  interface IFour
+  {
+  }
+}
+
+enum Example { One, Two, Three }
+
+enum Season
+{
+  Spring,
+  Summer,
+  Autumn,
+  Winter
+}
+
+enum ErrorCode : ushort
+{
+  None = 0,
+  Unknown = 1,
+
+  ConnectionLost = 100,
+  OutlierReading = 200
+}
+
+class ClassWithMethods
+{
+  ClassWithMethods() { }
+  ~ClassWithMethods() { }
+  public void MethodOne() { }
+  public static void MethodTwo() { }
+  ISomething MethodThree()
+  {
+    FunctionCall()
+  }
+  ISomething MethodFour()
+  {
+  }
+}
+
+
+#if (DEBUG)
+Console.WriteLine("Hello World");
+#else
+Console.WriteLine("Goodbye World");
+#endif

--- a/packages/cli/tests/unit/fixtures/source/sample.generic
+++ b/packages/cli/tests/unit/fixtures/source/sample.generic
@@ -1,0 +1,103 @@
+// dart
+// via https://dart.dev/language
+
+int fibonacci(int n) {
+  if (n == 0 || n == 1) return n;
+  return fibonacci(n - 1) + fibonacci(n - 2);
+}
+
+class Spacecraft {
+  String name;
+  DateTime? launchDate;
+
+  // Read-only non-final property
+  int? get launchYear => launchDate?.year;
+
+  // Constructor, with syntactic sugar for assignment to members.
+  Spacecraft(this.name, this.launchDate) {
+    // Initialization code goes here.
+  }
+
+  // Named constructor that forwards to the default one.
+  Spacecraft.unlaunched(String name) : this(name, null);
+
+  // Method.
+  void describe() {
+    print('Spacecraft: $name');
+    // Type promotion doesn't work on getters.
+    var launchDate = this.launchDate;
+    if (launchDate != null) {
+      int years = DateTime.now().difference(launchDate).inDays ~/ 365;
+      print('Launched: $launchYear ($years years ago)');
+    } else {
+      print('Unlaunched');
+    }
+  }
+}
+
+enum PlanetType { terrestrial, gas, ice }
+
+// swift
+// via https://docs.swift.org/swift-book/documentation/the-swift-programming-language
+
+struct Resolution {
+    var width = 0
+    var height = 0
+}
+
+class VideoMode {
+    var resolution = Resolution()
+    var interlaced = false
+    var frameRate = 0.0
+    var name: String?
+}
+
+class Counter {
+    var count = 0
+    func increment() {
+        count += 1
+    }
+    func increment(by amount: Int) {
+        count += amount
+    }
+    func reset() {
+        count = 0
+    }
+}
+
+// gdscript
+// via https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_basics.html
+
+func something(p1, p2):
+	super(p1, p2)
+
+
+# It's also possible to call another function in the super class:
+func other_something(p1, p2):
+	super.something(p1, p2)
+
+
+# Inner class
+class Something:
+	var a = 10
+
+
+# Constructor
+func _init():
+	print("Constructed!")
+	var lv = Something.new()
+	print(lv.a)
+
+
+// misc
+
+# fn dont_include_me
+# class CommentedOut {}
+
+// fn dont_include_me_either
+// class CommentedOutToo {}
+
+// qc
+void() perform_action = {
+
+}

--- a/packages/cli/tests/unit/fixtures/source/sample.go
+++ b/packages/cli/tests/unit/fixtures/source/sample.go
@@ -1,0 +1,36 @@
+type Locker interface {
+	Lock()
+	Unlock()
+}
+
+type MyInterface interface {
+	// TODO: Interface methods are not captured
+	//       This symbol will not be reported
+	MyMethod()
+}
+
+type LockerImpl struct {
+}
+
+func (l *LockerImpl) Lock() {
+}
+
+func (l *LockerImpl) Unlock() {
+}
+
+type Reader interface {
+	Read(p []byte) (n int, err error)
+}
+
+type ReadWriter interface {
+	Reader  // includes methods of Reader in ReadWriter's method set
+	Writer  // includes methods of Writer in ReadWriter's method set
+}
+
+func main() {
+	fmt.Println("Hello, World!")
+}
+
+func unicodeβ(s string) string {
+	return s
+}

--- a/packages/cli/tests/unit/fixtures/source/sample.java
+++ b/packages/cli/tests/unit/fixtures/source/sample.java
@@ -1,0 +1,21 @@
+public enum SampleEnum {
+    A, B, C
+}
+
+public @interface SampleAnnotation {
+}
+
+public interface ISample {
+    public void sampleMethod();
+}
+
+public class Sample {
+    public static void main(String[] args) {
+        System.out.println("Hello, world!");
+    }
+}
+
+public void performUserOperation(User user,
+                                 Operation op) {
+    super.performUserOperation(user, op);
+}

--- a/packages/cli/tests/unit/fixtures/source/sample.kt
+++ b/packages/cli/tests/unit/fixtures/source/sample.kt
@@ -1,0 +1,23 @@
+fun main(args: Array<String>) {
+    println(args.contentToString())
+}
+
+class Rectangle(val height: Double, val length: Double) {
+    val perimeter = (height + length) * 2
+}
+
+typealias Predicate<T> = (T) -> Boolean
+
+enum class Color(val value: Int) {
+    RED(1),
+    GREEN(2),
+    BLUE(3)
+}
+
+fun <T> List<T>.filter(predicate: Predicate<T>): List<T> {
+    return this.filter(predicate)
+}
+
+fun <T: Comparable<T>> sort(list: List<T>): List<T> {
+    return list.sorted()
+}

--- a/packages/cli/tests/unit/fixtures/source/sample.php
+++ b/packages/cli/tests/unit/fixtures/source/sample.php
@@ -1,0 +1,18 @@
+<?php
+class MyClass
+{
+    public function myMethod() {
+        print "Hello World";
+    }
+}
+
+trait Talk {
+  public function talk() {
+      echo 'Hello';
+  }
+}
+
+function myFunction() {
+  echo "Hello world!";
+}
+?>

--- a/packages/cli/tests/unit/fixtures/source/sample.py
+++ b/packages/cli/tests/unit/fixtures/source/sample.py
@@ -1,0 +1,9 @@
+def some_function():
+    print("Hello, world!")
+
+class MyClass:
+    def __init__(self, name):
+        self.name = name
+
+    def say_hello(self):
+        print(f"Hello, {self.name}!")

--- a/packages/cli/tests/unit/fixtures/source/sample.rb
+++ b/packages/cli/tests/unit/fixtures/source/sample.rb
@@ -1,0 +1,16 @@
+class MyClass
+  def my_method
+    puts 'Hello world'
+  end
+end
+
+module MyModule
+  def my_module_method
+    puts 'Hello world'
+  end
+end
+
+def some_function(name)
+  calling_a_method
+  puts "Hello #{name}"
+end

--- a/packages/cli/tests/unit/fixtures/source/sample.rs
+++ b/packages/cli/tests/unit/fixtures/source/sample.rs
@@ -1,0 +1,33 @@
+struct Foo {
+    bar: String,
+}
+
+impl Foo {
+    fn new(bar: String) -> Self {
+        Self { bar }
+    }
+}
+
+#[repr(C)]
+union MyUnion {
+    f1: u32,
+    f2: f32,
+}
+
+trait MyTrait {
+    fn my_function(&self);
+}
+
+type Point = (u8, u8);
+
+fn main() {
+    let foo = Foo {
+        bar: "Hello, world!".to_string(),
+    };
+
+    println!("{}", foo.bar);
+}
+
+fn Москва() -> Option<Self> {
+    None
+}

--- a/packages/cli/tests/unit/fixtures/source/sample.ts
+++ b/packages/cli/tests/unit/fixtures/source/sample.ts
@@ -1,0 +1,46 @@
+class MyClass {
+  public readonly name: string;
+
+  constructor() {
+    this.name = 'MyClass';
+  }
+
+  #myClassMethod() {
+    return 'myClassMethod';
+  }
+}
+
+function myFunction() {
+  return 'myFunction';
+}
+
+const myOtherFunction = () => 'myOtherFunction';
+
+type MyType = {
+  name: string;
+};
+
+interface MyInterface {
+  name: string;
+}
+
+enum MyEnum {
+  A = 'A',
+  B = 'B',
+  C = 'C',
+}
+
+const myObject = {
+  myObjectMethod: () => {},
+};
+
+// prettier-ignore
+function newLineBraces()
+{
+}
+
+// prettier-ignore
+const $lineBreak = () => 
+  {
+
+  };

--- a/packages/cli/tests/unit/fulltext/FileIndex.spec.ts
+++ b/packages/cli/tests/unit/fulltext/FileIndex.spec.ts
@@ -5,6 +5,7 @@ import sqlite3 from 'better-sqlite3';
 import tmp from 'tmp';
 
 import { FileIndex, filterFiles } from '../../../src/fulltext/FileIndex';
+import * as querySymbols from '../../../src/fulltext/querySymbols';
 
 describe('FileIndex', () => {
   let fileIndex: FileIndex;
@@ -41,9 +42,7 @@ describe('FileIndex', () => {
   describe('when matches are found', () => {
     beforeEach(() => {
       fileIndex = new FileIndex(database);
-      for (const file of files) {
-        fileIndex.indexFile(file.directory, file.fileName);
-      }
+      files.forEach(({ directory, fileName }) => fileIndex.indexFile(directory, fileName));
     });
     afterEach(() => fileIndex.close());
 
@@ -65,6 +64,15 @@ describe('FileIndex', () => {
     it('does not match directory nanmes', () => {
       const results = fileIndex.search(['dir1'], 10);
       expect(results.map((r) => ({ directory: r.directory, fileName: r.fileName }))).toEqual([]);
+    });
+  });
+
+  describe('indexFile', () => {
+    it('does not query symbols if allowSymbols is false', () => {
+      const querySymbolsFn = jest.spyOn(querySymbols, 'default');
+      const fileIndex = new FileIndex(database);
+      fileIndex.indexFile('dir1', 'file1', { allowSymbols: false });
+      expect(querySymbolsFn).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/cli/tests/unit/fulltext/listGitProjectFiles.spec.ts
+++ b/packages/cli/tests/unit/fulltext/listGitProjectFiles.spec.ts
@@ -1,9 +1,10 @@
-import * as executeCommandModule from '../../../src/lib/executeCommand';
 import * as utilsModule from '../../../src/utils';
 import listGitProjectFiles from '../../../src/fulltext/listGitProjectFIles';
+import * as childProcess from 'node:child_process';
+import type { ChildProcess } from 'node:child_process';
 
 // Mock dependencies
-jest.mock('../../../src/lib/executeCommand');
+jest.mock('node:child_process');
 jest.mock('../../../src/utils', () => ({
   ...jest.requireActual('../../../src/utils'),
   isFile: jest.fn(),
@@ -16,14 +17,19 @@ describe('listGitProjectFiles', () => {
     // Clear all mocks before each test
     jest.clearAllMocks();
     // Setup default return values for mocked functions
-    jest.mocked(executeCommandModule.executeCommand).mockImplementation(async (cmd) => {
+    jest.mocked(childProcess.exec).mockImplementation((cmd: string, _options, callback) => {
+      const cb = callback as (_: unknown, __: unknown) => void;
       if (cmd.includes('ls-files')) {
-        return 'file1.js\nfile2.png';
+        cb(null, { stdout: 'file1.js\nfile2.png' });
+      } else if (cmd.includes('status --porcelain')) {
+        cb(null, {
+          stdout: '?? newFile.ts\nM modifiedFile.js',
+        });
+      } else {
+        cb(null, { stdout: '' });
       }
-      if (cmd.includes('status --porcelain')) {
-        return '?? newFile.ts\nM modifiedFile.js';
-      }
-      return '';
+
+      return {} as ChildProcess;
     });
     jest.mocked(utilsModule.isFile).mockResolvedValue(true);
   });

--- a/packages/cli/tests/unit/fulltext/querySymbols.spec.ts
+++ b/packages/cli/tests/unit/fulltext/querySymbols.spec.ts
@@ -1,0 +1,188 @@
+import { join } from 'path';
+import querySymbols from '../../../src/fulltext/querySymbols';
+
+describe('querySymbols', () => {
+  describe('csharp', () => {
+    it('identifies symbols', () => {
+      const srcPath = join(__dirname, '../fixtures/source/sample.cs');
+      const symbols = querySymbols(srcPath);
+      expect(symbols.sort()).toStrictEqual(
+        [
+          'ClassOne',
+          'ClassTwo',
+          'ClassThree',
+          'ClassFour',
+          'StructOne',
+          'StructTwo',
+          'StructThree',
+          'IOne',
+          'ITwo',
+          'IThree',
+          'IFour',
+          'Example',
+          'Season',
+          'ErrorCode',
+          'ClassWithMethods',
+          'ClassWithMethods',
+          '~ClassWithMethods',
+          'MethodOne',
+          'MethodTwo',
+          'MethodThree',
+          'MethodFour',
+        ].sort()
+      );
+    });
+  });
+
+  describe('c/cpp', () => {
+    it('identifies symbols', () => {
+      const srcPath = join(__dirname, '../fixtures/source/sample.c');
+      const symbols = querySymbols(srcPath);
+      expect(symbols.sort()).toStrictEqual(
+        ['foo', 'main', 'MyStruct', 'MyOtherStruct', 'Point'].sort()
+      );
+    });
+  });
+
+  describe('rust', () => {
+    it('identifies symbols', () => {
+      const srcPath = join(__dirname, '../fixtures/source/sample.rs');
+      const symbols = querySymbols(srcPath);
+      expect(symbols.sort()).toStrictEqual(
+        ['Foo', 'new', 'MyUnion', 'MyTrait', 'my_function', 'Point', 'main', 'Москва'].sort()
+      );
+    });
+  });
+
+  describe('go', () => {
+    it('identifies symbols', () => {
+      const srcPath = join(__dirname, '../fixtures/source/sample.go');
+      const symbols = querySymbols(srcPath);
+      expect(symbols.sort()).toStrictEqual(
+        [
+          'Locker',
+          'MyInterface',
+          'LockerImpl',
+          'Lock',
+          'Unlock',
+          'Reader',
+          'ReadWriter',
+          'main',
+          'unicodeβ',
+        ].sort()
+      );
+    });
+  });
+
+  describe('ruby', () => {
+    it('identifies symbols', () => {
+      const srcPath = join(__dirname, '../fixtures/source/sample.rb');
+      const symbols = querySymbols(srcPath);
+      expect(symbols.sort()).toStrictEqual(
+        ['MyClass', 'MyModule', 'my_method', 'my_module_method', 'some_function'].sort()
+      );
+    });
+  });
+
+  describe('python', () => {
+    it('identifies symbols', () => {
+      const srcPath = join(__dirname, '../fixtures/source/sample.py');
+      const symbols = querySymbols(srcPath);
+      expect(symbols.sort()).toStrictEqual(
+        ['MyClass', '__init__', 'say_hello', 'some_function'].sort()
+      );
+    });
+  });
+
+  describe('java', () => {
+    it('identifies symbols', () => {
+      const srcPath = join(__dirname, '../fixtures/source/sample.java');
+      const symbols = querySymbols(srcPath);
+      expect(symbols.sort()).toStrictEqual(
+        [
+          'SampleEnum',
+          'SampleAnnotation',
+          'ISample',
+          'Sample',
+          'main',
+          'performUserOperation',
+        ].sort()
+      );
+    });
+  });
+
+  describe('javascript/typescript', () => {
+    it('identifies symbols', () => {
+      const srcPath = join(__dirname, '../fixtures/source/sample.ts');
+      const symbols = querySymbols(srcPath);
+      expect(symbols.sort()).toStrictEqual(
+        [
+          'MyClass',
+          'constructor',
+          '#myClassMethod',
+          'myFunction',
+          'myOtherFunction',
+          'MyType',
+          'MyInterface',
+          'MyEnum',
+          'myObjectMethod',
+          'newLineBraces',
+          '$lineBreak',
+        ].sort()
+      );
+    });
+  });
+
+  describe('kotlin', () => {
+    it('identifies symbols', () => {
+      const srcPath = join(__dirname, '../fixtures/source/sample.kt');
+      const symbols = querySymbols(srcPath);
+      expect(symbols.sort()).toStrictEqual(
+        ['main', 'Rectangle', 'Predicate', 'Color', 'filter', 'sort'].sort()
+      );
+    });
+  });
+
+  describe('php', () => {
+    it('identifies symbols', () => {
+      const srcPath = join(__dirname, '../fixtures/source/sample.php');
+      const symbols = querySymbols(srcPath);
+      expect(symbols.sort()).toStrictEqual(
+        ['MyClass', 'myMethod', 'Talk', 'talk', 'myFunction'].sort()
+      );
+    });
+  });
+
+  describe('generic', () => {
+    const srcPath = join(__dirname, '../fixtures/source/sample.generic');
+
+    it('identifies symbols', () => {
+      const symbols = querySymbols(srcPath);
+      expect(symbols.sort()).toStrictEqual(
+        [
+          'fibonacci',
+          'Spacecraft',
+          'Spacecraft',
+          'describe',
+          'PlanetType',
+          'Resolution',
+          'VideoMode',
+          'Counter',
+          'increment',
+          'increment',
+          'reset',
+          'Something',
+          '_init',
+          'other_something',
+          'something',
+          'perform_action',
+        ].sort()
+      );
+    });
+
+    it('does not run if allowGeneric is false', () => {
+      const symbols = querySymbols(srcPath, false);
+      expect(symbols).toStrictEqual([]);
+    });
+  });
+});

--- a/packages/telemetry/telemetry.spec.ts
+++ b/packages/telemetry/telemetry.spec.ts
@@ -190,15 +190,9 @@ describe('telemetry', () => {
       expect(contributors.length).toBeGreaterThan(0);
     });
 
-    it('properly caches the list of git contributors', async () => {
-      let firstResult: string[] | undefined;
-      for (let i = 0; i < 10; i++) {
-        if (!firstResult) {
-          firstResult = await Git.contributors(sinceDaysAgo);
-        }
-
-        expect(await Git.contributors(sinceDaysAgo)).toEqual(firstResult);
-      }
+    it('properly caches the list of git contributors', () => {
+      const firstResult = Git.contributors(sinceDaysAgo);
+      expect(Git.contributors(sinceDaysAgo)).toEqual(firstResult);
     });
 
     describe('state', () => {


### PR DESCRIPTION
This approach uses RegEx to scrape function, class, interface, union, etc. names from source when building a full text index. This should improve accuracy when searching for static context.

There's some work left to do here, including:
- [x] Adding execution flow keywords to tests (I know they're being included in some cases, see the sample)
- [x] Another pass on some of the RegEx patterns, some may be needlessly long
- [x] Low hanging optimization?

I've been testing this locally with [Quake](https://github.com/id-Software/Quake) and [UnrealEngine](https://github.com/epicgames/unrealengine) (31.4M lines parsed)
```
Indexed 592 files in /home/db/dev/id-software/Quake in 254ms
```

```
Indexed 182567 files in /home/db/dev/EpicGames/UnrealEngine in 44628ms
```

Sample
```
Indexing file path QW/client/gl_mesh.c with terms QW client gl mesh GL alias build display fan length lists make model strip tris
Indexing file path QW/client/gl_draw.c with terms QW client gl draw EXT GL alloc alpha alt background begin bind bit block cachepic char character clear conback console crosshair debug disc draw end fade fill find glmode glpic gltexture init load map map8 mip mode pic resample resample8 scrap screen select set2 string sub texture tile trans translate upload upload32 upload8
Indexing file path QW/client/gl_model.c with terms QW client gl model alias all bounds brush calc clear clipnodes edges entities extents faces fill flood floodfill frame group hull0 init leafs lighting load make marksurfaces mod model nodes parent planes print radius set skin sprite submodels surface surfedges texinfo textures touch vertexes visibility
Indexing file path QW/client/gl_model.h with terms QW client gl model aliashdr glpoly hull maliasframedesc maliasgroup maliasgroupframedesc medge mleaf mnode model modtype mplane msprite mspriteframe mspriteframedesc mspritegroup msurface mtexinfo mtriangle mvertex texture
Indexing file path QW/client/gl_ngraph.c with terms QW client gl ngraph char draw graph line net
Indexing file path QW/client/gl_refrag.c with terms QW client gl refrag add efrags entity node remove split store
Indexing file path QW/client/gl_rlight.c with terms QW client gl rlight add animate blend bubble dlight dlights init light lights mark point push recursive render
Indexing file path QW/client/gl_rmain.c with terms QW client gl rmain GL alias blend box clear cull draw entities entity frame frustum list mirror model perspective plane poly render rotate scene set setup shadow signbits sprite view yglu
Indexing file path QW/client/gl_rmisc.c with terms QW client gl rmisc caches envmap flush init map new particle player refresh skin texture textures time translate
Indexing file path QW/client/gl_rsurf.c with terms QW client gl rsurf GL add alloc blend block break brush build chain chains create disable display draw dynamic enable gl leaves light lightmap lightmaps lights list map mark mirror model multitexture node poly rect recursive render return sequential surface surfaces texture water world
Indexing file path QW/client/gl_screen.c with terms QW client gl screen FPS PC RS SCR bring calc center char check clear color console down draw fov header init loading message mip modal net notify pause print ram refdef screen set shot size snap string targa tile turtle up update write xfile
Indexing file path QW/client/gl_test.c with terms QW client gl test draw init puff spawn test
Indexing file path QW/client/gl_vidlinux.c with terms QW client gl vidlinux GL IN KBD VID begin buffer center commands direct end events findres force handler init init8bit is8bit key keyhandler lock matchmouse mouse mousehandler move palette rect rendering send set shift shutdown sig signal sys unlock view vtswitch
Indexing file path QW/client/gl_vidlinux_svga.c with terms QW client gl vidlinux svga GL IN KBD VID begin buffer center commands direct end events findres force gamma handler init init8bit is8bit key keyhandler lock matchmouse mouse mousehandler move palette rect rendering send set shift shutdown sig signal sys unlock view vtswitch
Indexing file path QW/client/gl_vidlinux_x11.c with terms QW client gl vidlinux x11 GL IN VID begin break buffer center commands direct end events force gamma handler init init8bit is8bit key keyboard late lock mouse move palette rect rendering send set shift shutdown sig signal sys unlock update view
Indexing file path QW/client/gl_vidlinuxglx.c with terms QW client gl vidlinuxglx GL IN VID begin break buffer center commands direct end event events force get grabs handler init init8bit install is8bit key late lock mouse move palette rect rendering send set shift shutdown sig signal sys uninstall unlock view
Indexing file path QW/client/gl_vidnt.c with terms QW client gl vidnt DIB GL VID all array begin break buffer center check clear current default describe direct draw end extensions force format full gamma handle init init8bit is8bit key lmode lock main map menu mode modedesc modes multi num palette pause pixel proc rect rendering return set setup shift shutdown state states status texture unlock unlocked update vmode window windowed wnd
Indexing file path QW/client/gl_warp.c with terms QW client gl warp GL PCX TGA both bound box chain clear clip draw emit fget header init layers little load long make pcx poly polygon polys short sky skys subdivide surface targa vec water
Indexing file path QW/client/gl_warp_sin.h with terms QW client gl warp sin 
Indexing file path QW/client/glquake.h with terms QW client glquake drawsurf glvert particle ptype surfcache
Indexing file path QW/client/glquake2.h with terms QW client glquake2 drawsurf glvert particle ptype surfcache
Indexing file path QW/client/in_null.c with terms QW client null IN changed commands init mode move shutdown
Indexing file path QW/client/input.h with terms QW client input 
Indexing file path QW/client/in_win.c with terms QW client win IN MYDATA accumulate activate advanced break center clear clip commands control cursor deactivate event force hide init input joy joystick list mouse move original pointer quake raw
Indexing file path QW/client/keys.c with terms QW client keys bind binding bindings check clear command complete console event init key keyname keynum message return set states string unbind unbindall write
Indexing file path QW/client/keys.h with terms QW client keys keydest
```