### PR TITLE
feat: Present activate with email errors to the user

### DIFF
--- a/packages/components/src/components/SignIn.vue
+++ b/packages/components/src/components/SignIn.vue
@@ -186,12 +186,11 @@ export default {
       if (response.status === 201) {
         this.error = '';
         this.submitted = true;
-      } else if (response.status < 500 && response.status >= 400) {
-        this.email = '';
-        this.error = this.generateInvalidFieldMsg('email address');
       } else {
         this.email = '';
-        this.error = GENERIC_ERROR_MSG;
+        const body = await response.json();
+        if ('error' in body) this.error = body.error;
+        this.error ??= GENERIC_ERROR_MSG;
       }
     },
     async completeActivation() {
@@ -355,6 +354,8 @@ export default {
       color: $hotpink;
       font-size: 0.9rem;
       margin: 0;
+      max-height: 4rem;
+      overflow-y: scroll;
     }
 
     .accept-tos {

--- a/packages/components/tests/e2e/specs/sidebarSignIn.spec.js
+++ b/packages/components/tests/e2e/specs/sidebarSignIn.spec.js
@@ -34,21 +34,19 @@ describe('Sidebar activation page', () => {
       .should('contain.text', expectedText2);
   });
 
-  it('shows an error message for an invalid email', () => {
-    cy.intercept('POST', 'https://getappmap.com/api/activations*', {
-      statusCode: 422,
-    });
-    cy.get('[data-cy="email-activation-button"]').click();
-    cy.get('.error').should('contain.text', INVALID_EMAIL_MSG);
-  });
-
-  it('shows an error message for a server error', () => {
-    cy.intercept('POST', 'https://getappmap.com/api/activations*', {
-      statusCode: 500,
-    });
-    cy.get('[data-cy="email-activation-button"]').click();
-    cy.get('.error').should('contain.text', GENERIC_ERROR_MSG);
-  });
+  [422, 500].forEach((code) =>
+    it('presents the error directly to the user for response ' + code, () => {
+      const errorMessage = 'An error occurred.';
+      cy.intercept('POST', 'https://getappmap.com/api/activations*', {
+        statusCode: 500,
+        body: {
+          error: errorMessage,
+        },
+      });
+      cy.get('[data-cy="email-activation-button"]').click();
+      cy.get('.error').should('contain.text', errorMessage);
+    })
+  );
 
   it('shows verification code page upon successful email submission', () => {
     cy.intercept('POST', 'https://getappmap.com/api/activations*', {


### PR DESCRIPTION
Fixes #1843.

- Presents the error directly to the user for all non-201 response codes coming from server.
- Limits the error text maximum height in order not to obscure the form.
- Adds a test to ensure that error messages for status codes 422 and 500 are shown directly in the UI and removes the old tests for 422 and 500.