### PR TITLE
fix: Improve context gathering performance

### DIFF
--- a/packages/cli/src/fulltext/listGitProjectFIles.ts
+++ b/packages/cli/src/fulltext/listGitProjectFIles.ts
@@ -1,7 +1,6 @@
 import { basename, join } from 'path';
 import { executeCommand } from '../lib/executeCommand';
 import { verbose, isFile } from '../utils';
-import { isBinaryFile } from './listProjectFiles';
 
 // Run git ls-files and git status to get a list of all git-managed files. By doing it this way,
 // we automatically apply any .gitignore rules.
@@ -36,11 +35,8 @@ export default async function listGitProjectFiles(directory: string): Promise<st
     if (!file) {
       continue;
     }
-    const filePath = join(directory, file);
-    if ((await isFile(filePath)) && !isBinaryFile(basename(filePath))) {
-      result.add(file);
-    }
+    result.add(file);
   }
 
-  return [...result].sort();
+  return [...result];
 }

--- a/packages/cli/src/fulltext/listProjectFiles.ts
+++ b/packages/cli/src/fulltext/listProjectFiles.ts
@@ -2,79 +2,9 @@ import assert from 'assert';
 import { readdir } from 'fs/promises';
 import { basename, join } from 'path';
 
-export const COMMON_REPO_BINARY_FILE_EXTENSIONS: string[] = [
-  'png',
-  'jpg',
-  'jpeg',
-  'gif',
-  'bmp',
-  'ico',
-  'tiff',
-  'webp',
-  'svg',
-  'mp3',
-  'wav',
-  'ogg',
-  'flac',
-  'aac',
-  'mp4',
-  'webm',
-  'mkv',
-  'avi',
-  'mov',
-  'wmv',
-  'mpg',
-  'flv',
-  'zip',
-  'tar',
-  'gz',
-  'bz2',
-  'xz',
-  '7z',
-  'rar',
-  'pdf',
-  'doc',
-  'docx',
-  'xls',
-  'xlsx',
-  'ppt',
-  'pptx',
-  'odt',
-  'ods',
-  'odp',
-  'rtf',
-  'woff',
-  'woff2',
-  'eot',
-  'ttf',
-  'otf',
-  'ico',
-  'flv',
-  'avi',
-  'mov',
-  'wmv',
-  'mpg',
-  'jar',
-  'war',
-  'ear',
-  'class',
-  'so',
-  'dll',
-  'exe',
-  'min.js',
-  'min.css',
-];
-
 const IGNORE_DIRECTORIES = ['node_modules', 'vendor', 'tmp', 'build', 'dist', 'target'];
 
 const DEFAULT_PROJECT_FILE_LIMIT = 1000;
-
-export function isBinaryFile(fileName: string): boolean {
-  const extension = fileName.split('.').pop();
-  if (extension && COMMON_REPO_BINARY_FILE_EXTENSIONS.includes(extension)) return true;
-
-  return false;
-}
 
 // Produce a modest-sized listing of files in the project.
 // Ignore a standard list of binary file extensions and directories that tend to be full of
@@ -86,7 +16,6 @@ export default async function listProjectFiles(
   const files = new Array<string>();
 
   const ignoreDirectory = (dir: string) => IGNORE_DIRECTORIES.includes(dir);
-  const ignoreFile = (file: string) => isBinaryFile(file);
 
   // Perform a breadth-first traversal of a directory, collecting all non-binary files and
   // applying the directory ignore list.
@@ -101,9 +30,7 @@ export default async function listProjectFiles(
         const fullPath = join(currentDir, entry.name);
         if (entry.isDirectory()) {
           if (!ignoreDirectory(entry.name)) queue.push(fullPath);
-        } else if (entry.isFile()) {
-          if (!ignoreFile(entry.name)) files.push(fullPath);
-        }
+        } else files.push(fullPath);
       }
     }
   };

