### PR TITLE
fix: Fall back to user input on empty vector search

### DIFF
--- a/packages/navie/src/lib/is-empty.ts
+++ b/packages/navie/src/lib/is-empty.ts
@@ -1,0 +1,31 @@
+// Returns whether or not the given value is deeply empty.
+// `maxDepth` is the maximum number of levels to recurse into.
+// e.g.:
+//   isEmpty({ a: undefined, b: null, c: false }) === true
+//   isEmpty(['']) === true
+const isEmpty = (value: unknown, maxDepth = 1): boolean => {
+  // If we made it beyond the max depth, we're done. Consider this value NOT empty.
+  if (maxDepth < 0) return false;
+
+  if (value === undefined || value === null) return true;
+
+  if (typeof value === 'string') return value.trim().length === 0;
+
+  if (Array.isArray(value)) {
+    // Recursively check each element.
+    // For example, [''] is considered empty.
+    return value.length === 0 || value.every((v) => isEmpty(v, maxDepth - 1));
+  }
+
+  if (typeof value === 'object') {
+    // Recursively check each key-value pair.
+    // For example, {example: undefined} is considered empty.
+    return (
+      Object.keys(value).length === 0 || Object.values(value).every((v) => isEmpty(v, maxDepth - 1))
+    );
+  }
+
+  return false;
+};
+
+export default isEmpty;

--- a/packages/navie/src/services/vector-terms-service.ts
+++ b/packages/navie/src/services/vector-terms-service.ts
@@ -5,6 +5,7 @@ import { ChatOpenAI } from '@langchain/openai';
 
 import InteractionHistory, { VectorTermsInteractionEvent } from '../interaction-history';
 import trimFences from '../lib/trim-fences';
+import isEmpty from '../lib/is-empty';
 
 const SYSTEM_PROMPT = `You are assisting a developer to search a code base.
 
@@ -136,6 +137,10 @@ export default class VectorTermsService {
       responseText = contentAfter(responseText, 'Terms:');
       responseText = trimFences(responseText);
       searchTermsObject = parseJSON(responseText) || parseText(responseText);
+      if (isEmpty(searchTermsObject)) {
+        warn('No search terms were returned. Falling back to raw input.');
+        searchTermsObject = question.split(/\s+/).filter(Boolean);
+      }
     }
 
     const terms = new Set<string>();

--- a/packages/navie/test/lib/is-empty.spec.ts
+++ b/packages/navie/test/lib/is-empty.spec.ts
@@ -1,0 +1,46 @@
+import isEmpty from '../../src/lib/is-empty';
+
+describe('isEmpty', () => {
+  it('returns true when expected', () => {
+    const examples = [
+      null,
+      undefined,
+      '',
+      ['', '', ''],
+      { a: null, b: undefined },
+      '         ',
+      { longEmptyString: ''.repeat(100) },
+    ];
+
+    examples.forEach((example) => expect(isEmpty(example, 10)).toBe(true));
+  });
+
+  it('returns false when expected', () => {
+    const examples = [
+      0,
+      1,
+      'a',
+      true,
+      false,
+      ['a'],
+      { a: 1 },
+      { b: true },
+      { c: false },
+      ' a',
+      { longString: 'a'.repeat(100) },
+    ];
+
+    examples.forEach((example) => expect(isEmpty(example, 10)).toBe(false));
+  });
+
+  it('respects maxDepth', () => {
+    const examples = [
+      { key: [''] },
+      { key: { key: [''] } },
+      { key: { key: { key: [''] } } },
+      { key: { key: { key: { key: [''] } } } },
+    ];
+
+    expect(examples.map((e) => isEmpty(e, 3))).toStrictEqual([true, true, false, false]);
+  });
+});

--- a/packages/navie/test/services/vector-terms-service.spec.ts
+++ b/packages/navie/test/services/vector-terms-service.spec.ts
@@ -103,5 +103,20 @@ describe('VectorTermsService', () => {
         expect(completionWithRetry).toHaveBeenCalledTimes(1);
       });
     });
+
+    describe('terms are empty', () => {
+      it('falls back to the user input', async () => {
+        const examples = ['', 'Terms: ', '{}', '```json\n[]\n```'];
+        const expected = ['user', 'management'];
+
+        for (let i = 0; i < examples.length; i++) {
+          const example = examples[i];
+          mockAIResponse(completionWithRetry, [example]);
+          const terms = await service.suggestTerms('user management');
+          expect(terms).toEqual(expected);
+          expect(completionWithRetry).toHaveBeenCalledTimes(i + 1);
+        }
+      });
+    });
   });
 });


### PR DESCRIPTION
If the LLM responds with no vector terms, the user input will be used verbatim.