### PR TITLE
feat: Define new History format and message organization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,4 +45,5 @@ notebooks
 tmp/appmap
 packages/*/tmp/
 *.appmap.json
+.navie
 

--- a/packages/cli/src/cmds/index/rpc.ts
+++ b/packages/cli/src/cmds/index/rpc.ts
@@ -10,7 +10,7 @@ import appmapFilter from '../../rpc/appmap/filter';
 import { RpcHandler } from '../../rpc/rpc';
 import metadata from '../../rpc/appmap/metadata';
 import sequenceDiagram from '../../rpc/appmap/sequenceDiagram';
-import { explainHandler, explainStatusHandler } from '../../rpc/explain/explain';
+import { explainHandler, explainStatusHandler, loadThreadHandler } from '../../rpc/explain/explain';
 import { buildNavieProvider, commonNavieArgsBuilder as navieBuilder } from '../navie';
 import RPCServer from './rpcServer';
 import appmapData from '../../rpc/appmap/data';
@@ -27,6 +27,10 @@ import { update } from '../../rpc/file/update';
 import { INavieProvider } from '../../rpc/explain/navie/inavie';
 import { navieMetadataV1 } from '../../rpc/navie/metadata';
 import { navieSuggestHandlerV1 } from '../../rpc/navie/suggest';
+import { initializeHistory } from '../../rpc/explain/navie/historyHelper';
+import History from '../../rpc/explain/navie/history';
+import { join } from 'path';
+import { homedir } from 'os';
 
 export const command = 'rpc';
 export const describe = 'Run AppMap JSON-RPC server';
@@ -59,6 +63,7 @@ export function rpcMethods(navie: INavieProvider, codeEditor?: string): RpcHandl
     sequenceDiagram(),
     explainHandler(navie, codeEditor),
     explainStatusHandler(),
+    loadThreadHandler(),
     update(navie),
     setConfigurationV1(),
     getConfigurationV1(),
@@ -81,6 +86,12 @@ export const handler = async (argv: HandlerArguments) => {
 
   loadConfiguration(false);
   await configureRpcDirectories(argv.directory);
+
+  {
+    const history = initializeHistory();
+    const oldHistoryDir = join(homedir(), '.appmap', 'navie', 'history');
+    await History.migrate(oldHistoryDir, history);
+  }
 
   const rpcServer = new RPCServer(argv.port, rpcMethods(navie, codeEditor));
   rpcServer.start();

--- a/packages/cli/src/cmds/navie.ts
+++ b/packages/cli/src/cmds/navie.ts
@@ -27,6 +27,7 @@ interface ExplainArgs {
   navieProvider?: string;
   logNavie?: boolean;
   prompt?: string;
+  threadId?: string;
 }
 
 interface NavieCommonCmdArgs extends ExplainArgs {
@@ -79,6 +80,11 @@ export function commonNavieArgsBuilder<T>(args: yargs.Argv<T>): yargs.Argv<T & N
       type: 'string',
       // Allow this to be any string. The code editor brand name may be a clue to the language
       // in use, or the user's intent.
+    })
+    .option('thread-id', {
+      describe:
+        'The thread ID to use for the question. If not provided, a new thread ID will be allocated. Valid only for local Navie provider.',
+      type: 'string',
     });
 }
 
@@ -138,6 +144,8 @@ export function buildNavieProvider(argv: ExplainArgs) {
   ) => {
     loadConfiguration(false);
     const navie = new LocalNavie(contextProvider, projectInfoProvider, helpProvider);
+    if (argv.threadId) navie.setThreadId(argv.threadId);
+
     applyAIOptions(navie);
 
     let START: number | undefined;
@@ -164,6 +172,11 @@ export function buildNavieProvider(argv: ExplainArgs) {
     loadConfiguration(true);
     const navie = new RemoteNavie(contextProvider, projectInfoProvider, helpProvider);
     applyAIOptions(navie);
+
+    if (argv.threadId) {
+      warn(`Ignoring --thread-id option for remote Navie provider`);
+    }
+
     return navie;
   };
 

--- a/packages/cli/src/fulltext/SourceIndex.ts
+++ b/packages/cli/src/fulltext/SourceIndex.ts
@@ -10,7 +10,7 @@ import { existsSync } from 'fs';
 import { FileIndexMatch } from './FileIndex';
 import { verbose } from '../utils';
 import { readFile } from 'fs/promises';
-import { join } from 'path';
+import { basename, join } from 'path';
 import queryKeywords from './queryKeywords';
 
 const debug = makeDebug('appmap:source-index');
@@ -128,7 +128,7 @@ export class SourceIndex {
         try {
           debug(`Indexing document ${fileName} from ${from} to ${to}`);
 
-          const terms = queryKeywords([chunk.pageContent]).join(' ');
+          const terms = queryKeywords([fileName, chunk.pageContent]).join(' ');
           this.#insert.run(directory, fileName, from, to, chunk.pageContent, terms);
         } catch (error) {
           console.warn(`Error indexing document ${fileName} from ${from} to ${to}`);

--- a/packages/cli/src/rpc/explain/navie/history.ts
+++ b/packages/cli/src/rpc/explain/navie/history.ts
@@ -1,0 +1,343 @@
+import { join } from 'path';
+import Thread from './thread';
+import { mkdir, readdir, readFile, readlink, rm, symlink, writeFile } from 'fs/promises';
+import { warn } from 'console';
+import { Message } from '@appland/navie';
+import { exists } from '../../../utils';
+import { OpenMode } from 'fs';
+import configuration from '../../configuration';
+
+export class ThreadAccessError extends Error {
+  constructor(public readonly threadId: string, public action: string, public cause?: Error) {
+    super(ThreadAccessError.errorMessage(threadId, action, cause));
+  }
+
+  static errorMessage(threadId: string, action: string, cause?: Error): string {
+    const messages = [`Failed to ${action} thread ${threadId}`];
+    if (cause) messages.push(cause.message);
+    return messages.join(': ');
+  }
+}
+
+export enum QuestionField {
+  Question = 'question',
+  CodeSelection = 'codeSelection',
+  Prompt = 'prompt',
+}
+
+export enum ResponseField {
+  AssistantMessageId = 'assistantMessageId',
+  Answer = 'answer',
+}
+
+type SequenceFile = { timestamp: number; messageId: string };
+
+const parseSequenceFile = (dir: string): SequenceFile => ({
+  timestamp: parseInt(dir.split('.')[0]),
+  messageId: dir.split('.')[1],
+});
+
+export default class History {
+  private firstResponse = new Map<string, number>();
+
+  public constructor(public readonly directory: string) {}
+
+  async question(
+    threadId: string,
+    userMessageId: string,
+    question: string,
+    codeSelection: string | undefined,
+    prompt: string | undefined,
+    extensions: Record<QuestionField, string> = {
+      question: 'txt',
+      codeSelection: 'txt',
+      prompt: 'md',
+    }
+  ) {
+    const threadDir = await this.ensureThreadDir(threadId);
+    const messageDir = await History.findOrCreateMessageDir(threadDir, userMessageId);
+
+    const writeMessageFile = async (field: QuestionField, content: string) => {
+      const messageFile = join(messageDir, [field, extensions[field]].join('.'));
+      await writeFile(messageFile, content);
+
+      const sequenceDir = join(threadDir, 'sequence');
+      await mkdir(sequenceDir, { recursive: true });
+      const sequenceFile = join(
+        sequenceDir,
+        [Date.now().toString(), field, extensions[field]].join('.')
+      );
+      await History.createSymlinkIfNotExists(
+        join('..', 'messages', userMessageId, [field, extensions[field]].join('.')),
+        sequenceFile
+      );
+    };
+
+    await writeMessageFile(QuestionField.Question, question);
+    if (codeSelection) await writeMessageFile(QuestionField.CodeSelection, codeSelection);
+    if (prompt) await writeMessageFile(QuestionField.Prompt, prompt);
+
+    const date = new Date().toISOString().split('T')[0];
+    const dateDir = join(this.directory, 'dates', date);
+    await mkdir(dateDir, { recursive: true });
+    const dateThreadFile = join(dateDir, threadId);
+    await History.createSymlinkIfNotExists(threadDir, dateThreadFile);
+  }
+
+  async token(
+    threadId: string,
+    userMessageId: string,
+    assistantMessageId: string,
+    token: string,
+    extensions: Record<ResponseField, string> = {
+      answer: 'md',
+      assistantMessageId: 'txt',
+    }
+  ) {
+    const threadDir = await this.ensureThreadDir(threadId);
+    const messageDir = await History.findOrCreateMessageDir(threadDir, userMessageId);
+    const timestamp = Date.now();
+
+    const writeMessageFile = async (
+      field: ResponseField,
+      content: string,
+      modeFlag: { flag: OpenMode | undefined } = { flag: 'w' }
+    ) => {
+      const messageFile = join(messageDir, [field, extensions[field]].join('.'));
+      await writeFile(messageFile, content, modeFlag);
+
+      const sequenceDir = join(threadDir, 'sequence');
+      await mkdir(sequenceDir, { recursive: true });
+      const sequenceFile = join(sequenceDir, [timestamp, field, extensions[field]].join('.'));
+      await History.createSymlinkIfNotExists(
+        join('..', 'messages', userMessageId, [field, extensions[field]].join('.')),
+        sequenceFile
+      );
+    };
+
+    if (!this.firstResponse.has(assistantMessageId)) {
+      this.firstResponse.set(assistantMessageId, timestamp);
+
+      await writeMessageFile(ResponseField.AssistantMessageId, assistantMessageId);
+      await writeMessageFile(ResponseField.Answer, token, { flag: 'a' });
+    } else {
+      const messageFile = join(
+        messageDir,
+        [ResponseField.Answer, extensions[ResponseField.Answer]].join('.')
+      );
+      await writeFile(messageFile, token, { flag: 'a' });
+    }
+  }
+
+  async load(threadId: string): Promise<Thread> {
+    const threadDir = join(this.directory, 'threads', threadId);
+    let projectDirectories: string[];
+    try {
+      projectDirectories = (await readFile(join(threadDir, 'projectDirectories.txt'), 'utf-8'))
+        .split('\n')
+        .filter(Boolean);
+    } catch (e) {
+      throw History.threadAccessError(threadId, 'load', e);
+    }
+
+    const messagesDir = join(this.directory, 'threads', threadId, 'messages');
+    const sequenceDir = join(this.directory, 'threads', threadId, 'sequence');
+
+    let messageSequenceFiles: string[];
+    try {
+      messageSequenceFiles = await readdir(sequenceDir);
+    } catch (e) {
+      throw History.threadAccessError(threadId, 'load', e);
+    }
+
+    messageSequenceFiles.sort(
+      (a, b) => parseSequenceFile(a).timestamp - parseSequenceFile(b).timestamp
+    );
+    const contentFileFieldName = (contentFile: string) => contentFile.split('.')[0];
+
+    const timestamp =
+      messageSequenceFiles.length > 0
+        ? parseSequenceFile(messageSequenceFiles[0]).timestamp
+        : Date.now();
+    const thread = new Thread(threadId, timestamp, projectDirectories);
+
+    const userMessageIds = new Set<string>();
+    for (const sequenceFile of messageSequenceFiles) {
+      const sequenceFilePath = join(sequenceDir, sequenceFile);
+      // Resolve the file name that the symlink points to.
+      let messageFile: string;
+      try {
+        messageFile = await readlink(sequenceFilePath);
+      } catch (e) {
+        warn(e);
+        continue;
+      }
+      const messageFileTokens = messageFile.split('/');
+      const userMessageId = messageFileTokens[messageFileTokens.length - 2];
+      userMessageIds.add(userMessageId);
+    }
+
+    for (const userMessageId of userMessageIds) {
+      const contentFiles = await readdir(join(messagesDir, userMessageId));
+      let threadTimestamp: number | undefined;
+
+      const readRecordFile = async (recordName: string): Promise<string | undefined> => {
+        const matchingContentFile = contentFiles.find(
+          (file) => contentFileFieldName(file) === recordName
+        );
+        if (!matchingContentFile) return undefined;
+
+        const contentFile = join(messagesDir, userMessageId, matchingContentFile);
+
+        // Read the file timestamp to use as the thread timestamp.
+        try {
+          const contentFileStat = await readFile(contentFile, 'utf-8');
+          const messageTimestamp = parseInt(contentFileStat.split('.')[0]);
+          if (!threadTimestamp || messageTimestamp < threadTimestamp)
+            threadTimestamp = messageTimestamp;
+        } catch (e) {
+          throw History.threadAccessError(threadId, 'read', e);
+        }
+
+        try {
+          return await readFile(contentFile, 'utf-8');
+        } catch (e) {
+          throw History.threadAccessError(threadId, 'read', e);
+        }
+      };
+
+      const question = await readRecordFile('question');
+      const codeSelection = await readRecordFile('codeSelection');
+      const prompt = await readRecordFile('prompt');
+      const assistantMessageId = await readRecordFile('assistantMessageId');
+      const answer = await readRecordFile('answer');
+
+      if (userMessageId && question)
+        thread.question(
+          threadTimestamp ?? Date.now(),
+          userMessageId,
+          question,
+          codeSelection,
+          prompt
+        );
+      if (userMessageId && assistantMessageId && answer) {
+        thread.answer(userMessageId, assistantMessageId, answer);
+      }
+    }
+
+    return thread;
+  }
+
+  // Message are stored within threadDir/message in subdirectories. Each subdirectory is named
+  // by joining the timestamp and the user message id with a period. This naming convention
+  // makes it easy to view and sort the messages in chronological order.
+  private static async findOrCreateMessageDir(
+    threadDir: string,
+    userMessageId: string
+  ): Promise<string> {
+    // List message directories in the thread directory.
+    const messagesDir = join(threadDir, 'messages');
+    await mkdir(messagesDir, { recursive: true });
+
+    let messageIds: string[];
+    try {
+      messageIds = await readdir(messagesDir);
+    } catch (e) {
+      throw this.threadAccessError(threadDir, 'initialize storage for', e);
+    }
+
+    // Find the message directory for the user message.
+    if (messageIds.includes(userMessageId)) {
+      return join(messagesDir, userMessageId);
+    }
+
+    const messagePath = join(messagesDir, userMessageId);
+    await mkdir(messagePath, { recursive: true });
+    return messagePath;
+  }
+
+  private static async createSymlinkIfNotExists(target: string, path: string) {
+    try {
+      await readlink(path);
+    } catch (e) {
+      const err = e as Error & { code?: string };
+      if (err.code === 'ENOENT') {
+        await symlink(target, path);
+      } else if (err.code === 'EEXIST') {
+        // Symlink already exists, do nothing.
+      } else {
+        throw err;
+      }
+    }
+  }
+
+  private async ensureThreadDir(threadId: string): Promise<string> {
+    const threadDir = join(this.directory, 'threads', threadId);
+    await mkdir(threadDir, { recursive: true });
+    const projectDirectoriesFile = join(threadDir, 'projectDirectories.txt');
+    if (!(await exists(projectDirectoriesFile))) {
+      const projectDirectories = configuration().projectDirectories;
+      await writeFile(projectDirectoriesFile, projectDirectories.join('\n'));
+    }
+    return threadDir;
+  }
+
+  static threadAccessError(threadId: string, action: string, e: any): ThreadAccessError {
+    const err = e as Error & { code?: string };
+    if (err.code === 'ENOENT') warn(`Thread ${threadId} not found`);
+
+    return new ThreadAccessError(threadId, action, e instanceof Error ? e : undefined);
+  }
+
+  // In the old-style history format, threads are stored in files named by their thread id
+  // and timestamp. In the new-style history format, threads are stored in files named by
+  // their thread id, and the thread file is symlinked to a file named for the date of the thread.
+  static async migrate(
+    oldDirectory: string,
+    history: History,
+    options: { cleanup: boolean } = { cleanup: true }
+  ): Promise<void> {
+    // List the contents of the old directory. Each one is a threadId directory, containing
+    // timestamped messages.
+    const threadIds = (await readdir(oldDirectory)).filter(
+      // Match UUIDs like 5278527e-c4ed-4e45-9fb6-372ed6a036f6 in the thread dir
+      // Being careful not to touch anything else, like the dates and threads directories that are
+      // created in the new history format.
+      (dir) => dir.match(/^(?:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/)
+    );
+
+    const threadFileAsTimestamp = (threadFile: string) => parseInt(threadFile.split('.')[0]);
+
+    for (const threadId of threadIds) {
+      warn(`[history] Migrating thread ${threadId} from old history format`);
+
+      const oldThreadDir = join(oldDirectory, threadId);
+      const threadFiles = await readdir(oldThreadDir);
+      threadFiles.sort((a, b) => threadFileAsTimestamp(a) - threadFileAsTimestamp(b));
+
+      let lastUserMessageId: string | undefined;
+      for (const threadFile of threadFiles) {
+        const timestamp = threadFileAsTimestamp(threadFile);
+        // MessageIds are not available, so fake them with timestamps.
+        const messageId = timestamp.toString();
+        const messageFile = join(oldThreadDir, threadFile);
+        const messageStr = await readFile(messageFile, 'utf-8');
+        const message = JSON.parse(messageStr) as Message;
+        if (message.role === 'user') {
+          lastUserMessageId = messageId;
+          // codeSelection and prompt are not available in the old format.
+          await history.question(threadId, messageId, message.content, undefined, undefined);
+        } else if (message.role === 'assistant' || message.role === 'system') {
+          if (lastUserMessageId)
+            await history.token(threadId, lastUserMessageId, messageId, message.content);
+        }
+
+        // Project directories are unknown, so overwrite the file contents with empty text.
+        const newThreadDir = join(history.directory, 'threads', threadId);
+        if (await exists(newThreadDir)) await writeFile(join(newThreadDir, 'projectDirectories.txt'), '');
+      }
+
+      if (options.cleanup) await rm(oldThreadDir, { recursive: true });
+    }
+  }
+}

--- a/packages/cli/src/rpc/explain/navie/history.ts
+++ b/packages/cli/src/rpc/explain/navie/history.ts
@@ -7,6 +7,8 @@ import { exists } from '../../../utils';
 import { OpenMode } from 'fs';
 import configuration from '../../configuration';
 
+export const THREAD_ID_REGEX = /^[0-9a-f]{4,16}(-[0-9a-f]{4,16}){3,6}$/;
+
 export class ThreadAccessError extends Error {
   constructor(public readonly threadId: string, public action: string, public cause?: Error) {
     super(ThreadAccessError.errorMessage(threadId, action, cause));
@@ -303,7 +305,7 @@ export default class History {
       // Match UUIDs like 5278527e-c4ed-4e45-9fb6-372ed6a036f6 in the thread dir
       // Being careful not to touch anything else, like the dates and threads directories that are
       // created in the new history format.
-      (dir) => dir.match(/^(?:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/)
+      (dir) => dir.match(THREAD_ID_REGEX)
     );
 
     const threadFileAsTimestamp = (threadFile: string) => parseInt(threadFile.split('.')[0]);

--- a/packages/cli/src/rpc/explain/navie/historyHelper.ts
+++ b/packages/cli/src/rpc/explain/navie/historyHelper.ts
@@ -1,0 +1,28 @@
+import { homedir } from 'os';
+import History, { ThreadAccessError } from './history';
+import Thread from './thread';
+import { join } from 'path';
+import { warn } from 'console';
+import configuration from '../../configuration';
+
+export function initializeHistory(): History {
+  return new History(join(homedir(), '.appmap', 'navie', 'history'));
+}
+
+export async function loadThread(history: History, threadId: string): Promise<Thread> {
+  let thread: Thread;
+
+  try {
+    thread = await history.load(threadId);
+  } catch (e) {
+    if (e instanceof ThreadAccessError) {
+      warn(`[remote-navie] Creating new thread ${threadId} (thread not found)`);
+      const projectDirectories = configuration().projectDirectories;
+      thread = new Thread(threadId, Date.now(), projectDirectories);
+    } else {
+      throw e;
+    }
+  }
+
+  return thread;
+}

--- a/packages/cli/src/rpc/explain/navie/navie-remote.ts
+++ b/packages/cli/src/rpc/explain/navie/navie-remote.ts
@@ -6,8 +6,126 @@ import { ContextV1, ContextV2, Help, ProjectInfo } from '@appland/navie';
 import { verbose } from '../../../utils';
 import { default as INavie } from './inavie';
 import assert from 'assert';
+import { initializeHistory, loadThread } from './historyHelper';
+import Thread from './thread';
+import History from './history';
+
+export class RemtoteCallbackHandler {
+  thread: Thread | undefined;
+  userMessageId: string | undefined;
+  assistantMessageId: string | undefined;
+  tokens: string[] = [];
+
+  constructor(
+    private readonly history: History,
+    private readonly contextProvider: ContextV2.ContextProvider,
+    private readonly projectInfoProvider: ProjectInfo.ProjectInfoProvider,
+    private readonly helpProvider: Help.HelpProvider
+  ) {}
+
+  async onAck(
+    assignedUserMessageId: string,
+    threadId: string,
+    question: string,
+    codeSelection?: string,
+    prompt?: string
+  ): Promise<void> {
+    if (verbose())
+      warn(`Explain received ack (userMessageId=${assignedUserMessageId}, threadId=${threadId})`);
+
+    this.thread = await loadThread(this.history, threadId);
+    this.userMessageId = assignedUserMessageId;
+    await this.history.question(threadId, this.userMessageId, question, codeSelection, prompt);
+  }
+
+  async onToken(token: string, messageId: string): Promise<void> {
+    if (!this.assistantMessageId) this.assistantMessageId = messageId;
+
+    this.tokens.push(token);
+
+    if (this.thread && this.userMessageId)
+      await this.history.token(
+        this.thread.threadId,
+        this.userMessageId,
+        this.assistantMessageId,
+        token
+      );
+    else warn(`[remote-navie] Received token but no thread is available to store it`);
+  }
+
+  async onRequestContext(
+    data: Record<string, unknown>
+  ): Promise<Record<string, unknown> | unknown[]> {
+    try {
+      if (data.type === 'search') {
+        const { version } = data;
+        const isVersion1 = !version || version === 1;
+
+        // ContextV2.ContextRequest is a superset of ContextV1.ContextRequest, so whether the input
+        // version is V1 or V2, we can treat it as V2.
+        const contextRequestV2: ContextV2.ContextRequest = data as ContextV2.ContextRequest;
+
+        const responseV2: ContextV2.ContextResponse = await this.contextProvider({
+          ...contextRequestV2,
+          type: 'search',
+          version: 2,
+        });
+
+        if (isVersion1) {
+          // Adapt from V2 response back to V1. Some data may be lost in this process.
+          const responseV1: ContextV1.ContextResponse = {
+            sequenceDiagrams: responseV2
+              .filter((item) => item.type === ContextV2.ContextItemType.SequenceDiagram)
+              .map((item) => item.content),
+            codeSnippets: responseV2
+              .filter((item) => item.type === ContextV2.ContextItemType.CodeSnippet)
+              .reduce((acc, item) => {
+                assert(item.type === ContextV2.ContextItemType.CodeSnippet);
+                if (ContextV2.isFileContextItem(item)) {
+                  acc[item.location] = item.content;
+                }
+                return acc;
+              }, {} as Record<string, string>),
+            codeObjects: responseV2
+              .filter((item) => item.type === ContextV2.ContextItemType.DataRequest)
+              .map((item) => item.content),
+          };
+          return responseV1;
+        } else {
+          return responseV2;
+        }
+      }
+      if (data.type === 'projectInfo') {
+        return (
+          (await this.projectInfoProvider(data as unknown as ProjectInfo.ProjectInfoRequest)) ?? {}
+        );
+      }
+      if (data.type === 'help') {
+        return (await this.helpProvider(data as unknown as Help.HelpRequest)) || {};
+      } else {
+        warn(`Unhandled context request type: ${data.type}`);
+        // A response is required from this function.
+        return {};
+      }
+    } catch (e) {
+      warn(`Explain context function ${JSON.stringify(data)} threw an error: ${e}`);
+      return {};
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-misused-promises
+  onComplete(): void {
+    if (verbose()) warn(`Explain is complete`);
+  }
+
+  onError(err: Error): void {
+    if (verbose()) warn(`Error handled by Explain: ${err}`);
+  }
+}
 
 export default class RemoteNavie extends EventEmitter implements INavie {
+  private history = initializeHistory();
+
   constructor(
     private contextProvider: ContextV2.ContextProvider,
     private projectInfoProvider: ProjectInfo.ProjectInfoProvider,
@@ -24,95 +142,53 @@ export default class RemoteNavie extends EventEmitter implements INavie {
     throw new Error(`RemoteNavie does not support option '${key}'`);
   }
 
-  async ask(
-    threadId: string,
-    question: string,
-    codeSelection?: string,
-    prompt?: string
-  ) {
-    if (prompt) {
-      warn(`RemoteNavie does not support a custom prompt option.`);
-    }
-    (
-      await AI.connect({
-        onAck: (userMessageId, threadId) => {
-          if (verbose())
-            warn(`Explain received ack (userMessageId=${userMessageId}, threadId=${threadId})`);
-          this.emit('ack', userMessageId, threadId);
-        },
-        onToken: (token, _messageId) => {
-          this.emit('token', token);
-        },
-        onRequestContext: async (data) => {
-          try {
-            if (data.type === 'search') {
-              const { version } = data;
-              const isVersion1 = !version || version === 1;
+  async ask(threadId: string, question: string, codeSelection?: string, prompt?: string) {
+    const callbackHandler = new RemtoteCallbackHandler(
+      this.history,
+      this.contextProvider,
+      this.projectInfoProvider,
+      this.helpProvider
+    );
 
-              // ContextV2.ContextRequest is a superset of ContextV1.ContextRequest, so whether the input
-              // version is V1 or V2, we can treat it as V2.
-              const contextRequestV2: ContextV2.ContextRequest = data as ContextV2.ContextRequest;
+    const onAck = async (userMessageId: string, threadId: string) => {
+      await callbackHandler.onAck(userMessageId, threadId, question, codeSelection, prompt);
 
-              const responseV2: ContextV2.ContextResponse = await this.contextProvider({
-                ...contextRequestV2,
-                type: 'search',
-                version: 2,
-              });
+      this.emit('ack', userMessageId, threadId);
+    };
 
-              if (isVersion1) {
-                // Adapt from V2 response back to V1. Some data may be lost in this process.
-                const responseV1: ContextV1.ContextResponse = {
-                  sequenceDiagrams: responseV2
-                    .filter((item) => item.type === ContextV2.ContextItemType.SequenceDiagram)
-                    .map((item) => item.content),
-                  codeSnippets: responseV2
-                    .filter((item) => item.type === ContextV2.ContextItemType.CodeSnippet)
-                    .reduce((acc, item) => {
-                      assert(item.type === ContextV2.ContextItemType.CodeSnippet);
-                      if (ContextV2.isFileContextItem(item)) {
-                        acc[item.location] = item.content;
-                      }
-                      return acc;
-                    }, {} as Record<string, string>),
-                  codeObjects: responseV2
-                    .filter((item) => item.type === ContextV2.ContextItemType.DataRequest)
-                    .map((item) => item.content),
-                };
-                return responseV1;
-              } else {
-                return responseV2;
-              }
-            }
-            if (data.type === 'projectInfo') {
-              return (
-                (await this.projectInfoProvider(
-                  data as unknown as ProjectInfo.ProjectInfoRequest
-                )) || {}
-              );
-            }
-            if (data.type === 'help') {
-              return (await this.helpProvider(data as unknown as Help.HelpRequest)) || {};
-            } else {
-              warn(`Unhandled context request type: ${data.type}`);
-              // A response is required from this function.
-              return {};
-            }
-          } catch (e) {
-            warn(`Explain context function ${JSON.stringify(data)} threw an error: ${e}`);
-            // TODO: Report an error object instead?
-            return {};
-          }
-        },
-        onComplete: () => {
-          if (verbose()) warn(`Explain is complete`);
-          this.emit('complete');
-        },
-        onError: (err: Error) => {
-          if (verbose()) warn(`Error handled by Explain: ${err}`);
-          this.emit('error', err);
-        },
-      })
-    ).inputPrompt(
+    const onToken = async (token: string, messageId: string): Promise<void> => {
+      await callbackHandler.onToken(token, messageId);
+
+      this.emit('token', token, messageId);
+    };
+
+    const onRequestContext = async (
+      data: Record<string, unknown>
+    ): Promise<Record<string, unknown> | unknown[]> => {
+      return await callbackHandler.onRequestContext(data);
+    };
+
+    const onComplete = () => {
+      callbackHandler.onComplete();
+
+      this.emit('complete');
+    };
+
+    const onError = (err: Error) => {
+      callbackHandler.onError(err);
+
+      this.emit('error', err);
+    };
+
+    const callbacksObj = {
+      onAck,
+      onToken,
+      onRequestContext,
+      onComplete,
+      onError,
+    };
+
+    (await AI.connect(callbacksObj)).inputPrompt(
       { question: question, codeSelection: codeSelection },
       { threadId, tool: 'explain' }
     );

--- a/packages/cli/src/rpc/explain/navie/thread.ts
+++ b/packages/cli/src/rpc/explain/navie/thread.ts
@@ -1,0 +1,122 @@
+import { warn } from 'console';
+
+import { ExplainRpc } from '@appland/rpc';
+import configuration from '../../configuration';
+import { getLLMConfiguration } from '../../llmConfiguration';
+
+export type Message = ExplainRpc.Message;
+
+export type Question = ExplainRpc.Question;
+
+export type Answer = ExplainRpc.Answer;
+
+export class Exchange {
+  readonly question: Question;
+  answer?: Answer;
+
+  constructor(
+    timestamp: number,
+    messageId: string,
+    question: string,
+    codeSelection?: string,
+    prompt?: string
+  ) {
+    this.question = {
+      timestamp,
+      messageId,
+      content: question,
+      role: 'user',
+      codeSelection,
+      prompt,
+    };
+  }
+
+  setAnswer(messageId: string, answer: string) {
+    this.answer = {
+      messageId,
+      content: answer,
+      role: 'assistant',
+    };
+  }
+}
+
+export type ThreadData = ExplainRpc.Thread;
+
+export default class Thread implements ThreadData {
+  public readonly exchanges: Exchange[] = [];
+
+  public constructor(
+    public readonly threadId: string,
+    public readonly timestamp: number,
+    public readonly projectDirectories: string[]
+  ) {}
+
+  get messages(): Message[] {
+    const result = new Array<Message>();
+    for (const exchange of this.exchanges) {
+      result.push(exchange.question);
+      if (exchange.answer) result.push(exchange.answer);
+    }
+    return result;
+  }
+
+  /**
+   * Gets the thread timestamp formatted as 'YYYY-mm-dd'.
+   */
+  date() {
+    const date = new Date(this.timestamp);
+    return date.toISOString().split('T')[0];
+  }
+
+  question(
+    timestamp: number,
+    messageId: string,
+    question: string,
+    codeSelection?: string,
+    prompt?: string
+  ) {
+    const exchange = new Exchange(timestamp, messageId, question, codeSelection, prompt);
+    this.exchanges.push(exchange);
+  }
+
+  answer(userMessageId: string, messageId: string, answer: string) {
+    const exchange = this.exchanges[this.exchanges.length - 1];
+    if (!exchange) {
+      warn(`[history/thread] No question to answer for message ${messageId}`);
+      return;
+    }
+    if (exchange.question.messageId !== userMessageId) {
+      warn(`[history/thread] Received an answer to a different question than the last one asked`);
+      return;
+    }
+    exchange.setAnswer(messageId, answer);
+  }
+
+  asJSON(): ThreadData {
+    return {
+      timestamp: this.timestamp,
+      projectDirectories: this.projectDirectories,
+      exchanges: this.exchanges,
+    };
+  }
+
+  static fromJSON(threadId: string, data: ThreadData): Thread {
+    const thread = new Thread(threadId, data.timestamp, data.projectDirectories);
+    for (const exchange of data.exchanges) {
+      thread.question(
+        exchange.question.timestamp,
+        exchange.question.messageId,
+        exchange.question.content,
+        exchange.question.codeSelection,
+        exchange.question.prompt
+      );
+      if (exchange.answer)
+        thread.answer(
+          exchange.question.messageId,
+          exchange.answer.messageId,
+          exchange.answer.content
+        );
+    }
+    return thread;
+  }
+}

