### PR TITLE
fix: Unsupported language install guide dead end

### DIFF
--- a/packages/components/src/components/install-guide/ProjectPickerRow.vue
+++ b/packages/components/src/components/install-guide/ProjectPickerRow.vue
@@ -229,26 +229,7 @@
         </template>
       </template>
       <template v-else>
-        <template v-if="!languageSupported">
-          <p>
-            This project does not meet all the requirements to create AppMaps. AppMap currently
-            supports the following languages:
-          </p>
-          <ul class="support-list">
-            <li><strong>Ruby</strong></li>
-            <li><strong>Python</strong></li>
-            <li><strong>JavaScript</strong></li>
-            <li><strong>Java</strong></li>
-          </ul>
-        </template>
-        <template v-else>
-          <p class="mb20">
-            We weren't able to find a supported web or test framework within this project. Please
-            visit
-            <a :href="documentationUrl">our {{ language.name }} documentation</a> for more
-            information.
-          </p>
-        </template>
+        <v-unsupported-project />
       </template>
     </div>
   </v-accordion>
@@ -273,6 +254,7 @@ import VLoaderIcon from '@/assets/eva_loader-outline.svg';
 import VFailureIcon from '@/assets/exclamation-circle.svg';
 import VSuccessIcon from '@/assets/check.svg';
 import VFlashMessage from '@/components/FlashMessage.vue';
+import VUnsupportedProject from '@/components/install-guide/UnsupportedProject.vue';
 
 import StatusState from '@/components/mixins/statusState';
 
