### PR TITLE
fix: "New chat" button doesn't destructively clear the chat anymore

### DIFF
--- a/packages/components/src/components/chat/Chat.vue
+++ b/packages/components/src/components/chat/Chat.vue
@@ -6,11 +6,12 @@
         <div id="header-navie-logo">Navie</div>
       </div>
       <v-button
+        v-if="openNewChat"
         data-cy="new-chat-btn"
         class="clear"
         size="small"
         kind="ghost"
-        @click.native="clear"
+        @click.native="openNewChat"
       >
         New chat
       </v-button>
@@ -151,6 +152,9 @@ export default {
     VButton,
   },
   props: {
+    openNewChat: {
+      type: Function,
+    },
     // Initial question to ask
     question: {
       type: String,
@@ -287,12 +291,6 @@ export default {
     onAck(_messageId: string, threadId: string) {
       this.setAuthorized(true);
       this.threadId = threadId;
-    },
-    clear() {
-      this.threadId = undefined;
-      this.messages.splice(0);
-      this.autoScrollTop = 0;
-      this.$emit('clear');
     },
     scrollToBottom() {
       // Allow one tick to progress to allow any DOM changes to be applied

--- a/packages/components/src/pages/ChatSearch.vue
+++ b/packages/components/src/pages/ChatSearch.vue
@@ -9,9 +9,9 @@
       <v-chat
         class="chat-search-chat"
         ref="vchat"
+        :open-new-chat="openNewChat"
         :send-message="sendMessage"
         :status-label="searchStatusLabel"
-        @clear="clear"
         :question="question"
         @isChatting="setIsChatting"
         :input-placeholder="inputPlaceholder"
@@ -65,6 +65,9 @@ export default {
   },
   mixins: [authenticatedClient],
   props: {
+    openNewChat: {
+      type: Function,
+    },
     question: {
       type: String,
     },
@@ -443,19 +446,6 @@ export default {
     },
     setAppMapStats(stats) {
       this.appmapStats = stats;
-    },
-    clear() {
-      this.searching = false;
-      this.searchStatus = undefined;
-      this.searchResponse = undefined;
-      this.selectedSearchResultId = undefined;
-      this.searchId = 0;
-      this.searchStatusLabel = undefined;
-      this.contextResponse = undefined;
-      this.ask?.removeAllListeners();
-      this.searching = false;
-      this.pinnedItems = [];
-      this.loadAppMapStats();
     },
     startResizing(event) {
       document.body.style.userSelect = 'none';

--- a/packages/components/src/stories/ChatSearch.stories.js
+++ b/packages/components/src/stories/ChatSearch.stories.js
@@ -71,6 +71,9 @@ ChatSearch.args = {
   mostRecentAppMaps,
   appmapYmlPresent: true,
   appmapRpcPort: 3002,
+  openNewChat() {
+    alert('open new chat');
+  },
 };
 
 export const ChatSearchWithCodeSelection = (args, { argTypes }) => ({


### PR DESCRIPTION
Instead of clearing the chat, "new chat" button now instead only shows when upstream (for example, a code editor) provides a method for that; if it does, it calls that. The intent is for the button to open a new tab instead.

Fixes #1922 (IDE patches to follow).