--- a/packages/cli/tests/unit/fixtures/history/oldFormat/9af0b3b0-4b3b-4b3b-4b3b-4b3b4b3b4b3b/1717705211685.json
+++ b/packages/cli/tests/unit/fixtures/history/oldFormat/9af0b3b0-4b3b-4b3b-4b3b-4b3b4b3b4b3b/1717705211685.json
@@ -1,0 +1,4 @@
+{
+  "content": "@plan upgrade the history system",
+  "role": "user"
+}

--- a/packages/cli/tests/unit/fixtures/history/oldFormat/9af0b3b0-4b3b-4b3b-4b3b-4b3b4b3b4b3b/1717705233502.json
+++ b/packages/cli/tests/unit/fixtures/history/oldFormat/9af0b3b0-4b3b-4b3b-4b3b-4b3b4b3b4b3b/1717705233502.json
@@ -1,0 +1,4 @@
+{
+  "content": "1) Migrate from CSV to JSON",
+  "role": "assistant"
+}

--- a/packages/cli/tests/unit/fixtures/history/oldFormat/9af0b3b0-4b3b-4b3b-4b3b-4b3b4b3b4b3c/1717700353547.json
+++ b/packages/cli/tests/unit/fixtures/history/oldFormat/9af0b3b0-4b3b-4b3b-4b3b-4b3b4b3b4b3c/1717700353547.json
@@ -1,0 +1,4 @@
+{
+  "content": "@plan Update the users table",
+  "role": "user"
+}