@@ -303,6 +285,7 @@ export default {
     VFailureIcon,
     VSuccessIcon,
     VFlashMessage,
+    VUnsupportedProject,
   },
   mixins: [StatusState],
   props: {

--- a/packages/components/src/components/install-guide/UnsupportedProject.vue
+++ b/packages/components/src/components/install-guide/UnsupportedProject.vue
@@ -1,0 +1,66 @@
+<template>
+  <div>
+    <template v-if="!languageSupported">
+      <p>
+        This project does not meet all the requirements to create AppMaps. AppMap currently supports
+        the following languages:
+      </p>
+      <ul class="support-list">
+        <li><strong>Ruby</strong></li>
+        <li><strong>Python</strong></li>
+        <li><strong>JavaScript</strong></li>
+        <li><strong>Java</strong></li>
+      </ul>
+      <p data-cy="inform-user">
+        While AppMap data cannot be recorded for this project,
+        <a href="#" @click.prevent="$root.$emit('open-navie')" data-cy="open-navie"> Navie </a>
+        can still search through the code available in your project.
+      </p>
+    </template>
+    <template v-else>
+      <p class="mb20">
+        We weren't able to find a supported web or test framework within this project. Please visit
+        <a :href="documentationUrl">our {{ language.name }} documentation</a> for more information.
+      </p>
+    </template>
+  </div>
+</template>
+
+<script>
+import { isFeatureSupported } from '@/lib/project';
+import { getAgentDocumentationUrl } from '@/lib/documentation';
+
+export default {
+  name: 'unsupported-project',
+  props: {
+    language: Object,
+  },
+  computed: {
+    languageSupported() {
+      return isFeatureSupported(this.language);
+    },
+    documentationUrl() {
+      return getAgentDocumentationUrl(this.language && this.language.name);
+    },
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.support-list {
+  margin: 1rem 0;
+  list-style-position: inside;
+  ul {
+    margin-left: 1rem;
+    margin-top: 0;
+    li {
+      strong {
+        color: #939fb1;
+      }
+    }
+  }
+  strong {
+    color: #939fb1;
+  }
+}
+</style>

--- a/packages/components/src/pages/install-guide/RecordAppMaps.vue
+++ b/packages/components/src/pages/install-guide/RecordAppMaps.vue
@@ -5,7 +5,7 @@
         <h1 data-cy="title">Record AppMaps</h1>
       </header>
       <main>
-        <article>
+        <article v-if="supported">
           <v-status
             next-step="Explore AppMaps"
             :status-states="statusStates"
@@ -77,8 +77,9 @@
             </p>
           </template>
         </article>
+        <v-unsupported-project v-if="!supported" />
       </main>
-      <v-navigation-buttons :first="first" :last="last" :complete="complete" />
+      <v-navigation-buttons v-if="supported" :first="first" :last="last" :complete="complete" />
     </section>
   </QuickstartLayout>
 </template>
@@ -94,8 +95,9 @@ import VRecordInstructions_JavaScript from '@/components/install-guide/record-in
 import Navigation from '@/components/mixins/navigation';
 import VStatus from '@/components/install-guide/Status.vue';
 import StatusState from '@/components/mixins/statusState.js';
+import VUnsupportedProject from '@/components/install-guide/UnsupportedProject.vue';
 
-import { isFeatureSupported } from '@/lib/project';
+import { isFeatureSupported, isProjectSupported } from '@/lib/project';
 import { DISABLE_PENDING_RECORD_STATE } from '@/lib/featureFlags';
 
 export default {
@@ -110,6 +112,7 @@ export default {
     VRecordInstructions_Java,
     VRecordInstructions_JavaScript,
     VStatus,
+    VUnsupportedProject,
   },
 
   mixins: [Navigation, StatusState],
@@ -191,6 +194,14 @@ export default {
     },
     testFrameworkSupported() {
       return isFeatureSupported(this.testFramework);
+    },
+    supported() {
+      return isProjectSupported({
+        name: this.projectName,
+        score: this.project?.score ?? 0,
+        webFramework: this.webFramework,
+        testFramework: this.testFramework,
+      });
     },
     automaticRecordingPrompts() {
       const prompts = [];

--- a/packages/components/tests/unit/RecordAppMaps.spec.js
+++ b/packages/components/tests/unit/RecordAppMaps.spec.js
@@ -4,7 +4,7 @@ import RecordAppMaps from '@/pages/install-guide/RecordAppMaps.vue';
 describe('RecordAppMaps.vue', () => {
   it('contains a link to the documentation by default', () => {
     const wrapper = shallowMount(RecordAppMaps, {
-      propsData: { editor: 'vscode', project: { language: 'java' } },
+      propsData: { editor: 'vscode', project: { language: 'java', name: 'hello-world', score: 3 } },
     });
     expect(wrapper.find('a[href]').text()).toBe('documentation.');
   });

--- a/packages/components/tests/unit/UnsupportedProject.spec.js
+++ b/packages/components/tests/unit/UnsupportedProject.spec.js
@@ -1,0 +1,17 @@
+import { shallowMount } from '@vue/test-utils';
+import UnsupportedProject from '@/components/install-guide/UnsupportedProject.vue';
+
+describe('UnsupportedProject.vue', () => {
+  it('user is informed of the state with a link to Navie', () => {
+    const wrapper = shallowMount(UnsupportedProject, {
+      propsData: { editor: 'vscode', project: { language: 'C#' } },
+    });
+    const informUserMessage = wrapper.find('[data-cy="inform-user"]').text();
+    expect(informUserMessage).toContain('While AppMap data cannot be recorded for this project,');
+    expect(informUserMessage).toContain('Navie');
+    expect(informUserMessage).toContain(
+      'can still search through the code available in your project.'
+    );
+    expect(wrapper.find('a[href]').text()).toBe('Navie');
+  });
+});


### PR DESCRIPTION
Fixes #1883.

- Adds an explanation to "Add AppMap to your project" and "Record AppMaps" steps to the installation guide when the project/language is unsupported.
- Adds a link to Navie inside this explanation.
- Hides irrelevant parts of the UI in "Record AppMaps" in unsupported projects/languages.
- Extracts the displayed unsuppported information as a separate Vue component to use it in both "Add AppMaps to your project" and "Record AppMaps" steps.
- Adds a test for the new UnsupportedProject.vue component.

Before
![image](https://github.com/user-attachments/assets/d0d0b640-15ec-4497-95f9-7569aeb96376)

![image](https://github.com/user-attachments/assets/5367858f-3b46-43eb-8253-51c79191b2d8)

After
<img width="724" alt="image" src="https://github.com/user-attachments/assets/79a00935-ffe6-43f1-9cb3-2ac33c16a673">

<img width="714" alt="image" src="https://github.com/user-attachments/assets/c71b2294-18c7-4437-8339-36e97851b4b8">


