### PR TITLE
feat: --prompt and /noterms options

### DIFF
--- a/.github/workflows/build-native-scanner.yml
+++ b/.github/workflows/build-native-scanner.yml
@@ -8,7 +8,7 @@ on:
       - '@appland/scanner-v*'
 
 jobs:
-  linux:
+  linux-x64:
     runs-on: ubuntu-latest
 
     if:
@@ -55,6 +55,56 @@ jobs:
           repo_token: ${{ secrets.GH_TOKEN }}
           file: packages/scanner/release/scanner-linux-x64.sha256
           asset_name: scanner-linux-x64.sha256
+          tag: ${{ github.ref }}
+          overwrite: true
+
+  linux-arm64:
+    runs-on: linux-arm64
+
+    if:
+      ${{ contains(github.event.pull_request.labels.*.name, 'build native') ||
+      startsWith(github.ref, 'refs/tags/@appland/scanner-v') }}
+
+    env:
+      PUPPETEER_SKIP_DOWNLOAD: 1
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Node
+        uses: ./.github/actions/setup-node
+
+      - name: Build
+        run: |
+          yarn build
+          cd packages/scanner
+          yarn build-native linux arm64
+          ${GITHUB_WORKSPACE}/bin/hash release/scanner-linux-arm64
+
+      - name: Publish scanner-linux-arm64 artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: scanner-linux-arm64
+          path: packages/scanner/release/scanner-linux-arm64
+
+      - name: 'Release: scanner-linux-arm64'
+        uses: svenstaro/upload-release-action@v2
+        if: github.ref_type == 'tag'
+        with:
+          repo_token: ${{ secrets.GH_TOKEN }}
+          file: packages/scanner/release/scanner-linux-arm64
+          asset_name: scanner-linux-arm64
+          tag: ${{ github.ref }}
+          overwrite: true
+
+      - name: 'Release: scanner-linux-arm64.sha256'
+        uses: svenstaro/upload-release-action@v2
+        if: github.ref_type == 'tag'
+        with:
+          repo_token: ${{ secrets.GH_TOKEN }}
+          file: packages/scanner/release/scanner-linux-arm64.sha256
+          asset_name: scanner-linux-arm64.sha256
           tag: ${{ github.ref }}
           overwrite: true
 
@@ -262,7 +312,8 @@ jobs:
     if: ${{ startsWith(github.ref, 'refs/tags/@appland/scanner-v') }}
     runs-on: ubuntu-latest
     needs:
-      - linux
+      - linux-x64
+      - linux-arm64
       - macos-x64
       - macos-arm
       - windows

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -7,7 +7,7 @@ on:
       - '@appland/appmap-v*'
 
 jobs:
-  linux:
+  linux-x64:
     runs-on: ubuntu-latest
 
     if:
@@ -54,6 +54,56 @@ jobs:
           repo_token: ${{ secrets.GH_TOKEN }}
           file: packages/cli/release/appmap-linux-x64.sha256
           asset_name: appmap-linux-x64.sha256
+          tag: ${{ github.ref }}
+          overwrite: true
+
+  linux-arm64:
+    runs-on: linux-arm64
+
+    if:
+      ${{ contains(github.event.pull_request.labels.*.name, 'build native') ||
+      startsWith(github.ref, 'refs/tags/@appland/appmap-v') }}
+
+    env:
+      PUPPETEER_SKIP_DOWNLOAD: 1
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Node
+        uses: ./.github/actions/setup-node
+
+      - name: Build
+        run: |
+          yarn build
+          cd packages/cli
+          yarn build-native linux arm64
+          ${GITHUB_WORKSPACE}/bin/hash release/appmap-linux-arm64
+
+      - name: Publish appmap-linux-arm64 artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: appmap-linux-arm64
+          path: packages/cli/release/appmap-linux-arm64
+
+      - name: 'Release: appmap-linux-arm64'
+        uses: svenstaro/upload-release-action@v2
+        if: github.ref_type == 'tag'
+        with:
+          repo_token: ${{ secrets.GH_TOKEN }}
+          file: packages/cli/release/appmap-linux-arm64
+          asset_name: appmap-linux-arm64
+          tag: ${{ github.ref }}
+          overwrite: true
+
+      - name: 'Release: appmap-linux-arm64.sha256'
+        uses: svenstaro/upload-release-action@v2
+        if: github.ref_type == 'tag'
+        with:
+          repo_token: ${{ secrets.GH_TOKEN }}
+          file: packages/cli/release/appmap-linux-arm64.sha256
+          asset_name: appmap-linux-arm64.sha256
           tag: ${{ github.ref }}
           overwrite: true
 
@@ -261,7 +311,8 @@ jobs:
     if: ${{ startsWith(github.ref, 'refs/tags/@appland/appmap-v') }}
     runs-on: ubuntu-latest
     needs:
-      - linux
+      - linux-x64
+      - linux-arm64
       - macos-x64
       - macos-arm
       - windows

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -133,7 +133,7 @@
     "openapi-types": "^12.1.3",
     "ora": "^5.4.1",
     "parse-diff": "^0.11.1",
-    "pkg": "^5.8.0",
+    "pkg": "^5.8.1",
     "port-pid": "^0.0.7",
     "pretty-bytes": "^5.6.0",
     "ps-node": "^0.1.6",