--- a/packages/cli/tests/unit/fixtures/history/oldFormat/9af0b3b0-4b3b-4b3b-4b3b-4b3b4b3b4b3c/1717700368618.json
+++ b/packages/cli/tests/unit/fixtures/history/oldFormat/9af0b3b0-4b3b-4b3b-4b3b-4b3b4b3b4b3c/1717700368618.json
@@ -1,0 +1,4 @@
+{
+  "content": "1) Migrate from SQL to MongoDB",
+  "role": "assistant"
+}

--- a/packages/cli/tests/unit/fixtures/history/oldFormatWithUnrecognizedRoles/9af0b3b0-4b3b-4b3b-4b3b-4b3b4b3b4b3b/1717705211685.json
+++ b/packages/cli/tests/unit/fixtures/history/oldFormatWithUnrecognizedRoles/9af0b3b0-4b3b-4b3b-4b3b-4b3b4b3b4b3b/1717705211685.json
@@ -1,0 +1,4 @@
+{
+  "content": "@plan upgrade the histroy system",
+  "role": "nobody"
+}

--- a/packages/cli/tests/unit/fixtures/history/oldFormatWithUnrecognizedRoles/9af0b3b0-4b3b-4b3b-4b3b-4b3b4b3b4b3b/1717705233502.json
+++ b/packages/cli/tests/unit/fixtures/history/oldFormatWithUnrecognizedRoles/9af0b3b0-4b3b-4b3b-4b3b-4b3b4b3b4b3b/1717705233502.json
@@ -1,0 +1,4 @@
+{
+  "content": "1) Migrate from CSV to JSON",
+  "role": "nobody"
+}

