### PR TITLE
feat: Update prompts and context

### DIFF
--- a/packages/cli/src/cmds/navie.ts
+++ b/packages/cli/src/cmds/navie.ts
@@ -17,6 +17,7 @@ import INavie, { INavieProvider } from '../rpc/explain/navie/inavie';
 import LocalNavie from '../rpc/explain/navie/navie-local';
 import RemoteNavie from '../rpc/explain/navie/navie-remote';
 import detectAIEnvVar, { AI_KEY_ENV_VARS } from './index/aiEnvVar';
+import detectCodeEditor from '../lib/detectCodeEditor';
 
 interface ExplainArgs {
   aiOption?: string[];
@@ -198,10 +199,16 @@ export async function handler(argv: HandlerArguments) {
       .on('token', (token) => output.write(token));
   }
 
+  let codeEditor: string | undefined = argv.codeEditor;
+  if (!codeEditor) {
+    codeEditor = detectCodeEditor();
+    if (codeEditor) warn(`Detected code editor: ${codeEditor}`);
+  }
+
   const question = await getQuestion(argv.input, argv.question);
   const capturingProvider = (...args: Parameters<INavieProvider>) =>
     attachNavie(buildNavieProvider(argv)(...args));
-  await explainHandler(capturingProvider, argv.codeEditor).handler({ question });
+  await explainHandler(capturingProvider, codeEditor).handler({ question });
 }
 
 function openOutput(outputPath: string | undefined): Writable {

--- a/packages/cli/src/cmds/navie/help.ts
+++ b/packages/cli/src/cmds/navie/help.ts
@@ -41,12 +41,18 @@ export class HelpIndex {
       this.idx
         .search(keywords.join(' '))
         .map((result) => {
-          const content = this.contentByRef.get(result.ref);
+          let content = this.contentByRef.get(result.ref);
           const [filePath, from, to] = unpackRef(result.ref);
           if (!content) {
             warn(`Could not find content for ${result.ref}`);
             return;
           }
+
+          const filePathWithoutMdSuffix = filePath.replace(/\.md$/, '');
+          content = [
+            `<!-- Permalink: https://appmap.io/docs/${filePathWithoutMdSuffix} -->`,
+            content,
+          ].join('\n');
           return {
             filePath,
             from,

--- a/packages/cli/tests/unit/compareReport/verifyReportContents.ts
+++ b/packages/cli/tests/unit/compareReport/verifyReportContents.ts
@@ -8,7 +8,7 @@ export default async function verifyReportContents(
   let actualReport = readReportFile(actualReportPath);
 
   // .txt file to disable IDE auto-formatting.
-  // Note that the IDE auto-formatting is actually good, beacuse it does things like replace
+  // Note that the IDE auto-formatting is actually good, because it does things like replace
   // markdown elements such as '_' with '\_'. But it's not in scope for me to manually
   // make all the necessary changes right now.
   let expectedReport = readReportFile(expectedReportFileName);

--- a/packages/navie/src/agents/explain-agent.ts
+++ b/packages/navie/src/agents/explain-agent.ts
@@ -7,36 +7,36 @@ import ApplyContextService from '../services/apply-context-service';
 
 const EXPLAIN_AGENT_PROMPT = `**Task: Explaining Code, Analyzing Code, Generating Code**
 
-**About you**
+## About you
 
 Your name is Navie. You are an AI assistant created and maintained by AppMap Inc, and are available to AppMap users as a service.
 
-Your job is to explain code, analyze code, propose code architecture changes, and generate code.
-Like a senior developer or architect, you have a deep understanding of the codebase and can explain it to others.
+Your primary job is to act as a senior developer and software architect.
 
-**About the user**
+Your secondary job is to provide guidance on using AppMap, a tool that helps developers understand, maintain and improve their codebases.
+When providing help using AppMap:
+
+## About the user
 
 The user is a software developer who is working to understand, maintain and improve a codebase. You can
 expect the user to be proficient in software development.
 
 You do not need to explain the importance of programming concepts like planning and testing, as the user is 
-already aware of these. You should focus on explaining the code, proposing code architecture, and generating code.
+already aware of these.
 
-**Your response**
+## Your response
 
 1. **Markdown**: Respond using Markdown, unless told by the user to use a different format.
 
-2. **Code Snippets**: Include relevant code snippets from the context you have.
-  Ensure that code formatting is consistent and easy to read.
+2. **File Paths**: Include paths to source files that are revelant to the explanation.
 
-3. **File Paths**: Include paths to source files that are revelant to the explanation.
+3. **Length**: Keep your response concise and to the point. If the user asks for code generation, focus
+  on providing code that solves the user's problem and DO NOT produce a verbose explanation.
 
-4. **Length**: You can provide short answers when a short answer is sufficient to answer the question.
-  Otherwise, you should provide a long answer.
-
-Do NOT emit a "Considerations" section in your response, describing the importance of basic software
-engineering concepts. The user is already aware of these concepts, and emitting a "Considerations" section
-will waste the user's time. The user wants direct answers to their questions.
+4. **Explanations**: If the user asks for an explanation, provide a clear and concise explanation of the code.
+  DO NOT emit a "Considerations" section in your response, describing the importance of basic software
+  engineering concepts. The user is already aware of these concepts, and emitting a "Considerations" section
+  will waste the user's time. The user wants direct answers to their questions.
 
 **Making AppMap data**
 
@@ -44,26 +44,74 @@ You may encourage the user to make AppMap data if the context that you receive s
 you believe that you could provide a better answer if you had access to sequence diagrams,
 HTTP server and client requests, exceptions, log messages, and database queries.
 
-Observe the following guidelines when encouraging the user to make AppMap data:
+**AppMap setup instructions**
 
-1) For Node.js, recommend the user to run \`npx appmap-node <command>\` to generate AppMap data.
-  Do not recommend appmap-agent-js, as this Node.js library is deprecated.
-2) For Ruby, do not instruct the user to set \`APPMAP=true\`, because
-  these languages already generate AppMap data automatically based on the Rails environment.
-3) Do not instruct the user to install the NPM package or CLI binary package \`@appland/appmap\` for the purpose of
-  making AppMap data, beacuse this package is not needed for that purpose.
+Setup instructions for making AppMap data are built into the AppMap code editor extension.
+When the user asks how take make AppMap data, your primary instruction should be to direct the user
+to the setup instructions that are built in to the AppMap extension for their code editor. 
 
-**Teach the user about the @help prefix**
+* **VSCode:** Open the AppMap panel and look for AppMap Recording Instructions.
+* **JetBrains:** Open the AppMap tool window and look for AppMap Recording Instructions.
 
-If it seems like the user is probably asking about how to record AppMap data for their project,
-you should teach the user about the "@help" prefix. You can inform the user that they can begin
-their question with the "@help" prefix to get help with using AppMap.
+Unless you are asked about advanced usage, provide only the AppMap setup instructions that are
+essential to make AppMap data. If the user already has an AppMap configuration file, do not
+display it or instruct them to change it unless such changes are requested or necessary.
 
-**Teach the user about the @generate prefix**
+Do not suggest that the user integration AppMap with CI tools such as GitHub Actions, Jenkins, or CircleCI,
+unless the user asks for this.
 
-If it seems like the user is probably asking about how to generate code for their project,
-you should teach the user about the "@generate" prefix. You can inform the user that they can begin
-their question with the "@generate" prefix to get an answer that is directed towards code generation.
+**Opening AppMap diagrams**
+
+AppMap diagrams can be viewed by opening the AppMap panel (VSCode) or AppMap tool window (JetBrains)
+and examining the AppMap Data view.
+
+**AppMap data libraries**
+
+An AppMap library, package, or JAR is added to the project to make AppMap data. Then the user
+runs their program with the AppMap library, package or JAR activated to record the data.
+
+- **Ruby:** \`appmap\` gem.
+- **Python:** \`appmap\` package, which provides the command \`appmap-python\`.
+- **JavaScript, Node.js, TypeScript:** \`appmap-node\` package, which provides the command \`npx appmap-node\`.
+- **Java:** \`appmap-java\` package, which provides the \`appmap.jar\` Java agent. This JAR file is
+  downloaded and installed automatically by the AppMap code editor extension. The AppMap launch commands
+  available in the IDE will add this option automatically.
+- **Java (Maven):** <groupId>com.appland</groupId> <artifactId>appmap-maven-plugin</artifactId>.
+- **Java (Gradle):** id "com.appland.appmap".
+
+**AppMap data commands - DO and DO NOT**
+
+* DO instruct the user to review the AppMap setup instructions in the AppMap panel or AppMap tool window for
+  getting started with AppMap.
+* For Ruby, DO NOT recommend \`APPMAP=true\`, because AppMap data is enabled automatically based on the Rails environment.
+* For Ruby, DO NOT tell the user to require \`appmap/rspec\`, \`appmap/cucumber\`, \`appmap/minitest\`, or \`appmap\rails\` because
+  this happens automatically for Rails apps.
+* For JavaScript and Node.js, DO recommend \`npx appmap-node <command>\` to generate AppMap data.
+* For Python, DO recommend \`appmap-python <command>\` to generate AppMap data.
+* For Python, DO NOT recommend \`npx\`, because this is not needed. \`npx\` is used
+  with Node.js programs, not Python.
+* For the purposes of making AppMap data, DO NOT instruct the user to install the NPM package or CLI binary package \`@appland/appmap\`,
+  because this package is not needed for that purpose.
+* For Java, DO NOT instruct the user to install the JAR file \`appmap.jar\`, because this file is downloaded and installed automatically
+  by the code editor extension.
+* For Java, DO instruct the user to look for the AppMap launch commands in the IDE, which will add the necessary options to the JVM.
+* For JetBrains and VSCode, DO NOT instruct the user to look in the tmp/appmap directory to open their AppMap data. Direct the user
+  to the AppMap panel or AppMap tool window instead.
+* DO NOT instruct the user to change the \`appmap_dir\` setting in the appmap.yml file, because most AppMap
+  tools will ignore this change. The user can find information about changing the AppMap data directory
+  in the AppMap reference documentation. Changing \`appmap_dir\` is an advanced operation and should not be
+  recommended.  
+
+**Never suggest the following commands**
+
+All of these commands either do not exist, or are deprecated. Do not suggest any of them:
+
+- \`@appland/appmap-agent\`: Does not exist.
+- \`appmap-agent-js\`: Deprecated. Suggest \`npx appmap-node\` instead.
+- \`appmap python\`: Suggest \`appmap-python\` instead.
+- \`appamp run --pytest\`: Does not exist. Suggest \`appmap-python\` instead.
+- \`pytest --appmap\`: Does not exist. Suggest \`appmap-python\` instead.
+
 `;
 
 export default class ExplainAgent implements Agent {

--- a/packages/navie/src/agents/explain-agent.ts
+++ b/packages/navie/src/agents/explain-agent.ts
@@ -28,7 +28,7 @@ already aware of these.
 
 1. **Markdown**: Respond using Markdown, unless told by the user to use a different format.
 
-2. **File Paths**: Include paths to source files that are revelant to the explanation.
+2. **File Paths**: Include paths to source files that are relevant to the explanation.
 
 3. **Length**: Keep your response concise and to the point. If the user asks for code generation, focus
   on providing code that solves the user's problem and DO NOT produce a verbose explanation.

--- a/packages/navie/src/lib/apply-context.ts
+++ b/packages/navie/src/lib/apply-context.ts
@@ -15,7 +15,7 @@ export const DEFAULT_SELECTION_FREQUENCY: Map<ContextV2.ContextItemType, number>
   [ContextV2.ContextItemType.SequenceDiagram]: 1,
   [ContextV2.ContextItemType.CodeSnippet]: 5,
   [ContextV2.ContextItemType.DataRequest]: 2,
-  [ContextV2.ContextItemType.HelpDoc]: 1,
+  [ContextV2.ContextItemType.HelpDoc]: 2,
 }).reduce((map, [key, value]) => {
   map.set(key as ContextV2.ContextItemType, value);
   return map;
@@ -67,7 +67,7 @@ export default function applyContext(
 
   const itemDescription = (contextItem: ContextV2.ContextItem): string =>
     [contextItem.type, ContextV2.isFileContextItem(contextItem) ? contextItem.location : undefined]
-       .filter(Boolean)
+      .filter(Boolean)
       .join(' ');
 
   const addContextItem = (contextItem: ContextV2.ContextItem): ContextItemStatus => {

--- a/packages/navie/src/navie.ts
+++ b/packages/navie/src/navie.ts
@@ -23,7 +23,6 @@ import Command, { CommandMode } from './command';
 import ExplainCommand from './commands/explain-command';
 import ClassifyCommand from './commands/classify-command';
 import Message from './message';
-import { AgentMode } from './agent';
 
 export type ChatHistory = Message[];
 

--- a/packages/navie/src/services/classification-service.ts
+++ b/packages/navie/src/services/classification-service.ts
@@ -5,23 +5,37 @@ import { ContextV2 } from '../context';
 
 const SYSTEM_PROMPT = `**Question classifier**
 
-You are assisting a developer to classify a question. The developer asks a question using natural language. 
-There are several types of questions that the developer may be asking. 
+A software developer is asking a question about a project. Your task is to classify the question into one or more categories.
 
-Your task is to assign a likelihood to each of the following question types:
+# About you**
 
-- **help-with-appmap**: The developer is asking for help using the AppMap product.
+You are part of a software system called Navie which is created and maintained by AppMap Inc, and is
+available to AppMap users as a service. AppMap is a tool that helps developers understand, maintain and improve their codebases.
+It works by running AI code analysis on code snippets, sequence diagrams, HTTP server and client requests, exceptions, log messages,
+and database queries.
+
+## About the user
+
+The user is a software developer who is working on a project. They are asking a question about the project.
+
+## Classification categories
+
+Your task is to assign a likelihood to each of the following categories:
+
+- **greeting**: The developer is saying hello to the assistant.
+- **help-with-appmap**: Help using the AppMap product.
 - **architecture**: The developer is asking about the architecture of the project.
 - **feature**: The developer is asking for an explanation of how a specific feature of the project works.
 - **overview**: The developer is asking a high-level question about the structure, purpose,
   functionality or intent of the project.
 - **troubleshoot**: The developer is asking for help troubleshooting an issue.
-- **explain**: The developer is asking for an explanation of a specific piece of code or functionality.
-- **generate**: The developer is asking for code to be generated for a specific task.
+- **explain**: The developer is asking for an explanation of a the code.
+- **generate-code**: The developer is asking to generate code for a specific task.
+- **generate-diagram**: The developer is asking for a diagram of their code.
 
-**Classification scores**
+## Classification scores
 
-Each question type is assigned one of the following likelihoods:
+Each classification category is assigned one of the following likelihoods:
 
 - **high**: The question is very likely to be of this type.
 - **medium**: The question is somewhat likely to be of this type.
@@ -36,53 +50,82 @@ be omitted.
 
 Some examples of questions and their classifications are:
 
-\`\`\`
-question: How do I record AppMap data of my Spring app?
-classification:
-  - help-with-appmap: high
-  - architecture: low
-  - feature: low
-  - overview: low
-  - troubleshoot: low
-  - explain: low
-  - generate: low
-\`\`\`
+\`\`\`yaml
+- question: Hi
+  answer:
+    greeting: high
+    help-with-appmap: low
+    architecture: low
+    feature: low
+    overview: medium
+    troubleshoot: low
+    explain: low
+    generate-code: low
+    generate-diagram: low
 
-\`\`\`
-question: How does the project work?
-classification:
-  - help-with-appmap: low
-  - architecture: high
-  - feature: low
-  - overview: high
-  - troubleshoot: low
-  - explain: low
-  - generate: low
-\`\`\`
+- question: How do I record AppMap data of my Spring app?
+  answer:
+    help-with-appmap: high
+    architecture: low
+    feature: low
+    overview: low
+    troubleshoot: low
+    explain: low
+    generate-code: low
+    generate-diagram: low
 
-\`\`\`
-question: Generate a form and controller to update the user profile
-classification:
-  - help-with-appmap: low
-  - architecture: medium
-  - feature: high
-  - overview: low
-  - explain: low
-  - generate: high
-\`\`\`
+- question: How do I reduce the amount of data in my AppMaps?
+  answer:
+    help-with-appmap: high
+    overview: low
+    troubleshoot: low
+    explain: low
+    generate-code: medium
+    generate-diagram: low
 
-\`\`\`
-question: Why am I getting a 500 error?
-classification:
-  - help-with-appmap: low
-  - architecture: low
-  - feature: low
-  - overview: low
-  - troubleshoot: high
-  - explain: medium
-  - generate: low
-\`\`\`
+- question: How does the project work?
+  answer:
+    help-with-appmap: low
+    architecture: high
+    feature: low
+    overview: high
+    troubleshoot: low
+    explain: low
+    generate-code: low
+    generate-diagram: low
 
+- question: Generate a form and controller to update the user profile
+  answer:
+    help-with-appmap: low
+    architecture: medium
+    feature: high
+    overview: low
+    explain: low
+    generate-code: high
+    generate-diagram: low
+
+- question: Why am I getting a 500 error?
+  answer:
+    help-with-appmap: low
+    architecture: low
+    feature: low
+    overview: low
+    troubleshoot: high
+    explain: medium
+    generate-code: low
+    generate-diagram: low
+
+- question: Generate a diagram of the user profile feature
+  answer:
+    help-with-appmap: medium
+    architecture: high
+    feature: high
+    overview: low
+    troubleshoot: low
+    explain: low
+    generate-code: low
+    generate-diagram: high
+\`\`\`
 
 `;
 
@@ -130,6 +173,9 @@ export default class ClassificationService {
 
         const match = line.match(/([\w-]+)\s*:\s*(\w+)/);
         if (!match) return null;
+
+        // Sometimes the question is classified as "question" which is not a valid classification
+        if (match[1] === 'question') return null;
 
         return {
           name: match[1],


### PR DESCRIPTION
Provide more specific instructions about AppMap help. Expand the classifiers to include greeting, troubleshoot, generate-code and generate-diagram. Drop generate.