### PR TITLE
fix: don't crash on bad AppMaps

### DIFF
--- a/packages/models/src/appMapBuilder/eventStack.js
+++ b/packages/models/src/appMapBuilder/eventStack.js
@@ -35,6 +35,12 @@ export default class EventStack {
         this.stack.pop();
 
         const parent = this.stack[this.stack.length - 1];
+        if (call === parent) {
+          // FIXME: This shouldn't ever happen, but there's an unknown issue in some AppMaps that
+          // causes it. Without this check, node will crash, so preempt that by throwing an Error.
+          throw new Error(`failed trying to compute event stack, call.id: ${call.id}`);
+        }
+
         if (parent) {
           parent.children.push(call);
           call.parent = parent;


### PR DESCRIPTION
When creating a stack while building an AppMap, there's an unknown issue that causes an infinite loop that will eventually crash node.

This change introduces a check for the error, and throws an Error to avoid the crash. It's not really a fix, just a bandaid.