### PR TITLE
feat: Improve classification of the latest question

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,12 @@ pnpm-debug.log*
 
 release
 
+# Jupyter
+notebooks
+.env.notebook
+
 # AppMap
 tmp/appmap
 packages/*/tmp/
 *.appmap.json
+

--- a/packages/navie/package.json
+++ b/packages/navie/package.json
@@ -45,6 +45,7 @@
     "fast-xml-parser": "^4.4.0",
     "js-yaml": "^4.1.0",
     "langchain": "^0.1.25",
+    "mermaid": "^9",
     "openai": "^4.28.0"
   }
 }

--- a/packages/navie/src/agent.ts
+++ b/packages/navie/src/agent.ts
@@ -1,10 +1,13 @@
 import { ContextV2 } from './context';
+import Filter, { Chunk } from './lib/filter';
 import { UserOptions } from './lib/parse-options';
 import { ProjectInfo } from './project-info';
+import CompletionService from './services/completion-service';
 
 export enum AgentMode {
   Explain = 'explain',
   Generate = 'generate',
+  Diagram = 'diagram',
   Help = 'help',
   Test = 'test',
   Plan = 'plan',
@@ -39,6 +42,8 @@ export type AgentResponse = {
 };
 
 export interface Agent {
+  newFilter(): Filter;
+
   perform(options: AgentOptions, tokensAvailable: () => number): Promise<AgentResponse | void>;
 
   temperature: number | undefined;

--- a/packages/navie/src/agents/diagram-agent.ts
+++ b/packages/navie/src/agents/diagram-agent.ts
@@ -1,0 +1,249 @@
+import { Agent, AgentOptions, AgentResponse } from '../agent';
+import InteractionHistory, { PromptInteractionEvent } from '../interaction-history';
+import Filter from '../lib/filter';
+import MermaidFilter from '../lib/mermaid-filter';
+import MermaidFixer from '../lib/mermaid-fixer';
+import { PromptType, buildPromptDescriptor, buildPromptValue } from '../prompt';
+import CompletionService from '../services/completion-service';
+import ContextService from '../services/context-service';
+
+export const DIAGRAM_AGENT_PROMPT = `**Task: Generation of Software Diagrams**
+
+**About you**
+
+Your name is Navie. You are an AI softwrare architect created and maintained by AppMap Inc, and are available to AppMap users as a service.
+
+Your job is to generate software diagrams based on a description provided by the user.
+
+**About the user**
+
+The user is an experienced software developer who will review the diagrams you generate, and use them
+to understand the code and design code solutions. You can expect the user to be proficient in software development.
+
+**About your response**
+
+Prefer to generate one or more of the response formats detailed below:
+
+* Flowchart
+* Entity-relationship diagram (ERD)
+* Sequence diagram
+* UML class diagram
+
+The user will indicate in their question which type, or types, of diagram they want.
+
+**Flowchart**
+
+DO use Mermaid flowchart syntax.
+DO represent URL parameters using syntax /path/:variable, rather than /path/{variable}.
+DO quote the text that is associated with diagram nodes.
+
+DO NOT include any styling or formatting in the diagram.
+DO NOT include diagram theme or styles.
+DO NOT include a text description of the diagram.
+
+<example format="flowchart">
+\`\`\`mermaid
+flowchart TD
+    A["GET /oauth/:provider"] --> B{oauth_provider_exists?}
+    B -->|No| C["Render 404"]
+    B -->|Yes| D["oauth_client"]
+    D --> E["oauth_client.authorization_uri"]
+    E --> F["Redirect to authorization_uri"]
+    
+    G["GET /oauth/:provider/confirm"] --> H{oauth_state}
+    H -->|State mismatch| I["login_failure('State mismatch')"]
+    I --> J["Redirect to login_path"]
+    
+    H -->|State match| K["oauth_client.fetch_access_token!"]
+    K --> L["oauth_access_token"]
+    L -->|Invalid code| M["login_failure('Bad code')"]
+    M --> J
+    
+    L -->|Valid code| N["User.create_or_update_oauth"]
+    N --> O{"User exists?"}
+    O -->|Yes| P["Login existing user"]
+    O -->|No| Q["Create new user"]
+    P --> R["Store session and redirect to /license"]
+    Q --> R
+\`\`\`
+</example>
+
+**Entity-Relationship Diagram (ERD)**
+
+DO use Mermaid ERD syntax.
+
+DO use Mermaid ERD syntax.
+
+DO NOT include any styling or formatting in the diagram.
+DO NOT include diagram theme or styles.
+DO NOT include a text description of the diagram.
+
+<example format="erd">
+\`\`\`mermaid
+erDiagram
+  USER {
+    int id
+    string login
+    string github_access_token
+    string github_username
+    text github_email_addresses
+    text[] azure_user_ids
+  }
+  ORG {
+    int id
+    string name
+  }
+  USER ||--o{ USERS_ORGS : has
+  ORG ||--o{ USERS_ORGS : includes
+
+  API_KEYS {
+      int id
+      int user_id
+      string key
+      datetime created_at
+  }
+  USER ||--o{ API_KEYS : has
+  USERS_ORGS {
+      int user_id
+      int org_id
+    }
+\`\`\`
+</example>
+
+**Sequence Diagram**
+
+DO use Mermaid sequence diagram syntax.
+DO place quotes around labels that contain spaces or special characters.
+
+<example format="sequence-diagram">
+\`\`\`mermaid
+sequenceDiagram
+    participant TestDeferredTax as TestDeferredTax
+    participant Strategy as Strategy
+    participant PricingPolicy as "Pricing Policy"
+    
+    TestDeferredTax->>Strategy: fetch_for_product
+    activate Strategy
+    Strategy->>PricingPolicy: pricing_policy
+    activate PricingPolicy
+    PricingPolicy->>Strategy: Unavailable
+    deactivate PricingPolicy
+    Strategy->>TestDeferredTax: PurchaseInfo
+    deactivate Strategy
+\`\`\`
+</example>
+
+**Class Diagram**
+
+DO use Mermaid class diagram syntax.
+
+<example format="class-diagram">
+\`\`\`mermaid
+classDiagram
+  direction LR
+
+  class PartnerStrategy {
+      +fetch_for_product(product: Product) : PurchaseInfo
+      +fetch_for_line(line: Line, stockrecord: StockRecord) : PurchaseInfo
+      +select_stockrecord(product: Product) : StockRecord
+  }
+
+  class PurchaseInfo {
+      +price: PricingPolicy
+      +availability: AvailabilityPolicy
+      +stockrecord: StockRecord
+  }
+
+  class StockRecord {
+      +price_currency: str
+      +price: Decimal
+      +num_in_stock: int
+  }
+
+  class Order {
+      +num_lines: int
+      +num_items: int
+      +total_incl_tax: Decimal
+      +date_placed: DateTime
+  }
+
+  class Basket {
+      +lines: List~Line~
+  }
+
+  class Line {
+      +product: Product
+  }
+
+  class Product {
+      +title: str
+      +upc: str
+  }
+
+  class PricingPolicy {
+  }
+
+  class AvailabilityPolicy {
+  }
+
+  class Partner {
+      +name: str
+  }
+
+  Basket "1" --> "*" Line
+  Line "1" --> "1" Product
+  Line "1" --> "1" StockRecord
+  StockRecord "1" --> "1" Partner
+  Order "1" --> "*" Line
+
+  PartnerStrategy --> Basket
+  PartnerStrategy --> Order
+  PurchaseInfo --> StockRecord
+  PurchaseInfo --> PricingPolicy
+  PurchaseInfo --> AvailabilityPolicy
+  PartnerStrategy --> PurchaseInfo
+  PartnerStrategy --> Product
+\`\`\`
+</example>
+`;
+
+export default class DiagramAgent implements Agent {
+  public readonly temperature = undefined;
+
+  constructor(
+    public history: InteractionHistory,
+    private contextService: ContextService,
+    private completionService: CompletionService
+  ) {}
+
+  // eslint-disable-next-line class-methods-use-this
+  newFilter(): Filter {
+    return new MermaidFilter(this.history, new MermaidFixer(this.history, this.completionService));
+  }
+
+  async perform(options: AgentOptions, tokensAvailable: () => number): Promise<AgentResponse> {
+    this.history.addEvent(new PromptInteractionEvent('agent', 'system', DIAGRAM_AGENT_PROMPT));
+
+    this.history.addEvent(
+      new PromptInteractionEvent(
+        PromptType.Question,
+        'system',
+        buildPromptDescriptor(PromptType.Question)
+      )
+    );
+
+    await this.contextService.perform(options, tokensAvailable);
+
+    return { response: 'Rendering diagram...\n', abort: false };
+  }
+
+  applyQuestionPrompt(question: string): void {
+    this.history.addEvent(
+      new PromptInteractionEvent(
+        PromptType.Question,
+        'user',
+        buildPromptValue(PromptType.Question, question)
+      )
+    );
+  }
+}

--- a/packages/navie/src/agents/explain-agent.ts
+++ b/packages/navie/src/agents/explain-agent.ts
@@ -32,6 +32,13 @@ already aware of these.
   engineering concepts. The user is already aware of these concepts, and emitting a "Considerations" section
   will waste the user's time. The user wants direct answers to their questions.
 
+  If the user's question is general in nature, don't provide extensive code listings, summaries, or explanations.
+
+  If the user's question is brief, ask the user to provide more context or focus.
+
+5. **Context items**: Do not include PlantUML sequence diagrams from context in your response.
+  The user will not be able to understand them.
+
 **Making AppMap data**
 
 You may encourage the user to make AppMap data if the context that you receive seems incomplete, and

--- a/packages/navie/src/agents/explain-agent.ts
+++ b/packages/navie/src/agents/explain-agent.ts
@@ -2,8 +2,9 @@ import InteractionHistory, { PromptInteractionEvent } from '../interaction-histo
 import { Agent, AgentOptions } from '../agent';
 import { PROMPTS, PromptType } from '../prompt';
 import ContextService from '../services/context-service';
+import Filter, { NopFilter } from '../lib/filter';
 
-const EXPLAIN_AGENT_PROMPT = `**Task: Explaining Code, Analyzing Code, Generating Code**
+const EXPLAIN_AGENT_PROMPT = `**Task: Answering User Questions about a Code Base**
 
 ## About you
 
@@ -20,24 +21,25 @@ already aware of these.
 
 ## Your response
 
-1. **Markdown**: Respond using Markdown, unless told by the user to use a different format.
+  1. **Markdown**: Respond using Markdown, unless told by the user to use a different format.
 
-2. **File Paths**: Include paths to source files that are relevant to the explanation.
+  2. **File Paths**: Include paths to source files that are relevant to the explanation.
 
-3. **Length**: Keep your response concise and to the point. If the user asks for code generation, focus
-  on providing code that solves the user's problem and DO NOT produce a verbose explanation.
+  3. **Length**: Keep your response concise and to the point. 
 
-4. **Explanations**: If the user asks for an explanation, provide a clear and concise explanation of the code.
-  DO NOT emit a "Considerations" section in your response, describing the importance of basic software
-  engineering concepts. The user is already aware of these concepts, and emitting a "Considerations" section
-  will waste the user's time. The user wants direct answers to their questions.
+  4. **Explanations**: Provide a brief, clear, and concise explanation of the code.
 
-  If the user's question is general in nature, don't provide extensive code listings, summaries, or explanations.
+  DO NOT output long code listings. Any code listings should be short, and illustrate a specific point.
 
-  If the user's question is brief, ask the user to provide more context or focus.
+  5. **Code generation**: If the user asks for code generation, focus
+    on providing code that solves the user's problem and DO NOT produce a verbose explanation.
 
-5. **Context items**: Do not include PlantUML sequence diagrams from context in your response.
-  The user will not be able to understand them.
+  5. **Diagrams**: DO NOT include diagrams in your response. If you think a diagram would be helpful,
+  you can suggest that the user ask for a diagram in a follow-up question.
+
+  6. **Considerations**: DO NOT emit a "Considerations" section in your response, describing the importance
+    of basic software engineering concepts. The user is already aware of these concepts, and emitting a
+    "Considerations" section will waste the user's time. The user wants direct answers to their questions.
 
 **Making AppMap data**
 
@@ -50,6 +52,11 @@ export default class ExplainAgent implements Agent {
   public temperature = undefined;
 
   constructor(public history: InteractionHistory, private contextService: ContextService) {}
+
+  // eslint-disable-next-line class-methods-use-this
+  newFilter(): Filter {
+    return new NopFilter();
+  }
 
   async perform(options: AgentOptions, tokensAvailable: () => number) {
     this.history.addEvent(new PromptInteractionEvent('agent', 'system', EXPLAIN_AGENT_PROMPT));

--- a/packages/navie/src/agents/generate-agent.ts
+++ b/packages/navie/src/agents/generate-agent.ts
@@ -1,5 +1,6 @@
 import { Agent, AgentOptions } from '../agent';
 import InteractionHistory, { PromptInteractionEvent } from '../interaction-history';
+import Filter, { NopFilter } from '../lib/filter';
 import { PromptType, buildPromptDescriptor, buildPromptValue } from '../prompt';
 import ContextService from '../services/context-service';
 
@@ -38,6 +39,11 @@ export default class GenerateAgent implements Agent {
   public temperature = undefined;
 
   constructor(public history: InteractionHistory, private contextService: ContextService) {}
+
+  // eslint-disable-next-line class-methods-use-this
+  newFilter(): Filter {
+    return new NopFilter();
+  }
 
   async perform(options: AgentOptions, tokensAvailable: () => number): Promise<void> {
     const agentPrompt = [GENERATE_AGENT_PROMPT];

--- a/packages/navie/src/agents/help-agent.ts
+++ b/packages/navie/src/agents/help-agent.ts
@@ -7,6 +7,7 @@ import LookupContextService from '../services/lookup-context-service';
 import TechStackService from '../services/tech-stack-service';
 import { CHARACTERS_PER_TOKEN } from '../message';
 import transformSearchTerms from '../lib/transform-search-terms';
+import Filter, { NopFilter } from '../lib/filter';
 
 export const HELP_AGENT_PROMPT = `**Task: Providing Help with AppMap**
 
@@ -178,6 +179,11 @@ export default class HelpAgent implements Agent {
     private vectorTermsService: VectorTermsService,
     private techStackService: TechStackService
   ) {}
+
+  // eslint-disable-next-line class-methods-use-this
+  newFilter(): Filter {
+    return new NopFilter();
+  }
 
   // eslint-disable-next-line consistent-return
   async perform(

--- a/packages/navie/src/agents/help-agent.ts
+++ b/packages/navie/src/agents/help-agent.ts
@@ -131,7 +131,7 @@ one of these approaches is not applicable to the user's environment.
 **Response**
 
 Your response should consist of short passages of descriptive text, emphasizing URLs to the documentation.
-For each documentatino URL, provide a brief description of why the link is relevant.
+For each documentation URL, provide a brief description of why the link is relevant.
 
 Do not emit code suggestions or code fences.
 
@@ -151,9 +151,9 @@ _Example_
 
 const MAKE_APPMAPS_PROMPT = `**Making AppMaps**
 
-If the user's question depends on having AppMaps, advise the user to make AppMaps for their project.
+If the user's question depends on having AppMap data, advise the user to record AppMaps for their project.
 
-Provide best practices for making AppMaps, taking into account the following considerations:
+Provide best practices for recording AppMap data, taking into account the following considerations:
 
 - **Language**: The programming language in use.
 - **Frameworks**: The user's application and testing frameworks.
@@ -175,8 +175,15 @@ export default class HelpAgent implements Agent {
     options: AgentOptions,
     tokensAvailable: () => number
   ): Promise<AgentResponse | void> {
-    const techStackTerms = await this.techStackService.detectTerms(options.aggregateQuestion);
+    const languages = [
+      ...new Set(
+        options.projectInfo.map((info) => info.appmapConfig?.language).filter(Boolean) as string[]
+      ),
+    ].sort();
 
+    const detectedTerms = await this.techStackService.detectTerms(options.aggregateQuestion);
+
+    const techStackTerms = [...languages, ...detectedTerms];
     if (techStackTerms.length === 0) {
       return {
         response: `What programming language and frameworks do you want help with?

--- a/packages/navie/src/agents/help-agent.ts
+++ b/packages/navie/src/agents/help-agent.ts
@@ -40,6 +40,15 @@ The following are the official AppMap documentation references for each supporte
 
 Languages that do not appear in this list are not supported by AppMap at this time.
 
+**Navie agent modes**
+
+Navie has several modes that you can activate by starting your question with a mode selector. The modes are:
+
+- @explain: Get an explanation of a concept or process. It's the most flexible mode.
+- @generate: Generate code.
+- @help: Get help with AppMap.
+- @plan: Create a code design and implementation plan from an issue description.
+
 **AppMap setup instructions**
 
 Setup instructions for making AppMap data are built into the AppMap code editor extension.

--- a/packages/navie/src/agents/plan-agent.ts
+++ b/packages/navie/src/agents/plan-agent.ts
@@ -1,5 +1,6 @@
 import { Agent, AgentOptions } from '../agent';
 import InteractionHistory, { PromptInteractionEvent } from '../interaction-history';
+import Filter, { NopFilter } from '../lib/filter';
 import { PromptType, buildPromptDescriptor, buildPromptValue } from '../prompt';
 import ContextService from '../services/context-service';
 
@@ -66,6 +67,11 @@ export class PlanAgent implements Agent {
   public readonly temperature = undefined;
 
   constructor(public history: InteractionHistory, private contextService: ContextService) {}
+
+  // eslint-disable-next-line class-methods-use-this
+  newFilter(): Filter {
+    return new NopFilter();
+  }
 
   async perform(options: AgentOptions, tokensAvailable: () => number): Promise<void> {
     this.history.addEvent(new PromptInteractionEvent('agent', 'system', GENERATE_AGENT_PROMPT));

--- a/packages/navie/src/agents/test-agent.ts
+++ b/packages/navie/src/agents/test-agent.ts
@@ -1,5 +1,6 @@
 import { Agent, AgentOptions } from '../agent';
 import InteractionHistory, { PromptInteractionEvent } from '../interaction-history';
+import Filter, { NopFilter } from '../lib/filter';
 import { PromptType, buildPromptDescriptor, buildPromptValue } from '../prompt';
 import ContextService from '../services/context-service';
 
@@ -59,6 +60,11 @@ export default class TestAgent implements Agent {
   public temperature = undefined;
 
   constructor(public history: InteractionHistory, private contextService: ContextService) {}
+
+  // eslint-disable-next-line class-methods-use-this
+  newFilter(): Filter {
+    return new NopFilter();
+  }
 
   async perform(options: AgentOptions, tokensAvailable: () => number): Promise<void> {
     this.history.addEvent(new PromptInteractionEvent('agent', 'system', TEST_AGENT_PROMPT));

--- a/packages/navie/src/commands/explain-command.ts
+++ b/packages/navie/src/commands/explain-command.ts
@@ -52,7 +52,8 @@ export default class ExplainCommand implements Command {
 
     const agentSelectionResult = this.agentSelectionService.selectAgent(
       baseQuestion,
-      contextLabels
+      contextLabels,
+      request.userOptions
     );
     const { question, agent: mode } = agentSelectionResult;
 

--- a/packages/navie/src/commands/explain-command.ts
+++ b/packages/navie/src/commands/explain-command.ts
@@ -50,10 +50,16 @@ export default class ExplainCommand implements Command {
         .join(', ')}`
     );
 
-    const { question, agent: mode } = this.agentSelectionService.selectAgent(
+    const agentSelectionResult = this.agentSelectionService.selectAgent(
       baseQuestion,
       contextLabels
     );
+    const { question, agent: mode } = agentSelectionResult;
+
+    if (agentSelectionResult.selectionMessage) {
+      yield agentSelectionResult.selectionMessage;
+      yield '\n\n';
+    }
 
     const tokensAvailable = (): number =>
       this.options.tokenLimit -

--- a/packages/navie/src/context.ts
+++ b/packages/navie/src/context.ts
@@ -79,6 +79,7 @@ export namespace ContextV2 {
 
   export enum ContextLabelName {
     HelpWithAppMap = 'help-with-appmap',
+    GenerateDiagram = 'generate-diagram',
     Architecture = 'architecture',
     Feature = 'feature',
     Overview = 'overview',

--- a/packages/navie/src/lib/filter.ts
+++ b/packages/navie/src/lib/filter.ts
@@ -1,0 +1,20 @@
+export type Chunk = {
+  type: 'markdown' | 'diagram';
+  content: string;
+};
+
+export default interface Filter {
+  transform(chunk: string): AsyncIterable<Chunk>;
+
+  end(): AsyncIterable<Chunk>;
+}
+
+export class NopFilter implements Filter {
+  // eslint-disable-next-line class-methods-use-this, @typescript-eslint/require-await
+  async *transform(chunk: string): AsyncIterable<Chunk> {
+    yield { type: 'markdown', content: chunk };
+  }
+
+  // eslint-disable-next-line class-methods-use-this, @typescript-eslint/no-empty-function
+  async *end(): AsyncIterable<Chunk> {}
+}

--- a/packages/navie/src/lib/mermaid-filter.ts
+++ b/packages/navie/src/lib/mermaid-filter.ts
@@ -1,0 +1,117 @@
+import assert from 'assert';
+
+import Filter, { Chunk } from './filter';
+import MermaidValidator from './mermaid-validator';
+
+import InteractionHistory from '../interaction-history';
+import MermaidFixer from './mermaid-fixer';
+import CompletionService from '../services/completion-service';
+
+export default class MermaidFilter implements Filter {
+  private diagram: string[] | undefined;
+  private buffer = '';
+
+  constructor(
+    private readonly history: InteractionHistory,
+    private readonly mermaidFixer: MermaidFixer
+  ) {}
+
+  get inDiagram() {
+    return this.diagram !== undefined;
+  }
+
+  async *transform(chunk: string): AsyncIterable<Chunk> {
+    // Lines are delineated by '\n'.
+    // When a new chunk is received, append the chunk to the buffer.
+    // Extract any complete lines from the buffer and process them.
+
+    this.buffer += chunk;
+
+    while (this.buffer.indexOf('\n') !== -1) {
+      const nextLine = this.buffer.slice(0, this.buffer.indexOf('\n'));
+      this.buffer = this.buffer.slice(this.buffer.indexOf('\n') + 1);
+      yield* this.processLine(nextLine);
+    }
+  }
+
+  async *end(): AsyncIterable<Chunk> {
+    if (this.inDiagram) yield* this.onDiagram();
+    else yield { type: 'markdown', content: this.buffer };
+    this.buffer = '';
+  }
+
+  private async *processLine(line: string): AsyncIterable<Chunk> {
+    this.history.log(`[mermaid-filter] ${line}`);
+    if (!this.inDiagram) {
+      const startMatch = line.trim() === '```mermaid';
+      if (startMatch) {
+        this.diagram = [];
+      } else {
+        yield { type: 'markdown', content: line };
+      }
+    } else {
+      const endMatch = line.trim() === '```';
+      if (endMatch) {
+        yield* this.onDiagram();
+      } else {
+        assert(this.diagram);
+        this.diagram.push(line);
+      }
+    }
+  }
+
+  async *onDiagram(): AsyncIterable<Chunk> {
+    const diagramContent = (this.diagram || []).join('\n');
+    this.diagram = undefined;
+
+    // Ensure that the diagram content parses correctly.
+    const validator = new MermaidValidator(diagramContent);
+    const validation = await validator.validate();
+
+    // TODO: This is a temporary fix to ignore errors that are not related to the diagram
+    // vN.sanitize error is appearing in Mermaid v9
+    const ignoreError = (error?: string) => error?.includes('vN.sanitize');
+
+    if (validation.valid || ignoreError(validation.error)) {
+      if (ignoreError(validation.error))
+        this.history.log(`[mermaid-filter] Ignoring error: ${validation.error || '(none)'}`);
+
+      this.history.log(`[mermaid-filter] Yielding diagram:\n${diagramContent}`);
+      const content = ['', '```mermaid', diagramContent, '```', ''].join('\n');
+      yield { type: 'diagram', content };
+    } else {
+      this.history.log(`[mermaid-filter] Generated diagram is not valid`);
+
+      // eslint-disable-next-line no-lonely-if
+      if (validation.error && !ignoreError(validation.error)) {
+        this.history.log(`[mermaid-filter] Error: ${validation.error}`);
+        yield* this.repairDiagram(diagramContent, validation.error);
+      } else {
+        yield { type: 'diagram', content: ['', '```text', diagramContent, '```', ''].join('\n') };
+      }
+    }
+  }
+
+  async *repairDiagram(diagram: string, error: string): AsyncIterable<Chunk> {
+    const repairedDiagram = await this.mermaidFixer.repairDiagram(diagram, error);
+
+    // Check if the repaired diagram is valid.
+    const validator = new MermaidValidator(repairedDiagram);
+    const validation = await validator.validate();
+    if (validation.valid) {
+      this.history.log(`[mermaid-filter] Diagram successfully repaired.`);
+
+      const content = ['', '```mermaid', repairedDiagram, '```', ''].join('\n');
+      yield { type: 'diagram', content };
+    } else {
+      this.history.log(
+        `[mermaid-filter] Diagram repair unsuccessful. Returning repaired content as text.`
+      );
+
+      // If the repaired diagram is still invalid, return the repaired diagram, but as a plain text
+      // block so that the frontend won't try and render it.
+      const content = ['', '```text', repairedDiagram, '```', ''].join('\n');
+      yield { type: 'diagram', content };
+    }
+  }
+}

--- a/packages/navie/src/lib/mermaid-fixer.ts
+++ b/packages/navie/src/lib/mermaid-fixer.ts
@@ -1,0 +1,54 @@
+import trimFences from './trim-fences';
+import Message from '../message';
+import InteractionHistory from '../interaction-history';
+import CompletionService from '../services/completion-service';
+
+export default class MermaidFixer {
+  constructor(
+    private readonly history: InteractionHistory,
+    private readonly completion: CompletionService
+  ) {}
+
+  async repairDiagram(diagram: string, error: string): Promise<string> {
+    this.history.log(`[mermaid-fixer] Attempting to repair diagram.`);
+
+    const systemPrompt = `**Mermaid Diagram Repair**
+
+There is an error present in the diagram. Please make the necessary corrections to the diagram,
+and return the corrected diagram.
+
+The diagram output format should be in the form of a Mermaid diagram, enclosed in a code block.
+
+<example>
+\`\`\`mermaid
+    the diagram content
+\`\`\`
+</example>
+
+<error>
+${error}
+</error>`;
+
+    const messages: Message[] = [
+      {
+        content: systemPrompt,
+        role: 'system',
+      },
+      {
+        content: diagram,
+        role: 'user',
+      },
+    ];
+    const response = this.completion.complete(messages);
+    const tokens = Array<string>();
+    for await (const token of response) {
+      tokens.push(token);
+    }
+    const repairedContent = tokens.join('');
+    const diagramContent = trimFences(repairedContent);
+    this.history.log(`[mermaid-fixer] Diagram repair attempt complete.`);
+    this.history.log(`[mermaid-fixer] Repaired diagram:\n${diagramContent}`);
+
+    return diagramContent;
+  }
+}

--- a/packages/navie/src/lib/mermaid-validator.ts
+++ b/packages/navie/src/lib/mermaid-validator.ts
@@ -1,0 +1,24 @@
+import mermaid from 'mermaid';
+
+export default class MermaidValidator {
+  constructor(public readonly diagram: string) {}
+
+  // Validate the diagram. If the diagram is valid, return true. If the diagram is invalid,
+  // return an array of error messages.
+  // TODO: Reconsider the async-ness of this code, based on what Mermaid does in v10+
+  // eslint-disable-next-line @typescript-eslint/require-await
+  validate(): Promise<{ valid: boolean; error?: string }> {
+    let error: string | undefined;
+    mermaid.setParseErrorHandler((err: Error) => {
+      error = err.message;
+    });
+
+    const valid = mermaid.parse(this.diagram);
+
+    mermaid.setParseErrorHandler(() => {});
+
+    if (valid) return Promise.resolve({ valid: true });
+
+    return Promise.resolve({ valid: false, error });
+  }
+}

--- a/packages/navie/src/navie.ts
+++ b/packages/navie/src/navie.ts
@@ -108,7 +108,8 @@ export default function navie(
       vectorTermsService,
       lookupContextService,
       applyContextService,
-      techStackService
+      techStackService,
+      completionService
     );
     const projectInfoService = new ProjectInfoService(interactionHistory, projectInfoProvider);
     const memoryService = new OpenAIMemoryService(options.modelName, options.temperature);

--- a/packages/navie/src/prompt.ts
+++ b/packages/navie/src/prompt.ts
@@ -49,12 +49,6 @@ The user is asking about specific lines of code that they have selected in their
 
 This is the primary question that the user wants you to answer. Your response should be
 focused primarily on answering this question.
-
-When the user is asking you to create a diagram, describe the code functionality in Markdown as
-well as you can from the context you have. 
-
-Avoid recommending other diagram tools such as Lucidchart, Draw.io, PlantUML, or Mermaid,
-except as supplemental resources to AppMap.
 `,
     tagName: 'question',
   },

--- a/packages/navie/src/services/agent-selection-service.ts
+++ b/packages/navie/src/services/agent-selection-service.ts
@@ -14,6 +14,8 @@ import TestAgent from '../agents/test-agent';
 import { PlanAgent } from '../agents/plan-agent';
 import ContextService from './context-service';
 import { UserOptions } from '../lib/parse-options';
+import DiagramAgent from '../agents/diagram-agent';
+import CompletionService from './completion-service';
 
 type AgentModeResult = {
   agentMode: AgentMode;
@@ -33,6 +35,7 @@ behavior, re-ask your question and start with the option \`/nohelp\` or with a m
 const MODE_PREFIXES = {
   '@explain ': AgentMode.Explain,
   '@generate ': AgentMode.Generate,
+  '@diagram ': AgentMode.Diagram,
   '@help ': AgentMode.Help,
   '@test ': AgentMode.Test,
   '@plan ': AgentMode.Plan,
@@ -44,7 +47,8 @@ export default class AgentSelectionService {
     private vectorTermsService: VectorTermsService,
     private lookupContextService: LookupContextService,
     private applyContextService: ApplyContextService,
-    private techStackService: TechStackService
+    private techStackService: TechStackService,
+    private completionService: CompletionService
   ) {}
 
   selectAgent(
@@ -72,13 +76,17 @@ export default class AgentSelectionService {
 
     const planAgent = () => new PlanAgent(this.history, contextService);
 
+    const diagramAgent = () =>
+      new DiagramAgent(this.history, contextService, this.completionService);
+
     const generateAgent = () => new GenerateAgent(this.history, contextService);
 
     const explainAgent = () => new ExplainAgent(this.history, contextService);
 
-    const buildAgent = {
+    const buildAgent: { [key in AgentMode]: () => Agent } = {
       [AgentMode.Help]: helpAgent,
       [AgentMode.Generate]: generateAgent,
+      [AgentMode.Diagram]: diagramAgent,
       [AgentMode.Explain]: explainAgent,
       [AgentMode.Test]: testAgent,
       [AgentMode.Plan]: planAgent,
@@ -106,22 +114,47 @@ export default class AgentSelectionService {
       }
     };
 
+    const classifierSelections: {
+      name: ContextV2.ContextLabelName;
+      mode: AgentMode;
+      disableOption?: string;
+      message?: string;
+    }[] = [
+      {
+        name: ContextV2.ContextLabelName.Explain,
+        mode: AgentMode.Explain,
+      },
+      {
+        name: ContextV2.ContextLabelName.GenerateDiagram,
+        mode: AgentMode.Diagram,
+      },
+      {
+        name: ContextV2.ContextLabelName.HelpWithAppMap,
+        mode: AgentMode.Help,
+        disableOption: 'help',
+        message: HELP_AGENT_SELECTED_MESSAGE,
+      },
+    ];
+
     const classifierMode = (): AgentModeResult | undefined => {
-      const isHelp =
-        userOptions.booleanValue('help', true) &&
+      const classifierSelection = classifierSelections.find((selection) =>
         classification.some(
           (label) =>
-            label.name === ContextV2.ContextLabelName.HelpWithAppMap &&
-            label.weight === ContextV2.ContextLabelWeight.High
-        );
-      if (isHelp) {
-        this.history.log(`[mode-selection] Activating agent due to classifier: ${AgentMode.Help}`);
+            label.name === selection.name &&
+            label.weight === ContextV2.ContextLabelWeight.High &&
+            (!selection.disableOption || userOptions.booleanValue(selection.disableOption, true))
+        )
+      );
+      if (classifierSelection) {
+        const { mode } = classifierSelection;
+        this.history.log(`[mode-selection] Activating agent due to classifier: ${mode}`);
+        const agent = buildAgent[mode]();
         return {
-          agentMode: AgentMode.Help,
+          agentMode: mode,
           question,
-          agent: helpAgent(),
+          agent,
           selectedByClassifier: true,
-          selectionMessage: HELP_AGENT_SELECTED_MESSAGE,
+          selectionMessage: classifierSelection.message,
         };
       }
     };

--- a/packages/navie/src/services/agent-selection-service.ts
+++ b/packages/navie/src/services/agent-selection-service.ts
@@ -13,6 +13,7 @@ import TechStackService from './tech-stack-service';
 import TestAgent from '../agents/test-agent';
 import { PlanAgent } from '../agents/plan-agent';
 import ContextService from './context-service';
+import { UserOptions } from '../lib/parse-options';
 
 type AgentModeResult = {
   agentMode: AgentMode;
@@ -46,7 +47,11 @@ export default class AgentSelectionService {
     private techStackService: TechStackService
   ) {}
 
-  selectAgent(question: string, classification: ContextV2.ContextLabel[]): AgentModeResult {
+  selectAgent(
+    question: string,
+    classification: ContextV2.ContextLabel[],
+    userOptions: UserOptions
+  ): AgentModeResult {
     let modifiedQuestion = question;
 
     const contextService = new ContextService(
@@ -102,11 +107,13 @@ export default class AgentSelectionService {
     };
 
     const classifierMode = (): AgentModeResult | undefined => {
-      const isHelp = classification.some(
-        (label) =>
-          label.name === ContextV2.ContextLabelName.HelpWithAppMap &&
-          label.weight === ContextV2.ContextLabelWeight.High
-      );
+      const isHelp =
+        userOptions.booleanValue('help', true) &&
+        classification.some(
+          (label) =>
+            label.name === ContextV2.ContextLabelName.HelpWithAppMap &&
+            label.weight === ContextV2.ContextLabelWeight.High
+        );
       if (isHelp) {
         this.history.log(`[mode-selection] Activating agent due to classifier: ${AgentMode.Help}`);
         return {

--- a/packages/navie/src/services/agent-selection-service.ts
+++ b/packages/navie/src/services/agent-selection-service.ts
@@ -14,7 +14,20 @@ import TestAgent from '../agents/test-agent';
 import { PlanAgent } from '../agents/plan-agent';
 import ContextService from './context-service';
 
-type AgentModeResult = { agentMode: AgentMode; agent: Agent; question: string };
+type AgentModeResult = {
+  agentMode: AgentMode;
+  agent: Agent;
+  // The question text with agent selection prefix removed.
+  question: string;
+  // True if the agent was selected based on classifiers (context labels).
+  selectedByClassifier?: boolean;
+  // Indicate to the user why the agent was selected.
+  selectionMessage?: string;
+};
+
+const HELP_AGENT_SELECTED_MESSAGE = `It looks like you are asking for help using AppMap, so
+I'm activating \`@help\` mode and basing my answer primarily on AppMap documentation. To disable this
+behavior, re-ask your question and start with the option \`/nohelp\` or with a mode selector such as \`@explain\`.`;
 
 const MODE_PREFIXES = {
   '@explain ': AgentMode.Explain,
@@ -88,7 +101,7 @@ export default class AgentSelectionService {
       }
     };
 
-    const classifierMode = () => {
+    const classifierMode = (): AgentModeResult | undefined => {
       const isHelp = classification.some(
         (label) =>
           label.name === ContextV2.ContextLabelName.HelpWithAppMap &&
@@ -96,7 +109,13 @@ export default class AgentSelectionService {
       );
       if (isHelp) {
         this.history.log(`[mode-selection] Activating agent due to classifier: ${AgentMode.Help}`);
-        return { agentMode: AgentMode.Help, question, agent: helpAgent() };
+        return {
+          agentMode: AgentMode.Help,
+          question,
+          agent: helpAgent(),
+          selectedByClassifier: true,
+          selectionMessage: HELP_AGENT_SELECTED_MESSAGE,
+        };
       }
     };
 

--- a/packages/navie/src/services/classification-service.ts
+++ b/packages/navie/src/services/classification-service.ts
@@ -21,18 +21,31 @@ The user is a software developer who is working on a project. They are asking a 
 
 ## Classification categories
 
-Your task is to assign a likelihood to each of the following categories:
+Your task is to assign a likelihood to question categories.
 
-- **greeting**: The developer is saying hello to the assistant.
-- **help-with-appmap**: Help using the AppMap product.
-- **architecture**: The developer is asking about the architecture of the project.
-- **feature**: The developer is asking for an explanation of how a specific feature of the project works.
+Choose exactly one from the following "Modes":
+
+- **greeting**: The developer is saying hello to the assistant. The response will also be a greeting.
+- **explain**: The developer is asking for an explanation of code behavior. The response will be
+  a combination of text, diagrams, and code.
+- **plan**: The developer is developing a plan to solve a code issue. The response will be
+  an analysis of the issue, along with a plan to solve it.
+- **troubleshoot**: The developer is asking for help troubleshooting an issue. The response will
+  be a combination of text, diagrams, and code.
+- **generate-code**: The developer is asking to generate code for a specific task. The response
+  will be code files and snippets.
+- **generate-diagram**: The developer is asking for a diagram of their code. The response will
+  be one or more diagrams.
+- **help-with-appmap**: Help using the AppMap product. The response will be an explanation of how to
+  use AppMap, along with links to documentation.
+
+Choose exactly one from the following "Scopes":
+
+- **architecture**: The developer is asking about the high-level architecture of the project.
+- **feature**: The developer is asking for an explanation of how a specific feature of the project
+  works.
 - **overview**: The developer is asking a high-level question about the structure, purpose,
   functionality or intent of the project.
-- **troubleshoot**: The developer is asking for help troubleshooting an issue.
-- **explain**: The developer is asking for an explanation of a the code.
-- **generate-code**: The developer is asking to generate code for a specific task.
-- **generate-diagram**: The developer is asking for a diagram of their code.
 
 ## Classification scores
 
@@ -44,8 +57,7 @@ Each classification category is assigned one of the following likelihoods:
 
 **Response**
 
-Respond with the likelihood of each question type. Question types with "low" likelihood may
-be omitted.
+Respond with a "Mode" and "Scope", and the likelihood of each one. 
 
 **Examples**
 
@@ -55,77 +67,51 @@ Some examples of questions and their classifications are:
 - question: Hi
   answer:
     greeting: high
-    help-with-appmap: low
-    architecture: low
-    feature: low
-    overview: medium
-    troubleshoot: low
-    explain: low
-    generate-code: low
-    generate-diagram: low
 
 - question: How do I record AppMap data of my Spring app?
   answer:
     help-with-appmap: high
-    architecture: low
-    feature: low
-    overview: low
-    troubleshoot: low
-    explain: low
-    generate-code: low
-    generate-diagram: low
+    architecture: medium
 
 - question: How do I reduce the amount of data in my AppMaps?
   answer:
     help-with-appmap: high
-    overview: low
-    troubleshoot: low
-    explain: low
-    generate-code: medium
-    generate-diagram: low
+    troubleshoot: medium
 
 - question: How does the project work?
   answer:
-    help-with-appmap: low
+    explain: high
     architecture: high
-    feature: low
-    overview: high
-    troubleshoot: low
-    explain: low
-    generate-code: low
-    generate-diagram: low
 
 - question: Generate a form and controller to update the user profile
   answer:
-    help-with-appmap: low
-    architecture: medium
-    feature: high
-    overview: low
-    explain: low
     generate-code: high
-    generate-diagram: low
+    feature: high
 
 - question: Why am I getting a 500 error?
   answer:
-    help-with-appmap: low
-    architecture: low
-    feature: low
-    overview: low
     troubleshoot: high
-    explain: medium
-    generate-code: low
-    generate-diagram: low
+    feature: medium
 
 - question: Generate a diagram of the user profile feature
   answer:
-    help-with-appmap: medium
-    architecture: high
-    feature: high
-    overview: low
-    troubleshoot: low
-    explain: low
-    generate-code: low
     generate-diagram: high
+    feature: high
+
+- question: Class map of the user profile feature
+  answer:
+    generate-diagram: high
+    feature: high
+
+- question: Sequence diagram
+  answer:
+    generate-diagram: high
+    overview: high
+
+- question: ERD of users
+  answer:
+    generate-diagram: high
+    architecture: high
 \`\`\`
 
 `;

--- a/packages/navie/src/services/completion-service.ts
+++ b/packages/navie/src/services/completion-service.ts
@@ -13,7 +13,7 @@ export default interface CompletionService {
   readonly temperature: number | undefined;
 }
 
-interface Usage extends Required<TokenUsage> {
+export interface Usage extends Required<TokenUsage> {
   cost?: number;
 }
 

--- a/packages/navie/test/agents/diagram-agent.spec.ts
+++ b/packages/navie/test/agents/diagram-agent.spec.ts
@@ -1,0 +1,66 @@
+import InteractionHistory, { PromptInteractionEvent } from '../../src/interaction-history';
+import { AgentOptions } from '../../src/agent';
+import ContextService from '../../src/services/context-service';
+import CompletionService from '../../src/services/completion-service';
+import DiagramAgent, { DIAGRAM_AGENT_PROMPT } from '../../src/agents/diagram-agent';
+import { UserOptions } from '../../src/lib/parse-options';
+
+describe('@diagram agent', () => {
+  let interactionHistory: InteractionHistory;
+  let contextService: ContextService;
+  let tokensAvailable: number;
+
+  const initialQuestionOptions = new AgentOptions(
+    'How does user management work?',
+    'How does user management work?',
+    new UserOptions(new Map()),
+    [],
+    [
+      {
+        directory: 'twitter',
+        appmapConfig: { language: 'ruby' } as unknown as any,
+        appmapStats: { numAppMaps: 1 } as unknown as any,
+      },
+    ]
+  );
+
+  beforeEach(async () => {
+    tokensAvailable = 1000;
+    interactionHistory = new InteractionHistory();
+    contextService = {
+      perform: jest.fn(),
+    } as unknown as ContextService;
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  it('should perform the diagram agent task', async () => {
+    const completionService = {
+      perform: jest.fn(),
+    } as unknown as CompletionService;
+
+    const diagramAgent = new DiagramAgent(interactionHistory, contextService, completionService);
+    const result = await diagramAgent.perform(initialQuestionOptions, () => tokensAvailable);
+
+    // Verify that the perform method writes the correct prompt interactions to the history
+    expect(interactionHistory.events).toContainEqual(
+      new PromptInteractionEvent('agent', 'system', DIAGRAM_AGENT_PROMPT)
+    );
+    expect(interactionHistory.events).toContainEqual(
+      expect.objectContaining({
+        name: 'question',
+        role: 'system',
+        type: 'prompt',
+      })
+    );
+
+    // Verify that the context service's perform method is called with the expected options
+    expect(contextService.perform).toHaveBeenCalledWith(
+      initialQuestionOptions,
+      expect.any(Function)
+    );
+
+    // Verify that the result returned by the perform method is as expected
+    expect(result).toEqual({ response: 'Rendering diagram...\n', abort: false });
+  });
+});

--- a/packages/navie/test/agents/explain-agent.spec.ts
+++ b/packages/navie/test/agents/explain-agent.spec.ts
@@ -5,7 +5,6 @@ import VectorTermsService from '../../src/services/vector-terms-service';
 import LookupContextService from '../../src/services/lookup-context-service';
 import { AgentOptions } from '../../src/agent';
 import { SEARCH_CONTEXT, suggestsVectorTerms } from '../fixture';
-import { HelpResponse } from '../../src/help';
 import { CHARACTERS_PER_TOKEN } from '../../src/message';
 import { UserOptions } from '../../src/lib/parse-options';
 import ContextService from '../../src/services/context-service';

--- a/packages/navie/test/commands/explain-command.spec.ts
+++ b/packages/navie/test/commands/explain-command.spec.ts
@@ -21,6 +21,7 @@ import {
 } from '../fixture';
 import { CommandRequest } from '../../src/command';
 import { UserOptions } from '../../src/lib/parse-options';
+import { NopFilter } from '../../src/lib/filter';
 
 const CompletionEvent = { type: 'completion', model: 'mock', temperature: 0.5 };
 describe('ExplainCommand', () => {
@@ -84,6 +85,7 @@ describe('ExplainCommand', () => {
 
   function mockAgent(): Agent {
     return {
+      newFilter: () => new NopFilter(),
       perform: jest.fn().mockResolvedValue(undefined),
       applyQuestionPrompt: jest.fn(),
     } as unknown as Agent;

--- a/packages/navie/test/lib/mermaid-filter.spec.ts
+++ b/packages/navie/test/lib/mermaid-filter.spec.ts
@@ -1,0 +1,99 @@
+import InteractionHistory from '../../src/interaction-history';
+import { Chunk } from '../../src/lib/filter';
+import MermaidFilter from '../../src/lib/mermaid-filter';
+import MermaidFixer from '../../src/lib/mermaid-fixer';
+import trimFences from '../../src/lib/trim-fences';
+
+describe('MermaidFilter', () => {
+  let history: InteractionHistory;
+  let repairDiagram: jest.Mock;
+  let mermaidFixer: MermaidFixer;
+  let filter: MermaidFilter;
+
+  beforeEach(() => {
+    history = new InteractionHistory();
+    repairDiagram = jest.fn();
+    mermaidFixer = {
+      repairDiagram,
+    } as unknown as MermaidFixer;
+    filter = new MermaidFilter(history, mermaidFixer);
+  });
+
+  const collectChunks = async (
+    result: AsyncIterable<Chunk>,
+    list: string[] = new Array<string>()
+  ) => {
+    for await (const chunk of result) {
+      list.push(chunk.content);
+    }
+    return list;
+  };
+
+  const transformContent = async (content: string, output: string[] = new Array<string>()) => {
+    while (content.length > 0) {
+      const chunk = content.slice(0, 5);
+      content = content.slice(5);
+      await collectChunks(filter.transform(chunk), output);
+    }
+    await collectChunks(filter.end(), output);
+
+    return output;
+  };
+
+  it('should process a single line', async () => {
+    const output = await collectChunks(filter.transform('graph TD'));
+    await collectChunks(filter.end(), output);
+
+    expect(output).toEqual(['graph TD']);
+  });
+
+  it('should process mixed content including a valid diagram', async () => {
+    let content = 'a diagram\n```mermaid\ngraph TD\n  A --> B\n````';
+    const output = await transformContent(content);
+    expect(output).toEqual(['a diagram', '\n```mermaid\ngraph TD\n  A --> B\n```\n']);
+  });
+
+  describe('when fed an invalid diagram', () => {
+    const validDiagram = `\`\`\`mermaid
+graph TD;
+  A-->B;
+  A-->C;
+  B-->D;
+  C-->D;
+\`\`\`
+`;
+
+    const invalidDiagram = `\`\`\`mermaid
+graph TD;
+  A--&gt;B;
+  A--&gt;C;
+  B-->D;
+  C--D;
+\`\`\`
+`;
+
+    describe('when the diagram is not repairable', () => {
+      it('should pass the diagram through', async () => {
+        repairDiagram.mockResolvedValue(trimFences(invalidDiagram));
+        const output = await transformContent(invalidDiagram);
+        expect(output.join('')).toEqual(`
+\`\`\`text
+${trimFences(invalidDiagram)}
+\`\`\`
+`);
+      });
+    });
+
+    describe('when the diagram is repairable', () => {
+      it('should repair the diagram', async () => {
+        repairDiagram.mockResolvedValue(trimFences(validDiagram));
+        const output = await transformContent(invalidDiagram);
+        expect(output.join('')).toEqual(`
+\`\`\`mermaid
+${trimFences(validDiagram)}
+\`\`\`
+`);
+      });
+    });
+  });
+});

--- a/packages/navie/test/lib/mermaid-fixer.spec.ts
+++ b/packages/navie/test/lib/mermaid-fixer.spec.ts
@@ -1,0 +1,35 @@
+import InteractionHistory from '../../src/interaction-history';
+import MermaidFixer from '../../src/lib/mermaid-fixer';
+import CompletionService, { Completion, Usage } from '../../src/services/completion-service';
+
+describe('MermaidFixer', () => {
+  let mermaidFixer: MermaidFixer;
+  let history: InteractionHistory;
+  let completion: CompletionService;
+  let complete: jest.Mock;
+
+  beforeEach(() => {
+    history = new InteractionHistory();
+    complete = jest.fn();
+    completion = {
+      complete,
+    } as unknown as CompletionService;
+    mermaidFixer = new MermaidFixer(history, completion);
+  });
+
+  it('should repair a diagram', async () => {
+    const diagram = 'graph TD\n  A --> B';
+    const error = 'Error: Something went wrong';
+    const repairedDiagram = 'graph TD\n  A --> B';
+
+    const completer = async function* () {
+      yield `graph TD\n  A --> B`;
+    };
+
+    complete.mockImplementation(completer);
+
+    const result = await mermaidFixer.repairDiagram(diagram, error);
+
+    expect(result).toEqual(repairedDiagram);
+  });
+});

--- a/packages/navie/test/lib/mermaid-validator.spec.ts
+++ b/packages/navie/test/lib/mermaid-validator.spec.ts
@@ -1,0 +1,80 @@
+import MermaidValidator from '../../src/lib/mermaid-validator';
+
+describe('MermaidValidator', () => {
+  test('should validate a correct Mermaid diagram', async () => {
+    const validDiagram = `
+      graph TD;
+        A-->B;
+        A-->C;
+        B-->D;
+        C-->D;
+    `;
+
+    const validator = new MermaidValidator(validDiagram.trim());
+    const result = await validator.validate();
+
+    expect(result.valid).toBe(true);
+    expect(result.error).toBeUndefined();
+  });
+
+  test('should invalidate an incorrect Mermaid diagram', async () => {
+    const invalidDiagram = `
+      graph TD;
+        A--&gt;B;
+        A--&gt;C;
+        B-->D;
+        C--D;
+    `;
+
+    const validator = new MermaidValidator(invalidDiagram.trim());
+    const result = await validator.validate();
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch('Parse error on line 2:');
+  });
+
+  test('should handle empty diagram', async () => {
+    const emptyDiagram = '';
+
+    const validator = new MermaidValidator(emptyDiagram);
+    const result = await validator.validate();
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  test('should handle syntax error in Mermaid diagram', async () => {
+    const invalidSyntaxDiagram = `
+      graph TD
+        A->>B
+        A->>C
+        B-->D
+        C->D
+    `;
+
+    const validator = new MermaidValidator(invalidSyntaxDiagram.trim());
+    const result = await validator.validate();
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch('Parse error on line 2:');
+  });
+
+  test('may produce an internal error', async () => {
+    const complexValidDiagram = `
+      graph LR
+        subgraph one
+          a1-->a2
+        end
+        subgraph two
+          b1-->b2
+        end
+        a1-->b1
+    `;
+
+    const validator = new MermaidValidator(complexValidDiagram.trim());
+    const result = await validator.validate();
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(`vN.sanitize is not a function`);
+  });
+});

--- a/packages/navie/test/services/agent-selection-service.spec.ts
+++ b/packages/navie/test/services/agent-selection-service.spec.ts
@@ -1,9 +1,11 @@
+import DiagramAgent from '../../src/agents/diagram-agent';
 import ExplainAgent from '../../src/agents/explain-agent';
 import HelpAgent from '../../src/agents/help-agent';
 import InteractionHistory, { AgentSelectionEvent } from '../../src/interaction-history';
 import { UserOptions } from '../../src/lib/parse-options';
 import AgentSelectionService from '../../src/services/agent-selection-service';
 import ApplyContextService from '../../src/services/apply-context-service';
+import CompletionService from '../../src/services/completion-service';
 import LookupContextService from '../../src/services/lookup-context-service';
 import TechStackService from '../../src/services/tech-stack-service';
 import VectorTermsService from '../../src/services/vector-terms-service';
@@ -14,6 +16,7 @@ describe('AgentSelectionService', () => {
   let lookupContextService: LookupContextService;
   let applyContextService: ApplyContextService;
   let techStackService: TechStackService;
+  let completionService: CompletionService;
   let genericQuestion = 'How does user management work?';
   let helpAgentQueston = '@help How to make a diagram?';
   const emptyUserOptions = new UserOptions(new Map());
@@ -24,7 +27,8 @@ describe('AgentSelectionService', () => {
       vectorTermsService,
       lookupContextService,
       applyContextService,
-      techStackService
+      techStackService,
+      completionService
     );
   }
 
@@ -34,6 +38,7 @@ describe('AgentSelectionService', () => {
     lookupContextService = {} as LookupContextService;
     applyContextService = {} as ApplyContextService;
     techStackService = {} as TechStackService;
+    completionService = {} as CompletionService;
   });
 
   const agentSelectionEvent = (): AgentSelectionEvent | undefined =>
@@ -101,6 +106,46 @@ describe('AgentSelectionService', () => {
         );
         expect(agent).toBeInstanceOf(ExplainAgent);
       });
+    });
+  });
+
+  describe('when the question is classified as generate-diagram', () => {
+    it('creates a Diagram agent', () => {
+      const { agent } = buildAgentSelectionService().selectAgent(
+        genericQuestion,
+        [
+          {
+            name: 'generate-diagram',
+            weight: 'high',
+          },
+        ],
+        emptyUserOptions
+      );
+      expect(agent).toBeInstanceOf(DiagramAgent);
+    });
+  });
+
+  describe('when the question is classified as explain', () => {
+    it('creates an Explain agent even if other classifiers are present', () => {
+      const { agent } = buildAgentSelectionService().selectAgent(
+        genericQuestion,
+        [
+          {
+            name: 'generate-diagram',
+            weight: 'high',
+          },
+          {
+            name: 'help-with-appmap',
+            weight: 'high',
+          },
+          {
+            name: 'explain',
+            weight: 'high',
+          },
+        ],
+        emptyUserOptions
+      );
+      expect(agent).toBeInstanceOf(ExplainAgent);
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -469,6 +469,7 @@ __metadata:
     jest: ^29.5.0
     js-yaml: ^4.1.0
     langchain: ^0.1.25
+    mermaid: ^9
     openai: ^4.28.0
     ts-jest: ^29.0.5
     ts-node: ^10.4.0
@@ -5225,6 +5226,13 @@ __metadata:
   version: 0.2.3
   resolution: "@bcoe/v8-coverage@npm:0.2.3"
   checksum: 850f9305536d0f2bd13e9e0881cb5f02e4f93fad1189f7b2d4bebf694e3206924eadee1068130d43c11b750efcc9405f88a8e42ef098b6d75239c0f047de1a27
+  languageName: node
+  linkType: hard
+
+"@braintree/sanitize-url@npm:^6.0.0":
+  version: 6.0.4
+  resolution: "@braintree/sanitize-url@npm:6.0.4"
+  checksum: f5ec6048973722ea1c46ae555d2e9eb848d7fa258994f8ea7d6db9514ee754ea3ef344ef71b3696d486776bcb839f3124e79f67c6b5b2814ed2da220b340627c
   languageName: node
   linkType: hard
 
@@ -17997,6 +18005,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cose-base@npm:^1.0.0":
+  version: 1.0.3
+  resolution: "cose-base@npm:1.0.3"
+  dependencies:
+    layout-base: ^1.0.0
+  checksum: 3f3d592316df74adb215ca91e430f1c22b6e890bc0025b32ae1f6464c73fdb9614816cb40a8d38b40c6a3e9e7b8c64eda90d53fb9a4a6948abec17dad496f30b
+  languageName: node
+  linkType: hard
+
+"cose-base@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "cose-base@npm:2.2.0"
+  dependencies:
+    layout-base: ^2.0.0
+  checksum: 2e694f340bf216c71fc126d237578a4168e138720011d0b48c88bf9bfc7fd45f912eff2c603ef3d1307d6e3ce6f465ed382285a764a3a6620db590c5457d2557
+  languageName: node
+  linkType: hard
+
 "cosmiconfig@npm:8.0.0":
   version: 8.0.0
   resolution: "cosmiconfig@npm:8.0.0"
@@ -18614,6 +18640,35 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cytoscape-cose-bilkent@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "cytoscape-cose-bilkent@npm:4.1.0"
+  dependencies:
+    cose-base: ^1.0.0
+  peerDependencies:
+    cytoscape: ^3.2.0
+  checksum: bea6aa139e21bf4135b01b99f8778eed061e074d1a1689771597e8164a999d66f4075d46be584b0a88a5447f9321f38c90c8821df6a9322faaf5afebf4848d97
+  languageName: node
+  linkType: hard
+
+"cytoscape-fcose@npm:^2.1.0":
+  version: 2.2.0
+  resolution: "cytoscape-fcose@npm:2.2.0"
+  dependencies:
+    cose-base: ^2.2.0
+  peerDependencies:
+    cytoscape: ^3.2.0
+  checksum: 94ffe6f131f9c08c2a0a7a6ce1c6c5e523a395bf8d84eba6d4a5f85e23f33788ea3ff807540861a5f78a6914a27729e06a7e6f66784f4f28ea1c030acf500121
+  languageName: node
+  linkType: hard
+
+"cytoscape@npm:^3.23.0":
+  version: 3.30.0
+  resolution: "cytoscape@npm:3.30.0"
+  checksum: 9bce0220de4aa39da788aa892fc9cf8c7954fa2b6157f7496d16afac75c0332470b2285230474bc330dcbf3393f3823218be79e8c09944b72d411fd351ac0c2a
+  languageName: node
+  linkType: hard
+
 "d3-array@npm:2 - 3, d3-array@npm:2.10.0 - 3, d3-array@npm:2.5.0 - 3, d3-array@npm:3, d3-array@npm:^3.1.1, d3-array@npm:^3.2.0":
   version: 3.2.3
   resolution: "d3-array@npm:3.2.3"
@@ -18910,6 +18965,44 @@ __metadata:
   languageName: node
   linkType: hard
 
+"d3@npm:^7.4.0, d3@npm:^7.8.2":
+  version: 7.9.0
+  resolution: "d3@npm:7.9.0"
+  dependencies:
+    d3-array: 3
+    d3-axis: 3
+    d3-brush: 3
+    d3-chord: 3
+    d3-color: 3
+    d3-contour: 4
+    d3-delaunay: 6
+    d3-dispatch: 3
+    d3-drag: 3
+    d3-dsv: 3
+    d3-ease: 3
+    d3-fetch: 3
+    d3-force: 3
+    d3-format: 3
+    d3-geo: 3
+    d3-hierarchy: 3
+    d3-interpolate: 3
+    d3-path: 3
+    d3-polygon: 3
+    d3-quadtree: 3
+    d3-random: 3
+    d3-scale: 4
+    d3-scale-chromatic: 3
+    d3-selection: 3
+    d3-shape: 3
+    d3-time: 3
+    d3-time-format: 4
+    d3-timer: 3
+    d3-transition: 3
+    d3-zoom: 3
+  checksum: 1c0e9135f1fb78aa32b187fafc8b56ae6346102bd0e4e5e5a5339611a51e6038adbaa293fae373994228100eddd87320e930b1be922baeadc07c9fd43d26d99b
+  languageName: node
+  linkType: hard
+
 "d3@npm:^7.8.4":
   version: 7.8.4
   resolution: "d3@npm:7.8.4"
@@ -18945,6 +19038,16 @@ __metadata:
     d3-transition: 3
     d3-zoom: 3
   checksum: 8dfea4d026e5597ab9c46035df7f0ca4f3891b2b52b21b181bd8660fc61d85f0bbe3cc2b8f1e922978084156cb017cbbfa350a8e42349310642023a9f1517471
+  languageName: node
+  linkType: hard
+
+"dagre-d3-es@npm:7.0.9":
+  version: 7.0.9
+  resolution: "dagre-d3-es@npm:7.0.9"
+  dependencies:
+    d3: ^7.8.2
+    lodash-es: ^4.17.21
+  checksum: 5f24ad9558e84066e70cfa6979320d93079979ac8b0a3b033e5330742aeeba74e205f66794ab6e0a82354b061a4e29c10a291590d7b2cf82b5780fab5443f5ba
   languageName: node
   linkType: hard
 
@@ -19018,6 +19121,13 @@ __metadata:
   version: 1.10.7
   resolution: "dayjs@npm:1.10.7"
   checksum: a0a4ca95abaa03d0702161dc2c35d16121188e342f5052b9c61cdf784dab68af766f477c04f87f71c6af666fd4d13db9b9853b87265850d6093b7b04e1bb1cd7
+  languageName: node
+  linkType: hard
+
+"dayjs@npm:^1.11.7":
+  version: 1.11.11
+  resolution: "dayjs@npm:1.11.11"
+  checksum: 84788275aad8a87fee4f1ce4be08861df29687aae6b7b43dd65350118a37dda56772a3902f802cb2dc651dfed447a5a8df62d88f0fb900dba8333e411190a5d5
   languageName: node
   linkType: hard
 
@@ -19879,6 +19989,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dompurify@npm:2.4.3":
+  version: 2.4.3
+  resolution: "dompurify@npm:2.4.3"
+  checksum: b440981f2a38cada2085759cc3d1e2f94571afc34343d011a8a6aa1ad91ae6abf651adbfa4994b0e2283f0ce81f7891cdb04b67d0b234c8d190cb70e9691f026
+  languageName: node
+  linkType: hard
+
 "dompurify@npm:^3.0.6":
   version: 3.0.6
   resolution: "dompurify@npm:3.0.6"
@@ -20106,6 +20223,13 @@ __metadata:
   version: 1.4.615
   resolution: "electron-to-chromium@npm:1.4.615"
   checksum: 9ffb1d0dac11c629bd8aa38efa7d2e3f41de943cf81fb41ab05e960e954c464c168d1f2f7e571813805e85b895279f2882bcafa551a2f23089646008d7a5bd06
+  languageName: node
+  linkType: hard
+
+"elkjs@npm:^0.8.2":
+  version: 0.8.2
+  resolution: "elkjs@npm:0.8.2"
+  checksum: ed615c485fa4ac1e858af509df24fdc9f61f2c6576df5f79f6a31c733fda69f235f53cd36af037aa9d2b8a935cb4f823fbd89d784b67f6e51be5100306ea1b39
   languageName: node
   linkType: hard
 
@@ -28886,6 +29010,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"khroma@npm:^2.0.0":
+  version: 2.1.0
+  resolution: "khroma@npm:2.1.0"
+  checksum: b34ba39d3a9a52d388110bded8cb1c12272eb69c249d8eb26feab12d18a96a9bc4ceec4851d2afa43de4569f7d5ea78fa305965a3d0e96a38e02fe77c53677da
+  languageName: node
+  linkType: hard
+
 "killable@npm:^1.0.1":
   version: 1.0.1
   resolution: "killable@npm:1.0.1"
@@ -29187,6 +29318,20 @@ __metadata:
     picocolors: ^1.0.0
     shell-quote: ^1.6.1
   checksum: 64fec34e5c7b2a26ca048c7ed79f51b662684221259de88d8c592c65691bb84ed80310cb0f6a36e423883022bf680efb69c6ee29089680b523d013c6826c1116
+  languageName: node
+  linkType: hard
+
+"layout-base@npm:^1.0.0":
+  version: 1.0.2
+  resolution: "layout-base@npm:1.0.2"
+  checksum: e4c312765ac4fa13b49c940e701461309c7a0aa07f784f81d31f626b945dced90a8abf83222388a5af16b7074271f745501a90ef5a3af676abb2e7eb16d55b2e
+  languageName: node
+  linkType: hard
+
+"layout-base@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "layout-base@npm:2.0.1"
+  checksum: ef93baf044f67c3680f4f3a6d628bf4c7faba0f70f3e0abb16e4811bed087045208560347ca749e123d169cbf872505ad84e11fb21b0be925997227e042c7f43
   languageName: node
   linkType: hard
 
@@ -29595,6 +29740,13 @@ __metadata:
   dependencies:
     p-locate: ^6.0.0
   checksum: c1b653bdf29beaecb3d307dfb7c44d98a2a98a02ebe353c9ad055d1ac45d6ed4e1142563d222df9b9efebc2bcb7d4c792b507fad9e7150a04c29530b7db570f8
+  languageName: node
+  linkType: hard
+
+"lodash-es@npm:^4.17.21":
+  version: 4.17.21
+  resolution: "lodash-es@npm:4.17.21"
+  checksum: 05cbffad6e2adbb331a4e16fbd826e7faee403a1a04873b82b42c0f22090f280839f85b95393f487c1303c8a3d2a010048bf06151a6cbe03eee4d388fb0a12d2
   languageName: node
   linkType: hard
 
@@ -30382,6 +30534,30 @@ __metadata:
   version: 4.3.9
   resolution: "meriyah@npm:4.3.9"
   checksum: eb43c4ca2295cbdaa6f4d13412f42fa97c968cbb3171899b1afcf5419715433b2906558aaabd08660592c5731d80341d81ce7bea7fd562942677c15a7bcbea4a
+  languageName: node
+  linkType: hard
+
+"mermaid@npm:^9":
+  version: 9.4.3
+  resolution: "mermaid@npm:9.4.3"
+  dependencies:
+    "@braintree/sanitize-url": ^6.0.0
+    cytoscape: ^3.23.0
+    cytoscape-cose-bilkent: ^4.1.0
+    cytoscape-fcose: ^2.1.0
+    d3: ^7.4.0
+    dagre-d3-es: 7.0.9
+    dayjs: ^1.11.7
+    dompurify: 2.4.3
+    elkjs: ^0.8.2
+    khroma: ^2.0.0
+    lodash-es: ^4.17.21
+    non-layered-tidy-tree-layout: ^2.0.2
+    stylis: ^4.1.2
+    ts-dedent: ^2.2.0
+    uuid: ^9.0.0
+    web-worker: ^1.2.0
+  checksum: 9e29177f289cc268ea4a2ca7a45ec0ca06f678007eae15a7cd54c682148a71367e861d2c9c0afa9f7474da154d9920524e59722186820e9bc0d79989305a7064
   languageName: node
   linkType: hard
 
@@ -31563,6 +31739,13 @@ __metadata:
   version: 2.0.10
   resolution: "node-releases@npm:2.0.10"
   checksum: d784ecde25696a15d449c4433077f5cce620ed30a1656c4abf31282bfc691a70d9618bae6868d247a67914d1be5cc4fde22f65a05f4398cdfb92e0fc83cadfbc
+  languageName: node
+  linkType: hard
+
+"non-layered-tidy-tree-layout@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "non-layered-tidy-tree-layout@npm:2.0.2"
+  checksum: 5defc1c459001b22816a4fb8b86259b9b76e7f3090df576122a41c760133ab2061934cacd6f176c98c2ae4fee3879b97941e8897e8882985cbfe830f155cd158
   languageName: node
   linkType: hard
 
@@ -38378,6 +38561,13 @@ resolve@1.1.7:
   languageName: node
   linkType: hard
 
+"stylis@npm:^4.1.2":
+  version: 4.3.2
+  resolution: "stylis@npm:4.3.2"
+  checksum: 0faa8a97ff38369f47354376cd9f0def9bf12846da54c28c5987f64aaf67dcb6f00dce88a8632013bfb823b2c4d1d62a44f4ac20363a3505a7ab4e21b70179fc
+  languageName: node
+  linkType: hard
+
 "stylus@npm:^0.54.5":
   version: 0.54.8
   resolution: "stylus@npm:0.54.8"
@@ -40990,6 +41180,13 @@ typescript@~4.4.3:
   version: 3.2.1
   resolution: "web-streams-polyfill@npm:3.2.1"
   checksum: b119c78574b6d65935e35098c2afdcd752b84268e18746606af149e3c424e15621b6f1ff0b42b2676dc012fc4f0d313f964b41a4b5031e525faa03997457da02
+  languageName: node
+  linkType: hard
+
+"web-worker@npm:^1.2.0":
+  version: 1.3.0
+  resolution: "web-worker@npm:1.3.0"
+  checksum: ed1f869aefd1d81a43d0fbfe7b315a65beb6d7d2486b378c436a7047eed4216be34b2e6afca738b6fa95d016326b765f5f816355db33267dbf43b2b8a1837c0c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This change introduces a short conversational context window with the goal of improving the classification of the latest user question.

From my own observation, classifications tend to stick around given the inclusion of the entire user message history despite the intent of the most recent prompt. E.g., a user who asked for a diagram will repeatedly be classified as `diagram`, causing the diagram agent to respond to inquiries.