--- a/packages/cli/tests/unit/fulltext/FileIndex.spec.ts
+++ b/packages/cli/tests/unit/fulltext/FileIndex.spec.ts
@@ -36,7 +36,6 @@ describe('FileIndex', () => {
   describe('when matches are found', () => {
     beforeEach(() => {
       fileIndex = new FileIndex(database);
-      fileIndex.initializeIndex();
       for (const file of files) {
         fileIndex.indexFile(file.directory, file.fileName);
       }

--- a/packages/cli/tests/unit/fulltext/SourceIndex.spec.ts
+++ b/packages/cli/tests/unit/fulltext/SourceIndex.spec.ts
@@ -22,7 +22,6 @@ describe('SourceIndex', () => {
 
     beforeEach(async () => {
       sourceIndex = new SourceIndex(database);
-      sourceIndex.initializeIndex();
       await sourceIndex.indexFiles(files);
     });
     afterEach(() => sourceIndex.close());

--- a/packages/cli/tests/unit/fulltext/listGitProjectFiles.spec.ts
+++ b/packages/cli/tests/unit/fulltext/listGitProjectFiles.spec.ts
@@ -1,6 +1,5 @@
 import * as executeCommandModule from '../../../src/lib/executeCommand';
 import * as utilsModule from '../../../src/utils';
-import { isBinaryFile } from '../../../src/fulltext/listProjectFiles';
 import listGitProjectFiles from '../../../src/fulltext/listGitProjectFIles';
 
 // Mock dependencies
@@ -8,9 +7,6 @@ jest.mock('../../../src/lib/executeCommand');
 jest.mock('../../../src/utils', () => ({
   ...jest.requireActual('../../../src/utils'),
   isFile: jest.fn(),
-}));
-jest.mock('../../../src/fulltext/listProjectFiles', () => ({
-  isBinaryFile: jest.fn(),
 }));
 
 describe('listGitProjectFiles', () => {
@@ -30,17 +26,13 @@ describe('listGitProjectFiles', () => {
       return '';
     });
     jest.mocked(utilsModule.isFile).mockResolvedValue(true);
-    jest
-      .mocked(isBinaryFile)
-      .mockImplementation((fileName) => !fileName.endsWith('.js') && !fileName.endsWith('.ts'));
   });
 
-  it('includes non-binary git-managed files and filters out binary and unmanaged files', async () => {
+  it('includes non-binary git-managed files and filters out unmanaged files', async () => {
     const files = await listGitProjectFiles(mockDirectory);
 
     expect(files).toContain('file1.js');
     expect(files).toContain('newFile.ts');
     expect(files).toContain('modifiedFile.js');
-    expect(files).not.toContain('file2.png'); // filter out binary file
   });
 });

--- a/packages/cli/tests/unit/fulltext/listProjectFiles.spec.ts
+++ b/packages/cli/tests/unit/fulltext/listProjectFiles.spec.ts
@@ -1,4 +1,4 @@
-import listProjectFiles, { isBinaryFile } from '../../../src/fulltext/listProjectFiles';
+import listProjectFiles from '../../../src/fulltext/listProjectFiles';
 import * as fs from 'fs';
 import * as fsp from 'fs/promises';
 import { join } from 'path';
@@ -12,7 +12,7 @@ describe('listProjectFiles', () => {
     jest.resetAllMocks();
   });
 
-  it('lists all non-binary, non-ignored files in a directory', async () => {
+  it('lists all files in a directory', async () => {
     const mockFiles = [
       { name: 'index.js', isFile: () => true, isDirectory: () => false } as unknown as fs.Dirent,
       { name: 'logo.png', isFile: () => true, isDirectory: () => false } as unknown as fs.Dirent,
@@ -31,7 +31,6 @@ describe('listProjectFiles', () => {
     const files = await listProjectFiles(baseDir);
     expect(files).toContain(join(baseDir, 'index.js'));
     expect(files).toContain(join(baseDir, 'utils', 'helper.js'));
-    expect(files).not.toContain(join(baseDir, 'logo.png'));
     expect(fsp.readdir).toHaveBeenCalledTimes(2); // baseDir + utils
   });
 
@@ -57,11 +56,5 @@ describe('listProjectFiles', () => {
     const files = await listProjectFiles(baseDir);
     expect(files).toEqual([]);
     expect(directoriesRead).toEqual([baseDir, join(baseDir, 'src')]);
-  });
-
-  it('identifies binary files correctly', () => {
-    expect(isBinaryFile('image.png')).toBe(true);
-    expect(isBinaryFile('document.pdf')).toBe(true);
-    expect(isBinaryFile('script.js')).toBe(false);
   });
 });


### PR DESCRIPTION
Before (some debugging added):
```
$ time node built/rpc/explain/try.js
collecting context,  ContextCollector {
  appmapDirectories: [ '/home/divide/projects/applandinc.github.io' ],
  sourceDirectories: [ '/home/divide/projects/applandinc.github.io' ],
  vectorTerms: [
    'edit',     'file',
    '+appmap',  'node',
    'diagnose', 'common',
    'problems'
  ],
  charLimit: 15924,
  query: 'edit file +appmap node diagnose common problems'
}
Wrote file index to /tmp/user/1000/appmap-files-1714750213119aYPMUP/index.sqlite
buildFileIndex: 16.683s
Requested char limit: 15924
Collecting context with 5 events per diagram.
collectEvents: 0.253ms
Building source index with 10 files
Indexing 10 files:
  6950 B	_docs/reference/appmap-node.md
   694 B	_plugins/file_exists.rb
  1274 B	_includes/docs/node_support_matrix.html
  1608 B	blog/_posts/2023-06-09-share-your-appmap-files-and-findings-with-your-team.markdown
 22545 B	blog/_posts/2021-02-04-eager-loading-and-the-n-plus-one-query-problem.markdown
   785 B	videos/_posts/2021-04-02-detect-the-n-plus-1-query-problem-in-rails-apps-in-under-5-minutes.markdown
  5609 B	blog/_posts/2022-01-18-why-we-are-bringing-google-maps-for-code-to-node-js-apps.markdown
   268 B	videos/_posts/2021-10-04-how-to-detect-and-fix-the-n-plus-one-problem-for-java-spring-framework-applications.md
   109 B	appmap.yml
576993 B	assets/appmaps/authn_provider_not_logged_in.appmap.json
indexFiles: 28.565s
Wrote file index to /tmp/user/1000/appmap-source-1714750229833CTnfnM/index.sqlite
buildSourceIndex: 28.597s
source index documents:  124
Remaining characters before context: 15924
Characterlimit reached.
Added 16203 characters out of a requested limit of 15924.
Collected an estimated 16203 characters.

real	0m45.678s
user	0m1.857s
sys	0m2.818s
```

After:
```
$ time node built/rpc/explain/try.js
collecting context,  ContextCollector {
  appmapDirectories: [ '/home/divide/projects/applandinc.github.io' ],
  sourceDirectories: [ '/home/divide/projects/applandinc.github.io' ],
  vectorTerms: [
    'edit',     'file',
    '+appmap',  'node',
    'diagnose', 'common',
    'problems'
  ],
  charLimit: 15924,
  query: 'edit file +appmap node diagnose common problems'
}
Wrote file index to /tmp/user/1000/appmap-files-17147501572813UoJhV/index.sqlite
buildFileIndex: 152.792ms
Requested char limit: 15924
Collecting context with 5 events per diagram.
collectEvents: 0.261ms
Building source index with 10 files
Indexing 10 files:
  6950 B	_docs/reference/appmap-node.md
   694 B	_plugins/file_exists.rb
  1274 B	_includes/docs/node_support_matrix.html
  1608 B	blog/_posts/2023-06-09-share-your-appmap-files-and-findings-with-your-team.markdown
 22545 B	blog/_posts/2021-02-04-eager-loading-and-the-n-plus-one-query-problem.markdown
   785 B	videos/_posts/2021-04-02-detect-the-n-plus-1-query-problem-in-rails-apps-in-under-5-minutes.markdown
  5609 B	blog/_posts/2022-01-18-why-we-are-bringing-google-maps-for-code-to-node-js-apps.markdown
   268 B	videos/_posts/2021-10-04-how-to-detect-and-fix-the-n-plus-one-problem-for-java-spring-framework-applications.md
   109 B	appmap.yml
576993 B	assets/appmaps/authn_provider_not_logged_in.appmap.json
indexFiles: 294.845ms
Wrote file index to /tmp/user/1000/appmap-source-1714750157438Qvdzs8/index.sqlite
buildSourceIndex: 343.727ms
source index documents:  124
Remaining characters before context: 15924
Characterlimit reached.
Added 16203 characters out of a requested limit of 15924.
Collected an estimated 16203 characters.

real	0m0.934s
user	0m0.933s
sys	0m0.302s
```

- Disable data safety SQLite features that don't make sense in the temporary databases.
- Insert rows in bulk using a single prepared statement inside a transaction.