### PR TITLE
Merge system messages everywhere

### DIFF
--- a/packages/navie/src/services/completion-service.ts
+++ b/packages/navie/src/services/completion-service.ts
@@ -1,26 +1,12 @@
 import { ChatOpenAI } from '@langchain/openai';
 
 import InteractionHistory, { CompletionEvent } from '../interaction-history';
-import type Message from '../message';
 import completion from '../lib/completion';
 
 export type Completion = AsyncIterable<string>;
 
 export default interface CompletionService {
   complete: (options: { temperature: number | undefined }) => Completion;
-}
-
-// Some LLMs only accept a single system message.
-// This functions merges all system messages into a single message
-// at the start of the list.
-function mergeSystemMessages(messages: Message[]): Message[] {
-  const systemMessages = messages.filter((message) => message.role === 'system');
-  const nonSystemMessages = messages.filter((message) => message.role !== 'system');
-  const mergedSystemMessage = {
-    role: 'system',
-    content: systemMessages.map((message) => message.content).join('\n'),
-  } as const;
-  return [mergedSystemMessage, ...nonSystemMessages];
 }
 
 export class OpenAICompletionService implements CompletionService {
@@ -43,6 +29,6 @@ export class OpenAICompletionService implements CompletionService {
       new CompletionEvent(this.modelName, options.temperature || this.temperature)
     );
 
-    yield* completion(chatAI, mergeSystemMessages(messages));
+    yield* completion(chatAI, messages);
   }
 }

--- a/packages/navie/src/services/vector-terms-service.ts
+++ b/packages/navie/src/services/vector-terms-service.ts
@@ -50,7 +50,7 @@ const promptExamples: OpenAI.ChatCompletionMessageParam[] = [
 Instructions: How to do it
 ---
 Terms: record appmap data java +spring`,
-    role: 'system',
+    role: 'assistant',
   },
 
   {
@@ -62,7 +62,7 @@ Terms: record appmap data java +spring`,
 Instructions: Explain how this is handled by the code
 ---
 Terms: user login handle +password validate invalid error`,
-    role: 'system',
+    role: 'assistant',
   },
 
   {
@@ -75,7 +75,7 @@ Terms: user login handle +password validate invalid error`,
 Instructions: Describe in detail with code snippets
 ---
 Terms: +redis get test group test project 1 blob main readme`,
-    role: 'system',
+    role: 'assistant',
   },
 
   {
@@ -88,7 +88,7 @@ Terms: +redis get test group test project 1 blob main readme`,
 Instructions: Create test cases, following established patterns for mocking with jest.
 ---
 Terms: test cases +log_context jest`,
-    role: 'system',
+    role: 'assistant',
   },
 
   {
@@ -100,7 +100,7 @@ Terms: test cases +log_context jest`,
 Instructions: Describe the authentication and authorization process
 ---
 Terms: +auth authentication authorization token strategy provider`,
-    role: 'system',
+    role: 'assistant',
   },
 ];
 


### PR DESCRIPTION
Fixes #1860 

This was caused by two problems:
- system message merging (which is done to make sure to support engines which only accept a single system message) was only applied in *explain*,
- examples given in vector terms prompt mistakenly used `system` role instead of `assistant`.