--- a/packages/cli/src/rpc/explain/collectContext.ts
+++ b/packages/cli/src/rpc/explain/collectContext.ts
@@ -102,6 +102,7 @@ export class SourceCollector {
 
 export class ContextCollector {
   public appmaps: string[] | undefined;
+  public excludePatterns: RegExp[] | undefined;
 
   query: string;
 
@@ -155,7 +156,8 @@ export class ContextCollector {
 
     const fileSearchResponse = await withIndex(
       'files',
-      (indexFileName: string) => buildFileIndex(this.sourceDirectories, indexFileName),
+      (indexFileName: string) =>
+        buildFileIndex(this.sourceDirectories, indexFileName, this.excludePatterns),
       (index) => index.search(this.vectorTerms, DEFAULT_MAX_FILES)
     );
 
@@ -215,7 +217,8 @@ export default async function collectContext(
   sourceDirectories: string[],
   appmaps: string[] | undefined,
   vectorTerms: string[],
-  charLimit: number
+  charLimit: number,
+  exclude?: string[]
 ): Promise<{
   searchResponse: SearchRpc.SearchResponse;
   context: ContextV2.ContextResponse;
@@ -227,5 +230,6 @@ export default async function collectContext(
     charLimit
   );
   if (appmaps) contextCollector.appmaps = appmaps;
+  if (exclude) contextCollector.excludePatterns = exclude.map((pattern) => new RegExp(pattern));
   return await contextCollector.collectContext();
 }

--- a/packages/cli/src/rpc/explain/explain.ts
+++ b/packages/cli/src/rpc/explain/explain.ts
@@ -52,7 +52,8 @@ export class Explain extends EventEmitter {
     public codeSelection: string | undefined,
     public appmaps: string[] | undefined,
     public status: ExplainRpc.ExplainStatusResponse,
-    public codeEditor: string | undefined
+    public codeEditor: string | undefined,
+    public prompt: string | undefined
   ) {
     super();
   }
@@ -102,7 +103,7 @@ export class Explain extends EventEmitter {
       }
     }
 
-    await navie.ask(this.status.threadId, this.question, this.codeSelection);
+    await navie.ask(this.status.threadId, this.question, this.codeSelection, this.prompt);
   }
 
   async searchContext(data: ContextV2.ContextRequest): Promise<ContextV2.ContextResponse> {
@@ -214,7 +215,8 @@ async function explain(
   codeSelection: string | undefined,
   appmaps: string[] | undefined,
   threadId: string | undefined,
-  codeEditor: string | undefined
+  codeEditor: string | undefined,
+  prompt: string | undefined
 ): Promise<ExplainRpc.ExplainResponse> {
   const status: ExplainRpc.ExplainStatusResponse = {
     step: ExplainRpc.Step.NEW,
@@ -236,7 +238,8 @@ async function explain(
     cachedCodeSelection,
     appmaps,
     status,
-    codeEditor
+    codeEditor,
+    prompt
   );
 
   const invokeContextFunction = async (data: any) => {
@@ -321,7 +324,8 @@ const explainHandler: (
         options.codeSelection,
         options.appmaps,
         options.threadId,
-        codeEditor
+        codeEditor,
+        options.prompt
       ),
   };
 };

--- a/packages/cli/src/rpc/explain/explain.ts
+++ b/packages/cli/src/rpc/explain/explain.ts
@@ -52,8 +52,8 @@ export class Explain extends EventEmitter {
     public codeSelection: string | undefined,
     public appmaps: string[] | undefined,
     public status: ExplainRpc.ExplainStatusResponse,
-    public codeEditor: string | undefined,
-    public prompt: string | undefined
+    public codeEditor?: string,
+    public prompt?: string
   ) {
     super();
   }
@@ -150,7 +150,8 @@ export class Explain extends EventEmitter {
       this.projectDirectories,
       this.appmaps,
       keywords,
-      charLimit
+      charLimit,
+      data.exclude
     );
 
     this.status.searchResponse = searchResult.searchResponse;

--- a/packages/cli/src/rpc/explain/navie/inavie.ts
+++ b/packages/cli/src/rpc/explain/navie/inavie.ts
@@ -8,7 +8,8 @@ export default interface INavie {
   ask(
     threadId: string | undefined,
     question: string,
-    codeSelection: string | undefined
+    codeSelection: string | undefined,
+    prompt: string | undefined
   ): Promise<void>;
 
   on(event: 'ack', listener: (userMessageId: string, threadId: string) => void): this;

--- a/packages/cli/src/rpc/explain/navie/navie-local.ts
+++ b/packages/cli/src/rpc/explain/navie/navie-local.ts
@@ -102,7 +102,8 @@ export default class LocalNavie extends EventEmitter implements INavie {
   async ask(
     threadId: string | undefined,
     question: string,
-    codeSelection: string | undefined
+    codeSelection: string | undefined,
+    prompt: string | undefined
   ): Promise<void> {
     if (!threadId) {
       warn(`[local-navie] No threadId provided for question. Allocating a new threadId.`);
@@ -149,6 +150,7 @@ export default class LocalNavie extends EventEmitter implements INavie {
       const clientRequest: Navie.ClientRequest = {
         question,
         codeSelection,
+        prompt,
       };
 
       const messages = await history.restoreMessages();

--- a/packages/cli/src/rpc/explain/navie/navie-local.ts
+++ b/packages/cli/src/rpc/explain/navie/navie-local.ts
@@ -102,8 +102,8 @@ export default class LocalNavie extends EventEmitter implements INavie {
   async ask(
     threadId: string | undefined,
     question: string,
-    codeSelection: string | undefined,
-    prompt: string | undefined
+    codeSelection?: string,
+    prompt?: string
   ): Promise<void> {
     if (!threadId) {
       warn(`[local-navie] No threadId provided for question. Allocating a new threadId.`);

--- a/packages/cli/src/rpc/explain/navie/navie-remote.ts
+++ b/packages/cli/src/rpc/explain/navie/navie-remote.ts
@@ -27,8 +27,8 @@ export default class RemoteNavie extends EventEmitter implements INavie {
   async ask(
     threadId: string,
     question: string,
-    codeSelection: string | undefined,
-    prompt: string | undefined
+    codeSelection?: string,
+    prompt?: string
   ) {
     if (prompt) {
       warn(`RemoteNavie does not support a custom prompt option.`);

--- a/packages/cli/src/rpc/explain/navie/navie-remote.ts
+++ b/packages/cli/src/rpc/explain/navie/navie-remote.ts
@@ -24,7 +24,15 @@ export default class RemoteNavie extends EventEmitter implements INavie {
     throw new Error(`RemoteNavie does not support option '${key}'`);
   }
 
-  async ask(threadId: string, question: string, codeSelection: string | undefined) {
+  async ask(
+    threadId: string,
+    question: string,
+    codeSelection: string | undefined,
+    prompt: string | undefined
+  ) {
+    if (prompt) {
+      warn(`RemoteNavie does not support a custom prompt option.`);
+    }
     (
       await AI.connect({
         onAck: (userMessageId, threadId) => {

--- a/packages/cli/tests/unit/fulltext/FileIndex.spec.ts
+++ b/packages/cli/tests/unit/fulltext/FileIndex.spec.ts
@@ -107,7 +107,7 @@ describe('FileIndex', () => {
       } as any);
       jest.spyOn(listGitProjectFiles, 'default').mockResolvedValue(fileNames);
 
-      await fileIndex.indexDirectories(['dir1'], batchSize);
+      await fileIndex.indexDirectories(['dir1'], undefined, batchSize);
 
       expect(indexDirectory).toHaveBeenCalledTimes(numFiles / batchSize);
       expect(indexFile).toHaveBeenCalledTimes(numFiles);

--- a/packages/cli/tests/unit/rpc/configuration.spec.ts
+++ b/packages/cli/tests/unit/rpc/configuration.spec.ts
@@ -82,7 +82,7 @@ describe('v2.configuration.get', () => {
       OPENAI_API_KEY: 'test',
     });
 
-    it('returns the expected config', async () => {
+    it('returns the expected config', () => {
       const result = getConfigurationV2().handler(undefined);
       expect(result).toStrictEqual({
         baseUrl: 'https://test.api.openai.com',
@@ -94,9 +94,10 @@ describe('v2.configuration.get', () => {
   });
 
   describe('with default settings', () => {
-    it('returns the expected config', async () => {
+    it('returns the expected config', () => {
       const result = getConfigurationV2().handler(undefined);
       expect(result).toStrictEqual({
+        // KEG: I am not sure why this isn't coming through as the default value of https://api.openai.com
         baseUrl: undefined,
         model: undefined,
         projectDirectories: [],

--- a/packages/cli/tests/unit/rpc/explain/Explain.spec.ts
+++ b/packages/cli/tests/unit/rpc/explain/Explain.spec.ts
@@ -167,7 +167,7 @@ describe('Explain', () => {
 
         expect(explain.conversationThread).toBeUndefined();
         expect(status).toEqual({ step: ExplainRpc.Step.NEW });
-        expect(navie.ask).toHaveBeenCalledWith(undefined, question, undefined);
+        expect(navie.ask).toHaveBeenCalledWith(undefined, question, undefined, undefined);
       });
 
       describe('and navie acks the message', () => {

--- a/packages/cli/tests/unit/rpc/explain/LocalNavie.spec.ts
+++ b/packages/cli/tests/unit/rpc/explain/LocalNavie.spec.ts
@@ -72,7 +72,7 @@ describe('LocalNavie', () => {
 
         await new Promise<void>((resolve) => {
           awaitResponse(resolve);
-          navie.ask('the-thread-id', 'What is the meaning of life?', undefined);
+          navie.ask('the-thread-id', 'What is the meaning of life?');
         });
       });
 
@@ -84,7 +84,7 @@ describe('LocalNavie', () => {
 
           await new Promise<void>((resolve) => {
             awaitResponse(resolve);
-            navie.ask(undefined, 'What is the meaning of life?', undefined);
+            navie.ask(undefined, 'What is the meaning of life?');
           });
         });
       });

--- a/packages/cli/tests/unit/rpc/explain/explainHandler.spec.ts
+++ b/packages/cli/tests/unit/rpc/explain/explainHandler.spec.ts
@@ -50,19 +50,19 @@ describe('explainHandler', () => {
       const codeSelection = 'int main() { return 0; }';
       const questions = ['how do i??', 'but i cant??'];
       await explain({ question: questions[0], codeSelection, threadId });
-      expect(navie.ask).toHaveBeenCalledWith(threadId, questions[0], codeSelection);
+      expect(navie.ask).toHaveBeenCalledWith(threadId, questions[0], codeSelection, undefined);
 
       // The same threadId should be used for the next call
       // Note that codeSelection is not given
       await explain({ question: questions[1], threadId });
-      expect(navie.ask).toHaveBeenCalledWith(threadId, questions[1], codeSelection);
+      expect(navie.ask).toHaveBeenCalledWith(threadId, questions[1], codeSelection, undefined);
     });
 
     it('does not cache the code selection by threadId if codeSelection is not given', async () => {
       const threadId = 'the-other-thread-id';
       for (const question of ['???', 'now what?']) {
         await explain({ question: question, threadId });
-        expect(navie.ask).toHaveBeenCalledWith(threadId, question, undefined);
+        expect(navie.ask).toHaveBeenCalledWith(threadId, question, undefined, undefined);
       }
     });
   });

--- a/packages/navie/src/agents/explain-agent.ts
+++ b/packages/navie/src/agents/explain-agent.ts
@@ -4,6 +4,7 @@ import { PromptType, buildPromptDescriptor, buildPromptValue } from '../prompt';
 import VectorTermsService from '../services/vector-terms-service';
 import LookupContextService from '../services/lookup-context-service';
 import ApplyContextService from '../services/apply-context-service';
+import transformSearchTerms from '../lib/transform-search-terms';
 
 const EXPLAIN_AGENT_PROMPT = `**Task: Explaining Code, Analyzing Code, Generating Code**
 
@@ -62,15 +63,18 @@ export default class ExplainAgent implements Agent {
       )
     );
 
-    const { aggregateQuestion } = options;
-
     const lookupContext = options.userOptions.isEnabled('context', true);
+    const transformTerms = options.userOptions.isEnabled('terms', true);
     if (lookupContext) {
       const tokenCount = tokensAvailable();
-      const vectorTerms = await this.vectorTermsService.suggestTerms(aggregateQuestion);
+      const searchTerms = await transformSearchTerms(
+        transformTerms,
+        options.aggregateQuestion,
+        this.vectorTermsService
+      );
 
       const context = await this.lookupContextService.lookupContext(
-        vectorTerms,
+        searchTerms,
         tokenCount,
         options.contextLabels
       );

--- a/packages/navie/src/agents/explain-agent.ts
+++ b/packages/navie/src/agents/explain-agent.ts
@@ -65,6 +65,7 @@ export default class ExplainAgent implements Agent {
 
     const lookupContext = options.userOptions.isEnabled('context', true);
     const transformTerms = options.userOptions.isEnabled('terms', true);
+    const exclude = options.userOptions.stringValue('exclude');
     if (lookupContext) {
       const tokenCount = tokensAvailable();
       const searchTerms = await transformSearchTerms(
@@ -76,7 +77,8 @@ export default class ExplainAgent implements Agent {
       const context = await this.lookupContextService.lookupContext(
         searchTerms,
         tokenCount,
-        options.contextLabels
+        options.contextLabels,
+        exclude ? [exclude] : undefined
       );
 
       LookupContextService.applyContext(context, [], this.applyContextService, tokenCount);

--- a/packages/navie/src/agents/generate-agent.ts
+++ b/packages/navie/src/agents/generate-agent.ts
@@ -66,6 +66,7 @@ export default class GenerateAgent implements Agent {
 
     const lookupContext = options.userOptions.isEnabled('context', true);
     const transformTerms = options.userOptions.isEnabled('terms', true);
+    const exclude = options.userOptions.stringValue('exclude');
     if (lookupContext) {
       const searchTerms = await transformSearchTerms(
         transformTerms,
@@ -73,7 +74,12 @@ export default class GenerateAgent implements Agent {
         this.vectorTermsService
       );
       const tokenCount = tokensAvailable();
-      const context = await this.lookupContextService.lookupContext(searchTerms, tokenCount);
+      const context = await this.lookupContextService.lookupContext(
+        searchTerms,
+        tokenCount,
+        undefined,
+        exclude ? [exclude] : undefined
+      );
       LookupContextService.applyContext(context, [], this.applyContextService, tokenCount);
     }
   }

--- a/packages/navie/src/agents/generate-agent.ts
+++ b/packages/navie/src/agents/generate-agent.ts
@@ -1,5 +1,6 @@
 import { Agent, AgentOptions } from '../agent';
 import InteractionHistory, { PromptInteractionEvent } from '../interaction-history';
+import transformSearchTerms from '../lib/transform-search-terms';
 import { PromptType, buildPromptDescriptor, buildPromptValue } from '../prompt';
 import ApplyContextService from '../services/apply-context-service';
 import LookupContextService from '../services/lookup-context-service';
@@ -64,10 +65,15 @@ export default class GenerateAgent implements Agent {
     );
 
     const lookupContext = options.userOptions.isEnabled('context', true);
+    const transformTerms = options.userOptions.isEnabled('terms', true);
     if (lookupContext) {
-      const vectorTerms = await this.vectorTermsService.suggestTerms(options.aggregateQuestion);
+      const searchTerms = await transformSearchTerms(
+        transformTerms,
+        options.aggregateQuestion,
+        this.vectorTermsService
+      );
       const tokenCount = tokensAvailable();
-      const context = await this.lookupContextService.lookupContext(vectorTerms, tokenCount);
+      const context = await this.lookupContextService.lookupContext(searchTerms, tokenCount);
       LookupContextService.applyContext(context, [], this.applyContextService, tokenCount);
     }
   }

--- a/packages/navie/src/agents/help-agent.ts
+++ b/packages/navie/src/agents/help-agent.ts
@@ -6,6 +6,7 @@ import VectorTermsService from '../services/vector-terms-service';
 import LookupContextService from '../services/lookup-context-service';
 import TechStackService from '../services/tech-stack-service';
 import { CHARACTERS_PER_TOKEN } from '../message';
+import transformSearchTerms from '../lib/transform-search-terms';
 
 export const HELP_AGENT_PROMPT = `**Task: Providing Help with AppMap**
 
@@ -210,7 +211,12 @@ export default class HelpAgent implements Agent {
       );
     }
 
-    const vectorTerms = await this.vectorTermsService.suggestTerms(options.aggregateQuestion);
+    const transformTerms = options.userOptions.isEnabled('terms', true);
+    const searchTerms = await transformSearchTerms(
+      transformTerms,
+      options.aggregateQuestion,
+      this.vectorTermsService
+    );
     const tokenCount = tokensAvailable();
 
     const collectLanguages = () => {
@@ -222,7 +228,7 @@ export default class HelpAgent implements Agent {
 
     let helpContext = await this.lookupContextService.lookupHelp(
       [...new Set([...collectLanguages(), ...techStackTerms])].sort(),
-      vectorTerms,
+      searchTerms,
       tokenCount
     );
 

--- a/packages/navie/src/agents/plan-agent.ts
+++ b/packages/navie/src/agents/plan-agent.ts
@@ -88,7 +88,7 @@ export class PlanAgent implements Agent {
 
     const lookupContext = options.userOptions.isEnabled('context', true);
     const transformTerms = options.userOptions.isEnabled('terms', true);
-
+    const exclude = options.userOptions.stringValue('exclude');
     if (lookupContext) {
       const searchTerms = await transformSearchTerms(
         transformTerms,
@@ -96,7 +96,7 @@ export class PlanAgent implements Agent {
         this.vectorTermsService
       );
       const tokenCount = tokensAvailable();
-      const context = await this.lookupContextService.lookupContext(searchTerms, tokenCount);
+      const context = await this.lookupContextService.lookupContext(searchTerms, tokenCount, undefined, exclude ? [exclude] : undefined);
       LookupContextService.applyContext(context, [], this.applyContextService, tokenCount);
     }
   }

--- a/packages/navie/src/agents/plan-agent.ts
+++ b/packages/navie/src/agents/plan-agent.ts
@@ -1,5 +1,6 @@
 import { Agent, AgentOptions } from '../agent';
 import InteractionHistory, { PromptInteractionEvent } from '../interaction-history';
+import transformSearchTerms from '../lib/transform-search-terms';
 import { PromptType, buildPromptDescriptor, buildPromptValue } from '../prompt';
 import ApplyContextService from '../services/apply-context-service';
 import LookupContextService from '../services/lookup-context-service';
@@ -86,10 +87,16 @@ export class PlanAgent implements Agent {
     );
 
     const lookupContext = options.userOptions.isEnabled('context', true);
+    const transformTerms = options.userOptions.isEnabled('terms', true);
+
     if (lookupContext) {
-      const vectorTerms = await this.vectorTermsService.suggestTerms(options.aggregateQuestion);
+      const searchTerms = await transformSearchTerms(
+        transformTerms,
+        options.aggregateQuestion,
+        this.vectorTermsService
+      );
       const tokenCount = tokensAvailable();
-      const context = await this.lookupContextService.lookupContext(vectorTerms, tokenCount);
+      const context = await this.lookupContextService.lookupContext(searchTerms, tokenCount);
       LookupContextService.applyContext(context, [], this.applyContextService, tokenCount);
     }
   }

--- a/packages/navie/src/agents/test-agent.ts
+++ b/packages/navie/src/agents/test-agent.ts
@@ -79,12 +79,18 @@ export default class TestAgent implements Agent {
     );
 
     const lookupContext = options.userOptions.isEnabled('context', true);
+    const exclude = options.userOptions.stringValue('exclude');
     if (lookupContext) {
       const vectorTerms = await this.vectorTermsService.suggestTerms(options.aggregateQuestion);
       vectorTerms.push('test');
       vectorTerms.push('spec');
       const tokenCount = tokensAvailable();
-      const context = await this.lookupContextService.lookupContext(vectorTerms, tokenCount);
+      const context = await this.lookupContextService.lookupContext(
+        vectorTerms,
+        tokenCount,
+        undefined,
+        exclude ? [exclude] : undefined
+      );
       LookupContextService.applyContext(context, [], this.applyContextService, tokenCount);
     }
   }

--- a/packages/navie/src/commands/context-command.ts
+++ b/packages/navie/src/commands/context-command.ts
@@ -20,7 +20,8 @@ export default class ContextCommand implements Command {
     const fence = request.userOptions.isEnabled('fence', true);
     const format = request.userOptions.stringValue('format') || 'yaml';
     const tokenLimit = request.userOptions.numberValue('tokenlimit') || this.options.tokenLimit;
-    const transformTerms = request.userOptions.booleanValue('terms', true);
+    const transformTerms = request.userOptions.isEnabled('terms', true);
+    const exclude = request.userOptions.stringValue('exclude');
 
     const aggregateQuestion = [
       ...(chatHistory || [])
@@ -37,7 +38,12 @@ export default class ContextCommand implements Command {
       aggregateQuestion,
       this.vectorTermsService
     );
-    const context = await this.lookupContextService.lookupContext(searchTerms, tokenLimit, []);
+    const context = await this.lookupContextService.lookupContext(
+      searchTerms,
+      tokenLimit,
+      [],
+      exclude ? [exclude] : undefined
+    );
 
     let contextStr: string;
     if (format === 'yaml') {

--- a/packages/navie/src/commands/explain-command.ts
+++ b/packages/navie/src/commands/explain-command.ts
@@ -7,7 +7,7 @@ import CodeSelectionService from '../services/code-selection-service';
 import CompletionService from '../services/completion-service';
 import MemoryService from '../services/memory-service';
 import ProjectInfoService from '../services/project-info-service';
-import InteractionHistory from '../interaction-history';
+import InteractionHistory, { PromptInteractionEvent } from '../interaction-history';
 import { ProjectInfo } from '../project-info';
 import Command, { CommandRequest } from '../command';
 import { ChatHistory } from '../navie';
@@ -92,6 +92,12 @@ export default class ExplainCommand implements Command {
     const hasChatHistory = chatHistory && chatHistory.length > 0;
     if (hasChatHistory) {
       await this.memoryService.predictSummary(chatHistory);
+    }
+
+    if (request.prompt) {
+      this.interactionHistory.addEvent(
+        new PromptInteractionEvent('customPrompt', 'system', request.prompt)
+      );
     }
 
     if (codeSelection) this.codeSelectionService.applyCodeSelection(codeSelection);

--- a/packages/navie/src/context.ts
+++ b/packages/navie/src/context.ts
@@ -114,6 +114,8 @@ export namespace ContextV2 {
     itemTypes?: ContextItemType[];
     // Emphasize context items that are relevant to the classification of the user's request.
     labels?: ContextLabel[];
+    // Optional list of file patterns to exclude.
+    exclude?: string[];
   };
 
   export type ContextResponse = Array<ContextItem | FileContextItem>;

--- a/packages/navie/src/interaction-history.ts
+++ b/packages/navie/src/interaction-history.ts
@@ -76,7 +76,7 @@ export class ClassificationEvent extends InteractionEvent {
 export class PromptInteractionEvent extends InteractionEvent {
   constructor(
     public name: PromptType | string,
-    public role: 'user' | 'system',
+    public role: 'user' | 'assistant' | 'system',
     public content: string,
     public prefix?: string
   ) {

--- a/packages/navie/src/lib/parse-options.ts
+++ b/packages/navie/src/lib/parse-options.ts
@@ -6,7 +6,7 @@ export class UserOptions {
     return this.options.has(key);
   }
 
-  isEnabled(key: string, defaultValue?: boolean): boolean | undefined {
+  isEnabled(key: string, defaultValue: boolean): boolean {
     return this.booleanValue(key, defaultValue);
   }
 
@@ -22,7 +22,7 @@ export class UserOptions {
     return defaultValue;
   }
 
-  booleanValue(key: string, defaultValue?: boolean): boolean | undefined {
+  booleanValue(key: string, defaultValue: boolean): boolean {
     if (!this.options.has(key)) return defaultValue;
 
     const value = this.options.get(key);

--- a/packages/navie/src/lib/transform-search-terms.ts
+++ b/packages/navie/src/lib/transform-search-terms.ts
@@ -1,0 +1,29 @@
+import { warn } from 'console';
+import VectorTermsService from '../services/vector-terms-service';
+
+export default async function transformSearchTerms(
+  transformTerms: boolean,
+  aggregateQuestion: string,
+  vectorTermsService: VectorTermsService
+): Promise<string[]> {
+  let result: string[];
+  if (transformTerms) {
+    result = await vectorTermsService.suggestTerms(aggregateQuestion);
+  } else {
+    const terms = new Array<string>();
+    for (const term of aggregateQuestion.split(/[._-\s]/))
+      terms.push(term.match(/\+?[\p{Alphabetic}|\p{Number}]+/u)?.[0] || '');
+    result = terms
+      .map((word) => word.trim())
+      .filter((word) => word.length > 2)
+      .map((word) => word.toLowerCase());
+  }
+
+  if (result.length === 0) {
+    warn('No search terms were generated.');
+  } else {
+    warn(`Transformed search terms: ${result.join(' ')}`);
+  }
+
+  return result;
+}

--- a/packages/navie/src/navie.ts
+++ b/packages/navie/src/navie.ts
@@ -32,12 +32,14 @@ import FileChangeExtractorService from './services/file-change-extractor-service
 import FileUpdateService from './services/file-update-service';
 import parseOptions from './lib/parse-options';
 import ListFilesCommand from './commands/list-files-command';
+import { warn } from 'console';
 
 export type ChatHistory = Message[];
 
 export interface ClientRequest {
   question: string;
   codeSelection?: string;
+  prompt?: string;
 }
 
 export interface INavie extends InteractionHistoryEvents {
@@ -50,14 +52,16 @@ export interface INavie extends InteractionHistoryEvents {
   execute(): AsyncIterable<string>;
 }
 
+export const DEFAULT_MODEL_NAME = 'gpt-4o';
 export const DEFAULT_TOKEN_LIMIT = 8000;
 export const DEFAULT_TEMPERATURE = 0.2;
+export const DEFAULT_RESPONSE_TOKENS = 1000;
 
 export class NavieOptions {
-  modelName = process.env.APPMAP_NAVIE_MODEL ?? 'gpt-4o';
+  modelName = process.env.APPMAP_NAVIE_MODEL ?? DEFAULT_MODEL_NAME;
   tokenLimit = Number(process.env.APPMAP_NAVIE_TOKEN_LIMIT ?? DEFAULT_TOKEN_LIMIT);
   temperature = Number(process.env.APPMAP_NAVIE_TEMPERATURE ?? DEFAULT_TEMPERATURE);
-  responseTokens = 1000;
+  responseTokens = Number(process.env.APPMAP_NAVIE_RESPONSE_TOKENS ?? DEFAULT_RESPONSE_TOKENS);
 }
 
 export default function navie(
@@ -68,6 +72,12 @@ export default function navie(
   options: NavieOptions,
   chatHistory?: ChatHistory
 ): INavie {
+  if (options.modelName !== DEFAULT_MODEL_NAME) warn(`Using model ${options.modelName}`);
+  if (options.tokenLimit !== DEFAULT_TOKEN_LIMIT) warn(`Using token limit ${options.tokenLimit}`);
+  if (options.temperature !== DEFAULT_TEMPERATURE) warn(`Using temperature ${options.temperature}`);
+  if (options.responseTokens !== DEFAULT_RESPONSE_TOKENS)
+    warn(`Using response tokens ${options.responseTokens}`);
+
   const interactionHistory = new InteractionHistory();
   const completionService = new OpenAICompletionService(
     interactionHistory,

--- a/packages/navie/src/services/file-update-service.ts
+++ b/packages/navie/src/services/file-update-service.ts
@@ -18,18 +18,16 @@ function findLineMatch(
   assert(trimmed.length && haystack.length);
 
   let needlePos = 0;
-  let start = -1;
-  for (let i = 0; i <= haystack.length; i += 1) {
+  let start = 0;
+  for (let i = 0; i < haystack.length; i += 1) {
     const hay = haystack[i].trim();
     // skip blank lines
     if (hay) {
+      if (trimmed[needlePos] !== hay) needlePos = 0;
       if (trimmed[needlePos] === hay) {
-        if (start < 0) start = i;
+        if (!needlePos) start = i;
         needlePos += 1;
         if (needlePos === trimmed.length) return [start, i - start + 1];
-      } else {
-        needlePos = 0;
-        start = -1;
       }
     }
   }

--- a/packages/navie/src/services/file-update-service.ts
+++ b/packages/navie/src/services/file-update-service.ts
@@ -10,19 +10,29 @@ export type FileUpdate = {
   modified: string;
 };
 
-function findLineMatch(haystack: readonly string[], needle: readonly string[]): number | undefined {
-  assert(needle.length && haystack.length);
-  const trimmed = needle.map((s) => s.trim());
+function findLineMatch(
+  haystack: readonly string[],
+  needle: readonly string[]
+): [number, number] | undefined {
+  const trimmed = needle.map((s) => s.trim()).filter((s) => s); // skip blank lines
+  assert(trimmed.length && haystack.length);
 
-  /* eslint-disable no-labels */
-  /* eslint-disable no-continue */
-  next: for (let i = 0; i <= haystack.length - needle.length; i += 1) {
-    for (let j = 0; j < needle.length; j += 1)
-      if (haystack[i + j].trim() !== trimmed[j]) continue next;
-    return i;
+  let needlePos = 0;
+  let start = -1;
+  for (let i = 0; i <= haystack.length; i += 1) {
+    const hay = haystack[i].trim();
+    // skip blank lines
+    if (hay) {
+      if (trimmed[needlePos] === hay) {
+        if (start < 0) start = i;
+        needlePos += 1;
+        if (needlePos === trimmed.length) return [start, i - start + 1];
+      } else {
+        needlePos = 0;
+        start = -1;
+      }
+    }
   }
-  /* eslint-enable no-continue */
-  /* eslint-enable no-labels */
 
   return undefined;
 }
@@ -67,8 +77,10 @@ export default class FileUpdateService {
 
     const originalLines = fileUpdate.original.split('\n');
 
-    const index = findLineMatch(fileLines, originalLines);
-    if (!index) return [`[file-update] Failed to find match for ${fileUpdate.file}.\n`];
+    const match = findLineMatch(fileLines, originalLines);
+    if (!match) return [`[file-update] Failed to find match for ${fileUpdate.file}.\n`];
+
+    const [index, length] = match;
 
     const nonEmptyIndex = originalLines.findIndex((s) => s.trim());
     const adjustWhitespace = makeWhitespaceAdjuster(
@@ -81,11 +93,7 @@ export default class FileUpdateService {
         adjustWhitespace.desc
       }\n`
     );
-    fileLines.splice(
-      index,
-      originalLines.length,
-      ...fileUpdate.modified.split('\n').map(adjustWhitespace)
-    );
+    fileLines.splice(index, length, ...fileUpdate.modified.split('\n').map(adjustWhitespace));
 
     await writeFile(fileUpdate.file, fileLines.join('\n'), 'utf8');
 

--- a/packages/navie/src/services/lookup-context-service.ts
+++ b/packages/navie/src/services/lookup-context-service.ts
@@ -1,4 +1,4 @@
-import { log } from 'console';
+import { warn } from 'console';
 import InteractionHistory, { ContextLookupEvent, HelpLookupEvent } from '../interaction-history';
 import { ContextV2 } from '../context';
 import { CHARACTERS_PER_TOKEN } from '../message';
@@ -19,6 +19,11 @@ export default class LookupContextService {
     tokenCount: number,
     contextLabels?: ContextV2.ContextLabel[]
   ): Promise<ContextV2.ContextResponse> {
+    if (keywords.length === 0) {
+      warn('WARNING: No keywords provided');
+      return [];
+    }
+
     const contextRequestPayload: ContextV2.ContextRequest & { version: 2; type: 'search' } = {
       version: 2,
       type: 'search',
@@ -33,7 +38,7 @@ export default class LookupContextService {
     if (contextFound) {
       this.interactionHistory.addEvent(new ContextLookupEvent(context));
     } else {
-      log('No context found');
+      warn('No context found');
       this.interactionHistory.addEvent(new ContextLookupEvent(undefined));
     }
 
@@ -56,7 +61,7 @@ export default class LookupContextService {
     if (helpFound) {
       this.interactionHistory.addEvent(new HelpLookupEvent(help));
     } else {
-      log('No help found');
+      warn('No help found');
       this.interactionHistory.addEvent(new HelpLookupEvent(undefined));
     }
 

--- a/packages/navie/src/services/lookup-context-service.ts
+++ b/packages/navie/src/services/lookup-context-service.ts
@@ -17,7 +17,8 @@ export default class LookupContextService {
   async lookupContext(
     keywords: string[],
     tokenCount: number,
-    contextLabels?: ContextV2.ContextLabel[]
+    contextLabels?: ContextV2.ContextLabel[],
+    exclude?: string[]
   ): Promise<ContextV2.ContextResponse> {
     if (keywords.length === 0) {
       warn('WARNING: No keywords provided');
@@ -31,6 +32,7 @@ export default class LookupContextService {
       tokenCount,
     };
     if (contextLabels) contextRequestPayload.labels = contextLabels;
+    if (exclude) contextRequestPayload.exclude = exclude;
 
     const context = await this.contextFn(contextRequestPayload);
 

--- a/packages/navie/test/agents/explain-agent.spec.ts
+++ b/packages/navie/test/agents/explain-agent.spec.ts
@@ -76,6 +76,7 @@ describe('@explain agent', () => {
       expect(lookupContextService.lookupContext).toHaveBeenCalledWith(
         ['user', 'management'],
         tokensAvailable,
+        undefined,
         undefined
       );
       expect(lookupContextService.lookupHelp).not.toHaveBeenCalled();

--- a/packages/navie/test/agents/generate-agent.spec.ts
+++ b/packages/navie/test/agents/generate-agent.spec.ts
@@ -62,7 +62,9 @@ describe('@generate agent', () => {
 
       expect(lookupContextService.lookupContext).toHaveBeenCalledWith(
         ['user', 'management'],
-        tokensAvailable
+        tokensAvailable,
+        undefined,
+        undefined
       );
       expect(lookupContextService.lookupHelp).not.toHaveBeenCalled();
     });

--- a/packages/navie/test/lib/parse-options.spec.ts
+++ b/packages/navie/test/lib/parse-options.spec.ts
@@ -3,18 +3,19 @@ import parseOptions from '../../src/lib/parse-options';
 describe('parseOptions', () => {
   it(`interprets a no-arg option as 'true'`, () => {
     const { options, question } = parseOptions('/verbose');
-    expect(options.isEnabled('verbose', undefined)).toBe(true);
+    expect(options.isEnabled('verbose', false)).toBe(true);
     expect(question).toBe('');
   });
 
   it(`interprets 'true' as true`, () => {
     const { options, question } = parseOptions('/verbose=true');
-    expect(options.isEnabled('verbose')).toBe(true);
+    expect(options.isEnabled('verbose', false)).toBe(true);
     expect(question).toBe('');
   });
 
   it(`returns the default boolean value if the option isn't present`, () => {
     const { options, question } = parseOptions('');
+    expect(options.isEnabled('verbose', false)).toBe(false);
     expect(options.isEnabled('verbose', false)).toBe(false);
     expect(question).toBe('');
   });
@@ -27,31 +28,31 @@ describe('parseOptions', () => {
 
   it('interprets "yes" as true', () => {
     const { options, question } = parseOptions('/verbose=yes');
-    expect(options.isEnabled('verbose')).toBe(true);
+    expect(options.isEnabled('verbose', false)).toBe(true);
     expect(question).toBe('');
   });
 
   it('interprets "on" as true', () => {
     const { options, question } = parseOptions('/verbose=on');
-    expect(options.isEnabled('verbose')).toBe(true);
+    expect(options.isEnabled('verbose', false)).toBe(true);
     expect(question).toBe('');
   });
 
   it(`interprets 'false' as false`, () => {
     const { options, question } = parseOptions('/verbose=false');
-    expect(options.isEnabled('verbose')).toBe(false);
+    expect(options.isEnabled('verbose', true)).toBe(false);
     expect(question).toBe('');
   });
 
   it('interprets "no" as false', () => {
     const { options, question } = parseOptions('/verbose=no');
-    expect(options.isEnabled('verbose')).toBe(false);
+    expect(options.isEnabled('verbose', true)).toBe(false);
     expect(question).toBe('');
   });
 
   it('interprets "off" as false', () => {
     const { options, question } = parseOptions('/verbose=off');
-    expect(options.isEnabled('verbose')).toBe(false);
+    expect(options.isEnabled('verbose', true)).toBe(false);
     expect(question).toBe('');
   });
 
@@ -63,39 +64,41 @@ describe('parseOptions', () => {
 
   it(`interprets nooption as 'false'`, () => {
     const { options, question } = parseOptions('/noverbose');
-    expect(options.isEnabled('verbose')).toBe(false);
-    expect(options.isEnabled('noverbose')).toBe(undefined);
+    expect(options.isEnabled('verbose', true)).toBe(false);
+    expect(options.isEnabled('noverbose', true)).toBe(true);
+    expect(options.isEnabled('noverbose', false)).toBe(false);
     expect(question).toBe('');
   });
 
   it(`ignores an option that isn't at the beginning of the question`, () => {
     const { options, question } = parseOptions('hello /verbose');
-    expect(options.isEnabled('verbose')).toBe(undefined);
+    expect(options.isEnabled('verbose', true)).toBe(true);
+    expect(options.isEnabled('verbose', false)).toBe(false);
     expect(question).toBe('hello /verbose');
   });
 
   it(`prunes the option out of the question`, () => {
     const { options, question } = parseOptions('/verbose hello');
-    expect(options.isEnabled('verbose')).toBe(true);
+    expect(options.isEnabled('verbose', false)).toBe(true);
     expect(question).toBe('hello');
   });
 
   it(`ignores leading spaces`, () => {
     const { options, question } = parseOptions(' /verbose hello');
-    expect(options.isEnabled('verbose')).toBe(true);
+    expect(options.isEnabled('verbose', false)).toBe(true);
     expect(question).toBe('hello');
   });
 
   it(`preserves trailing space`, () => {
     const { options, question } = parseOptions('/verbose hello ');
-    expect(options.isEnabled('verbose')).toBe(true);
+    expect(options.isEnabled('verbose', false)).toBe(true);
     expect(question).toBe('hello ');
   });
 
   it('parses multiple options', () => {
     const { options, question } = parseOptions('/verbose /quiet hello');
-    expect(options.isEnabled('verbose')).toBe(true);
-    expect(options.isEnabled('quiet')).toBe(true);
+    expect(options.isEnabled('verbose', false)).toBe(true);
+    expect(options.isEnabled('quiet', false)).toBe(true);
     expect(question).toBe('hello');
   });
 });

--- a/packages/navie/test/services/file-update-service.spec.ts
+++ b/packages/navie/test/services/file-update-service.spec.ts
@@ -23,6 +23,7 @@ describe(FileUpdateService, () => {
 
   it('correctly applies an update even with broken whitespace', example('whitespace-mismatch'));
   it('correctly applies an update even with trailing newlines', example('trailing-newlines'));
+  it('correctly applies an update even when blank lines mismatch', example('mismatch-blank-count'));
 
   let service: FileUpdateService;
 

--- a/packages/navie/test/services/file-update-service.spec.ts
+++ b/packages/navie/test/services/file-update-service.spec.ts
@@ -24,6 +24,10 @@ describe(FileUpdateService, () => {
   it('correctly applies an update even with broken whitespace', example('whitespace-mismatch'));
   it('correctly applies an update even with trailing newlines', example('trailing-newlines'));
   it('correctly applies an update even when blank lines mismatch', example('mismatch-blank-count'));
+  it(
+    'correctly applies an update even when there are repeated similar but mismatching lines',
+    example('mismatched-similar')
+  );
 
   let service: FileUpdateService;
 

--- a/packages/navie/test/services/file-update-service/mismatch-blank-count/apply.txt
+++ b/packages/navie/test/services/file-update-service/mismatch-blank-count/apply.txt
@@ -1,0 +1,42 @@
+<change>
+    <file change-number-for-this-file="1">original.txt</file>
+    <original line-count="20" no-ellipsis="true"><![CDATA[
+        DEFAULT_LOG_FORMAT = "%(filename)-25s %(lineno)4d %(levelname)-8s %(message)s"
+        DEFAULT_LOG_DATE_FORMAT = "%H:%M:%S"
+
+        class ColoredLevelFormatter(logging.Formatter):
+            """
+            Colorize the %(levelname)..s part of the log format passed to __init__.
+            """
+
+
+            LOGLEVEL_COLOROPTS = {
+                logging.CRITICAL: {"red"},
+                logging.ERROR: {"red", "bold"},
+                logging.WARNING: {"yellow"},
+                logging.WARN: {"yellow"},
+                logging.INFO: {"green"},
+                logging.DEBUG: {"purple"},
+                logging.NOTSET: set(),
+            }
+    ]]></original>
+    <modified no-ellipsis="true"><![CDATA[
+        DEFAULT_LOG_FORMAT = "%(name)-25s %(lineno)4d %(levelname)-8s %(message)s"
+        DEFAULT_LOG_DATE_FORMAT = "%H:%M:%S"
+
+        class ColoredLevelFormatter(logging.Formatter):
+            """
+            Colorize the %(levelname)..s part of the log format passed to __init__.
+            """
+
+            LOGLEVEL_COLOROPTS = {
+                logging.CRITICAL: {"red"},
+                logging.ERROR: {"red", "bold"},
+                logging.WARNING: {"yellow"},
+                logging.WARN: {"yellow"},
+                logging.INFO: {"green"},
+                logging.DEBUG: {"purple"},
+                logging.NOTSET: set(),
+            }
+    ]]></modified>
+</change>

--- a/packages/navie/test/services/file-update-service/mismatch-blank-count/expected.txt
+++ b/packages/navie/test/services/file-update-service/mismatch-blank-count/expected.txt
@@ -1,0 +1,20 @@
+from _pytest.pathlib import Path
+
+DEFAULT_LOG_FORMAT = "%(name)-25s %(lineno)4d %(levelname)-8s %(message)s"
+DEFAULT_LOG_DATE_FORMAT = "%H:%M:%S"
+
+class ColoredLevelFormatter(logging.Formatter):
+    """
+    Colorize the %(levelname)..s part of the log format passed to __init__.
+    """
+
+    LOGLEVEL_COLOROPTS = {
+        logging.CRITICAL: {"red"},
+        logging.ERROR: {"red", "bold"},
+        logging.WARNING: {"yellow"},
+        logging.WARN: {"yellow"},
+        logging.INFO: {"green"},
+        logging.DEBUG: {"purple"},
+        logging.NOTSET: set(),
+    }
+    LEVELNAME_FMT_REGEX = re.compile(r"%\(levelname\)([+-]?\d*s)")

--- a/packages/navie/test/services/file-update-service/mismatch-blank-count/original.txt
+++ b/packages/navie/test/services/file-update-service/mismatch-blank-count/original.txt
@@ -1,0 +1,21 @@
+from _pytest.pathlib import Path
+
+DEFAULT_LOG_FORMAT = "%(filename)-25s %(lineno)4d %(levelname)-8s %(message)s"
+DEFAULT_LOG_DATE_FORMAT = "%H:%M:%S"
+
+
+class ColoredLevelFormatter(logging.Formatter):
+    """
+    Colorize the %(levelname)..s part of the log format passed to __init__.
+    """
+
+    LOGLEVEL_COLOROPTS = {
+        logging.CRITICAL: {"red"},
+        logging.ERROR: {"red", "bold"},
+        logging.WARNING: {"yellow"},
+        logging.WARN: {"yellow"},
+        logging.INFO: {"green"},
+        logging.DEBUG: {"purple"},
+        logging.NOTSET: set(),
+    }
+    LEVELNAME_FMT_REGEX = re.compile(r"%\(levelname\)([+-]?\d*s)")

--- a/packages/navie/test/services/file-update-service/mismatched-similar/apply.txt
+++ b/packages/navie/test/services/file-update-service/mismatched-similar/apply.txt
@@ -1,0 +1,11 @@
+<change>
+    <file change-number-for-this-file="1">original.txt</file>
+    <original line-count="20" no-ellipsis="true"><![CDATA[
+        DEFAULT_LOG_FORMAT = "%(filename)-25s %(lineno)4d %(levelname)-8s %(message)s"
+        DEFAULT_LOG_DATE_FORMAT = "%H:%M:%S"
+    ]]></original>
+    <modified no-ellipsis="true"><![CDATA[
+        DEFAULT_LOG_FORMAT = "%(name)-25s %(lineno)4d %(levelname)-8s %(message)s"
+        DEFAULT_LOG_DATE_FORMAT = "%H:%M:%S"
+    ]]></modified>
+</change>

--- a/packages/navie/test/services/file-update-service/mismatched-similar/expected.txt
+++ b/packages/navie/test/services/file-update-service/mismatched-similar/expected.txt
@@ -1,0 +1,3 @@
+DEFAULT_LOG_FORMAT = "%(filename)-25s %(lineno)4d %(levelname)-8s %(message)s"
+DEFAULT_LOG_FORMAT = "%(name)-25s %(lineno)4d %(levelname)-8s %(message)s"
+DEFAULT_LOG_DATE_FORMAT = "%H:%M:%S"

--- a/packages/navie/test/services/file-update-service/mismatched-similar/original.txt
+++ b/packages/navie/test/services/file-update-service/mismatched-similar/original.txt
@@ -1,0 +1,3 @@
+DEFAULT_LOG_FORMAT = "%(filename)-25s %(lineno)4d %(levelname)-8s %(message)s"
+DEFAULT_LOG_FORMAT = "%(filename)-25s %(lineno)4d %(levelname)-8s %(message)s"
+DEFAULT_LOG_DATE_FORMAT = "%H:%M:%S"

--- a/packages/rpc/src/explain.ts
+++ b/packages/rpc/src/explain.ts
@@ -19,6 +19,7 @@ export namespace ExplainRpc {
     codeSelection?: string;
     appmaps?: string[];
     threadId?: string;
+    prompt?: string;
   };
 
   export type ExplainResponse = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -225,7 +225,7 @@ __metadata:
     openapi-types: ^12.1.3
     ora: ^5.4.1
     parse-diff: ^0.11.1
-    pkg: ^5.8.0
+    pkg: ^5.8.1
     port-pid: ^0.0.7
     prettier: ^2.7.1
     pretty-bytes: ^5.6.0
@@ -1775,6 +1775,13 @@ __metadata:
   dependencies:
     "@babel/types": ^7.22.5
   checksum: e141cace583b19d9195f9c2b8e17a3ae913b7ee9b8120246d0f9ca349ca6f03cb2c001fd5ec57488c544347c0bb584afec66c936511e447fd20a360e591ac921
+  languageName: node
+  linkType: hard
+
+"@babel/helper-string-parser@npm:^7.18.10":
+  version: 7.24.7
+  resolution: "@babel/helper-string-parser@npm:7.24.7"
+  checksum: 09568193044a578743dd44bf7397940c27ea693f9812d24acb700890636b376847a611cdd0393a928544e79d7ad5b8b916bd8e6e772bc8a10c48a647a96e7b1a
   languageName: node
   linkType: hard
 
@@ -5125,6 +5132,17 @@ __metadata:
     "@babel/helper-validator-identifier": ^7.16.7
     to-fast-properties: ^2.0.0
   checksum: 85df59beb99c1b95e9e41590442f2ffa1e5b1b558d025489db40c9f7c906bd03a17da26c3ec486e5800e80af27c42ca7eee9506d9212ab17766d2d68d30fbf52
+  languageName: node
+  linkType: hard
+
+"@babel/types@npm:7.19.0":
+  version: 7.19.0
+  resolution: "@babel/types@npm:7.19.0"
+  dependencies:
+    "@babel/helper-string-parser": ^7.18.10
+    "@babel/helper-validator-identifier": ^7.18.6
+    to-fast-properties: ^2.0.0
+  checksum: 9b346715a68aeede70ba9c685a144b0b26c53bcd595d448e24c8fa8df4d5956a5712e56ebadb7c85dcc32f218ee42788e37b93d50d3295c992072224cb3ef3fe
   languageName: node
   linkType: hard
 
@@ -33405,6 +33423,35 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pkg@npm:^5.8.1":
+  version: 5.8.1
+  resolution: "pkg@npm:5.8.1"
+  dependencies:
+    "@babel/generator": 7.18.2
+    "@babel/parser": 7.18.4
+    "@babel/types": 7.19.0
+    chalk: ^4.1.2
+    fs-extra: ^9.1.0
+    globby: ^11.1.0
+    into-stream: ^6.0.0
+    is-core-module: 2.9.0
+    minimist: ^1.2.6
+    multistream: ^4.1.0
+    pkg-fetch: 3.4.2
+    prebuild-install: 7.1.1
+    resolve: ^1.22.0
+    stream-meter: ^1.0.4
+  peerDependencies:
+    node-notifier: ">=9.0.1"
+  peerDependenciesMeta:
+    node-notifier:
+      optional: true
+  bin:
+    pkg: lib-es5/bin.js
+  checksum: 5e750e716c3426706ea1fbd26832faf6a3ab8376b99f20aeb9c40fd48ad48e7b51375cd077b77669f3bfbefee69cc8111f49e0ca39e353fd0fc2dff95a57f822
+  languageName: node
+  linkType: hard
+
 "please-upgrade-node@npm:^3.2.0":
   version: 3.2.0
   resolution: "please-upgrade-node@npm:3.2.0"
@@ -34136,6 +34183,28 @@ __metadata:
   bin:
     prebuild-install: bin.js
   checksum: de4313eda821305912af922700a2db04bb8e77fe8aa9c2788550f1000c026cbefc82da468ec0c0a37764c5417bd8169dbd540928535fb38d00bb9bbd673dd217
+  languageName: node
+  linkType: hard
+
+"prebuild-install@npm:7.1.1":
+  version: 7.1.1
+  resolution: "prebuild-install@npm:7.1.1"
+  dependencies:
+    detect-libc: ^2.0.0
+    expand-template: ^2.0.3
+    github-from-package: 0.0.0
+    minimist: ^1.2.3
+    mkdirp-classic: ^0.5.3
+    napi-build-utils: ^1.0.1
+    node-abi: ^3.3.0
+    pump: ^3.0.0
+    rc: ^1.2.7
+    simple-get: ^4.0.0
+    tar-fs: ^2.0.0
+    tunnel-agent: ^0.6.0
+  bin:
+    prebuild-install: bin.js
+  checksum: dbf96d0146b6b5827fc8f67f72074d2e19c69628b9a7a0a17d0fad1bf37e9f06922896972e074197fc00a52eae912993e6ef5a0d471652f561df5cb516f3f467
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Sideload system prompt text to Navie.

Pass `/noterms` to skip vector term expansion, and use the raw question history and code selection for context search.