### PR TITLE
feat: Add conversation parameters

### DIFF
--- a/packages/cli/src/cmds/index/index.ts
+++ b/packages/cli/src/cmds/index/index.ts
@@ -109,12 +109,11 @@ export const handler = async (argv) => {
       };
 
       const buildLocalNavie = (
-        threadId: string | undefined,
         contextProvider: ContextV2.ContextProvider,
         projectInfoProvider: ProjectInfo.ProjectInfoProvider,
         helpProvider: Help.HelpProvider
       ) => {
-        const navie = new LocalNavie(threadId, contextProvider, projectInfoProvider, helpProvider);
+        const navie = new LocalNavie(contextProvider, projectInfoProvider, helpProvider);
 
         let START: number | undefined;
 
@@ -133,11 +132,10 @@ export const handler = async (argv) => {
         return navie;
       };
       const buildRemoteNavie = (
-        threadId: string | undefined,
         contextProvider: ContextV2.ContextProvider,
         projectInfoProvider: ProjectInfo.ProjectInfoProvider,
         helpProvider: Help.HelpProvider
-      ) => new RemoteNavie(threadId, contextProvider, projectInfoProvider, helpProvider);
+      ) => new RemoteNavie(contextProvider, projectInfoProvider, helpProvider);
 
       const navieProvider = useLocalNavie() ? buildLocalNavie : buildRemoteNavie;
 

