### PR TITLE
fix: Skip searching for context on empty input

### DIFF
--- a/packages/cli/src/cmds/navie/help.ts
+++ b/packages/cli/src/cmds/navie/help.ts
@@ -137,10 +137,13 @@ export function buildHelpIndex(directory: string): Promise<HelpIndex> {
 export default async function collectHelp(
   helpRequest: Help.HelpRequest
 ): Promise<Help.HelpResponse> {
+  const { vectorTerms } = helpRequest;
+  if (vectorTerms.length === 0 || vectorTerms.every((v) => v.trim() === '')) return [];
+
   if (!helpIndex) {
     assert(DOCS_DIR, 'Could not find AppMap docs directory');
     helpIndex = await buildHelpIndex(DOCS_DIR);
   }
 
-  return await helpIndex.search(helpRequest.vectorTerms);
+  return await helpIndex.search(vectorTerms);
 }

--- a/packages/cli/src/rpc/explain/collectContext.ts
+++ b/packages/cli/src/rpc/explain/collectContext.ts
@@ -6,7 +6,7 @@ import FindEvents, {
 } from '../../fulltext/FindEvents';
 import { DEFAULT_MAX_DIAGRAMS, DEFAULT_MAX_FILES } from '../search/search';
 import buildContext from './buildContext';
-import { log } from 'console';
+import { log, warn } from 'console';
 import { isAbsolute, join } from 'path';
 import { ContextV2, applyContext } from '@appland/navie';
 import { FileIndexMatch, buildFileIndex } from '../../fulltext/FileIndex';
@@ -118,6 +118,11 @@ export class ContextCollector {
     searchResponse: SearchRpc.SearchResponse;
     context: ContextV2.ContextResponse;
   }> {
+    if (this.vectorTerms.length === 0 || this.vectorTerms.every((term) => term.trim() === '')) {
+      warn('No vector terms received. Context search will be skipped.');
+      return { searchResponse: { results: [], numResults: 0 }, context: [] };
+    }
+
     const query = this.vectorTerms.join(' ');
 
     let appmapSearchResponse: AppMapSearchResponse;

--- a/packages/cli/tests/unit/cmds/navie/help.spec.ts
+++ b/packages/cli/tests/unit/cmds/navie/help.spec.ts
@@ -1,0 +1,16 @@
+import collectHelp from '../../../../src/cmds/navie/help';
+
+describe('collectHelp', () => {
+  it('returns an empty response if no vector terms are provided', async () => {
+    const emptyVectorTerms = [[], [''], [' ']];
+    for (const vectorTerms of emptyVectorTerms) {
+      const res = await collectHelp({ type: 'help', vectorTerms, tokenCount: 1000 });
+      expect(res).toEqual([]);
+    }
+  });
+
+  it('searches the help index if vector terms are provided', async () => {
+    const res = await collectHelp({ type: 'help', vectorTerms: ['appmap'], tokenCount: 1000 });
+    expect(res.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/cli/tests/unit/rpc/explain/ContextCollector.spec.ts
+++ b/packages/cli/tests/unit/rpc/explain/ContextCollector.spec.ts
@@ -1,6 +1,7 @@
 import { SearchRpc } from '@appland/rpc';
 import { ContextCollector, EventCollector } from '../../../../src/rpc/explain/collectContext';
 import AppMapIndex from '../../../../src/fulltext/AppMapIndex';
+import * as withIndex from '../../../../src/fulltext/withIndex';
 import * as navie from '@appland/navie';
 
 jest.mock('../../../../src/fulltext/AppMapIndex');
@@ -98,6 +99,32 @@ describe('ContextCollector', () => {
         });
         expect(collectedContext.searchResponse.numResults).toBe(10);
         expect(collectedContext.context).toEqual(mockContext);
+      });
+    });
+
+    describe('with empty vector terms', () => {
+      it('returns an empty context', async () => {
+        const indexSearch = jest.spyOn(withIndex, 'default');
+        const emptyVectorTerms = [[], [''], [' ']];
+
+        for (const vectorTerms of emptyVectorTerms) {
+          const contextCollector = new ContextCollector(
+            ['example'],
+            ['src'],
+            vectorTerms,
+            charLimit
+          );
+          const result = await contextCollector.collectContext();
+          expect(result).toStrictEqual({
+            searchResponse: {
+              results: [],
+              numResults: 0,
+            },
+            context: [],
+          });
+        }
+
+        expect(indexSearch).not.toHaveBeenCalled();
       });
     });
   });


### PR DESCRIPTION
This change prevents context search from continuing if the supplied list of vector terms is empty.

Fixes https://github.com/getappmap/appmap-js/issues/1767 