### PR TITLE
fix: Directory resolution

### DIFF
--- a/packages/cli/src/cmds/index/index.ts
+++ b/packages/cli/src/cmds/index/index.ts
@@ -141,7 +141,7 @@ export const handler = async (argv) => {
 
       const navieProvider = useLocalNavie() ? buildLocalNavie : buildRemoteNavie;
 
-      configureRpcDirectories([process.cwd()]);
+      await configureRpcDirectories([process.cwd()]);
 
       const rpcMethods: RpcHandler<any, any>[] = [
         numProcessed(cmd),

--- a/packages/cli/src/cmds/index/rpc.ts
+++ b/packages/cli/src/cmds/index/rpc.ts
@@ -183,7 +183,8 @@ export const handler = async (argv) => {
 
   const navieProvider = useLocalNavie() ? buildLocalNavie : buildRemoteNavie;
 
-  configureRpcDirectories(directories);
+  loadConfiguration(false);
+  await configureRpcDirectories(directories);
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const rpcMethods: RpcHandler<any, any>[] = [

--- a/packages/cli/src/fulltext/listProjectFiles.ts
+++ b/packages/cli/src/fulltext/listProjectFiles.ts
@@ -20,17 +20,17 @@ export default async function listProjectFiles(
   // Perform a breadth-first traversal of a directory, collecting all non-binary files and
   // applying the directory ignore list.
   const processDir = async (dir: string) => {
-    const queue = [dir];
+    const queue = ['.'];
     while (queue.length > 0 && files.length < fileLimit) {
       const currentDir = queue.shift();
       assert(currentDir, 'queue should not be empty');
 
-      const entries = await readdir(currentDir, { withFileTypes: true });
+      const entries = await readdir(join(dir, currentDir), { withFileTypes: true });
       for (const entry of entries) {
-        const fullPath = join(currentDir, entry.name);
+        const path = currentDir === '.' ? entry.name : join(currentDir, entry.name);
         if (entry.isDirectory()) {
-          if (!ignoreDirectory(entry.name)) queue.push(fullPath);
-        } else files.push(fullPath);
+          if (!ignoreDirectory(entry.name)) queue.push(path);
+        } else files.push(path);
       }
     }
   };

--- a/packages/cli/src/lib/handleWorkingDirectory.ts
+++ b/packages/cli/src/lib/handleWorkingDirectory.ts
@@ -1,12 +1,12 @@
 import { join } from 'path';
-import { setConfigurationV1 } from '../rpc/configuration';
+import { setConfigurationV2 } from '../rpc/configuration';
 
 export function handleWorkingDirectory(directory?: string) {
   if (directory) process.chdir(directory);
 }
 
-export function configureRpcDirectories(directory: string | string[]) {
+export async function configureRpcDirectories(directory: string | string[]) {
   const directories = Array.isArray(directory) ? directory : [directory];
   const appmapConfigFiles = directories.map((dir) => join(dir, 'appmap.yml'));
-  setConfigurationV1().handler({ appmapConfigFiles });
+  await setConfigurationV2().handler({ projectDirectories: directories, appmapConfigFiles });
 }

--- a/packages/cli/src/rpc/configuration.ts
+++ b/packages/cli/src/rpc/configuration.ts
@@ -3,6 +3,7 @@ import { RpcHandler } from './rpc';
 import { dirname } from 'path';
 import loadAppMapConfig, { AppMapConfig } from '../lib/loadAppMapConfig';
 import { getLLMConfiguration } from './llmConfiguration';
+import { warn } from 'console';
 
 export type AppMapDirectory = {
   directory: string;
@@ -73,6 +74,7 @@ export function setConfigurationV2(): RpcHandler<
   return {
     name: ConfigurationRpc.V2.Set.Method,
     handler: async (params) => {
+      warn(`Setting RPC configuration: ${JSON.stringify(params)}`);
       config = await Configuration.buildFromRpcParams(params);
       return undefined;
     },

--- a/packages/cli/tests/integration/RPCTest.ts
+++ b/packages/cli/tests/integration/RPCTest.ts
@@ -55,7 +55,7 @@ export default abstract class RPCTest {
   }
 
   async setupEach() {
-    configureRpcDirectories(this.directories);
+    await configureRpcDirectories(this.directories);
 
     this.appmaps = new Array<string>();
     for (const dir of this.directories) {
@@ -80,7 +80,7 @@ export default abstract class RPCTest {
     }
 
     // Reset the RPC configuration.
-    configureRpcDirectories([]);
+    await configureRpcDirectories([]);
 
     // RPC services should not rely on setting cwd. Warn if the cwd has been changed.
     const cwd = process.cwd();

--- a/packages/cli/tests/unit/fulltext/listProjectFiles.spec.ts
+++ b/packages/cli/tests/unit/fulltext/listProjectFiles.spec.ts
@@ -29,8 +29,8 @@ describe('listProjectFiles', () => {
     });
 
     const files = await listProjectFiles(baseDir);
-    expect(files).toContain(join(baseDir, 'index.js'));
-    expect(files).toContain(join(baseDir, 'utils', 'helper.js'));
+    expect(files).toContain('index.js');
+    expect(files).toContain(join('utils', 'helper.js'));
     expect(fsp.readdir).toHaveBeenCalledTimes(2); // baseDir + utils
   });
 


### PR DESCRIPTION
`listProjectFiles` is yielding a full path if there is a match in the project directory. Fix this function so that all matches are relative to the project directory.

Related: When the `rpc` command gets multiple `-d` options, handle these directories using the configuration v2 style.