--- a/packages/cli/src/cmds/navie.ts
+++ b/packages/cli/src/cmds/navie.ts
@@ -119,13 +119,12 @@ export function buildNavieProvider(argv: ExplainArgs) {
   };
 
   const buildLocalNavie = (
-    threadId: string | undefined,
     contextProvider: ContextV2.ContextProvider,
     projectInfoProvider: ProjectInfo.ProjectInfoProvider,
     helpProvider: Help.HelpProvider
   ) => {
     loadConfiguration(false);
-    const navie = new LocalNavie(threadId, contextProvider, projectInfoProvider, helpProvider);
+    const navie = new LocalNavie(contextProvider, projectInfoProvider, helpProvider);
     applyAIOptions(navie);
 
     let START: number | undefined;
@@ -145,13 +144,12 @@ export function buildNavieProvider(argv: ExplainArgs) {
   };
 
   const buildRemoteNavie = (
-    threadId: string | undefined,
     contextProvider: ContextV2.ContextProvider,
     projectInfoProvider: ProjectInfo.ProjectInfoProvider,
     helpProvider: Help.HelpProvider
   ) => {
     loadConfiguration(true);
-    const navie = new RemoteNavie(threadId, contextProvider, projectInfoProvider, helpProvider);
+    const navie = new RemoteNavie(contextProvider, projectInfoProvider, helpProvider);
     applyAIOptions(navie);
     return navie;
   };

--- a/packages/cli/src/rpc/explain/navie/inavie.ts
+++ b/packages/cli/src/rpc/explain/navie/inavie.ts
@@ -1,9 +1,15 @@
 import { ContextV2, Help, ProjectInfo } from '@appland/navie';
 
 export default interface INavie {
+  get providerName(): string;
+
   setOption(key: string, value: string | number): void;
 
-  ask(question: string, codeSelection: string | undefined): Promise<void>;
+  ask(
+    threadId: string | undefined,
+    question: string,
+    codeSelection: string | undefined
+  ): Promise<void>;
 
   on(event: 'ack', listener: (userMessageId: string, threadId: string) => void): this;
   on(event: 'token', listener: (token: string, messageId: string) => void): this;
@@ -12,7 +18,6 @@ export default interface INavie {
 }
 
 export type INavieProvider = (
-  threadId: string | undefined,
   contextProvider: ContextV2.ContextProvider,
   projectInfoProvider: ProjectInfo.ProjectInfoProvider,
   helpProvider: Help.HelpProvider

--- a/packages/cli/src/rpc/explain/navie/navie-remote.ts
+++ b/packages/cli/src/rpc/explain/navie/navie-remote.ts
@@ -9,7 +9,6 @@ import assert from 'assert';
 
 export default class RemoteNavie extends EventEmitter implements INavie {
   constructor(
-    public threadId: string | undefined,
     private contextProvider: ContextV2.ContextProvider,
     private projectInfoProvider: ProjectInfo.ProjectInfoProvider,
     private helpProvider: Help.HelpProvider
@@ -17,11 +16,15 @@ export default class RemoteNavie extends EventEmitter implements INavie {
     super();
   }
 
+  get providerName() {
+    return 'remote';
+  }
+
   setOption(key: string, _value: string | number) {
     throw new Error(`RemoteNavie does not support option '${key}'`);
   }
 
-  async ask(question: string, codeSelection: string | undefined) {
+  async ask(threadId: string, question: string, codeSelection: string | undefined) {
     (
       await AI.connect({
         onAck: (userMessageId, threadId) => {
@@ -103,7 +106,7 @@ export default class RemoteNavie extends EventEmitter implements INavie {
       })
     ).inputPrompt(
       { question: question, codeSelection: codeSelection },
-      { threadId: this.threadId, tool: 'explain' }
+      { threadId, tool: 'explain' }
     );
   }
 }

--- a/packages/cli/src/rpc/explain/navie/report-fetch-error.ts
+++ b/packages/cli/src/rpc/explain/navie/report-fetch-error.ts
@@ -1,0 +1,38 @@
+import { warn } from 'console';
+import { verbose } from '../../../utils';
+
+const ENDPOINT_FAILURES_REPORTED = new Set<string>();
+
+export default async function reportFetchError<T>(
+  endpoint: string,
+  remoteFunction: () => Promise<T>
+): Promise<T | undefined> {
+  // Wrap the error handling in its own error handler so that we don't inadvertently
+  // blow up the request with bad error handling.
+  function handleError(error: any) {
+    try {
+      let message: string;
+      if (error instanceof Error) {
+        message = error.message;
+      } else {
+        message = String(error);
+      }
+      const errorKey = [endpoint, message].join(' : ');
+      if (!ENDPOINT_FAILURES_REPORTED.has(errorKey)) {
+        warn(errorKey);
+        if (verbose()) warn(error);
+        ENDPOINT_FAILURES_REPORTED.add(errorKey);
+      }
+    } catch (handlingError) {
+      warn(handlingError);
+      warn(error);
+    }
+  }
+
+  try {
+    return await remoteFunction();
+  } catch (error) {
+    handleError(error);
+    return undefined;
+  }
+}

--- a/packages/cli/tests/integration/rpc.explain.spec.ts
+++ b/packages/cli/tests/integration/rpc.explain.spec.ts
@@ -41,11 +41,10 @@ describe('RPC', () => {
     describe('via local AI service', () => {
       beforeAll(() => {
         navieProvider = (
-          threadId: string | undefined,
           contextProvider: ContextV2.ContextProvider,
           projectInfoProvider: ProjectInfo.ProjectInfoProvider,
           helpProvider: Help.HelpProvider
-        ) => new LocalNavie(threadId, contextProvider, projectInfoProvider, helpProvider);
+        ) => new LocalNavie(contextProvider, projectInfoProvider, helpProvider);
         rpcTest = new SingleDirectoryRPCTest(DEFAULT_WORKING_DIR, navieProvider);
       });
 
@@ -102,11 +101,10 @@ describe('RPC', () => {
     describe('via remote AI service', () => {
       beforeAll(() => {
         navieProvider = (
-          threadId: string | undefined,
           contextProvider: ContextV2.ContextProvider,
           projectInfoProvider: ProjectInfo.ProjectInfoProvider,
           helpProvider: Help.HelpProvider
-        ) => new RemoteNavie(threadId, contextProvider, projectInfoProvider, helpProvider);
+        ) => new RemoteNavie(contextProvider, projectInfoProvider, helpProvider);
         rpcTest = new SingleDirectoryRPCTest(DEFAULT_WORKING_DIR, navieProvider);
       });
 
@@ -129,7 +127,6 @@ describe('RPC', () => {
               options?: AIInputPromptOptions
             ): Promise<void> {
               expect(input).toEqual({ question, codeSelection: undefined });
-              expect(options?.tool).toEqual('explain');
               this.callbacks.onAck!(userMessageId, threadId);
 
               const searchContextOptions: ContextV2.ContextRequest = {
@@ -162,6 +159,13 @@ describe('RPC', () => {
           jest
             .spyOn(AI, 'connect')
             .mockImplementation((callbacks: AICallbacks) => Promise.resolve(aiClient(callbacks)));
+          jest.spyOn(AI, 'createConversationThread').mockImplementation(() =>
+            Promise.resolve({
+              id: threadId,
+              permissions: { useNavieAIProxy: true },
+              usage: { conversationCounts: [] },
+            })
+          );
 
           const explainOptions: ExplainRpc.ExplainOptions = {
             question,

--- a/packages/cli/tests/unit/rpc/explain/Explain.spec.ts
+++ b/packages/cli/tests/unit/rpc/explain/Explain.spec.ts
@@ -1,0 +1,197 @@
+/* eslint-disable prefer-const */
+import { ExplainRpc } from '@appland/rpc';
+import { AI, ConversationThread } from '@appland/client';
+
+import * as Config from '../../../../src/rpc/configuration';
+import * as LLMConfiguration from '../../../../src/rpc/llmConfiguration';
+import * as AIEnvVar from '../../../../src/cmds/index/aiEnvVar';
+import { AppMapDirectory } from '../../../../src/rpc/configuration';
+import { Explain } from '../../../../src/rpc/explain/explain';
+import INavie from '../../../../src/rpc/explain/navie/inavie';
+import EventEmitter from 'events';
+
+describe('Explain', () => {
+  let explain: Explain;
+  let appmapDirectories: AppMapDirectory[] = [
+    {
+      directory: 'the-appmap-directory',
+      appmapConfig: {
+        name: 'the-appmap-config-name',
+        language: 'java',
+        packages: [{ path: 'org.example.package1' }],
+      },
+    },
+  ];
+  let projectDirectories = ['the-project-directory'];
+  let question = 'What is the meaning of life?';
+  let codeSelection: string | undefined;
+  let appmaps: string[] | undefined;
+  let status: ExplainRpc.ExplainStatusResponse;
+  let codeEditor: string | undefined;
+
+  beforeEach(() => {
+    status = {
+      step: ExplainRpc.Step.NEW,
+    };
+    explain = new Explain(
+      appmapDirectories,
+      projectDirectories,
+      question,
+      codeSelection,
+      appmaps,
+      status,
+      codeEditor
+    );
+  });
+
+  describe('enrollConversationThread', () => {
+    const navie = {
+      providerName: 'custom',
+    } as unknown as INavie;
+
+    describe('with minimal options', () => {
+      it('collects the conversation metadata', async () => {
+        jest.spyOn(Config, 'default').mockReturnValue({
+          appmapDirectories: jest.fn().mockResolvedValue([]),
+        } as unknown as Config.Configuration);
+        jest.spyOn(LLMConfiguration, 'getLLMConfiguration').mockReturnValue({});
+
+        jest.spyOn(AI, 'createConversationThread').mockResolvedValue({
+          id: 'the-conversation-thread-id',
+          permissions: { useNavieAIProxy: true },
+          usage: { conversationCounts: [] },
+        });
+
+        jest.spyOn(AIEnvVar, 'default').mockReturnValue(undefined);
+
+        await explain.enrollConversationThread(navie);
+
+        expect(AI.createConversationThread).toHaveBeenCalledWith({
+          modelParameters: {
+            provider: 'custom',
+          },
+          projectParameters: {
+            directoryCount: 0,
+            directories: [],
+          },
+        });
+      });
+    });
+
+    describe('with many options', () => {
+      it('collects the conversation metadata', async () => {
+        jest.spyOn(Config, 'default').mockReturnValue({
+          appmapDirectories: jest.fn().mockResolvedValue([
+            {
+              directory: 'the-appmap-directory',
+              appmapConfig: {
+                name: 'the-appmap-config-name',
+                language: 'java',
+                packages: [{ path: 'org.example.package1' }],
+              },
+            },
+          ]),
+        } as unknown as Config.Configuration);
+        jest.spyOn(LLMConfiguration, 'getLLMConfiguration').mockReturnValue({
+          baseUrl: 'the-base-url',
+          model: 'the-model',
+        });
+
+        jest.spyOn(AI, 'createConversationThread').mockResolvedValue({
+          id: 'the-conversation-thread-id',
+          permissions: { useNavieAIProxy: true },
+          usage: { conversationCounts: [] },
+        });
+
+        jest.spyOn(AIEnvVar, 'default').mockReturnValue('THE_AI_KEY');
+
+        await explain.enrollConversationThread(navie);
+
+        expect(AI.createConversationThread).toHaveBeenCalledWith({
+          modelParameters: {
+            aiKeyName: 'THE_AI_KEY',
+            baseUrl: 'the-base-url',
+            model: 'the-model',
+            provider: 'custom',
+          },
+          projectParameters: {
+            directoryCount: 1,
+            directories: [
+              {
+                hasAppMapConfig: true,
+                language: 'java',
+              },
+            ],
+          },
+        });
+      });
+    });
+  });
+
+  describe('explain', () => {
+    describe('when conversation enrollment succeeds', () => {
+      let conversationThread: ConversationThread;
+
+      beforeEach(() => {
+        conversationThread = {
+          id: 'the-conversation-thread-id',
+          permissions: { useNavieAIProxy: true },
+          usage: { conversationCounts: [] },
+        };
+        jest.spyOn(explain, 'enrollConversationThread').mockResolvedValue(conversationThread);
+      });
+
+      it('the thread id is utilized', async () => {
+        const navie = {
+          ask: jest.fn().mockResolvedValue('the-answer'),
+          on: jest.fn(),
+        } as unknown as INavie;
+        await explain.explain(navie);
+
+        expect(explain.conversationThread).toEqual(conversationThread);
+        expect(status).toEqual({ step: ExplainRpc.Step.NEW, threadId: conversationThread.id });
+      });
+    });
+
+    describe('when conversation enrollment fails', () => {
+      beforeEach(() => {
+        jest.spyOn(explain, 'enrollConversationThread').mockResolvedValue(undefined);
+      });
+
+      it('the thread id is not utilized', async () => {
+        const navie = {
+          ask: jest.fn().mockResolvedValue('the-answer'),
+          on: jest.fn(),
+        } as unknown as INavie;
+        await explain.explain(navie);
+
+        expect(explain.conversationThread).toBeUndefined();
+        expect(status).toEqual({ step: ExplainRpc.Step.NEW });
+        expect(navie.ask).toHaveBeenCalledWith(undefined, question, undefined);
+      });
+
+      describe('and navie acks the message', () => {
+        it('the thread id is obtained', async () => {
+          const navie = new EventEmitter() as any;
+          navie.ask = jest.fn().mockImplementation((threadId, question, codeSelection) => {
+            expect(threadId).toBeUndefined();
+            expect(question).toEqual('What is the meaning of life?');
+            expect(codeSelection).toBeUndefined();
+
+            navie.emit('ack', 'the-user-message-id', 'the-thread-id');
+          });
+          await new Promise<void>((resolve) => {
+            explain.addListener('ack', (userMessageId, threadId) => {
+              expect(userMessageId).toEqual('the-user-message-id');
+              expect(threadId).toEqual('the-thread-id');
+              expect(status).toEqual({ step: ExplainRpc.Step.NEW, threadId: 'the-thread-id' });
+
+              resolve();
+            });
+            explain.explain(navie as INavie);
+          });
+        });
+      });
+    });
+  });
+});

--- a/packages/cli/tests/unit/rpc/explain/LocalNavie.spec.ts
+++ b/packages/cli/tests/unit/rpc/explain/LocalNavie.spec.ts
@@ -1,4 +1,9 @@
+import EventEmitter from 'events';
+import { navie as navieFn, Navie } from '@appland/navie';
+
 import LocalNavie from '../../../../src/rpc/explain/navie/navie-local';
+
+jest.mock('@appland/navie');
 
 describe('LocalNavie', () => {
   let navie: LocalNavie;
@@ -6,9 +11,7 @@ describe('LocalNavie', () => {
   let projectInfoProvider = jest.fn();
   let helpProvider = jest.fn();
 
-  beforeEach(
-    () => (navie = new LocalNavie('threadId', contextProvider, projectInfoProvider, helpProvider))
-  );
+  beforeEach(() => (navie = new LocalNavie(contextProvider, projectInfoProvider, helpProvider)));
 
   describe('setOptions', () => {
     it("should set 'temperature'", () => {
@@ -30,6 +33,61 @@ describe('LocalNavie', () => {
       expect(() => navie.setOption('unsupported', 'value')).toThrowError(
         "LocalNavie does not support option 'unsupported'"
       );
+    });
+  });
+
+  describe('ask', () => {
+    describe('when invoked with a threadId', () => {
+      let navieImpl: Navie.INavie;
+      let tokens: string[];
+      const answer = ["It's", ' 42'];
+
+      beforeEach(() => {
+        navieImpl = new EventEmitter() as unknown as Navie.INavie;
+        navieImpl.execute = jest.fn().mockImplementation((): AsyncIterable<string> => {
+          return (async function* () {
+            for (const word of answer) {
+              yield word;
+            }
+          })();
+        });
+
+        jest.mocked(navieFn).mockReturnValue(navieImpl);
+
+        tokens = new Array<string>();
+        navie.on('token', (token: string) => tokens.push(token));
+      });
+
+      const awaitResponse = (resolve: () => void) => {
+        navie.on('complete', () => {
+          expect(tokens.join('')).toEqual("It's 42");
+          resolve();
+        });
+      };
+
+      it('uses the threadId and processes the question', async () => {
+        navie.on('ack', (_messageId: string, threadId: string) =>
+          expect(threadId).toBe('the-thread-id')
+        );
+
+        await new Promise<void>((resolve) => {
+          awaitResponse(resolve);
+          navie.ask('the-thread-id', 'What is the meaning of life?', undefined);
+        });
+      });
+
+      describe('when invoked without a threadId', () => {
+        it('allocates a new threadId', async () => {
+          navie.on('ack', (_messageId: string, threadId: string) => {
+            expect(threadId).toBeDefined();
+          });
+
+          await new Promise<void>((resolve) => {
+            awaitResponse(resolve);
+            navie.ask(undefined, 'What is the meaning of life?', undefined);
+          });
+        });
+      });
     });
   });
 });

--- a/packages/cli/tests/unit/rpc/explain/RemoteNavie.spec.ts
+++ b/packages/cli/tests/unit/rpc/explain/RemoteNavie.spec.ts
@@ -13,10 +13,11 @@ describe('RemoteNavie', () => {
   let aiClient: AIClient;
   let inputPrompt = jest.fn();
   const question = 'What is the meaning of life?';
+  const threadId = 'the-thread-id';
   let codeSelection: string | undefined;
 
   beforeEach(() => {
-    navie = new RemoteNavie('threadId', contextProvider, projectInfoProvider, helpProvider);
+    navie = new RemoteNavie(contextProvider, projectInfoProvider, helpProvider);
 
     aiClient = {
       inputPrompt,
@@ -68,7 +69,7 @@ describe('RemoteNavie', () => {
     });
 
     it('provides ContextV2', async () => {
-      await navie.ask(question, codeSelection);
+      await navie.ask(threadId, question, codeSelection);
 
       callbacks.onAck!('userMessageId', 'threadId');
       expect(ackFn).toHaveBeenCalledWith('userMessageId', 'threadId');
@@ -106,7 +107,7 @@ describe('RemoteNavie', () => {
     });
 
     it('adapts ContextV1 to ContextV2', async () => {
-      await navie.ask(question, codeSelection);
+      await navie.ask(threadId, question, codeSelection);
 
       callbacks.onAck!('userMessageId', 'threadId');
       expect(ackFn).toHaveBeenCalledWith('userMessageId', 'threadId');

--- a/packages/navie/src/explain.ts
+++ b/packages/navie/src/explain.ts
@@ -1,0 +1,223 @@
+import { warn } from 'console';
+import EventEmitter from 'events';
+
+import Message from './message';
+import MemoryService from './services/memory-service';
+import VectorTermsService from './services/vector-terms-service';
+import CompletionService, { OpenAICompletionService } from './services/completion-service';
+import InteractionHistory, {
+  AgentSelectionEvent,
+  ClassificationEvent,
+  InteractionEvent,
+  InteractionHistoryEvents,
+} from './interaction-history';
+import { ContextV2 } from './context';
+import ProjectInfoService from './services/project-info-service';
+import { ProjectInfo, ProjectInfoProvider } from './project-info';
+import CodeSelectionService from './services/code-selection-service';
+import { AgentMode, AgentOptions } from './agent';
+import { HelpProvider } from './help';
+import AgentSelectionService from './services/agent-selection-service';
+import LookupContextService from './services/lookup-context-service';
+import ApplyContextService from './services/apply-context-service';
+import ClassificationService from './services/classification-service';
+
+export const DEFAULT_TOKEN_LIMIT = 8000;
+
+export type ChatHistory = Message[];
+
+export interface ClientRequest {
+  question: string;
+  codeSelection?: string;
+}
+
+export class ExplainOptions {
+  agentMode: AgentMode | undefined;
+  modelName = process.env.APPMAP_NAVIE_MODEL ?? 'gpt-4o';
+  tokenLimit = Number(process.env.APPMAP_NAVIE_TOKEN_LIMIT ?? DEFAULT_TOKEN_LIMIT);
+  temperature = 0.4;
+  responseTokens = 1000;
+}
+
+export class CodeExplainerService {
+  constructor(
+    public readonly interactionHistory: InteractionHistory,
+    private readonly completionService: CompletionService,
+    private readonly classifierService: ClassificationService,
+    private readonly agentSelectionService: AgentSelectionService,
+    private readonly codeSelectionService: CodeSelectionService,
+    private readonly projectInfoService: ProjectInfoService,
+    private readonly memoryService: MemoryService
+  ) {}
+
+  async *execute(
+    clientRequest: ClientRequest,
+    options: ExplainOptions,
+    chatHistory?: ChatHistory
+  ): AsyncIterable<string> {
+    const { question: baseQuestion, codeSelection } = clientRequest;
+
+    const contextLabelsFn = this.classifierService.classifyQuestion(baseQuestion);
+
+    const projectInfoResponse = await this.projectInfoService.lookupProjectInfo();
+    const projectInfo: ProjectInfo[] = Array.isArray(projectInfoResponse)
+      ? projectInfoResponse
+      : [projectInfoResponse];
+
+    const { question, agent: mode } = this.agentSelectionService.selectAgent(
+      baseQuestion,
+      projectInfo
+    );
+
+    const tokensAvailable = (): number =>
+      options.tokenLimit - options.responseTokens - this.interactionHistory.computeTokenSize();
+
+    const aggregateQuestion = [
+      ...(chatHistory || [])
+        .filter((message) => message.role === 'user')
+        .map((message) => message.content),
+      question,
+      codeSelection,
+    ]
+      .filter(Boolean)
+      .join('\n\n');
+
+    const contextLabels = await contextLabelsFn;
+    warn(
+      `Classification: ${contextLabels
+        .map((label) => [label.name, label.weight].join('='))
+        .join(', ')}`
+    );
+
+    const agentOptions = new AgentOptions(
+      question,
+      aggregateQuestion,
+      chatHistory?.map((message) => message.content) || [],
+      projectInfo,
+      codeSelection,
+      contextLabels
+    );
+
+    const isArchitecture = contextLabels
+      .filter((label) => label.weight === 'high')
+      .some((label) => label.name === 'architecture' || label.name === 'overview');
+
+    this.projectInfoService.promptProjectInfo(isArchitecture, projectInfo);
+    await mode.perform(agentOptions, tokensAvailable);
+
+    if (codeSelection) this.codeSelectionService.addSystemPrompt();
+
+    const hasChatHistory = chatHistory && chatHistory.length > 0;
+    if (hasChatHistory) {
+      await this.memoryService.predictSummary(chatHistory);
+    }
+
+    if (codeSelection) this.codeSelectionService.applyCodeSelection(codeSelection);
+    mode.applyQuestionPrompt(question);
+
+    const response = this.completionService.complete();
+    for await (const token of response) {
+      yield token;
+    }
+  }
+}
+
+export interface IExplain extends InteractionHistoryEvents {
+  on(event: 'event', listener: (event: InteractionEvent) => void): void;
+
+  on(event: 'agent', listener: (agent: string) => void): void;
+
+  on(event: 'classification', listener: (labels: ContextV2.ContextLabel[]) => void): void;
+
+  execute(): AsyncIterable<string>;
+}
+
+export default function explain(
+  clientRequest: ClientRequest,
+  contextProvider: ContextV2.ContextProvider,
+  projectInfoProvider: ProjectInfoProvider,
+  helpProvider: HelpProvider,
+  options: ExplainOptions,
+  chatHistory?: ChatHistory
+): IExplain {
+  const interactionHistory = new InteractionHistory();
+  const completionService = new OpenAICompletionService(
+    interactionHistory,
+    options.modelName,
+    options.temperature
+  );
+
+  const classificationService = new ClassificationService(
+    interactionHistory,
+    options.modelName,
+    options.temperature
+  );
+
+  const codeSelectionService = new CodeSelectionService(interactionHistory);
+  const vectorTermsService = new VectorTermsService(
+    interactionHistory,
+    options.modelName,
+    options.temperature
+  );
+
+  const contextProviderV2 = async (
+    request: ContextV2.ContextRequest
+  ): Promise<ContextV2.ContextResponse> =>
+    contextProvider({ ...request, version: 2, type: 'search' });
+
+  const lookupContextService = new LookupContextService(
+    interactionHistory,
+    contextProviderV2,
+    helpProvider
+  );
+  const applyContextService = new ApplyContextService(interactionHistory);
+
+  const agentSelectionService = new AgentSelectionService(
+    interactionHistory,
+    helpProvider,
+    vectorTermsService,
+    lookupContextService,
+    applyContextService
+  );
+  const projectInfoService = new ProjectInfoService(interactionHistory, projectInfoProvider);
+  const memoryService = new MemoryService(
+    interactionHistory,
+    options.modelName,
+    options.temperature
+  );
+
+  const codeExplainerService = new CodeExplainerService(
+    interactionHistory,
+    completionService,
+    classificationService,
+    agentSelectionService,
+    codeSelectionService,
+    projectInfoService,
+    memoryService
+  );
+
+  class ExplainImplementation extends EventEmitter implements IExplain {
+    constructor() {
+      super();
+
+      interactionHistory.on('event', (event: InteractionEvent) => {
+        this.emit('event', event);
+
+        if (event instanceof AgentSelectionEvent) {
+          this.emit('agent', event.agent);
+        }
+
+        if (event instanceof ClassificationEvent) {
+          this.emit('classification', event.classification);
+        }
+      });
+    }
+
+    // eslint-disable-next-line class-methods-use-this
+    async *execute(): AsyncIterable<string> {
+      yield* codeExplainerService.execute(clientRequest, options, chatHistory);
+    }
+  }
+
+  return new ExplainImplementation();
+}

--- a/packages/navie/src/navie.ts
+++ b/packages/navie/src/navie.ts
@@ -1,5 +1,5 @@
-import EventEmitter from 'events';
 import assert from 'assert';
+import EventEmitter from 'events';
 
 import MemoryService from './services/memory-service';
 import VectorTermsService from './services/vector-terms-service';


### PR DESCRIPTION
See https://github.com/getappmap/appmap-services/pull/70

These changes apply to navie-local only:

* Allocate thread and message ids by making API calls to api-services.
* Emit events when the agent name and classifiers are chosen.
* Update message metadata as the conversation progresses.

## TODO

- [x] Local Navie should not fail if the remote service is not available. For example, if the outbound calls are blocked by proxy.
- [x] Local Navie should allocate its own thread id if thread pre-allocation fails.
- [x] Local Navie should submit message metadata. Obtain the data from the Navie interaction history.
- [x] If thread pre-allocation fails, Local Navie should not attempt to post the conversation messages metadata (because the server will not have the thread id).
