### PR TITLE
fix: parse git status output correctly

### DIFF
--- a/packages/cli/src/fulltext/listGitProjectFIles.ts
+++ b/packages/cli/src/fulltext/listGitProjectFIles.ts
@@ -38,8 +38,9 @@ export default async function listGitProjectFiles(directory: string): Promise<st
       return stdout
         .split('\n')
         .map((line) => {
-          const [, fileName] = line.split(' ');
-          return fileName;
+          // git status --porcelain output starts with 3 characters: staged status, unstaged status,
+          // and a space.
+          return line.slice(3);
         })
         .filter(Boolean);
     } catch (e) {


### PR DESCRIPTION
The output from `git status --porcelain` starts with 3 columns. Make sure it's parsed correctly.

Fixes #1931 .