### PR TITLE
fix: Agent selection mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,12 @@ pnpm-debug.log*
 
 release
 
+# Jupyter
+notebooks
+.env.notebook
+
 # AppMap
 tmp/appmap
 packages/*/tmp/
 *.appmap.json
+

--- a/packages/navie/src/agents/explain-agent.ts
+++ b/packages/navie/src/agents/explain-agent.ts
@@ -32,6 +32,13 @@ already aware of these.
   engineering concepts. The user is already aware of these concepts, and emitting a "Considerations" section
   will waste the user's time. The user wants direct answers to their questions.
 
+  If the user's question is general in nature, don't provide extensive code listings, summaries, or explanations.
+
+  If the user's question is brief, ask the user to provide more context or focus.
+
+5. **Context items**: Do not include PlantUML sequence diagrams from context in your response.
+  The user will not be able to understand them.
+
 **Making AppMap data**
 
 You may encourage the user to make AppMap data if the context that you receive seems incomplete, and

--- a/packages/navie/src/agents/help-agent.ts
+++ b/packages/navie/src/agents/help-agent.ts
@@ -131,7 +131,7 @@ one of these approaches is not applicable to the user's environment.
 **Response**
 
 Your response should consist of short passages of descriptive text, emphasizing URLs to the documentation.
-For each documentatino URL, provide a brief description of why the link is relevant.
+For each documentation URL, provide a brief description of why the link is relevant.
 
 Do not emit code suggestions or code fences.
 
@@ -151,9 +151,9 @@ _Example_
 
 const MAKE_APPMAPS_PROMPT = `**Making AppMaps**
 
-If the user's question depends on having AppMaps, advise the user to make AppMaps for their project.
+If the user's question depends on having AppMap data, advise the user to record AppMaps for their project.
 
-Provide best practices for making AppMaps, taking into account the following considerations:
+Provide best practices for recording AppMap data, taking into account the following considerations:
 
 - **Language**: The programming language in use.
 - **Frameworks**: The user's application and testing frameworks.
@@ -175,8 +175,15 @@ export default class HelpAgent implements Agent {
     options: AgentOptions,
     tokensAvailable: () => number
   ): Promise<AgentResponse | void> {
-    const techStackTerms = await this.techStackService.detectTerms(options.aggregateQuestion);
+    const languages = [
+      ...new Set(
+        options.projectInfo.map((info) => info.appmapConfig?.language).filter(Boolean) as string[]
+      ),
+    ].sort();
 
+    const detectedTerms = await this.techStackService.detectTerms(options.aggregateQuestion);
+
+    const techStackTerms = [...languages, ...detectedTerms];
     if (techStackTerms.length === 0) {
       return {
         response: `What programming language and frameworks do you want help with?

--- a/packages/navie/src/agents/help-agent.ts
+++ b/packages/navie/src/agents/help-agent.ts
@@ -40,6 +40,15 @@ The following are the official AppMap documentation references for each supporte
 
 Languages that do not appear in this list are not supported by AppMap at this time.
 
+**Navie agent modes**
+
+Navie has several modes that you can activate by starting your question with a mode selector. The modes are:
+
+- @explain: Get an explanation of a concept or process. It's the most flexible mode.
+- @generate: Generate code.
+- @help: Get help with AppMap.
+- @plan: Create a code design and implementation plan from an issue description.
+
 **AppMap setup instructions**
 
 Setup instructions for making AppMap data are built into the AppMap code editor extension.

--- a/packages/navie/src/commands/explain-command.ts
+++ b/packages/navie/src/commands/explain-command.ts
@@ -52,7 +52,8 @@ export default class ExplainCommand implements Command {
 
     const agentSelectionResult = this.agentSelectionService.selectAgent(
       baseQuestion,
-      contextLabels
+      contextLabels,
+      request.userOptions
     );
     const { question, agent: mode } = agentSelectionResult;
 

--- a/packages/navie/src/commands/explain-command.ts
+++ b/packages/navie/src/commands/explain-command.ts
@@ -50,10 +50,16 @@ export default class ExplainCommand implements Command {
         .join(', ')}`
     );
 
-    const { question, agent: mode } = this.agentSelectionService.selectAgent(
+    const agentSelectionResult = this.agentSelectionService.selectAgent(
       baseQuestion,
       contextLabels
     );
+    const { question, agent: mode } = agentSelectionResult;
+
+    if (agentSelectionResult.selectionMessage) {
+      yield agentSelectionResult.selectionMessage;
+      yield '\n\n';
+    }
 
     const tokensAvailable = (): number =>
       this.options.tokenLimit -

--- a/packages/navie/src/services/agent-selection-service.ts
+++ b/packages/navie/src/services/agent-selection-service.ts
@@ -13,6 +13,7 @@ import TechStackService from './tech-stack-service';
 import TestAgent from '../agents/test-agent';
 import { PlanAgent } from '../agents/plan-agent';
 import ContextService from './context-service';
+import { UserOptions } from '../lib/parse-options';
 
 type AgentModeResult = {
   agentMode: AgentMode;
@@ -46,7 +47,11 @@ export default class AgentSelectionService {
     private techStackService: TechStackService
   ) {}
 
-  selectAgent(question: string, classification: ContextV2.ContextLabel[]): AgentModeResult {
+  selectAgent(
+    question: string,
+    classification: ContextV2.ContextLabel[],
+    userOptions: UserOptions
+  ): AgentModeResult {
     let modifiedQuestion = question;
 
     const contextService = new ContextService(
@@ -102,11 +107,13 @@ export default class AgentSelectionService {
     };
 
     const classifierMode = (): AgentModeResult | undefined => {
-      const isHelp = classification.some(
-        (label) =>
-          label.name === ContextV2.ContextLabelName.HelpWithAppMap &&
-          label.weight === ContextV2.ContextLabelWeight.High
-      );
+      const isHelp =
+        userOptions.booleanValue('help', true) &&
+        classification.some(
+          (label) =>
+            label.name === ContextV2.ContextLabelName.HelpWithAppMap &&
+            label.weight === ContextV2.ContextLabelWeight.High
+        );
       if (isHelp) {
         this.history.log(`[mode-selection] Activating agent due to classifier: ${AgentMode.Help}`);
         return {

--- a/packages/navie/src/services/agent-selection-service.ts
+++ b/packages/navie/src/services/agent-selection-service.ts
@@ -14,7 +14,20 @@ import TestAgent from '../agents/test-agent';
 import { PlanAgent } from '../agents/plan-agent';
 import ContextService from './context-service';
 
-type AgentModeResult = { agentMode: AgentMode; agent: Agent; question: string };
+type AgentModeResult = {
+  agentMode: AgentMode;
+  agent: Agent;
+  // The question text with agent selection prefix removed.
+  question: string;
+  // True if the agent was selected based on classifiers (context labels).
+  selectedByClassifier?: boolean;
+  // Indicate to the user why the agent was selected.
+  selectionMessage?: string;
+};
+
+const HELP_AGENT_SELECTED_MESSAGE = `It looks like you are asking for help using AppMap, so
+I'm activating \`@help\` mode and basing my answer primarily on AppMap documentation. To disable this
+behavior, re-ask your question and start with the option \`/nohelp\` or with a mode selector such as \`@explain\`.`;
 
 const MODE_PREFIXES = {
   '@explain ': AgentMode.Explain,
@@ -88,7 +101,7 @@ export default class AgentSelectionService {
       }
     };
 
-    const classifierMode = () => {
+    const classifierMode = (): AgentModeResult | undefined => {
       const isHelp = classification.some(
         (label) =>
           label.name === ContextV2.ContextLabelName.HelpWithAppMap &&
@@ -96,7 +109,13 @@ export default class AgentSelectionService {
       );
       if (isHelp) {
         this.history.log(`[mode-selection] Activating agent due to classifier: ${AgentMode.Help}`);
-        return { agentMode: AgentMode.Help, question, agent: helpAgent() };
+        return {
+          agentMode: AgentMode.Help,
+          question,
+          agent: helpAgent(),
+          selectedByClassifier: true,
+          selectionMessage: HELP_AGENT_SELECTED_MESSAGE,
+        };
       }
     };
 


### PR DESCRIPTION
* @help mode considers configured languages
* @help mode has built-in knowledge of Navie modes
* Tell the user when an agent mode is auto-selected
* `/nohelp` disables help mode

When experimenting this, I found that requiring `help-with-appmap=high` to be the only `high` selected classifier was too strict, and resulted in Navie running in `@explain` mode and trying to provide AppMap help without the benefit of the doc lookup RAG. 

So instead, Navie will inform the user that they are in `@help` mode and tell them how to get out of it. It would be nice if the Navie UI had a native way to indicate and explain the active mode.

Also, the `language` information in appmap.yml is considered sufficient for the help command to proceed; the user won't be prompted to enter their language if they have a language configured in appmap.yml. I observed a user having trouble with this.

## Examples

**@help mode selection via classifier**

Note the message to the user at the beginning of the response.

<img width="851" alt="Screen Shot 2024-07-08 at 12 58 12 PM" src="https://github.com/getappmap/appmap-js/assets/86395/bc6a517d-fef9-4986-a519-22cfd979c954">

**@help mode disabled via `/nohelp`**

<img width="665" alt="Screen Shot 2024-07-08 at 12 58 01 PM" src="https://github.com/getappmap/appmap-js/assets/86395/886e6a0a-f258-47d4-bbd0-5c5651da2e80">