--- a/packages/cli/tests/unit/fulltext/SourceIndex.spec.ts
+++ b/packages/cli/tests/unit/fulltext/SourceIndex.spec.ts
@@ -31,11 +31,22 @@ describe('SourceIndex', () => {
 
       const results = sourceIndex.search(['SourceIndex'], 10);
       expect(results.length).toBeTruthy();
-      expect(
-        results.every((r) =>
-          queryKeywords(r.content).some((keyword) => indexWords.includes(keyword))
-        )
-      ).toBeTruthy();
+
+      for (const result of results) {
+        if (
+          !queryKeywords([result.directory, result.fileName, result.content]).some((keyword) =>
+            indexWords.includes(keyword)
+          )
+        ) {
+          throw new Error(
+            `Expected result content (${queryKeywords([
+              result.directory,
+              result.fileName,
+              result.content,
+            ]).join(', ')}) to contain one of ${indexWords.join(', ')}`
+          );
+        }
+      }
     });
   });
 });

--- a/packages/cli/tests/unit/rpc/explain/LocalNavie.spec.ts
+++ b/packages/cli/tests/unit/rpc/explain/LocalNavie.spec.ts
@@ -110,6 +110,16 @@ describe('LocalNavie', () => {
       });
 
       describe('when invoked without a threadId', () => {
+        it('should assign a thread id if not provided', async () => {
+          const mockThreadId = 'mock-thread-id';
+          navie.setThreadId(mockThreadId);
+
+          const question = 'What is the meaning of life?';
+          await navie.ask(undefined, question);
+
+          expect(mockHistoryLoad).toHaveBeenCalledWith(mockThreadId);
+        });
+
         it('allocates a new threadId', async () => {
           let allocatedThreadId: string;
 

--- a/packages/cli/tests/unit/rpc/explain/RemoteNavie.spec.ts
+++ b/packages/cli/tests/unit/rpc/explain/RemoteNavie.spec.ts
@@ -1,8 +1,11 @@
 import { ContextV1, ContextV2 } from '@appland/navie';
 import RemoteNavie from '../../../../src/rpc/explain/navie/navie-remote';
 import { AI, AIClient, AICallbacks } from '@appland/client';
+import { verbose } from '../../../../src/utils';
 
 jest.mock('@appland/client');
+
+if (process.env.VERBOSE === 'true') verbose(true);
 
 describe('RemoteNavie', () => {
   let navie: RemoteNavie;
@@ -71,7 +74,7 @@ describe('RemoteNavie', () => {
     it('provides ContextV2', async () => {
       await navie.ask(threadId, question, codeSelection);
 
-      callbacks.onAck!('userMessageId', 'threadId');
+      await callbacks.onAck!('userMessageId', 'threadId');
       expect(ackFn).toHaveBeenCalledWith('userMessageId', 'threadId');
 
       const contextRequestV2: ContextV2.ContextRequest = {
@@ -109,7 +112,7 @@ describe('RemoteNavie', () => {
     it('adapts ContextV1 to ContextV2', async () => {
       await navie.ask(threadId, question, codeSelection);
 
-      callbacks.onAck!('userMessageId', 'threadId');
+      await callbacks.onAck!('userMessageId', 'threadId');
       expect(ackFn).toHaveBeenCalledWith('userMessageId', 'threadId');
 
       const contextRequestV1: ContextV1.ContextRequest = {
@@ -130,7 +133,7 @@ describe('RemoteNavie', () => {
         codeObjects: ['SELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT 1'],
       });
 
-      callbacks.onComplete();
+      await callbacks.onComplete();
       expect(completeFn).toHaveBeenCalled();
     });
   });

--- a/packages/cli/tests/unit/rpc/explain/history.spec.ts
+++ b/packages/cli/tests/unit/rpc/explain/history.spec.ts
@@ -1,0 +1,165 @@
+import { mkdtempSync, rmSync } from 'fs';
+import History from '../../../../src/rpc/explain/navie/history';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { readdir, readFile, readlink, rm } from 'fs/promises';
+import configuration from '../../../../src/rpc/configuration';
+import { exists, verbose } from '../../../../src/utils';
+
+describe(History, () => {
+  const oldFixtureDir = join(__dirname, '..', '..', 'fixtures', 'history', 'oldFormat');
+  let tempDir: string;
+
+  const uuid1 = '9af0b3b0-4b3b-4b3b-4b3b-4b3b4b3b4b3b';
+  const uuid2 = '9af0b3b0-4b3b-4b3b-4b3b-4b3b4b3b4b3c';
+
+  beforeEach(() => (tempDir = mkdtempSync(join(tmpdir(), 'history-test-'))));
+  if (!verbose()) afterEach(() => rmSync(tempDir, { recursive: true }));
+
+  it('migrates old-style history to new-style history', async () => {
+    const history = new History(tempDir);
+    await History.migrate(oldFixtureDir, history, { cleanup: false });
+
+    // List the threads in the new-style history directory
+    const threads = await readdir(join(tempDir, 'threads'));
+    expect(threads).toEqual([uuid1, uuid2]);
+
+    // List the symlinks by date in the new history directory
+    const dates = await readdir(join(tempDir, 'dates'));
+    const todaysDate = new Date().toISOString().split('T')[0];
+    expect(dates).toEqual([todaysDate]);
+
+    const threadIds = await readdir(join(tempDir, 'dates', todaysDate));
+    expect(threadIds).toEqual([uuid1, uuid2]);
+  });
+
+  it('ignores old-style history with no messages', async () => {
+    const emptyOldFixtureDir = join(__dirname, '..', '..', 'fixtures', 'history', 'emptyOldFormat');
+    const history = new History(tempDir);
+    await History.migrate(emptyOldFixtureDir, history, { cleanup: false });
+
+    expect(await exists(join(tempDir, 'threads'))).toBe(false);
+    expect(await exists(join(tempDir, 'dates'))).toBe(false);
+  });
+
+  it('ignores old-style history when messages contain unrecognized roles', async () => {
+    const oldFixtureDirWithUnrecognizedRoles = join(
+      __dirname,
+      '..',
+      '..',
+      'fixtures',
+      'history',
+      'oldFormatWithUnrecognizedRoles'
+    );
+    const history = new History(tempDir);
+    await History.migrate(oldFixtureDirWithUnrecognizedRoles, history, { cleanup: false });
+
+    expect(await exists(join(tempDir, 'threads'))).toBe(false);
+    expect(await exists(join(tempDir, 'dates'))).toBe(false);
+  });
+
+  describe('load', () => {
+    it('loads a thread from the new-style history', async () => {
+      const history = new History(tempDir);
+
+      await history.question(
+        'thread-1',
+        'question-1',
+        'question 1',
+        'code selection 1',
+        'prompt 1'
+      );
+      await history.token('thread-1', 'question-1', 'answer-1', 'answer 1');
+
+      await history.question(
+        'thread-1',
+        'question-2',
+        'question 2',
+        'code selection 2',
+        'prompt 2'
+      );
+      await history.token('thread-1', 'question-2', 'answer-2', 'answer 2\n');
+      await history.token('thread-1', 'question-2', 'answer-2', 'answer 3');
+
+      const thread = await history.load('thread-1');
+      const timestamps = thread.exchanges.map((e) => e.question.timestamp);
+      const projectDirectories = configuration().projectDirectories;
+      expect(thread.projectDirectories).toEqual(projectDirectories);
+      expect(thread.exchanges).toEqual([
+        {
+          question: {
+            role: 'user',
+            timestamp: timestamps[0],
+            messageId: 'question-1',
+            content: 'question 1',
+            prompt: 'prompt 1',
+            codeSelection: 'code selection 1',
+          },
+          answer: {
+            role: 'assistant',
+            messageId: 'answer-1',
+            content: 'answer 1',
+          },
+        },
+        {
+          question: {
+            role: 'user',
+            timestamp: timestamps[1],
+            messageId: 'question-2',
+            content: 'question 2',
+            prompt: 'prompt 2',
+            codeSelection: 'code selection 2',
+          },
+          answer: { role: 'assistant', messageId: 'answer-2', content: 'answer 2\nanswer 3' },
+        },
+      ]);
+    });
+
+    it('tests sequence of question() and token() calls and verifies filesystem output', async () => {
+      const history = new History(tempDir);
+
+      await history.question(
+        'thread-1',
+        'question-1',
+        'question 1',
+        'code selection 1',
+        'prompt 1'
+      );
+
+      await history.token('thread-1', 'question-1', 'assistant-1', 'token 1\n');
+      await history.token('thread-1', 'question-1', 'assistant-1', 'token 2\n');
+      await history.token('thread-1', 'question-1', 'assistant-1', 'token 3');
+
+      const messageDir = join(tempDir, 'threads', 'thread-1', 'messages', 'question-1');
+      const sequenceDir = join(tempDir, 'threads', 'thread-1', 'sequence');
+      const dateDir = join(tempDir, 'dates', new Date().toISOString().split('T')[0]);
+
+      // Verify the existence of directories and files
+      expect(await exists(messageDir)).toBe(true);
+      expect(await exists(sequenceDir)).toBe(true);
+      expect(await exists(dateDir)).toBe(true);
+
+      // Verify the content of the files
+      const questionFile = await readFile(join(messageDir, 'question.txt'), 'utf-8');
+      expect(questionFile).toBe('question 1');
+
+      const tokenFile = await readFile(join(messageDir, 'answer.md'), 'utf-8');
+      expect(tokenFile).toBe('token 1\ntoken 2\ntoken 3');
+
+      // Verify the symlinks
+      const sequenceFiles = await readdir(sequenceDir);
+      const sequenceFileNames = sequenceFiles.map((f) => f.split('.')[1]).sort();
+      expect(sequenceFileNames).toEqual([
+        'answer',
+        'assistantMessageId',
+        'codeSelection',
+        'prompt',
+        'question',
+      ]);
+      for (const sequenceFile of sequenceFiles) {
+        const symlinkTarget = await readlink(join(sequenceDir, sequenceFile));
+        expect(symlinkTarget).toContain('question-1');
+      }
+    });
+  });
+});

--- a/packages/components/src/lib/AppMapRPC.ts
+++ b/packages/components/src/lib/AppMapRPC.ts
@@ -1,4 +1,4 @@
-import { AppMapRpc, ConfigurationRpc, NavieRpc } from '@appland/rpc';
+import { AppMapRpc, ConfigurationRpc, ExplainRpc, NavieRpc } from '@appland/rpc';
 import { browserClient, reportError } from './RPC';
 
 import { EventEmitter } from 'events';
@@ -237,6 +237,20 @@ export default class AppMapRPC {
         NavieRpc.V1.Suggest.Method,
         { threadId },
         (err: any, error: any, result: NavieRpc.V1.Suggest.Response) => {
+          if (err || error) return reportError(reject, err, error);
+
+          resolve(result);
+        }
+      );
+    });
+  }
+
+  loadThread(threadId: string): Promise<ExplainRpc.LoadThreadResponse> {
+    return new Promise((resolve, reject) => {
+      this.client.request(
+        ExplainRpc.ExplainThreadLoadFunctionName,
+        { threadId },
+        (err: any, error: any, result: ExplainRpc.LoadThreadResponse) => {
           if (err || error) return reportError(reject, err, error);
 
           resolve(result);

--- a/packages/components/src/pages/ChatSearch.vue
+++ b/packages/components/src/pages/ChatSearch.vue
@@ -250,6 +250,11 @@ export default {
     },
   },
   methods: {
+    async loadThread(threadId: string) {
+      const thread = await this.rpcClient.loadThread(threadId);
+      const chat = this.$refs.vchat;
+      chat.restoreThread(threadId, thread);
+    },
     // This converts the old search context into the new context format
     createContextResponse() {
       if (!this.searchStatus) return;

--- a/packages/components/src/pages/ChatSearch.vue
+++ b/packages/components/src/pages/ChatSearch.vue
@@ -83,10 +83,6 @@ export default {
     appmapRpcFn: {
       type: Function,
     },
-    savedFilters: {
-      type: Array,
-      default: () => [],
-    },
     appmaps: {
       type: Array,
       default: () => [],
@@ -331,9 +327,6 @@ export default {
     },
     setAppMapState(state) {
       this.$refs.vappmap?.setState(state);
-    },
-    updateFilters(updatedFilters) {
-      this.$store.commit(SET_SAVED_FILTERS, updatedFilters);
     },
     onStop() {
       // This will stop token emission from this.ask immediately

--- a/packages/components/src/stories/ChatSearch.stories.js
+++ b/packages/components/src/stories/ChatSearch.stories.js
@@ -117,6 +117,15 @@ export const ChatSearchMock = (args, { argTypes }) => ({
   },
 });
 
+export const ChatSearchMockWithThreadId = (args, { argTypes }) => ({
+  props: Object.keys(argTypes),
+  components: { VChatSearch },
+  template: `<v-chat-search v-bind="$props" ref="chatSearch"></v-chat-search>`,
+  mounted() {
+    this.$refs.chatSearch.loadThread('the-thread-id');
+  },
+});
+
 export const ChatSearchMockWithCodeSelection = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
   components: { VChatSearch },
@@ -310,6 +319,26 @@ function buildMockRpc(
         baseUrl,
         model: 'gpt-4-turbo',
       });
+    } else if (method == 'explain.thread.load') {
+      callback(null, null, {
+        timestamp: Date.now(),
+        exchanges: [
+          {
+            question: {
+              role: 'user',
+              messageId: 'user-message-id-1',
+              content: 'How does password reset work?',
+            },
+            answer: {
+              role: 'assistant',
+              messageId: 'assistant-message-id-1',
+              content:
+                'Password reset works by sending an email to the user with a link to reset their password.',
+            },
+          },
+        ],
+        projectDirectories: [],
+      });
     } else if (method === 'v1.navie.metadata') {
       callback(null, null, {
         welcomeMessage:
@@ -365,6 +394,12 @@ const emptyMockRpc = buildMockRpc(
 );
 
 ChatSearchMock.args = {
+  appmapRpcFn: nonEmptyMockRpc,
+  appmapYmlPresent: true,
+  mostRecentAppMaps,
+};
+
+ChatSearchMockWithThreadId.args = {
   appmapRpcFn: nonEmptyMockRpc,
   appmapYmlPresent: true,
   mostRecentAppMaps,

--- a/packages/components/tests/unit/chat/ChatComponent.spec.js
+++ b/packages/components/tests/unit/chat/ChatComponent.spec.js
@@ -16,9 +16,16 @@ describe('components/Chat.vue', () => {
         },
       });
 
+      let receivedThreadId;
+      wrapper.vm.$root.$on('thread-id', (id) => {
+        receivedThreadId = id;
+      });
+
       await wrapper.vm.onSend('Hello from the user');
+      await wrapper.vm.$nextTick();
 
       expect(wrapper.vm.threadId).toBe(threadId);
+      expect(receivedThreadId).toBe(threadId);
     });
   });
 

--- a/packages/components/tests/unit/chat/ChatSearch.spec.js
+++ b/packages/components/tests/unit/chat/ChatSearch.spec.js
@@ -572,4 +572,44 @@ describe('pages/ChatSearch.vue', () => {
 
     expect(wrapper.find('[data-cy="autocomplete"]').exists()).toBe(false);
   });
+
+  describe('loadThred', () => {
+    it('loads the thread', async () => {
+      const wrapper = chatSearchWrapper({
+        'v2.configuration.get': noConfig(),
+        'v1.navie.metadata': rpcNavieMetadata(),
+        'explain.thread.load': [
+          [
+            null,
+            null,
+            {
+              timestamp: Date.now(),
+              exchanges: [
+                {
+                  question: {
+                    role: 'user',
+                    messageId: 'user-message-id-1',
+                    content: 'How does password reset work?',
+                  },
+                  answer: {
+                    role: 'assistant',
+                    messageId: 'assistant-message-id-1',
+                    content:
+                      'Password reset works by sending an email to the user with a link to reset their password.',
+                  },
+                },
+              ],
+              projectDirectories: [],
+            },
+          ],
+        ],
+      });
+
+      await wrapper.vm.loadThread('the-thread-id');
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.vm.$refs.vchat.threadId).toBe('the-thread-id');
+      expect(wrapper.vm.$refs.vchat.messages).toBeArrayOfSize(2);
+    });
+  });
 });

--- a/packages/models/package.json
+++ b/packages/models/package.json
@@ -38,7 +38,7 @@
     "eslint-plugin-react": "^7.33.2",
     "jest": "^27.4.7",
     "lint-staged": "^10.5.4",
-    "lru-cache": "6.0.0",
+    "lru-cache": "10.2.2",
     "prettier": "^2.7.1",
     "ts-jest": "^27.1.4",
     "tsup": "^6.5.0",

--- a/packages/models/types/index.d.ts
+++ b/packages/models/types/index.d.ts
@@ -1,5 +1,5 @@
 import type { SqliteParser } from './sqlite-parser';
-import type LRUCache from 'lru-cache';
+import type { LRUCache } from 'lru-cache';
 
 declare module '@appland/models' {
   export type CodeObjectType =

--- a/packages/navie/src/agents/test-agent.ts
+++ b/packages/navie/src/agents/test-agent.ts
@@ -12,8 +12,7 @@ export const TEST_AGENT_PROMPT = `**Task: Generation a Test Case**
 
 Your name is Navie. You are code generation AI created and maintained by AppMap Inc, and are available to AppMap users as a service.
 
-Your job is to generate test case code that exercises and tests specific functionality within the project code.
-The requirements for the test will be provided in the form of a description of the desired functionality.
+Your job is to generate test case code. The requirements for the test will be provided by the user.
 
 **About the user**
 
@@ -35,7 +34,7 @@ DOs and DO NOTs:
 * DO begin the code snippet with a comment containing the path to the test case file.
 * DO extend an existing test case with new code, rather than creating a new test case.
 * DO limit the amount of text explanation you emit to the minimum necessary. The user is primarily interested in the code itself.
-* DO an explanation of the test case as a comment in the test case code.
+* DO provide an explanation of the test case as a comment in the test case code.
 * DO generate code rather than test data (e.g. YAML or JSON fixture data), because when you generate
   data changes only, the user will not know how to invoke the test.
 * DO NOT propose wrapping the project with other code, running the project in a different environment, wrapping the project with

--- a/packages/rpc/src/explain.ts
+++ b/packages/rpc/src/explain.ts
@@ -1,8 +1,10 @@
+import { ConfigurationRpc } from './configuration';
 import { SearchRpc } from './search';
 
 export namespace ExplainRpc {
   export const ExplainFunctionName = 'explain';
   export const ExplainStatusFunctionName = 'explain.status';
+  export const ExplainThreadLoadFunctionName = 'explain.thread.load';
 
   export enum Step {
     NEW = 'new',
@@ -60,4 +62,38 @@ export namespace ExplainRpc {
     contextResponse?: ContextItem[];
     explanation?: string[];
   };
+
+  export type Message = {
+    messageId: string;
+    content: string;
+    role: 'user' | 'assistant';
+  };
+
+  export type Question = Message & {
+    role: 'user';
+    timestamp: number;
+    codeSelection?: string;
+    prompt?: string;
+  };
+
+  export type Answer = Message & {
+    role: 'assistant';
+  };
+
+  export type Exchange = {
+    question: Question;
+    answer?: Answer;
+  };
+
+  export type Thread = {
+    timestamp: number;
+    projectDirectories: string[];
+    exchanges: Exchange[];
+  };
+
+  export type LoadThreadOptions = {
+    threadId: string;
+  };
+
+  export type LoadThreadResponse = Thread;
 }

--- a/packages/sequence-diagram/package.json
+++ b/packages/sequence-diagram/package.json
@@ -23,7 +23,7 @@
     "@datastructures-js/priority-queue": "^6.1.3",
     "crypto-js": "^4.1.1",
     "diff": "^5.1.0",
-    "lru-cache": "6.0.0"
+    "lru-cache": "10.2.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/sequence-diagram/src/buildDiagram.ts
+++ b/packages/sequence-diagram/src/buildDiagram.ts
@@ -1,7 +1,7 @@
 import { AppMap, Event } from '@appland/models';
 import { classNameToOpenAPIType } from '@appland/openapi';
 import sha256 from 'crypto-js/sha256.js';
-import LRUCache from 'lru-cache';
+import { LRUCache } from 'lru-cache';
 import { merge } from './mergeWindow';
 import { selectEvents } from './selectEvents';
 import Specification from './specification';

--- a/packages/sequence-diagram/src/mergeWindow.ts
+++ b/packages/sequence-diagram/src/mergeWindow.ts
@@ -1,5 +1,5 @@
 import sha256 from 'crypto-js/sha256.js';
-import LRUCache from 'lru-cache';
+import { LRUCache } from 'lru-cache';
 import { Action, Loop, NodeType } from './types';
 
 const sha256Cache = new LRUCache<string, string>({ max: 3000 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -440,7 +440,7 @@ __metadata:
     eslint-plugin-react: ^7.33.2
     jest: ^27.4.7
     lint-staged: ^10.5.4
-    lru-cache: 6.0.0
+    lru-cache: 10.2.2
     prettier: ^2.7.1
     ts-jest: ^27.1.4
     tsup: ^6.5.0
@@ -600,7 +600,7 @@ __metadata:
     eslint-plugin-node: ^11.1.0
     eslint-plugin-prettier: ^3.4.1
     jest: ^29.5.0
-    lru-cache: 6.0.0
+    lru-cache: 10.2.2
     prettier: ^2.7.1
     ts-jest: ^29.0.5
     typescript: ^4.4.2
@@ -30155,12 +30155,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lru-cache@npm:6.0.0, lru-cache@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "lru-cache@npm:6.0.0"
-  dependencies:
-    yallist: ^4.0.0
-  checksum: f97f499f898f23e4585742138a22f22526254fdba6d75d41a1c2526b3b6cc5747ef59c5612ba7375f42aca4f8461950e925ba08c991ead0651b4918b7c978297
+"lru-cache@npm:10.2.2, lru-cache@npm:^10.2.2":
+  version: 10.2.2
+  resolution: "lru-cache@npm:10.2.2"
+  checksum: 98e8fc93691c546f719a76103ef2bee5a3ac823955c755a47641ec41f8c7fafa1baeaba466937cc1cbfa9cfd47e03536d10e2db3158a64ad91ff3a58a32c893e
   languageName: node
   linkType: hard
 
@@ -30168,13 +30166,6 @@ __metadata:
   version: 10.2.0
   resolution: "lru-cache@npm:10.2.0"
   checksum: eee7ddda4a7475deac51ac81d7dd78709095c6fa46e8350dc2d22462559a1faa3b81ed931d5464b13d48cbd7e08b46100b6f768c76833912bc444b99c37e25db
-  languageName: node
-  linkType: hard
-
-"lru-cache@npm:^10.2.2":
-  version: 10.2.2
-  resolution: "lru-cache@npm:10.2.2"
-  checksum: 98e8fc93691c546f719a76103ef2bee5a3ac823955c755a47641ec41f8c7fafa1baeaba466937cc1cbfa9cfd47e03536d10e2db3158a64ad91ff3a58a32c893e
   languageName: node
   linkType: hard
 
@@ -30194,6 +30185,15 @@ __metadata:
   dependencies:
     yallist: ^3.0.2
   checksum: c154ae1cbb0c2206d1501a0e94df349653c92c8cbb25236d7e85190bcaf4567a03ac6eb43166fabfa36fd35623694da7233e88d9601fbf411a9a481d85dbd2cb
+  languageName: node
+  linkType: hard
+
+"lru-cache@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "lru-cache@npm:6.0.0"
+  dependencies:
+    yallist: ^4.0.0
+  checksum: f97f499f898f23e4585742138a22f22526254fdba6d75d41a1c2526b3b6cc5747ef59c5612ba7375f42aca4f8461950e925ba08c991ead0651b4918b7c978297
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Related to: 

* https://github.com/orgs/getappmap/projects/15?pane=issue&itemId=74967761
* https://github.com/getappmap/vscode-appland/pull/1006

## Analysis

1. **Unify the history management** into a centralized and structured framework.
2. **Introduce new history functionalities** to better retrieve and store interaction data.
3. **Add migration support** to seamlessly transition from the old history format to the new format.
4. **Enhance RPC support** for better integration and communication with other system components.

## Proposed Changes

1. **Command Handler (rpc.ts)**:
   - Import and integrate new history helpers and handlers.
   - Include initialization and migration logic for the history system in the command handler.

2. **Explain RPC Handlers (explain.ts)**:
   - Add a new `loadThread` function to handle fetching of specific threads.
   - Export new handler functions for explain commands.

3. **History Management (history.ts)**:
   - Define a new `History` class encapsulating methods to manage questions, tokens, and answers.
   - Implement logic for loading history, organizing data, and handling errors.
   - Add a `migrate` method to transition from old history format to the new format.

4. **Local Navie Integration (navie-local.ts)**:
   - Replace the old local history management logic with the new centralized history mechanism.
   - Utilize the new `History` class along with its methods to manage conversation threads.

5. **Remote Navie Integration (navie-remote.ts)**:
   - Introduce a callback handler for managing various events such as acknowledgment, token reception, context requests, and completion using the new history system.
   - Modify the ask method to use the new remote callback handler for history operations.

6. **Components Integration (AppMapRPC.ts and ChatSearch.vue)**:
    - Update components to interface with the new RPC methods for loading threads and managing history state in the UI.

## History storage design

```
history/
|-- threads/
|   |-- <threadId>/
|       |-- messages/
|       |   |-- <userMessageId>/
|       |   |   |-- question.txt
|       |   |   |-- codeSelection.txt
|       |   |   |-- prompt.md
|       |   |   |-- assistantMessageId.txt
|       |   |   |-- answer.md
|       |-- sequence/
|       |   |-- <timestamp>.<field>.<extension> (symlinks to ../messages/<userMessageId>/<field>.<extension>)
|       |-- projectDirectories.txt
|-- dates/
|   |-- <YYYY-MM-DD>/
|       |-- <threadId> (symlink to ../threads/<threadId>/)
```

### Explanation:

- **`history/`**: The root directory containing all history-related data.
- **`threads/`**: Subdirectory containing individual thread directories.
  - **`<threadId>/`**: Directory for each thread identified by its unique thread ID.
    - **`messages/`**: Subdirectory containing user and assistant messages.
      - **`<userMessageId>/`**: Subdirectory containing message files for a specific user message.
        - **`question.txt`**: File containing the user's question.
        - **`codeSelection.txt`**: Optional file containing code selection information.
        - **`prompt.md`**: Optional file containing any prompts.
        - **`assistantMessageId.txt`**: File containing the assistant message ID.
        - **`answer.md`**: File containing the assistant's answer.
    - **`sequence/`**: Subdirectory containing sequence files.
      - **`<timestamp>.<field>.<extension>`**: Symlinks to the corresponding message files in the messages directory.
    - **`projectDirectories.txt`**: File containing the list of project directories associated with the thread.
- **`dates/`**: Subdirectory categorizing threads by date.
  - **`<YYYY-MM-DD>/`**: Directory for each date.
    - **`<threadId>`**: Symlink to the thread directory under `threads/`.

This structure allows for easy access and sorting of messages and threads based on their timestamps and other criteria.

## UI Example

<img width="953" alt="Screen Shot 2024-08-20 at 9 06 11 AM" src="https://github.com/user-attachments/assets/95299e29-12fb-457a-9123-8e7bc46d1266">


