### PR TITLE
fix: conditionally create sql_warnings.txt

### DIFF
--- a/packages/cli/src/lib/sqlErrorLog.ts
+++ b/packages/cli/src/lib/sqlErrorLog.ts
@@ -8,13 +8,19 @@ let SqlParseErrorFileOpened = false;
 async function writeErrorToFile(error: ParseError) {
   const flags = SqlParseErrorFileOpened ? 'a' : 'w';
   SqlParseErrorFileOpened = true;
-  open(SqlParseErrorFileName, flags).then((handle) => {
-    handle.write([String(error), ''].join('\n')).finally(handle.close.bind(handle));
-  });
+  const msg = [String(error), ''].join('\n');
+  try {
+    open(SqlParseErrorFileName, flags).then((handle) => {
+      handle.write(msg).finally(handle.close.bind(handle));
+    });
+  } catch (e) {
+    console.warn(e);
+    console.warn(`SQL Error: ${msg}`);
+  }
 }
 
 export default function sqlErrorLog(parseError: ParseError) {
-  if (!SqlErrors.has(parseError.sql)) {
+  if (process.env['APPMAP_SQL_WARNING'] && !SqlErrors.has(parseError.sql)) {
     writeErrorToFile(parseError);
     SqlErrors.add(parseError.sql);
   }

--- a/packages/cli/tests/unit/lib/sqlErrorLog.spec.ts
+++ b/packages/cli/tests/unit/lib/sqlErrorLog.spec.ts
@@ -1,0 +1,65 @@
+import * as fs from 'fs/promises';
+
+import sqlErrorLog from '../../../src/lib/sqlErrorLog';
+
+jest.mock('fs/promises');
+interface MockFd extends fs.FileHandle {
+  write: jest.Mock;
+  close: jest.Mock;
+}
+
+describe('sqlErrorLog', () => {
+  const parseError = {
+    sql: '',
+    name: 'ParseError',
+    message: 'failed parsing SQL',
+    toString() {
+      return this.message;
+    },
+  };
+
+  beforeEach(() => {
+    const mockfd: Partial<MockFd> = {
+      write: jest.fn().mockResolvedValue({}),
+      close: jest.fn().mockResolvedValue(undefined),
+    };
+
+    jest.mocked(fs.open).mockResolvedValue(mockfd as fs.FileHandle);
+    console.warn = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+    delete process.env.APPMAP_SQL_WARNING;
+  });
+
+  it('should write error to file when APPMAP_SQL_WARNING is set', async () => {
+    process.env.APPMAP_SQL_WARNING = '1';
+    parseError.sql = 'select from TABLE1';
+    sqlErrorLog(parseError);
+
+    expect(fs.open).toHaveBeenCalledWith('sql_warning.txt', 'w');
+    expect((await (fs.open as jest.Mock).mock.results[0].value).write).toHaveBeenCalledWith(
+      expect.stringContaining(parseError.message)
+    );
+  });
+
+  it('should not attempt to write to file when APPMAP_SQL_WARNING is not set', async () => {
+    sqlErrorLog(parseError);
+    expect(fs.open).not.toHaveBeenCalled();
+  });
+
+  it('should log warning to console if file operations fail', async () => {
+    process.env.APPMAP_SQL_WARNING = '1';
+    jest.mocked(fs.open).mockImplementationOnce(() => {
+      throw new Error('Mocked file open error');
+    });
+
+    parseError.sql = 'select from TABLE2';
+    sqlErrorLog(parseError);
+
+    expect(fs.open).toHaveBeenCalled();
+    expect(console.warn).toHaveBeenCalledWith(expect.any(Error));
+    expect(console.warn).toHaveBeenCalledWith(`SQL Error: ${parseError.message}\n`);
+  });
+});

--- a/packages/scanner/src/sqlWarning.ts
+++ b/packages/scanner/src/sqlWarning.ts
@@ -8,12 +8,22 @@ let SqlParseErrorFileOpened = false;
 async function writeErrorToFile(error: ParseError) {
   const flags = SqlParseErrorFileOpened ? 'a' : 'w';
   SqlParseErrorFileOpened = true;
-  open(SqlParseErrorFileName, flags).then((handle) => {
-    handle.write([error.toString(), ''].join('\n')).finally(handle.close.bind(handle));
-  });
+  const msg = [String(error), ''].join('\n');
+  try {
+    open(SqlParseErrorFileName, flags).then((handle) => {
+      handle.write([error.toString(), ''].join('\n')).finally(handle.close.bind(handle));
+    });
+  } catch (e) {
+    console.warn(e);
+    console.warn(`SQL Error: ${msg}`);
+  }
 }
 
 export default function sqlWarning(parseError: ParseError): void {
+  if (!process.env['APPMAP_SQL_WARNING']) {
+    return;
+  }
+
   if (!SqlErrors.has(parseError.sql)) {
     writeErrorToFile(parseError);
     SqlErrors.add(parseError.sql);

--- a/packages/scanner/test/sqlWarning.spec.ts
+++ b/packages/scanner/test/sqlWarning.spec.ts
@@ -1,0 +1,65 @@
+import * as fs from 'fs/promises';
+
+import sqlWarning from '../src/sqlWarning';
+
+jest.mock('fs/promises');
+interface MockFd extends fs.FileHandle {
+  write: jest.Mock;
+  close: jest.Mock;
+}
+
+describe('sqlWarning', () => {
+  const parseError = {
+    sql: '',
+    name: 'ParseError',
+    message: 'failed parsing SQL',
+    toString() {
+      return this.message;
+    },
+  };
+
+  beforeEach(() => {
+    const mockfd: Partial<MockFd> = {
+      write: jest.fn().mockResolvedValue({}),
+      close: jest.fn().mockResolvedValue(undefined),
+    };
+
+    jest.mocked(fs.open).mockResolvedValue(mockfd as fs.FileHandle);
+    console.warn = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+    delete process.env.APPMAP_SQL_WARNING;
+  });
+
+  it('should write error to file when APPMAP_SQL_WARNING is set', async () => {
+    process.env.APPMAP_SQL_WARNING = '1';
+    parseError.sql = 'select from TABLE1';
+    sqlWarning(parseError);
+
+    expect(fs.open).toHaveBeenCalledWith('sql_warning.txt', 'w');
+    expect((await (fs.open as jest.Mock).mock.results[0].value).write).toHaveBeenCalledWith(
+      expect.stringContaining(parseError.message)
+    );
+  });
+
+  it('should not attempt to write to file when APPMAP_SQL_WARNING is not set', async () => {
+    sqlWarning(parseError);
+    expect(fs.open).not.toHaveBeenCalled();
+  });
+
+  it('should log warning to console if file operations fail', async () => {
+    process.env.APPMAP_SQL_WARNING = '1';
+    jest.mocked(fs.open).mockImplementationOnce(() => {
+      throw new Error('Mocked file open error');
+    });
+
+    parseError.sql = 'select from TABLE2';
+    sqlWarning(parseError);
+
+    expect(fs.open).toHaveBeenCalled();
+    expect(console.warn).toHaveBeenCalledWith(expect.any(Error));
+    expect(console.warn).toHaveBeenCalledWith(`SQL Error: ${parseError.message}\n`);
+  });
+});


### PR DESCRIPTION
Only create sql_warnings.txt if the env var APPMAP_SQL_WARNING is set. Also, if it is created, catch any errors and write them to the console.

Fixes #1902 