### PR TITLE
Navie oneshot command

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -35,6 +35,7 @@ const InventoryCommand = require('./cmds/inventory/inventory');
 const InventoryReportCommand = require('./cmds/inventory-report/inventoryReport');
 const SearchCommand = require('./cmds/search/search');
 import * as RpcCommand from './cmds/index/rpc';
+import * as NavieCommand from './cmds/navie';
 import UploadCommand from './cmds/upload';
 import { default as sqlErrorLog } from './lib/sqlErrorLog';
 
@@ -140,6 +141,7 @@ yargs(process.argv.slice(2))
   .command(InventoryReportCommand)
   .command(SearchCommand)
   .command(RpcCommand)
+  .command(NavieCommand)
   .option('verbose', {
     alias: 'v',
     type: 'boolean',

--- a/packages/cli/src/cmds/index/rpc.ts
+++ b/packages/cli/src/cmds/index/rpc.ts
@@ -1,25 +1,20 @@
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-/* eslint-disable @typescript-eslint/no-unsafe-argument */
+import { warn } from 'node:console';
+
 import yargs from 'yargs';
-import chalk from 'chalk';
-import { ContextV2, Help, ProjectInfo, Agents } from '@appland/navie';
+
 import { loadConfiguration } from '@appland/client';
 
 import { verbose } from '../../utils';
-import { log } from 'console';
 import { search } from '../../rpc/search/search';
 import appmapFilter from '../../rpc/appmap/filter';
 import { RpcHandler } from '../../rpc/rpc';
 import metadata from '../../rpc/appmap/metadata';
 import sequenceDiagram from '../../rpc/appmap/sequenceDiagram';
 import { explainHandler, explainStatusHandler } from '../../rpc/explain/explain';
+import { buildNavieProvider, commonNavieArgsBuilder as navieBuilder } from '../navie';
 import RPCServer from './rpcServer';
 import appmapData from '../../rpc/appmap/data';
 import { appmapStatsV1, appmapStatsV2 } from '../../rpc/appmap/stats';
-import LocalNavie from '../../rpc/explain/navie/navie-local';
-import RemoteNavie from '../../rpc/explain/navie/navie-remote';
-import { InteractionEvent } from '@appland/navie/dist/interaction-history';
 import { configureRpcDirectories } from '../../lib/handleWorkingDirectory';
 import {
   getConfigurationV1,
@@ -28,162 +23,39 @@ import {
   setConfigurationV2,
 } from '../../rpc/configuration';
 import detectCodeEditor from '../../lib/detectCodeEditor';
-import detectAIEnvVar, { AI_KEY_ENV_VARS } from './aiEnvVar';
 
 export const command = 'rpc';
 export const describe = 'Run AppMap JSON-RPC server';
 
-export const builder = (args: yargs.Argv) => {
-  args.option('directory', {
-    describe: 'program working directory',
-    type: 'string',
-    alias: 'd',
-    array: true,
-  });
-  args.option('port', {
-    describe:
-      'port to listen on for JSON-RPC requests. Use port 0 to let the OS choose a port. The port number will be printed to stdout on startup.',
-    type: 'number',
-    alias: 'p',
-  });
-  args.option('navie-provider', {
-    describe: 'navie provider to use',
-    type: 'string',
-    choices: ['local', 'remote'],
-  });
-  args.option('log-navie', {
-    describe: 'Log Navie events to stderr',
-    boolean: true,
-    default: false,
-  });
-  args.option('ai-option', {
-    describe:
-      'Specify an extended option to the AI provider, in the form of a key=value pair. May be repeated.',
-    type: 'string',
-    array: true,
-  });
-
-  args.option('agent-mode', {
-    describe: `Agent mode which to run the Navie AI. The agent can also be controlled by starting the question with '@<agent> '.`,
-    choices: Object.values(Agents).map((agent) => agent.toLowerCase()),
-  });
-
-  args.option('code-editor', {
-    describe:
-      'Active code editor. This information is used to tune the @help responses. If unspecified, the code editor may be picked up from environment variables APPMAP_CODE_EDITOR, TERM_PROGRAM and TERMINAL_EMULATOR.',
-    type: 'string',
-    // Allow this to be any string. The code editor brand name may be a clue to the language
-    // in use, or the user's intent.
-  });
-
-  return args.strict();
+export const builder = <T>(args: yargs.Argv<T>) => {
+  return navieBuilder(args)
+    .option('port', {
+      describe:
+        'port to listen on for JSON-RPC requests. Use port 0 to let the OS choose a port. The port number will be printed to stdout on startup.',
+      type: 'number',
+      alias: 'p',
+      default: 0,
+    })
+    .strict();
 };
 
-export const handler = async (argv) => {
+type GetArgv<T> = T extends yargs.Argv<infer A> ? A : never;
+type HandlerArguments = yargs.ArgumentsCamelCase<
+  GetArgv<ReturnType<typeof builder>> & { verbose?: boolean }
+>;
+
+export const handler = async (argv: HandlerArguments) => {
   verbose(argv.verbose);
 
-  const directories: string[] = [];
-  if (argv.directory) {
-    Array.isArray(argv.directory)
-      ? directories.push(...argv.directory)
-      : directories.push(argv.directory);
-  }
-
-  const { port, logNavie } = argv;
-  let aiOptions: string[] | undefined = argv.aiOption;
-  if (aiOptions) {
-    aiOptions = Array.isArray(aiOptions) ? aiOptions : [aiOptions];
-  }
-  const agentModeStr: string | undefined = argv.explainMode;
-  let agentMode: Agents | undefined;
-  if (agentModeStr) agentMode = agentModeStr as Agents;
-
+  const navie = buildNavieProvider(argv);
   let codeEditor: string | undefined = argv.codeEditor;
   if (!codeEditor) {
     codeEditor = detectCodeEditor();
-    if (codeEditor) log(`Detected code editor: ${codeEditor}`);
+    if (codeEditor) warn(`Detected code editor: ${codeEditor}`);
   }
 
-  const useLocalNavie = () => {
-    if (argv.navieProvider === 'local') {
-      log(`Using local Navie provider due to explicit --navie-provider=local option`);
-      return true;
-    }
-
-    if (argv.navieProvider === 'remote') {
-      log(`Using remote Navie provider due to explicit --navie-provider=remote option`);
-      return false;
-    }
-
-    const aiEnvVar = detectAIEnvVar();
-    if (aiEnvVar) {
-      log(`Using local Navie provider due to presence of environment variable ${aiEnvVar}`);
-      return true;
-    }
-
-    log(
-      `--navie-provider option not provided, and none of ${AI_KEY_ENV_VARS.join(
-        ' '
-      )} are available. Using remote Navie provider.`
-    );
-    return false;
-  };
-
-  const applyAIOptions = (navie: LocalNavie | RemoteNavie) => {
-    if (aiOptions) {
-      for (const option of aiOptions) {
-        const [key, value] = option.split('=');
-        if (key && value) {
-          navie.setOption(key, value);
-        }
-      }
-    }
-    if (agentMode) {
-      navie.setOption('explainMode', agentMode);
-    }
-  };
-
-  const buildLocalNavie = (
-    threadId: string | undefined,
-    contextProvider: ContextV2.ContextProvider,
-    projectInfoProvider: ProjectInfo.ProjectInfoProvider,
-    helpProvider: Help.HelpProvider
-  ) => {
-    const navie = new LocalNavie(threadId, contextProvider, projectInfoProvider, helpProvider);
-    applyAIOptions(navie);
-
-    let START: number | undefined;
-    const logEvent = (event: InteractionEvent) => {
-      if (!logNavie) return;
-
-      if (!START) START = Date.now();
-
-      const elapsed = Date.now() - START;
-      process.stderr.write(chalk.gray(`${elapsed}ms `));
-      process.stderr.write(chalk.gray(event.message));
-      process.stderr.write(chalk.gray('\n'));
-    };
-
-    navie.on('event', logEvent);
-    return navie;
-  };
-
-  const buildRemoteNavie = (
-    threadId: string | undefined,
-    contextProvider: ContextV2.ContextProvider,
-    projectInfoProvider: ProjectInfo.ProjectInfoProvider,
-    helpProvider: Help.HelpProvider
-  ) => {
-    loadConfiguration(false);
-    const navie = new RemoteNavie(threadId, contextProvider, projectInfoProvider, helpProvider);
-    applyAIOptions(navie);
-    return navie;
-  };
-
-  const navieProvider = useLocalNavie() ? buildLocalNavie : buildRemoteNavie;
-
   loadConfiguration(false);
-  await configureRpcDirectories(directories);
+  await configureRpcDirectories(argv.directory);
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const rpcMethods: RpcHandler<any, any>[] = [
@@ -194,13 +66,13 @@ export const handler = async (argv) => {
     appmapData(),
     metadata(),
     sequenceDiagram(),
-    explainHandler(navieProvider, codeEditor),
+    explainHandler(navie, codeEditor),
     explainStatusHandler(),
     setConfigurationV1(),
     getConfigurationV1(),
     setConfigurationV2(),
     getConfigurationV2(),
   ];
-  const rpcServer = new RPCServer(port, rpcMethods);
+  const rpcServer = new RPCServer(argv.port, rpcMethods);
   rpcServer.start();
 };

--- a/packages/cli/src/cmds/navie.ts
+++ b/packages/cli/src/cmds/navie.ts
@@ -1,0 +1,236 @@
+import { warn } from 'node:console';
+import { createWriteStream } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import type { Writable } from 'node:stream';
+import { text } from 'node:stream/consumers';
+
+import chalk from 'chalk';
+import yargs from 'yargs';
+
+import { loadConfiguration } from '@appland/client';
+import { Agents, ContextV2, Help, ProjectInfo } from '@appland/navie';
+import { InteractionEvent } from '@appland/navie/dist/interaction-history';
+
+import { configureRpcDirectories } from '../lib/handleWorkingDirectory';
+import { explainHandler } from '../rpc/explain/explain';
+import INavie, { INavieProvider } from '../rpc/explain/navie/inavie';
+import LocalNavie from '../rpc/explain/navie/navie-local';
+import RemoteNavie from '../rpc/explain/navie/navie-remote';
+import detectAIEnvVar, { AI_KEY_ENV_VARS } from './index/aiEnvVar';
+
+interface ExplainArgs {
+  aiOption?: string[];
+  agentMode?: Agents;
+  navieProvider?: string;
+  logNavie?: boolean;
+}
+
+interface NavieCommonCmdArgs extends ExplainArgs {
+  codeEditor?: string;
+  directory: string[];
+}
+
+export function commonNavieArgsBuilder<T>(args: yargs.Argv<T>): yargs.Argv<T & NavieCommonCmdArgs> {
+  return args
+    .option('directory', {
+      describe: 'program working directory',
+      type: 'string',
+      alias: 'd',
+      array: true,
+      nargs: 1, // this is so that it doesn't slurp all positionals
+      default: [process.cwd()],
+    })
+    .option('navie-provider', {
+      describe: 'navie provider to use',
+      type: 'string',
+      choices: ['local', 'remote'],
+    })
+    .option('log-navie', {
+      describe: 'Log Navie events to stderr',
+      boolean: true,
+      default: false,
+    })
+    .option('ai-option', {
+      describe:
+        'Specify an extended option to the AI provider, in the form of a key=value pair. May be repeated.',
+      type: 'string',
+      array: true,
+    })
+    .option('agent-mode', {
+      describe: `Agent mode which to run the Navie AI. The agent can also be controlled by starting the question with '@<agent> '.`,
+      choices: Object.values(Agents).map((agent) => agent.toLowerCase()),
+    })
+    .option('code-editor', {
+      describe:
+        'Active code editor. This information is used to tune the @help responses. If unspecified, the code editor may be picked up from environment variables APPMAP_CODE_EDITOR, TERM_PROGRAM and TERMINAL_EMULATOR.',
+      type: 'string',
+      // Allow this to be any string. The code editor brand name may be a clue to the language
+      // in use, or the user's intent.
+    });
+}
+
+export function buildNavieProvider(argv: ExplainArgs) {
+  const { logNavie } = argv;
+  let aiOptions: string[] | undefined = argv.aiOption;
+  if (aiOptions) {
+    aiOptions = Array.isArray(aiOptions) ? aiOptions : [aiOptions];
+  }
+  const agentModeStr: string | undefined = argv.agentMode;
+  let agentMode: Agents | undefined;
+  if (agentModeStr) agentMode = agentModeStr as Agents;
+
+  const useLocalNavie = () => {
+    if (argv.navieProvider === 'local') {
+      warn(`Using local Navie provider due to explicit --navie-provider=local option`);
+      return true;
+    }
+
+    if (argv.navieProvider === 'remote') {
+      warn(`Using remote Navie provider due to explicit --navie-provider=remote option`);
+      return false;
+    }
+
+    const aiEnvVar = detectAIEnvVar();
+    if (aiEnvVar) {
+      warn(`Using local Navie provider due to presence of environment variable ${aiEnvVar}`);
+      return true;
+    }
+
+    warn(
+      `--navie-provider option not provided, and none of ${AI_KEY_ENV_VARS.join(
+        ' '
+      )} are available. Using remote Navie provider.`
+    );
+    return false;
+  };
+
+  const applyAIOptions = (navie: LocalNavie | RemoteNavie) => {
+    if (aiOptions) {
+      for (const option of aiOptions) {
+        const [key, value] = option.split('=');
+        if (key && value) {
+          navie.setOption(key, value);
+        }
+      }
+    }
+    if (agentMode) {
+      navie.setOption('explainMode', agentMode);
+    }
+  };
+
+  const buildLocalNavie = (
+    threadId: string | undefined,
+    contextProvider: ContextV2.ContextProvider,
+    projectInfoProvider: ProjectInfo.ProjectInfoProvider,
+    helpProvider: Help.HelpProvider
+  ) => {
+    loadConfiguration(false);
+    const navie = new LocalNavie(threadId, contextProvider, projectInfoProvider, helpProvider);
+    applyAIOptions(navie);
+
+    let START: number | undefined;
+    const logEvent = (event: InteractionEvent) => {
+      if (!logNavie) return;
+
+      if (!START) START = Date.now();
+
+      const elapsed = Date.now() - START;
+      process.stderr.write(chalk.gray(`${elapsed}ms `));
+      process.stderr.write(chalk.gray(event.message));
+      process.stderr.write(chalk.gray('\n'));
+    };
+
+    navie.on('event', logEvent);
+    return navie;
+  };
+
+  const buildRemoteNavie = (
+    threadId: string | undefined,
+    contextProvider: ContextV2.ContextProvider,
+    projectInfoProvider: ProjectInfo.ProjectInfoProvider,
+    helpProvider: Help.HelpProvider
+  ) => {
+    loadConfiguration(true);
+    const navie = new RemoteNavie(threadId, contextProvider, projectInfoProvider, helpProvider);
+    applyAIOptions(navie);
+    return navie;
+  };
+
+  return useLocalNavie() ? buildLocalNavie : buildRemoteNavie;
+}
+
+export const command = 'navie [question..]';
+export const describe = 'Explain a question using Navie';
+
+export function builder<T>(args: yargs.Argv<T>) {
+  return commonNavieArgsBuilder(args)
+    .positional('question', {
+      describe: 'Question text; appended to any other input',
+      type: 'string',
+      array: true,
+    })
+    .option('output', {
+      describe: 'Output path',
+      type: 'string',
+      alias: 'o',
+    })
+    .option('input', {
+      describe: 'Input path',
+      type: 'string',
+      alias: 'i',
+    });
+}
+
+type HandlerArguments = yargs.ArgumentsCamelCase<
+  ReturnType<typeof builder> extends yargs.Argv<infer A> ? A : never
+>;
+
+export async function handler(argv: HandlerArguments) {
+  await configureRpcDirectories(argv.directory);
+
+  const output = openOutput(argv.output);
+
+  function attachNavie(navie: INavie) {
+    return navie
+      .on('error', (err) => {
+        warn(err);
+        process.exitCode = 1;
+      })
+      .on('token', (token) => output.write(token));
+  }
+
+  const question = await getQuestion(argv.input, argv.question);
+  const capturingProvider = (...args: Parameters<INavieProvider>) =>
+    attachNavie(buildNavieProvider(argv)(...args));
+  await explainHandler(capturingProvider, argv.codeEditor).handler({ question });
+}
+
+function openOutput(outputPath: string | undefined): Writable {
+  switch (outputPath) {
+    case '-':
+    case undefined:
+      // prevent other things from messing with the output
+      console.log = console.debug = console.warn;
+
+      warn('No output specified, writing to stdout');
+      return process.stdout;
+    default:
+      warn(`Writing output to ${outputPath}`);
+      return createWriteStream(outputPath);
+  }
+}
+
+async function getQuestion(path?: string, literal?: string[]): Promise<string> {
+  const question = [...(literal ?? [])];
+  const targetPath = path ?? (question.length ? undefined : '-');
+
+  if (targetPath === '-') {
+    warn('Reading question from stdin');
+    question.unshift(await text(process.stdin));
+  } else if (targetPath) {
+    warn(`Reading question from ${targetPath}`);
+    question.unshift(await readFile(targetPath, 'utf-8'));
+  }
+
+  return question.join(' ');
+}


### PR DESCRIPTION
This adds `appmap navie` command to run one-shot interactions with Navie that do the same context gathering as the RPC commands.

```console
$ LC_ALL=C ./built/cli.js navie --help
cli.js navie [question..]

Explain a question using Navie

Positionals:
  question  Question text; appended to any other input     [array] [default: []]

Options:
      --version         Show version number                            [boolean]
  -v, --verbose         Run with verbose logging                       [boolean]
      --help            Show help                                      [boolean]
  -d, --directory       program working directory
             [array] [default: ["/home/divide/projects/appmap-js/packages/cli"]]
      --navie-provider  navie provider to use
                                           [string] [choices: "local", "remote"]
      --log-navie       Log Navie events to stderr    [boolean] [default: false]
      --ai-option       Specify an extended option to the AI provider, in the
                        form of a key=value pair. May be repeated.       [array]
      --agent-mode      Agent mode which to run the Navie AI. The agent can also
                        be controlled by starting the question with '@<agent> '.
                                        [choices: "explain", "generate", "help"]
      --code-editor     Active code editor. This information is used to tune the
                        @help responses. If unspecified, the code editor may be
                        picked up from environment variables APPMAP_CODE_EDITOR,
                        TERM_PROGRAM and TERMINAL_EMULATOR.             [string]
  -o, --output          Output path                                     [string]
  -i, --input           Input path                                      [string]

$ ./built/cli.js navie -d /tmp/user/1000/swe-navie-marshmallow-3.0-d14cebrt/ "what does this project do?" 2>/dev/null
The project appears to revolve around Marshmallow, a Python library used for object serialization. Marshmallow assists in converting complex data types, like ORM/ODM entities or custom class objects, to and from native Python data types like dictionaries, which can then be rendered into standard formats such as JSON.
[...]
```