### PR TITLE
fix: Don't prompt with appmapStats for non-arch questions

### DIFF
--- a/packages/navie/src/explain.ts
+++ b/packages/navie/src/explain.ts
@@ -19,7 +19,7 @@ import LookupContextService from './services/lookup-context-service';
 import ApplyContextService from './services/apply-context-service';
 import ClassificationService from './services/classification-service';
 
-export const DEFAULT_TOKEN_LIMIT = 12000;
+export const DEFAULT_TOKEN_LIMIT = 8000;
 
 export type ChatHistory = Message[];
 
@@ -95,6 +95,12 @@ export class CodeExplainerService {
       codeSelection,
       contextLabels
     );
+
+    const isArchitecture = contextLabels
+      .filter((label) => label.weight === 'high')
+      .some((label) => label.name === 'architecture' || label.name === 'overview');
+
+    this.projectInfoService.promptProjectInfo(isArchitecture, projectInfo);
     await mode.perform(agentOptions, tokensAvailable);
 
     if (codeSelection) this.codeSelectionService.addSystemPrompt();

--- a/packages/navie/src/services/project-info-service.ts
+++ b/packages/navie/src/services/project-info-service.ts
@@ -1,9 +1,22 @@
 import { dump } from 'js-yaml';
-import { ProjectInfo, ProjectInfoProvider } from '../project-info';
+import {
+  AppMapConfig,
+  AppMapStats,
+  CodeEditorInfo,
+  ProjectInfo,
+  ProjectInfoProvider,
+} from '../project-info';
 import InteractionHistory, { PromptInteractionEvent } from '../interaction-history';
 import { PromptType, buildPromptDescriptor, buildPromptValue } from '../prompt';
+import assert from 'assert';
 
 type Test = () => boolean;
+
+type MinimumStats = Omit<AppMapStats, 'routes' | 'tables' | 'packages'> & {
+  routes?: string[];
+  tables?: string[];
+  packages?: string[];
+};
 
 export default class ProjectInfoService {
   constructor(
@@ -20,57 +33,107 @@ export default class ProjectInfoService {
 
     const projectInfo = Array.isArray(response) ? response : [response];
     this.interactionHistory.log('Project info obtained');
+    return projectInfo;
+  }
 
-    const projectInfoKeys: [
-      PromptType,
-      'appmapConfig' | 'appmapStats' | 'codeEditor',
-      Test,
-      string
-    ][] = [
-      [
-        PromptType.AppMapConfig,
-        'appmapConfig',
-        () => projectInfo.some(({ appmapConfig }) => Boolean(appmapConfig)),
-        `The project does not contain an AppMap config file (appmap.yml).`,
-      ],
-      [
-        PromptType.AppMapStats,
-        'appmapStats',
-        () =>
-          projectInfo.some(
-            ({ appmapStats }) => appmapStats?.numAppMaps && appmapStats.numAppMaps > 0
-          ),
-        `The project does not contain any AppMaps.`,
-      ],
-      [
-        PromptType.CodeEditor,
-        'codeEditor',
-        () => projectInfo.some(({ codeEditor }) => Boolean(codeEditor)),
-        `The code editor is not specified.`,
-      ],
-    ];
-    projectInfoKeys.forEach(([promptType, projectInfoKey, isPresent, missingInfoMessage]) => {
-      if (!isPresent()) {
-        this.interactionHistory.addEvent(
-          new PromptInteractionEvent(promptType, 'user', missingInfoMessage)
-        );
-        return;
-      }
+  promptProjectInfo(isArchitecture: boolean, projectInfo: ProjectInfo[]) {
+    const isLargeProject = (appmapStats: AppMapStats) =>
+      appmapStats.packages.length > 20 ||
+      appmapStats.routes.length > 20 ||
+      appmapStats.tables.length > 20;
 
-      const promptValue = projectInfo.map((info) => info[projectInfoKey]).filter(Boolean);
+    const pruneStats = (stats: AppMapStats): MinimumStats => {
+      if (isArchitecture || !isLargeProject(stats)) return stats;
 
+      return {
+        numAppMaps: stats.numAppMaps,
+      };
+    };
+
+    const appmapConfigs = projectInfo
+      .map((info) => info.appmapConfig)
+      .filter(Boolean) as AppMapConfig[];
+    const appmapStats = projectInfo
+      .map((info) => info.appmapStats)
+      .filter(Boolean)
+      .map((stats) => (assert(stats), pruneStats(stats)));
+    const codeEditors = projectInfo
+      .map((info) => info.codeEditor)
+      .filter(Boolean) as CodeEditorInfo[];
+
+    if (appmapConfigs.length > 0) {
       this.interactionHistory.addEvent(
-        new PromptInteractionEvent(promptType, 'system', buildPromptDescriptor(promptType))
+        new PromptInteractionEvent(
+          PromptType.AppMapConfig,
+          'system',
+          buildPromptDescriptor(PromptType.AppMapConfig)
+        )
       );
       this.interactionHistory.addEvent(
         new PromptInteractionEvent(
-          promptType,
+          PromptType.AppMapConfig,
           'user',
-          buildPromptValue(promptType, dump(promptValue))
+          buildPromptValue(PromptType.AppMapConfig, dump(appmapConfigs))
         )
       );
-    });
+    } else {
+      this.interactionHistory.addEvent(
+        new PromptInteractionEvent(
+          PromptType.AppMapConfig,
+          'user',
+          'The project does not contain an AppMap config file (appmap.yml).'
+        )
+      );
+    }
 
-    return projectInfo;
+    if (appmapStats.map((stats) => stats.numAppMaps).reduce((a, b) => a + b, 0) > 0) {
+      this.interactionHistory.addEvent(
+        new PromptInteractionEvent(
+          PromptType.AppMapStats,
+          'system',
+          buildPromptDescriptor(PromptType.AppMapStats)
+        )
+      );
+      this.interactionHistory.addEvent(
+        new PromptInteractionEvent(
+          PromptType.AppMapStats,
+          'user',
+          buildPromptValue(PromptType.AppMapStats, dump(appmapStats))
+        )
+      );
+    } else {
+      this.interactionHistory.addEvent(
+        new PromptInteractionEvent(
+          PromptType.AppMapStats,
+          'user',
+          'The project does not contain any AppMaps.'
+        )
+      );
+    }
+
+    if (codeEditors.length > 0) {
+      this.interactionHistory.addEvent(
+        new PromptInteractionEvent(
+          PromptType.CodeEditor,
+          'system',
+          buildPromptDescriptor(PromptType.CodeEditor)
+        )
+      );
+      this.interactionHistory.addEvent(
+        new PromptInteractionEvent(
+          PromptType.CodeEditor,
+          'user',
+          buildPromptValue(PromptType.CodeEditor, dump(codeEditors))
+        )
+      );
+    } else {
+      this.interactionHistory.addEvent(
+        new PromptInteractionEvent(
+          PromptType.CodeEditor,
+          'user',
+          'The code editor is not specified.'
+        )
+      );
+    }
   }
 }

--- a/packages/navie/test/explain.spec.ts
+++ b/packages/navie/test/explain.spec.ts
@@ -116,6 +116,7 @@ describe('CodeExplainerService', () => {
     codeSelectionService = new CodeSelectionService(interactionHistory);
     projectInfoService = {
       lookupProjectInfo: providesProjectInfo(),
+      promptProjectInfo: jest.fn(),
     } as unknown as ProjectInfoService;
   });
 


### PR DESCRIPTION
Prompt is too verbose with routes and packages for large projects.

Omit this info unless the user has asked a general architecture question.