### PR TITLE
Don't prompt extension users to install the extension

### DIFF
--- a/packages/navie/src/explain.ts
+++ b/packages/navie/src/explain.ts
@@ -20,6 +20,7 @@ import ApplyContextService from './services/apply-context-service';
 import ClassificationService from './services/classification-service';
 
 export const DEFAULT_TOKEN_LIMIT = 8000;
+export const DEFAULT_TEMPERATURE = 0.2;
 
 export type ChatHistory = Message[];
 
@@ -32,7 +33,7 @@ export class ExplainOptions {
   agentMode: AgentMode | undefined;
   modelName = process.env.APPMAP_NAVIE_MODEL ?? 'gpt-4o';
   tokenLimit = Number(process.env.APPMAP_NAVIE_TOKEN_LIMIT ?? DEFAULT_TOKEN_LIMIT);
-  temperature = 0.4;
+  temperature = Number(process.env.APPMAP_NAVIE_TEMPERATURE ?? DEFAULT_TEMPERATURE);
   responseTokens = 1000;
 }
 

--- a/packages/navie/src/prompt.ts
+++ b/packages/navie/src/prompt.ts
@@ -135,7 +135,8 @@ information about installing, configuring, and using AppMap.`,
   [PromptType.CodeEditor]: {
     content: `**Code editor**
 
-You're provided with information about the user's code editor. This information includes the code editor's name.`,
+You're provided with information about the user's code editor, in which you run as an AI assistant via a plugin.
+Do not mention installation or activation of the AppMap extension, because the user has already accomplished these steps.`,
     tagName: 'code-editor',
   },
 };

--- a/packages/navie/src/services/project-info-service.ts
+++ b/packages/navie/src/services/project-info-service.ts
@@ -123,7 +123,10 @@ export default class ProjectInfoService {
         new PromptInteractionEvent(
           PromptType.CodeEditor,
           'user',
-          buildPromptValue(PromptType.CodeEditor, dump(codeEditors))
+          buildPromptValue(
+            PromptType.CodeEditor,
+            dump(codeEditors.map(({ name }) => ({ name, installed: true, activated: true })))
+          )
         )
       );
     } else {


### PR DESCRIPTION
This PR updates the code editor prompt to inform the LLM that they're talking to a code editor user and not to provide additional instructions as to how to install the extension.

I've added an additional commit that will allow us to easily tweak the temperature via environment variable.


`how do i use appmap in this editor`
```
  To use AppMap in VS Code for your Ruby project, follow these steps to ensure that AppMap is properly configured and you're able to record and visualize your code execution:
  
  1. **Verify `appmap` gem Installation**:
     
     Ensure the `appmap` gem is added at the beginning of your Gemfile in the `:development, :test` group:
  
     ```ruby
     group :development, :test do
       gem 'appmap'
     end
     ```
  
     Run `bundle install` to install the gem if it's not already installed.
  
  2. **Configuration with `appmap.yml`**:
  
     Your `appmap.yml` is correctly configured as follows:
  
     ```yaml
     name: sample_app_6th_ed
     language: ruby
     appmap_dir: tmp/appmap
     packages:
       - path: app
       - path: lib
     compare:
       filter:
         hide_external: true
         dependency_folders: [ vendor ]
         hide_name: 
           - /^external-route:.*\bhttp:\/\/127\.0\.0\.1:\d+\/session\/[a-f0-9]{32,}\//
           - /^query:[\s\S]*\bSAVEPOINT\b/
           - /^query:[\s\S]*\bPRAGMA\b/,
           - /^query:[\s\S]*\bsqlite_master\b/
     update:
       test_folders: [ test ]
       test_commands:
         test:
           - env DISABLE_SPRING=true rails test {testFiles}
     ```
  
  3. **Enable AppMap in your Test Framework**:
     
     Depending on the test framework you're using (RSpec, Minitest, Cucumber), ensure AppMap is properly required.
  
     **RSpec**:
     
     Add `require 'appmap/rspec'` to your `spec_helper.rb` before loading the environment:
  
     ```ruby
     require 'appmap/rspec'
     require File.expand_path("../../config/environment", __FILE__)
     ```
  
     Run specs normally:
  
     ```sh
     bundle exec rspec
     ```
  
     **Minitest**:
     
     Add `require 'appmap/minitest'` to your `test_helper.rb` before loading the environment:
  
     ```ruby
     require 'appmap/minitest'
     require_relative '../config/environment'
     ```
  
     Run tests normally:
  
     ```sh
     rails test
     ```
  
     **Cucumber**:
     
     Add `require 'appmap/cucumber'` in `support/env.rb` and configure the Around hook in `support/hooks.rb`:
  
     ```ruby
     require 'appmap/cucumber'
     ```
  
     ```ruby
     if AppMap::Cucumber.enabled?
       Around('not @appmap-disable') do |scenario, block|
         appmap = AppMap.record do
           block.call
         end
  
         AppMap::Cucumber.write_scenario(scenario, appmap)
       end
     end
     ```
  
     Run features normally:
  
     ```sh
     bundle exec cucumber
     ```
  
  4. **Run AppMap Task**:
     
     The provided Rake task `lib/tasks/appmap.rake` can update AppMaps. Run the architecture task to update AppMaps based on your tests:
  
     ```sh
     bundle exec rake appmap:architecture
     ```
  
  5. **Open and View AppMaps in VS Code**:
  
     - Open the VS Code Command Palette (`Ctrl+Shift+P` or `Cmd+Shift+P` on macOS).
     - Search for and select `AppMap: Show Views`.
     - Use the AppMap panel to explore the recorded AppMaps.
  
  6. **Label Important Methods**:
  
     Optionally, you can add labels to your methods to improve the analysis and visualization:
  
     ```ruby
     class ApiKey
       # @labels provider.authentication security
       def authenticate(key)
         # logic
       end
     end
     ```
  
  By following these steps, you should be able to record and visualize your application’s runtime behavior using AppMap within your VS Code environment. If you encounter any issues or need further assistance, feel free to ask!
```