### PR TITLE
feat: Update Java, Ruby and Python recording instructions

### DIFF
--- a/packages/components/src/assets/code-block-icon.svg
+++ b/packages/components/src/assets/code-block-icon.svg
@@ -1,6 +1,6 @@
-<svg width="25" height="18" fill="none" xmlns="http://www.w3.org/2000/svg">
-<rect x="5" width="18" height="3" fill="white"/>
-<rect y="5" width="18" height="3" fill="white"/>
-<rect x="5" y="10" width="18" height="3" fill="white"/>
-<rect y="15" width="18" height="3" fill="white"/>
+<svg viewBox="0 0 25 18" xmlns="http://www.w3.org/2000/svg">
+<rect x="5" width="18" height="3" />
+<rect y="5" width="18" height="3" />
+<rect x="5" y="10" width="18" height="3" />
+<rect y="15" width="18" height="3" />
 </svg>

--- a/packages/components/src/components/CodeSnippet.vue
+++ b/packages/components/src/components/CodeSnippet.vue
@@ -104,6 +104,7 @@ export default {
 
   &__line {
     min-height: 1rem;
+    padding-top: 0.33rem;
   }
 
   &__input {
@@ -112,8 +113,9 @@ export default {
     color: $base07;
     padding: 0.75rem 1.25rem;
     margin: 0;
-    border: none;
-    border-radius: 0;
+    border: 1px solid rgba(white, 0.2);
+    border-right: none;
+    border-radius: $border-radius 0 0 $border-radius;
     background: transparent;
     outline: none;
     appearance: none;

--- a/packages/components/src/components/install-guide/record-instructions/IntelliJ.vue
+++ b/packages/components/src/components/install-guide/record-instructions/IntelliJ.vue
@@ -1,5 +1,6 @@
 <template>
   <section>
+    <h3>Getting started</h3>
     <p>
       Use the <component :is="runConfigIcon" class="run-config-icon" /> "Start with AppMap" option
       from the "Run" menu to start your run configurations with AppMap enabled.
@@ -10,124 +11,163 @@
       to enable AppMap recording.
     </p>
     <div id="IntelliJ-screenshot"><img src="../../../assets/run-with-appmap-menu-item.png" /></div>
-    <h2>Choose the best recording method for this project</h2>
-    <template v-if="testFramework">
-      <section class="recording-method">
-        <h3>
-          <i class="header-icon"><TestsIcon /></i>Tests recording<span class="recommended-badge"
-            >recommended</span
-          >
-        </h3>
-        <p>
-          When you run your JUnit tests with the AppMap <code class="inline">javaagent</code> JVM
-          argument, an AppMap will be created for each test.
-        </p>
-        <p>
-          Right-click on any test class or package, and choose
-          <component :is="runConfigIcon" class="run-config-icon" /> "Start with AppMap". This will
-          add the required JVM argument to enable AppMap recording.
-        </p>
-        <p>
-          For more information, visit
-          <a
-            href="https://appmap.io/docs/reference/jetbrains.html#create-appmaps-from-junit-test-runs"
-            target="_blank"
-            >AppMap docs - IntelliJ Tests recording</a
-          >.
-        </p>
-      </section>
-    </template>
-    <template v-else> <VTestsPrompt framework="JUnit or TestNG" /></template>
-    <template v-if="webFramework">
-      <section class="recording-method">
-        <h3>
-          <i class="header-icon"><RemoteRecordingIcon /></i>Remote recording
-        </h3>
-        <p>
-          When your application uses {{ this.webFramework.name }}, and you run your application with
-          the AppMap <code class="inline">javaagent</code> JVM argument, remote recording is
-          enabled. To make a remote recording, run your application using
-          <component :is="runConfigIcon" class="run-config-icon" /> "Start with AppMap". Then use
-          the "Record" button to start recording. Interact with your application, through its user
-          interface and/or by making API requests using a tool such as Postman. When you are done,
-          click the "Record" button again to stop the recording and view the AppMap.
-        </p>
-        <p>
-          For more information, visit
-          <a
-            href="https://appmap.io/docs/reference/jetbrains.html#running-a-java-application-with-appmap"
-            target="_blank"
-            >AppMap docs - IntelliJ Remote recording</a
-          >.
-        </p>
-      </section>
-    </template>
-    <template v-else>
-      <div class="recording-method recording-method--disabled">
-        <h3>
-          <i class="header-icon header-icon--disabled"><RemoteRecordingIcon /></i>Remote recording
-        </h3>
-        <p>
-          Did you know? When you run a Spring app, you can make AppMaps of all the HTTP requests
-          served by your app. Spring wasn't detected in this project, though.
-        </p>
-      </div>
-    </template>
-    <section class="recording-method">
-      <h3>
-        <i class="header-icon"><ProcessIcon /></i>Process recording
-      </h3>
-      <p>
-        AppMap can record an entire Java process from start to finish. To use process recording, set
-        the Java system property <code class="inline">appmap.recording.auto=true</code>. You must
-        set this system property as a JVM argument. If you are using a graphical run configuration,
-        add the option <code class="inline">-Dappmap.recording.auto=true</code> to the "VM options"
-        field. If you are running on the command line, add the option
-        <code class="inline">-Dappmap.recording.auto=true</code> to the JVM CLI arguments. Next, run
-        your application using <component :is="runConfigIcon" class="run-config-icon" /> "Start with
-        AppMap". When your application exits, the AppMap will be saved and opened.
-      </p>
-      <p>
-        Visit
-        <a
-          href="https://appmap.io/docs/reference/appmap-java.html#process-recording"
-          target="_blank"
-          >AppMap Docs - Java Process recording</a
-        >
-        for more information.
-      </p>
-    </section>
-    <section class="recording-method">
-      <h3>
-        <i class="header-icon"><PlayIcon /></i>Code Block recording
-      </h3>
-      <p>
-        You can use the AppMap Java library directly to record a specific span of code. With this
-        method, you can control exactly what code is recorded, and where the recording is saved. To
-        use code block recording, add an AppMap code snippet to the section of code you want to
-        record, then run your application using
-        <component :is="runConfigIcon" class="run-config-icon" /> "Start with AppMap".
-      </p>
-      <p>
-        Visit
-        <a
-          href="https://appmap.io/docs/reference/appmap-java.html#code-block-recording"
-          target="_blank"
-          >AppMap Docs - Java Code Block recording</a
-        >
-        for more information.
-      </p>
-    </section>
+    <h3>Recording methods</h3>
+    <p>The following recording methods are available to Java applications.</p>
+    <v-recording-method-grid>
+      <v-recording-method
+        title="HTTP request recording"
+        documentation-url="https://appmap.io/docs/reference/appmap-java.html#requests-recording"
+        :supported="!!webFramework"
+        :default-behavior="true"
+        :prompt-suggestions="promptSuggestions.httpRequest"
+      >
+        <template #icon>
+          <RequestsIcon />
+        </template>
+        <template #supported>
+          <p>
+            {{ webFramework.name }} will automatically begin recording upon receiving an inbound
+            HTTP request. The recording will span the entire lifetime of the request.
+          </p>
+        </template>
+        <template #unsupported>
+          <p>
+            In Spring applications, AppMap will automatically record the execution flow of your
+            application as it serves inbound HTTP requests.
+          </p>
+        </template>
+      </v-recording-method>
+      <v-recording-method
+        title="Remote recording"
+        title-lowercase="remote recording"
+        documentation-url="https://appmap.io/docs/reference/appmap-java.html#remote-recording"
+        :supported="!!webFramework"
+        :default-behavior="false"
+        :prompt-suggestions="promptSuggestions.remote"
+      >
+        <template #icon>
+          <RemoteRecordingIcon />
+        </template>
+        <template #supported>
+          <p>
+            Web services running {{ webFramework.name }} can toggle recordings on and off remotely
+            via an HTTP API. This is useful in cases where you need control over the lifetime of the
+            recording.
+          </p>
+          <p>
+            Use the "Record" button in the IDE to start recording. Interact with your application,
+            through its user interface and/or by making API requests using a tool such as Postman.
+            When you are done, click the "Record" button again to save the recording and view the
+            AppMap diagrams.
+          </p>
+        </template>
+        <template #unsupported>
+          <p>
+            In Spring applications, recording can optionally be toggled on and off via an HTTP API.
+            This is useful in cases where control is needed over the lifetime of a recording.
+          </p>
+        </template>
+      </v-recording-method>
+      <v-recording-method
+        title="Test recording"
+        title-lowercase="test recording"
+        documentation-url="https://appmap.io/docs/reference/appmap-java.html#tests-recording"
+        :supported="!!testFramework"
+        :default-behavior="true"
+        :prompt-suggestions="promptSuggestions.test"
+      >
+        <template #icon>
+          <TestsIcon
+            :style="{ width: '1.5rem', height: '1.5rem', transform: 'translateY(0.1rem)' }"
+          />
+        </template>
+        <template #supported>
+          <p>
+            When running {{ testFramework.name }} tests, AppMap will automatically start and stop
+            recording for each test case. With adequate test coverage, this method can quickly
+            record a broad range of your application's behavior.
+          </p>
+          <p>
+            A subset of tests can be run by right-clicking on any test class or package, and choose
+            <component :is="runConfigIcon" class="run-config-icon" /> "Start with AppMap".
+          </p>
+        </template>
+        <template #unsupported>
+          <p>
+            Testing frameworks such as JUnit or TestNG will automatically start and stop recordings
+            for each test case. With adequate test coverage, this method can quickly record a broad
+            range of the application's behavior.
+          </p>
+        </template>
+      </v-recording-method>
+      <v-recording-method
+        title="Code block recording"
+        title-lowercase="code block recording"
+        documentation-url="https://appmap.io/docs/reference/appmap-java.html#code-block-recording"
+        :supported="true"
+        :default-behavior="false"
+        :prompt-suggestions="promptSuggestions.codeBlock"
+      >
+        <template #icon>
+          <CodeBlockIcon />
+        </template>
+        <template #supported>
+          <p>
+            Use the <code class="inline">com.appland.appmap.record.Recording</code> class to record
+            specific spans of code.
+          </p>
+          <p>
+            Note that this method still requires your application be run with the AppMap Java agent
+            for recording to be enabled.
+          </p>
+          <p>Visit the documentation for examples.</p>
+        </template>
+      </v-recording-method>
+      <v-recording-method
+        title="Process recording"
+        title-lowercase="process recording"
+        documentation-url="https://appmap.io/docs/reference/appmap-java.html#process-recording"
+        :supported="true"
+        :default-behavior="false"
+        :prompt-suggestions="promptSuggestions.process"
+      >
+        <template #icon>
+          <ProcessIcon :style="{ width: '1.25rem', height: '1.25rem' }" />
+        </template>
+        <template #supported>
+          <p>
+            AppMap can record the entire process lifetime from start to finish. To enable this
+            behavior, set the Java system property
+            <code class="inline">appmap.recording.auto=true</code>.
+          </p>
+          <p>You must set this system property as a JVM argument.</p>
+          <p>
+            If you are using a graphical run configuration, add the option
+            <code class="inline">-Dappmap.recording.auto=true</code> to the "VM options" field.
+          </p>
+          <p>
+            If you are running on the command line, add the option
+            <code class="inline">-Dappmap.recording.auto=true</code> to the JVM CLI arguments. Next,
+            run your application using
+            <component :is="runConfigIcon" class="run-config-icon" /> "Start with AppMap". When your
+            application exits, the AppMap diagrams will be saved and opened.
+          </p>
+        </template>
+      </v-recording-method>
+    </v-recording-method-grid>
   </section>
 </template>
 <script>
-import TestsIcon from '@/assets/tests-icon.svg';
+import RequestsIcon from '@/assets/request-arrows-icon.svg';
 import RemoteRecordingIcon from '@/assets/remote-recording-icon.svg';
-import ProcessIcon from '@/assets/process-icon.svg';
-import PlayIcon from '@/assets/play-icon.svg';
+import CodeBlockIcon from '@/assets/code-block-icon.svg';
+import TestsIcon from '@/assets/record-test.svg';
+import ProcessIcon from '@/assets/record-process.svg';
 import VRunConfigDark from '@/assets/jetbrains_run_config_execute_dark.svg';
 import VRunConfigLight from '@/assets/jetbrains_run_config_execute.svg';
-import VTestsPrompt from './TestsPrompt.vue';
+import VRecordingMethod from './RecordingMethod.vue';
+import VRecordingMethodGrid from './RecordingMethodGrid.vue';
+import buildPrompts from '@/lib/buildPrompts';
 
 export default {
   name: 'IntelliJ',
@@ -141,11 +181,24 @@ export default {
   components: {
     VRunConfigDark,
     VRunConfigLight,
-    VTestsPrompt,
-    PlayIcon,
-    ProcessIcon,
+    RequestsIcon,
     RemoteRecordingIcon,
+    CodeBlockIcon,
     TestsIcon,
+    ProcessIcon,
+    VRecordingMethod,
+    VRecordingMethodGrid,
+  },
+
+  data() {
+    return {
+      promptSuggestions: buildPrompts(
+        'Ruby',
+        this.editor,
+        this.webFramework?.name,
+        this.testFramework?.name
+      ),
+    };
   },
 
   computed: {

--- a/packages/components/src/components/install-guide/record-instructions/Java.vue
+++ b/packages/components/src/components/install-guide/record-instructions/Java.vue
@@ -1,5 +1,6 @@
 <template>
   <section>
+    <h3>Getting started</h3>
     <p>
       Use the "Run with AppMap" debug configuration to launch your application or run your tests
       through Microsoft's Test Runner for Java extension.
@@ -12,127 +13,156 @@
     <div class="vscode-screenshot">
       <img src="../../../assets/vscode-java.gif" />
     </div>
-    <h2>Choose the best recording method for this project</h2>
-    <template v-if="testFramework">
-      <section class="recording-method">
-        <h3>
-          <i class="header-icon"><TestsIcon /></i>
-          Tests recording
-          <span class="recommended-badge">recommended</span>
-        </h3>
-        <p>
-          When you run your {{ testFramework.name }} tests with the AppMap
-          <code class="inline">javaagent</code> JVM argument, an AppMap will be created for each
-          test.
-        </p>
-        <p>
-          This will automatically be configured for you by running your tests via the "Testing"
-          button available in the sidebar or by pressing F1 and running the
-          <code class="inline">Test: Run All Tests</code> command.
-        </p>
-        <p>
-          For more information, visit
-          <a
-            href="https://appmap.io/docs/reference/vscode.html#create-appmaps-from-junit-test-runs"
-            target="_blank"
-          >
-            AppMap docs - VSCode Tests recording
-          </a>
-        </p>
-      </section>
-    </template>
-    <template v-else>
-      <VTestsPrompt framework="JUnit or TestNG" />
-    </template>
-    <template v-if="webFramework">
-      <section class="recording-method">
-        <h3>
-          <i class="header-icon"><RemoteRecordingIcon /></i>
-          Remote recording
-        </h3>
-        <p>
-          When your application uses {{ this.webFramework.name }}, and you run your application with
-          the AppMap <code class="inline">javaagent</code> JVM argument, remote recording is
-          enabled. To make a remote recording, run your application using the "Run with AppMap"
-          debug configuration with AppMap. Then use the "Record" button to start recording. Interact
-          with your application, through its user interface and/or by making API requests using a
-          tool such as Postman. When you are done, click the "Record" button again to save the
-          recording and view the AppMap.
-        </p>
-        <p>
-          For more information, visit
-          <a
-            href="https://appmap.io/docs/reference/vscode.html#running-a-java-application-with-appmap"
-            target="_blank"
-            >AppMap docs - VSCode Remote recording</a
-          >
-        </p>
-      </section>
-    </template>
-    <template v-else>
-      <div class="recording-method recording-method--disabled">
-        <h3>
-          <i class="header-icon header-icon--disabled"><RemoteRecordingIcon /></i>
-          Remote recording
-        </h3>
-        <p>
-          Did you know? When you run a Spring app, you can make AppMaps of all the HTTP requests
-          served by your app. Spring wasn't detected in this project, though.
-        </p>
-      </div>
-    </template>
-    <section class="recording-method">
-      <h3>
-        <i class="header-icon"><ProcessIcon /></i>Process recording
-      </h3>
-      <p>
-        AppMap can record an entire Java process from start to finish. To use process recording,
-        modify <code class="inline">.vscode/launch.json</code> to include
-        <code class="inline">-Dappmap.recording.auto=true</code> in
-        <code class="inline">vmArgs</code>. After running this configuration, an AppMap will be
-        saved once your application exits.
-      </p>
-      <p>
-        Visit
-        <a
-          href="https://appmap.io/docs/reference/appmap-java.html#process-recording"
-          target="_blank"
-        >
-          AppMap Docs - Java Process recording
-        </a>
-        for more information.
-      </p>
-    </section>
-    <section class="recording-method">
-      <h3>
-        <i class="header-icon"><PlayIcon /></i>
-        Code Block recording
-      </h3>
-      <p>
-        You can use the AppMap Java library directly to record a specific span of code. With this
-        method, you can control exactly what code is recorded, and where the recording is saved. To
-        use code block recording, add an AppMap code snippet to the section of code you want to
-        record, then run your application using the Debug Configuration with AppMap.
-      </p>
-      <p>
-        Visit
-        <a
-          href="https://appmap.io/docs/reference/appmap-java.html#code-block-recording"
-          target="_blank"
-        >
-          AppMap Docs - Java Code Block recording
-        </a>
-        for more information.
-      </p>
-    </section>
+    <h3>Recording methods</h3>
+    <p>The following recording methods are available to Java applications.</p>
+    <v-recording-method-grid>
+      <v-recording-method
+        title="HTTP request recording"
+        documentation-url="https://appmap.io/docs/reference/appmap-java.html#requests-recording"
+        :supported="!!webFramework"
+        :default-behavior="true"
+        :prompt-suggestions="promptSuggestions.httpRequest"
+      >
+        <template #icon>
+          <RequestsIcon />
+        </template>
+        <template #supported>
+          <p>
+            {{ webFramework.name }} will automatically begin recording upon receiving an inbound
+            HTTP request. The recording will span the entire lifetime of the request.
+          </p>
+        </template>
+        <template #unsupported>
+          <p>
+            In Spring applications, AppMap will automatically record the execution flow of your
+            application as it serves inbound HTTP requests.
+          </p>
+        </template>
+      </v-recording-method>
+      <v-recording-method
+        title="Remote recording"
+        title-lowercase="remote recording"
+        documentation-url="https://appmap.io/docs/reference/appmap-java.html#remote-recording"
+        :supported="!!webFramework"
+        :default-behavior="false"
+        :prompt-suggestions="promptSuggestions.remote"
+      >
+        <template #icon>
+          <RemoteRecordingIcon />
+        </template>
+        <template #supported>
+          <p>
+            Web services running {{ webFramework.name }} can toggle recordings on and off remotely
+            via an HTTP API. This is useful in cases where you need control over the lifetime of the
+            recording.
+          </p>
+          <p>
+            Use the "Record" button in the IDE to start recording. Interact with your application,
+            through its user interface and/or by making API requests using a tool such as Postman.
+            When you are done, click the "Record" button again to save the recording and view the
+            AppMap diagrams.
+          </p>
+        </template>
+        <template #unsupported>
+          <p>
+            In Spring applications, recording can optionally be toggled on and off via an HTTP API.
+            This is useful in cases where control is needed over the lifetime of a recording.
+          </p>
+        </template>
+      </v-recording-method>
+      <v-recording-method
+        title="Test recording"
+        title-lowercase="test recording"
+        documentation-url="https://appmap.io/docs/reference/appmap-java.html#tests-recording"
+        :supported="!!testFramework"
+        :default-behavior="true"
+        :prompt-suggestions="promptSuggestions.test"
+      >
+        <template #icon>
+          <TestsIcon
+            :style="{ width: '1.5rem', height: '1.5rem', transform: 'translateY(0.1rem)' }"
+          />
+        </template>
+        <template #supported>
+          <p>
+            When running {{ testFramework.name }} tests, AppMap will automatically start and stop
+            recording for each test case. With adequate test coverage, this method can quickly
+            record a broad range of your application's behavior.
+          </p>
+          <p>
+            This will automatically be configured for you by running your tests via the "Testing"
+            button available in the sidebar or by pressing F1 and running the
+            <code class="inline">Test: Run All Tests</code> command.
+          </p>
+        </template>
+        <template #unsupported>
+          <p>
+            Testing frameworks such as JUnit or TestNG will automatically start and stop recordings
+            for each test case. With adequate test coverage, this method can quickly record a broad
+            range of the application's behavior.
+          </p>
+        </template>
+      </v-recording-method>
+      <v-recording-method
+        title="Code block recording"
+        title-lowercase="code block recording"
+        documentation-url="https://appmap.io/docs/reference/appmap-java.html#code-block-recording"
+        :supported="true"
+        :default-behavior="false"
+        :prompt-suggestions="promptSuggestions.codeBlock"
+      >
+        <template #icon>
+          <CodeBlockIcon />
+        </template>
+        <template #supported>
+          <p>
+            Use the <code class="inline">com.appland.appmap.record.Recording</code> class to record
+            specific spans of code.
+          </p>
+          <p>
+            Note that this method still requires your application be run with the AppMap Java agent
+            for recording to be enabled.
+          </p>
+          <p>Visit the documentation for examples.</p>
+        </template>
+      </v-recording-method>
+      <v-recording-method
+        title="Process recording"
+        title-lowercase="process recording"
+        documentation-url="https://appmap.io/docs/reference/appmap-java.html#process-recording"
+        :supported="true"
+        :default-behavior="false"
+        :prompt-suggestions="promptSuggestions.process"
+      >
+        <template #icon>
+          <ProcessIcon :style="{ width: '1.25rem', height: '1.25rem' }" />
+        </template>
+        <template #supported>
+          <p>
+            AppMap can record the entire process lifetime from start to finish. To enable this
+            behavior, set the Java system property
+            <code class="inline">appmap.recording.auto=true</code>.
+          </p>
+          <p>
+            For example, you can modify <code class="inline">.vscode/launch.json</code> to include
+            <code class="inline">-Dappmap.recording.auto=true</code> in
+            <code class="inline">vmArgs</code>. When running this configuration, an AppMap recording
+            will be saved after your application exits.
+          </p>
+        </template>
+      </v-recording-method>
+    </v-recording-method-grid>
   </section>
 </template>
 <script>
-import TestsIcon from '@/assets/tests-icon.svg';
+import RequestsIcon from '@/assets/request-arrows-icon.svg';
 import RemoteRecordingIcon from '@/assets/remote-recording-icon.svg';
-import ProcessIcon from '@/assets/process-icon.svg';
-import PlayIcon from '@/assets/play-icon.svg';
-import VTestsPrompt from './TestsPrompt.vue';
+import CodeBlockIcon from '@/assets/code-block-icon.svg';
+import TestsIcon from '@/assets/record-test.svg';
+import ProcessIcon from '@/assets/record-process.svg';
+import VRecordingMethod from './RecordingMethod.vue';
+import VRecordingMethodGrid from './RecordingMethodGrid.vue';
+import buildPrompts from '@/lib/buildPrompts';
 
 export default {
   name: 'JavaRecordInstructions',
@@ -140,14 +170,28 @@ export default {
   props: {
     webFramework: Object,
     testFramework: Object,
+    editor: String,
   },
 
   components: {
-    VTestsPrompt,
-    PlayIcon,
     ProcessIcon,
     RemoteRecordingIcon,
+    RequestsIcon,
+    CodeBlockIcon,
     TestsIcon,
+    VRecordingMethod,
+    VRecordingMethodGrid,
+  },
+
+  data() {
+    return {
+      promptSuggestions: buildPrompts(
+        'Java',
+        this.editor,
+        this.webFramework?.name,
+        this.testFramework?.name
+      ),
+    };
   },
 };
 </script>

--- a/packages/components/src/components/install-guide/record-instructions/JavaScript.vue
+++ b/packages/components/src/components/install-guide/record-instructions/JavaScript.vue
@@ -147,6 +147,7 @@ import ProcessIcon from '@/assets/record-process.svg';
 import VRecordingMethod from './RecordingMethod.vue';
 import VRecordingMethodGrid from './RecordingMethodGrid.vue';
 import buildPrompts from '@/lib/buildPrompts';
+import typewrite from '@/components/mixins/typewriter';
 
 export default Vue.extend({
   components: {
@@ -157,6 +158,8 @@ export default Vue.extend({
     VRecordingMethod,
     VRecordingMethodGrid,
   },
+
+  mixins: [typewrite],
 
   props: {
     webFramework: Object,
@@ -184,41 +187,15 @@ export default Vue.extend({
   },
 
   mounted() {
-    const startCommands = ['<start command>', 'npm start', 'yarn dev', 'node server.js'];
+    if (!this.$refs.startCommand) return;
+    if (!(this.$refs.startCommand instanceof HTMLElement)) return;
 
-    async function typewriter(el: HTMLElement, text: string) {
-      return new Promise<void>(async (resolve) => {
-        let textQueue = text;
-        while (textQueue.length) {
-          const char = textQueue[0];
-          el.innerText += char;
-          textQueue = textQueue.slice(1);
-          await new Promise((resolve) => setTimeout(resolve, 100 + (Math.random() * 100 - 50)));
-        }
-        resolve();
-      });
-    }
-
-    let currentIndex = 0;
-    const typeNextCommand = async () => {
-      if (!this.$refs.startCommand) return;
-      if (!(this.$refs.startCommand instanceof HTMLElement)) return;
-
-      const startCommand = startCommands[currentIndex];
-      this.$refs.startCommand.innerText = '';
-      await new Promise<void>((resolve) => {
-        setTimeout(() => {
-          if (!(this.$refs.startCommand instanceof HTMLElement)) return;
-          typewriter(this.$refs.startCommand, startCommand).then(resolve);
-        }, 1000);
-      });
-      currentIndex += 1;
-      currentIndex = currentIndex % startCommands.length;
-      await new Promise<void>((resolve) => setTimeout(resolve, Math.random() * 1000 + 1000));
-      typeNextCommand();
-    };
-
-    typeNextCommand();
+    this.typewrite(this.$refs.startCommand, [
+      '<start command>',
+      'npm start',
+      'yarn dev',
+      'node server.js',
+    ]);
   },
 });
 </script>

--- a/packages/components/src/components/install-guide/record-instructions/JavaScript.vue
+++ b/packages/components/src/components/install-guide/record-instructions/JavaScript.vue
@@ -33,8 +33,9 @@
         </template>
         <template #unsupported>
           <p>
-            Express-based web frameworks, such as NestJS or Next.js, you can make AppMaps of all the
-            HTTP requests served by your app. These weren't detected in this project, though.
+            In Express-based web frameworks such as NestJS or Next.js, AppMap will automatically
+            record the execution flow of your application as it serves inbound HTTP requests.
+            Express wasn't located in this project.
           </p>
           <p>
             Note that most projects serving HTTP using the <code class="inline">http</code> Node
@@ -63,14 +64,14 @@
             Use the "Record" button in the IDE to start recording. Interact with your application,
             through its user interface and/or by making API requests using a tool such as Postman.
             When you are done, click the "Record" button again to save the recording and view the
-            AppMap.
+            AppMap diagrams.
           </p>
         </template>
         <template #unsupported>
           <p>
-            In Express-based web frameworks, such as NestJS or Next.js, recording can be toggled on
-            and off via an HTTP API. This is useful in cases where you need control over the
-            lifetime of the recording.
+            In Express-based web frameworks such as NestJS or Next.js, recording can optionally be
+            toggled on and off via an HTTP API. This is useful in cases where control is needed over
+            the lifetime of a recording.
           </p>
           <p>
             Note that most projects serving HTTP using the <code class="inline">http</code> Node

--- a/packages/components/src/components/install-guide/record-instructions/Python.vue
+++ b/packages/components/src/components/install-guide/record-instructions/Python.vue
@@ -1,115 +1,202 @@
 <template>
   <section>
+    <h3>Getting started</h3>
     <p>
-      When you run your Python code with the <code class="inline"> appmap </code> package, AppMap
-      will be enabled for recording.
+      To record your Python application with AppMap, run your application using the
+      <code class="inline">appmap-python</code> command.
     </p>
-    <h2>Choose the best recording method for this project</h2>
-    <template v-if="testFramework">
-      <section class="recording-method">
-        <h3>
-          <!--TODO make recommended tag dynamic-->
-          <i class="header-icon"><TestsIcon /></i>Tests recording<span class="recommended-badge"
-            >recommended</span
-          >
-        </h3>
-        <p>
-          When you run your {{ testFramework.name }} tests with AppMap enabled, an AppMap will be
-          created for each test.
-        </p>
-        <template v-if="testFramework.name.toLowerCase() == 'pytest'">
-          Run Pytest tests:
-          <v-code-snippet clipboard-text="pytest" :kind="codeSnippetType" />
+    <pre><code>$ appmap-python <span ref="startCommand">&lt;start-command&gt;</span></code></pre>
+    <h3>Recording methods</h3>
+    <p>The following recording methods are available to Python applications.</p>
+    <v-recording-method-grid>
+      <v-recording-method
+        title="HTTP request recording"
+        documentation-url="https://appmap.io/docs/reference/appmap-python.html#request-recording"
+        :supported="!!webFramework"
+        :default-behavior="true"
+        :prompt-suggestions="promptSuggestions.httpRequest"
+      >
+        <template #icon>
+          <RequestsIcon />
         </template>
-        <p>
-          For more information, visit
-          <a
-            href="https://appmap.io/docs/reference/appmap-python.html#tests-recording"
-            target="_blank"
-            >AppMap docs - Python Tests recording</a
-          >.
-        </p>
-      </section>
-    </template>
-    <template v-else> <VTestsPrompt framework="pytest or unittest" /> </template>
-    <template v-if="webFramework">
-      <section class="recording-method">
-        <h3>
-          <i class="header-icon"><RequestsIcon /></i>Requests recording
-        </h3>
-        <p>
-          When your application uses Django or Flask, and you run your application with AppMap
-          enabled, HTTP server requests recording is enabled. To record requests, first run your
-          application:
-        </p>
-        <p>
-          Start your Django server:
-          <v-code-snippet clipboard-text="python manage.py runserver" :kind="codeSnippetType" />
-        </p>
-        <p>
-          Start your Flask server:
-          <v-code-snippet clipboard-text="flask run" :kind="codeSnippetType" />
-        </p>
-        <p>
-          Then, interact with your application through its user interface and/or by making API
-          requests using a tool such as Postman. An AppMap will be created for each HTTP server
-          request that's served by your app.
-        </p>
-        <p>
-          For more information, visit
-          <a
-            href="https://appmap.io/docs/reference/appmap-python.html#requests-recording"
-            target="_blank"
-            >AppMap docs - Python Requests recording</a
-          >.
-        </p>
-      </section>
-    </template>
-    <template v-else> <VWebFrameworkPrompt frameworks="Django or Flask" /> </template>
-    <section class="recording-method">
-      <h3>
-        <i class="header-icon"><CodeIcon /></i>Context manager recording
-      </h3>
-      <p>
-        You can use the AppMap Python package directly to record a specific span of code. With this
-        method, you can control exactly what code is recorded, and where the recording is saved. To
-        use Context manager recording, add an AppMap code snippet to the section of code you want to
-        record, then run your application with AppMap enabled. Visit
-        <a
-          href="https://appmap.io/docs/reference/appmap-python.html#context-manager-recording"
-          target="_blank"
-          >AppMap Docs - Python Context manager recording</a
-        >
-        for more information.
-      </p>
-    </section>
+        <template #supported>
+          <p>
+            {{ webFramework.name }} will automatically begin recording upon receiving an inbound
+            HTTP request. The recording will span the entire lifetime of the request.
+          </p>
+          <template v-if="webFramework.name.toLowerCase() == 'flask'">
+            <p>Start your Flask server with the following command.</p>
+            <v-code-snippet clipboard-text="appmap-python flask run" :kind="codeSnippetType" />
+          </template>
+          <template v-if="webFramework.name.toLowerCase() == 'django'">
+            <p>Start your Django server with the following command.</p>
+            <v-code-snippet
+              clipboard-text="appmap-python manage.py runserver"
+              :kind="codeSnippetType"
+            />
+          </template>
+        </template>
+        <template #unsupported>
+          <p>
+            In Django or Flask applications, AppMap will automatically record the execution flow of
+            your application as it serves inbound HTTP requests.
+          </p>
+        </template>
+      </v-recording-method>
+      <v-recording-method
+        title="Remote recording"
+        title-lowercase="remote recording"
+        documentation-url="https://appmap.io/docs/reference/appmap-python.html#remote-recording"
+        :supported="!!webFramework"
+        :default-behavior="false"
+        :prompt-suggestions="promptSuggestions.remote"
+      >
+        <template #icon>
+          <RemoteRecordingIcon />
+        </template>
+        <template #supported>
+          <p>
+            Web services running {{ webFramework.name }} can toggle recordings on and off remotely
+            via an HTTP API. This is useful in cases where you need control over the lifetime of the
+            recording.
+          </p>
+          <p>
+            Use the "Record" button in the IDE to start recording. Interact with your application,
+            through its user interface and/or by making API requests using a tool such as Postman.
+            When you are done, click the "Record" button again to save the recording and view the
+            AppMap diagrams.
+          </p>
+        </template>
+        <template #unsupported>
+          <p>
+            In Django or Flask applications, recording can optionally be toggled on and off via an
+            HTTP API. This is useful in cases where control is needed over the lifetime of a
+            recording.
+          </p>
+        </template>
+      </v-recording-method>
+      <v-recording-method
+        title="Test recording"
+        title-lowercase="test recording"
+        documentation-url="https://appmap.io/docs/reference/appmap-python.html#test-recording"
+        :supported="!!testFramework"
+        :default-behavior="true"
+        :prompt-suggestions="promptSuggestions.test"
+      >
+        <template #icon>
+          <TestsIcon
+            :style="{ width: '1.5rem', height: '1.5rem', transform: 'translateY(0.1rem)' }"
+          />
+        </template>
+        <template #supported>
+          <p>
+            When running {{ testFramework.name }} tests, AppMap will automatically start and stop
+            recording for each test case. With adequate test coverage, this method can quickly
+            record a broad range of your application's behavior.
+            <template v-if="testFramework.name.toLowerCase() == 'pytest'">
+              <p>Run your pytest tests with the following command.</p>
+              <v-code-snippet clipboard-text="appmap-python pytest" :kind="codeSnippetType" />
+            </template>
+          </p>
+        </template>
+        <template #unsupported>
+          <p>
+            Testing frameworks such as <code class="inline">pytest</code> or
+            <code class="inline">unittest</code> will automatically start and stop recordings for
+            each test case. With adequate test coverage, this method can quickly record a broad
+            range of the application's behavior.
+          </p>
+        </template>
+      </v-recording-method>
+      <v-recording-method
+        title="Code block recording"
+        title-lowercase="code block recording"
+        documentation-url="https://appmap.io/docs/reference/appmap-python.html#code-block-recording"
+        :supported="true"
+        :default-behavior="false"
+        :prompt-suggestions="promptSuggestions.codeBlock"
+      >
+        <template #icon>
+          <CodeBlockIcon />
+        </template>
+        <template #supported>
+          <p>
+            Wrap sections of your code in <code class="inline">appmap.record</code> blocks to record
+            specific spans of execution.
+          </p>
+          <p>Visit the documentation for examples.</p>
+        </template>
+      </v-recording-method>
+      <v-recording-method
+        title="Process recording"
+        title-lowercase="process recording"
+        documentation-url="https://appmap.io/docs/reference/appmap-python.html#process-recording"
+        :supported="true"
+        :default-behavior="false"
+        :prompt-suggestions="promptSuggestions.process"
+      >
+        <template #icon>
+          <ProcessIcon :style="{ width: '1.25rem', height: '1.25rem' }" />
+        </template>
+        <template #supported>
+          <p>
+            AppMap can record the entire process lifetime from start to finish. To enable this
+            behavior, specify <code class="inline">--record process</code> when running
+            <code class="inline">appmap-python</code>.
+          </p>
+          <p>See the example below.</p>
+          <pre><code>$ appmap-python --record process app.py</code></pre>
+        </template>
+      </v-recording-method>
+    </v-recording-method-grid>
   </section>
 </template>
+
 <script>
-import CodeIcon from '@/assets/code-icon.svg';
-import TestsIcon from '@/assets/tests-icon.svg';
 import RequestsIcon from '@/assets/request-arrows-icon.svg';
+import RemoteRecordingIcon from '@/assets/remote-recording-icon.svg';
+import CodeBlockIcon from '@/assets/code-block-icon.svg';
+import TestsIcon from '@/assets/record-test.svg';
+import ProcessIcon from '@/assets/record-process.svg';
 import VCodeSnippet from '@/components/CodeSnippet.vue';
-import VTestsPrompt from './TestsPrompt.vue';
-import VWebFrameworkPrompt from './WebFrameworkPrompt.vue';
+import VRecordingMethod from './RecordingMethod.vue';
+import VRecordingMethodGrid from './RecordingMethodGrid.vue';
+import buildPrompts from '@/lib/buildPrompts';
+import typewrite from '@/components/mixins/typewriter';
 
 export default {
   name: 'PythonRecordingInstructions',
 
   components: {
     VCodeSnippet,
-    VTestsPrompt,
-    VWebFrameworkPrompt,
-    CodeIcon,
-    TestsIcon,
     RequestsIcon,
+    RemoteRecordingIcon,
+    CodeBlockIcon,
+    TestsIcon,
+    ProcessIcon,
+    VRecordingMethod,
+    VRecordingMethodGrid,
   },
+
+  mixins: [typewrite],
 
   props: {
     webFramework: Object,
     testFramework: Object,
     theme: String,
     complete: Boolean,
+    editor: String,
+  },
+
+  data() {
+    return {
+      promptSuggestions: buildPrompts(
+        'Python',
+        this.editor,
+        this.webFramework?.name,
+        this.testFramework?.name
+      ),
+    };
   },
 
   computed: {
@@ -117,5 +204,28 @@ export default {
       return this.complete ? 'ghost' : 'primary';
     },
   },
+
+  mounted() {
+    if (!this.$refs.startCommand) return;
+    if (!(this.$refs.startCommand instanceof HTMLElement)) return;
+
+    this.typewrite(this.$refs.startCommand, [
+      '<start command>',
+      'script.py',
+      'flask --app main.app',
+      'pytest',
+      'manage.py runserver',
+    ]);
+  },
 };
 </script>
+
+<style lang="scss" scoped>
+code {
+  line-height: 1;
+  padding: 1rem;
+  padding-bottom: 0.75rem;
+  background-color: rgba(black, 0.35);
+  max-width: unset;
+}
+</style>

--- a/packages/components/src/components/install-guide/record-instructions/Python.vue
+++ b/packages/components/src/components/install-guide/record-instructions/Python.vue
@@ -212,7 +212,7 @@ export default {
     this.typewrite(this.$refs.startCommand, [
       '<start command>',
       'script.py',
-      'flask --app main.app',
+      'flask --debug --app main.app',
       'pytest',
       'manage.py runserver',
     ]);

--- a/packages/components/src/components/install-guide/record-instructions/RecordingMethod.vue
+++ b/packages/components/src/components/install-guide/record-instructions/RecordingMethod.vue
@@ -183,9 +183,11 @@ export default Vue.extend({
   }
 
   &__badge {
-    background-color: rgba($blue, 0.2);
-    padding: 0.125rem 0.5rem;
-    padding-top: 0.25rem;
+    // DB: Marked important because these styles are getting overwritten in VS Code.
+    // It's not clear why.
+    background-color: rgba($blue, 0.2) !important;
+    padding: 0.125rem 0.5rem !important;
+    padding-top: 0.25rem !important;
   }
 
   &__icon {
@@ -203,6 +205,7 @@ export default Vue.extend({
     svg {
       width: 1rem;
       height: 1rem;
+      fill: $white;
     }
   }
 
@@ -239,7 +242,7 @@ export default Vue.extend({
       border-bottom: 1px solid rgba(white, 0.1);
 
       h2 {
-        margin: 0;
+        margin: 0 !important; // DB: Overridden in VS Code.
       }
     }
   }

--- a/packages/components/src/components/install-guide/record-instructions/Ruby.vue
+++ b/packages/components/src/components/install-guide/record-instructions/Ruby.vue
@@ -1,5 +1,6 @@
 <template>
   <section>
+    <h3>Getting started</h3>
     <p>
       When you run your Ruby code with the <code class="inline">appmap</code> gem in your bundle,
       AppMap will be enabled for recording. By default, the <code class="inline">appmap</code> gem
@@ -10,114 +11,150 @@
       command <code class="inline">spring stop</code>, or you can run your Ruby program with the
       environment variable <code class="inline">DISABLE_SPRING=true</code>.
     </p>
-    <h2>Choose the best recording method for this project</h2>
-    <template v-if="testFramework">
-      <section class="recording-method">
-        <h3>
-          <i class="header-icon"><TestsIcon /></i>Tests recording<span class="recommended-badge"
-            >recommended</span
-          >
-        </h3>
-        <p>
-          When you run your {{ testFramework.name }} tests with AppMap enabled, an AppMap will be
-          created for each test.
-        </p>
-        <p>
-          <template v-if="testFramework.name.toLowerCase() == 'minitest'">
-            Run Minitest tests:
-            <v-code-snippet
-              clipboard-text="DISABLE_SPRING=true rails test"
-              :kind="codeSnippetType"
-            />
-          </template>
-          <template v-if="testFramework.name.toLowerCase() == 'rspec'">
-            Run Rspec tests:
-            <v-code-snippet clipboard-text="DISABLE_SPRING=true rspec" :kind="codeSnippetType" />
-          </template>
-        </p>
-        <p>
-          For more information, visit
-          <a
-            href="https://appmap.io/docs/reference/appmap-ruby.html#tests-recording"
-            target="_blank"
-            >AppMap docs - Ruby Tests recording</a
-          >.
-        </p>
-      </section>
-    </template>
-    <template v-else>
-      <VTestsPrompt framework="RSpec or Minitest" />
-    </template>
-    <template v-if="webFramework">
-      <section class="recording-method">
-        <h3>
-          <i class="header-icon"><RequestsIcon /></i>Requests recording
-        </h3>
-        <p>
-          When your application uses {{ this.webFramework.name }}, and you run your application with
-          AppMap enabled, HTTP server request recording will be enabled. To record requests, first
-          run your application:
-        </p>
-        <p>
-          Start your Rails server:
+    <h3>Recording methods</h3>
+    <p>The following recording methods are available to Ruby applications.</p>
+    <v-recording-method-grid>
+      <v-recording-method
+        title="HTTP request recording"
+        documentation-url="https://appmap.io/docs/reference/appmap-ruby.html#requests-recording"
+        :supported="!!webFramework"
+        :default-behavior="true"
+        :prompt-suggestions="promptSuggestions.httpRequest"
+      >
+        <template #icon>
+          <RequestsIcon />
+        </template>
+        <template #supported>
+          <p>
+            {{ webFramework.name }} will automatically begin recording upon receiving an inbound
+            HTTP request. The recording will span the entire lifetime of the request.
+          </p>
+          <p>Start your Rails with the following command.</p>
           <v-code-snippet
             clipboard-text="DISABLE_SPRING=true rails server"
             :kind="codeSnippetType"
           />
-        </p>
-        <p>
-          Interact with your application, through its user interface and/or by making API requests
-          using a tool such as Postman. An AppMap will be created for each HTTP server request
-          that's served by your app.
-        </p>
-        <p>
-          For more information, visit
-          <a
-            href="https://appmap.io/docs/reference/appmap-ruby.html#requests-recording"
-            target="_blank"
-            >AppMap docs - Ruby Requests recording</a
-          >.
-        </p>
-      </section>
-    </template>
-    <template v-else>
-      <VWebFrameworkPrompt frameworks="Rails" />
-    </template>
-    <section class="recording-method">
-      <h3>
-        <i class="header-icon"><CodeBlockIcon /></i>Block recording
-      </h3>
-      <p>
-        You can use the AppMap Ruby gem directly to record a specific span of code. With this
-        method, you can control exactly what code is recorded, and where the recording is saved. To
-        use Block recording, add an AppMap code snippet to the section of code you want to record,
-        then run your application with AppMap enabled. Visit
-        <a href="https://appmap.io/docs/reference/appmap-ruby.html#block-recording" target="_blank"
-          >AppMap Docs - Ruby Block recording</a
-        >
-        for more information.
-      </p>
-    </section>
+        </template>
+        <template #unsupported>
+          <p>
+            In Rails applications, AppMap will automatically record the execution flow of your
+            application as it serves inbound HTTP requests.
+          </p>
+        </template>
+      </v-recording-method>
+      <v-recording-method
+        title="Remote recording"
+        title-lowercase="remote recording"
+        documentation-url="https://appmap.io/docs/reference/appmap-ruby.html#remote-recording"
+        :supported="!!webFramework"
+        :default-behavior="false"
+        :prompt-suggestions="promptSuggestions.remote"
+      >
+        <template #icon>
+          <RemoteRecordingIcon />
+        </template>
+        <template #supported>
+          <p>
+            Web services running {{ webFramework.name }} can toggle recordings on and off remotely
+            via an HTTP API. This is useful in cases where you need control over the lifetime of the
+            recording.
+          </p>
+          <p>
+            Use the "Record" button in the IDE to start recording. Interact with your application,
+            through its user interface and/or by making API requests using a tool such as Postman.
+            When you are done, click the "Record" button again to save the recording and view the
+            AppMap diagrams.
+          </p>
+        </template>
+        <template #unsupported>
+          <p>
+            In Rails applications, recording can optionally be toggled on and off via an HTTP API.
+            This is useful in cases where control is needed over the lifetime of a recording.
+          </p>
+        </template>
+      </v-recording-method>
+      <v-recording-method
+        title="Test recording"
+        title-lowercase="test recording"
+        documentation-url="https://appmap.io/docs/reference/appmap-ruby.html#tests-recording"
+        :supported="!!testFramework"
+        :default-behavior="true"
+        :prompt-suggestions="promptSuggestions.test"
+      >
+        <template #icon>
+          <TestsIcon
+            :style="{ width: '1.5rem', height: '1.5rem', transform: 'translateY(0.1rem)' }"
+          />
+        </template>
+        <template #supported>
+          <p>
+            When running {{ testFramework.name }} tests, AppMap will automatically start and stop
+            recording for each test case. With adequate test coverage, this method can quickly
+            record a broad range of your application's behavior.
+            <template v-if="testFramework.name.toLowerCase() == 'minitest'">
+              <p>Run Minitest tests with the following command.</p>
+              <v-code-snippet
+                clipboard-text="DISABLE_SPRING=true rails test"
+                :kind="codeSnippetType"
+              />
+            </template>
+            <template v-if="testFramework.name.toLowerCase() == 'rspec'">
+              <p>Run Rspec tests with the following command.</p>
+              <v-code-snippet clipboard-text="DISABLE_SPRING=true rspec" :kind="codeSnippetType" />
+            </template>
+          </p>
+        </template>
+        <template #unsupported>
+          <p>
+            Testing frameworks such as RSpec or Minitest will automatically start and stop
+            recordings for each test case. With adequate test coverage, this method can quickly
+            record a broad range of the application's behavior.
+          </p>
+        </template>
+      </v-recording-method>
+      <v-recording-method
+        title="Code block recording"
+        title-lowercase="code block recording"
+        documentation-url="https://appmap.io/docs/reference/appmap-ruby.html#code-block-recording"
+        :supported="true"
+        :default-behavior="false"
+        :prompt-suggestions="promptSuggestions.codeBlock"
+      >
+        <template #icon>
+          <CodeBlockIcon />
+        </template>
+        <template #supported>
+          <p>
+            Wrap sections of your code in <code class="inline">AppMap.record</code> blocks to record
+            specific spans of execution.
+          </p>
+          <p>Visit the documentation for examples.</p>
+        </template>
+      </v-recording-method>
+    </v-recording-method-grid>
   </section>
 </template>
 <script>
 import RequestsIcon from '@/assets/request-arrows-icon.svg';
+import RemoteRecordingIcon from '@/assets/remote-recording-icon.svg';
 import CodeBlockIcon from '@/assets/code-block-icon.svg';
-import TestsIcon from '@/assets/tests-icon.svg';
+import TestsIcon from '@/assets/record-test.svg';
 import VCodeSnippet from '@/components/CodeSnippet.vue';
-import VTestsPrompt from './TestsPrompt.vue';
-import VWebFrameworkPrompt from './WebFrameworkPrompt.vue';
+import VRecordingMethod from './RecordingMethod.vue';
+import VRecordingMethodGrid from './RecordingMethodGrid.vue';
+import buildPrompts from '@/lib/buildPrompts';
 
 export default {
   name: 'RubyRecordingInstructions',
 
   components: {
     VCodeSnippet,
-    VTestsPrompt,
-    VWebFrameworkPrompt,
     TestsIcon,
     RequestsIcon,
     CodeBlockIcon,
+    VRecordingMethod,
+    VRecordingMethodGrid,
+    RemoteRecordingIcon,
   },
 
   props: {
@@ -125,6 +162,18 @@ export default {
     testFramework: Object,
     theme: String,
     complete: Boolean,
+    editor: String,
+  },
+
+  data() {
+    return {
+      promptSuggestions: buildPrompts(
+        'Ruby',
+        this.editor,
+        this.webFramework?.name,
+        this.testFramework?.name
+      ),
+    };
   },
 
   computed: {

--- a/packages/components/src/components/mixins/typewriter.ts
+++ b/packages/components/src/components/mixins/typewriter.ts
@@ -1,0 +1,36 @@
+export default {
+  methods: {
+    typewrite(el: HTMLElement, startCommands: string[]) {
+      async function typewriter(el: HTMLElement, text: string) {
+        return new Promise<void>(async (resolve) => {
+          let textQueue = text;
+          while (textQueue.length) {
+            const char = textQueue[0];
+            el.innerText += char;
+            textQueue = textQueue.slice(1);
+            await new Promise((resolve) => setTimeout(resolve, 100 + (Math.random() * 100 - 50)));
+          }
+          resolve();
+        });
+      }
+
+      let currentIndex = 0;
+      const typeNextCommand = async () => {
+        const startCommand = startCommands[currentIndex];
+        el.innerText = '';
+        await new Promise<void>((resolve) => {
+          setTimeout(() => {
+            if (!(el instanceof HTMLElement)) return;
+            typewriter(el, startCommand).then(resolve);
+          }, 1000);
+        });
+        currentIndex += 1;
+        currentIndex = currentIndex % startCommands.length;
+        await new Promise<void>((resolve) => setTimeout(resolve, Math.random() * 1000 + 1000));
+        typeNextCommand();
+      };
+
+      typeNextCommand();
+    },
+  },
+};

--- a/packages/components/src/lib/buildPrompts.ts
+++ b/packages/components/src/lib/buildPrompts.ts
@@ -39,6 +39,7 @@ export default function buildPrompts(
   process: NaviePromptSuggestion[];
   remote: NaviePromptSuggestion[];
   test: NaviePromptSuggestion[];
+  codeBlock: NaviePromptSuggestion[];
 } {
   const prettyEditorName = editor === 'vscode' ? 'Visual Studio Code' : 'JetBrains';
   return {
@@ -185,6 +186,38 @@ export default function buildPrompts(
           webFramework,
           testFramework,
           'What is the benefit of recording tests and how does additional AppMap data help Navie understand my application?'
+        ),
+      },
+    ],
+    codeBlock: [
+      {
+        label: 'How do I record a code block?',
+        prompt: buildPrompt(
+          false,
+          false,
+          webFramework,
+          testFramework,
+          'How do I record a code block?'
+        ),
+      },
+      {
+        label: 'What is a code block recording?',
+        prompt: buildPrompt(
+          false,
+          false,
+          webFramework,
+          testFramework,
+          'What is a code block recording?'
+        ),
+      },
+      {
+        label: 'When would I use a code block recording?',
+        prompt: buildPrompt(
+          false,
+          false,
+          webFramework,
+          testFramework,
+          'When would I need to use a code block recording to record parts of my application?'
         ),
       },
     ],


### PR DESCRIPTION
This brings them in line with the (already released and live in VS Code) JavaScript instructions.

Python is also updated to include changes introduced in v2 of the agent, such as running `appmap-python`. This will need some fact checking.
