### PR TITLE
Feat/command completions

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -91,7 +91,7 @@
     "@appland/models": "workspace:^2.10.2",
     "@appland/navie": "^1.19.0",
     "@appland/openapi": "workspace:^1.8.0",
-    "@appland/rpc": "workspace:^1.9.0",
+    "@appland/rpc": "workspace:^1.11.0",
     "@appland/scanner": "workspace:^1.86.0",
     "@appland/sequence-diagram": "workspace:^1.12.0",
     "@octokit/rest": "^20.0.1",

--- a/packages/cli/src/cmds/index/rpc.ts
+++ b/packages/cli/src/cmds/index/rpc.ts
@@ -25,6 +25,7 @@ import {
 import detectCodeEditor from '../../lib/detectCodeEditor';
 import { update } from '../../rpc/file/update';
 import { INavieProvider } from '../../rpc/explain/navie/inavie';
+import { navieMetadataV1 } from '../../rpc/navie/metadata';
 
 export const command = 'rpc';
 export const describe = 'Run AppMap JSON-RPC server';
@@ -62,6 +63,7 @@ export function rpcMethods(navie: INavieProvider, codeEditor?: string): RpcHandl
     getConfigurationV1(),
     setConfigurationV2(),
     getConfigurationV2(),
+    navieMetadataV1(),
   ];
 }
 

--- a/packages/cli/src/cmds/index/rpc.ts
+++ b/packages/cli/src/cmds/index/rpc.ts
@@ -26,6 +26,7 @@ import detectCodeEditor from '../../lib/detectCodeEditor';
 import { update } from '../../rpc/file/update';
 import { INavieProvider } from '../../rpc/explain/navie/inavie';
 import { navieMetadataV1 } from '../../rpc/navie/metadata';
+import { navieUiEventHandlerV1 } from '../../rpc/navie/uiEvent';
 
 export const command = 'rpc';
 export const describe = 'Run AppMap JSON-RPC server';
@@ -64,6 +65,7 @@ export function rpcMethods(navie: INavieProvider, codeEditor?: string): RpcHandl
     setConfigurationV2(),
     getConfigurationV2(),
     navieMetadataV1(),
+    navieUiEventHandlerV1(),
   ];
 }
 

--- a/packages/cli/src/rpc/navie/metadata.ts
+++ b/packages/cli/src/rpc/navie/metadata.ts
@@ -1,0 +1,51 @@
+import { NavieRpc } from '@appland/rpc';
+import { RpcHandler } from '../rpc';
+
+export function navieMetadataV1(): RpcHandler<
+  NavieRpc.V1.Metadata.Params,
+  NavieRpc.V1.Metadata.Response
+> {
+  return {
+    name: NavieRpc.V1.Metadata.Method,
+    handler: () => ({
+      welcomeMessage:
+        "### Hi, I'm Navie!\n\nI can help you answer questions about your codebase, plan solutions, and generate code. Enter `@` to see a list of commands.",
+      inputPlaceholder: "Ask a question or enter '@' for commands",
+      commands: [
+        {
+          name: '@explain',
+          description:
+            'Ask questions about the codebase, and Navie will respond with explanations, diagrams, code snippets, and more. This is the default mode.',
+          referenceUrl: 'https://appmap.io/docs/reference/navie.html#explain',
+        },
+        {
+          name: '@diagram',
+          description: 'Navie can generate Mermaid diagrams based on your request.',
+          referenceUrl: 'https://appmap.io/docs/reference/navie.html#diagram',
+          demoUrls: [],
+        },
+        {
+          name: '@plan',
+          description: 'Create a plan to implement a solution to a code issue or feature.',
+          referenceUrl: 'https://appmap.io/docs/reference/navie.html#plan',
+          demoUrls: ['https://vimeo.com/985121150'],
+        },
+        {
+          name: '@generate',
+          description: 'Generate code based on a given plan.',
+          referenceUrl: 'https://appmap.io/docs/reference/navie.html#generate',
+          demoUrls: ['https://vimeo.com/985121150'],
+        },
+        {
+          name: '@test',
+          description: 'Write tests for your code.',
+        },
+        {
+          name: '@help',
+          description: 'Get help with AppMap and Navie AI.',
+          referenceUrl: 'https://appmap.io/docs/reference/navie.html#help',
+        },
+      ],
+    }),
+  };
+}

--- a/packages/cli/src/rpc/navie/uiEvent.ts
+++ b/packages/cli/src/rpc/navie/uiEvent.ts
@@ -1,0 +1,39 @@
+import { NavieRpc } from '@appland/rpc';
+import { RpcHandler } from '../rpc';
+
+function handleUiEvent(params: NavieRpc.V1.UIEvent.Params): NavieRpc.V1.UIEvent.Response {
+  switch (params.event) {
+    case 'generate-code':
+      return {
+        action: 'submit_prompt',
+        prompt: '@generate',
+      };
+    case 'create-diagram':
+      return {
+        action: 'submit_prompt',
+        prompt: '@diagram',
+      };
+    case 'plan':
+      return {
+        action: 'submit_prompt',
+        prompt: '@plan an implementation of the above',
+      };
+    case 'test-cases':
+      return {
+        action: 'submit_prompt',
+        prompt: '@test',
+      };
+    default:
+      throw new Error(`Unknown event: ${params.event}`);
+  }
+}
+
+export function navieUiEventHandlerV1(): RpcHandler<
+  NavieRpc.V1.UIEvent.Params,
+  NavieRpc.V1.UIEvent.Response
+> {
+  return {
+    name: NavieRpc.V1.UIEvent.Method,
+    handler: handleUiEvent,
+  };
+}

--- a/packages/components/src/components/chat-search/StreamingMessageContent.ts
+++ b/packages/components/src/components/chat-search/StreamingMessageContent.ts
@@ -1,6 +1,7 @@
 import Vue from 'vue';
 import VMarkdownCodeSnippet from '@/components/chat/MarkdownCodeSnippet.vue';
 import VMermaidDiagram from '@/components/chat/MermaidDiagram.vue';
+import VEventButton from '@/components/chat/EventButton.vue';
 
 function findCursorNode(node: Node): Node | undefined {
   const children = Array.from(node.childNodes);
@@ -81,6 +82,7 @@ export default Vue.extend({
   components: {
     VMarkdownCodeSnippet,
     VMermaidDiagram,
+    VEventButton,
   },
   data() {
     return {

--- a/packages/components/src/components/chat/AutoComplete.vue
+++ b/packages/components/src/components/chat/AutoComplete.vue
@@ -1,0 +1,206 @@
+<template>
+  <v-popper :arrow="false" align="left" placement="top" ref="autocomplete" class="autocomplete">
+    <template #content>
+      <ul data-cy="autocomplete">
+        <li
+          v-for="(command, i) in autoCompletions"
+          :key="i"
+          :class="{ selected: i === selectionIndex }"
+          data-cy="autocomplete-item"
+          @click.prevent="onSubmitCompletion(command.name)"
+          @mouseover.prevent="selectionIndex = i"
+        >
+          <div class="command">
+            <b :data-active="selectionIndex === i">{{ command.name }}</b>
+          </div>
+          <span class="description">{{ command.description }}</span>
+        </li>
+      </ul>
+    </template>
+  </v-popper>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+import VPopper from '@/components/Popper.vue';
+import { NavieRpc } from '@appland/rpc';
+
+type PopperRef = Vue & { show: () => void; hide: () => void; isVisible: Readonly<boolean> };
+
+export default Vue.extend({
+  name: 'v-auto-complete',
+
+  components: {
+    VPopper,
+  },
+
+  props: {
+    input: {
+      type: String,
+      required: true,
+    },
+    commands: {
+      type: Array as () => NavieRpc.V1.Metadata.Command[],
+      default: () => [],
+    },
+  },
+
+  data() {
+    return {
+      caretOffset: undefined as number | undefined,
+      selectionIndex: 0,
+      onInput: (() => {}) as (e: KeyboardEvent) => void,
+      onCaretChange: () => {},
+    };
+  },
+
+  watch: {
+    autoCompletions(val) {
+      if (val.length) {
+        this.onDisplay();
+      } else {
+        this.onHide();
+      }
+    },
+    input: {
+      immediate: true,
+      handler() {
+        this.onCaretChange();
+      },
+    },
+  },
+
+  computed: {
+    popperRef(): PopperRef | undefined {
+      return this.$refs.autocomplete as PopperRef | undefined;
+    },
+    activeToken(): string | undefined {
+      if (!this.commands.length || !this.caretOffset || !this.input) return undefined;
+
+      // Don't consider any other token but the first. Commands are always at the beginning of the
+      // input.
+      const firstTokenBoundary = this.input.match(/\s|$/)?.index;
+      if (firstTokenBoundary && this.caretOffset > firstTokenBoundary) return undefined;
+
+      // Find an index to the end of the token the cursor is on
+      const tokenEnd = this.input.slice(this.caretOffset).match(/\s|$/);
+
+      // Calculate the index of the end of the token
+      let endIndex = this.caretOffset;
+      if (tokenEnd) endIndex += tokenEnd?.index ?? 0;
+
+      // activeText is the string from the start of the input to the cursor
+      const activeText = this.input.slice(0, endIndex);
+
+      // We need the word the cursor is on, so we split on whitespace and take the last token
+      const tokens = activeText.split(/\s+/);
+      return tokens[tokens.length - 1];
+    },
+    autoCompletions(): NavieRpc.V1.Metadata.Command[] {
+      if (!this.activeToken) return [];
+      return this.commands.filter(
+        ({ name }) => name !== this.activeToken && name.startsWith(this.activeToken!)
+      );
+    },
+    isVisible(): boolean {
+      return this.popperRef?.isVisible ?? false;
+    },
+  },
+
+  methods: {
+    onDisplay() {
+      this.selectionIndex = 0;
+      this.popperRef?.show();
+      window.addEventListener('keydown', this.onInput);
+    },
+    onHide() {
+      this.popperRef?.hide();
+      window.removeEventListener('keydown', this.onInput);
+    },
+    onSubmitCompletion(command: string) {
+      this.onHide();
+      if (command) this.$emit('submit', command);
+    },
+  },
+
+  mounted() {
+    this.onInput = (e: KeyboardEvent) => {
+      if (!this.popperRef?.isVisible) return;
+
+      switch (e.key) {
+        case 'ArrowUp':
+          this.selectionIndex = Math.max(0, this.selectionIndex - 1);
+          e.preventDefault();
+          break;
+
+        case 'ArrowDown':
+          this.selectionIndex = Math.min(this.autoCompletions.length - 1, this.selectionIndex + 1);
+          e.preventDefault();
+          break;
+
+        case 'Tab':
+        case 'Enter': {
+          if (this.autoCompletions.length > 0) {
+            const { name } = this.autoCompletions[this.selectionIndex];
+            this.onSubmitCompletion(name);
+          }
+
+          e.preventDefault();
+          break;
+        }
+
+        case 'Escape':
+          this.onHide();
+          e.preventDefault();
+          break;
+
+        default:
+          return;
+      }
+    };
+
+    this.onCaretChange = () => {
+      const selection = document.getSelection();
+      this.caretOffset = selection?.focusOffset;
+    };
+
+    document.addEventListener('selectionchange', this.onCaretChange);
+  },
+
+  destroyed() {
+    document.removeEventListener('selectionchange', this.onCaretChange);
+  },
+});
+</script>
+
+<style lang="scss" scoped>
+.autocomplete {
+  right: inherit;
+  left: 0;
+  z-index: 100;
+  bottom: inherit !important;
+
+  &::v-deep {
+    .popper__text {
+      background-color: $black;
+    }
+  }
+
+  ul {
+    padding-inline-start: 0;
+    margin: 0;
+    list-style-type: none;
+    pointer-events: initial !important;
+    user-select: none;
+
+    li.selected {
+      background-color: rgba($color: $white, $alpha: 0.1);
+    }
+
+    li {
+      cursor: pointer;
+      padding: 0.5rem;
+    }
+  }
+}
+</style>

--- a/packages/components/src/components/chat/Chat.vue
+++ b/packages/components/src/components/chat/Chat.vue
@@ -25,6 +25,7 @@
       ref="messages"
       @scroll="manageScroll"
     >
+      <slot name="not-chatting" v-if="!isChatting"></slot>
       <v-user-message
         v-for="(message, i) in messages"
         :key="i"

--- a/packages/components/src/components/chat/Chat.vue
+++ b/packages/components/src/components/chat/Chat.vue
@@ -61,6 +61,7 @@
       :question="question"
       :code-selections="codeSelections"
       :is-stop-active="isResponseStreaming"
+      :metadata="metadata"
       ref="input"
     />
   </div>
@@ -68,12 +69,13 @@
 
 <script lang="ts">
 //@ts-nocheck
-import Vue from 'vue';
+import Vue, { PropType } from 'vue';
 import VUserMessage from '@/components/chat/UserMessage.vue';
 import VChatInput from '@/components/chat/ChatInput.vue';
 import VAppMapNavieLogo from '@/assets/appmap-full-logo.svg';
 import VButton from '@/components/Button.vue';
 import { AI } from '@appland/client';
+import { NavieRpc } from '@appland/rpc';
 
 export type CodeSelection = {
   path: string;
@@ -166,6 +168,9 @@ export default {
       type: String,
       default: 'What are you working on today?',
     },
+    metadata: {
+      type: Object as PropType<NavieRpc.V1.Metadata.Response | undefined>,
+    },
   },
   data() {
     return {
@@ -177,26 +182,6 @@ export default {
       codeSelections: [] as CodeSelection[],
       appmaps: [] as string[],
       scrollLog: (message: string) => (this.enableScrollLog ? console.log(message) : undefined),
-      modeInstructions: [
-        {
-          id: 'explain',
-          title: '@explain',
-          subTitle:
-            'Navie will help you understand your project. This mode is used when there is no prefix.',
-          default: true,
-        },
-        {
-          id: 'help',
-          title: '@help',
-          subTitle:
-            'Navie will help you setup AppMap, including generating AppMap recordings and diagrams.',
-        },
-        {
-          id: 'generate',
-          title: '@generate',
-          subTitle: 'Navie will help you generate new code.',
-        },
-      ],
     };
   },
   computed: {

--- a/packages/components/src/components/chat/ChatInput.vue
+++ b/packages/components/src/components/chat/ChatInput.vue
@@ -17,9 +17,15 @@
       />
     </div>
     <div class="input-container">
+      <v-auto-complete
+        :input="input"
+        :commands="commands"
+        @submit="onAutoComplete"
+        ref="autocomplete"
+      />
       <div
         contenteditable="plaintext-only"
-        :placeholder="placeholder"
+        :placeholder="placeholderOverride"
         role="textbox"
         @input="onInput"
         @keydown="onKeyDown"
@@ -55,10 +61,13 @@
 <script lang="ts">
 //@ts-nocheck
 
+import type { PropType } from 'vue';
 import VSendIcon from '@/assets/compass-icon.svg';
 import VStopIcon from '@/assets/stop-icon.svg';
 import VPopper from '@/components/Popper.vue';
 import VCodeSelection from '@/components/chat/CodeSelection.vue';
+import VAutoComplete from '@/components/chat/AutoComplete.vue';
+import { NavieRpc } from '@appland/rpc';
 
 export default {
   name: 'v-chat-input',
@@ -67,6 +76,7 @@ export default {
     VStopIcon,
     VPopper,
     VCodeSelection,
+    VAutoComplete,
   },
   props: {
     question: {
@@ -83,6 +93,10 @@ export default {
       type: Boolean,
       default: false,
     },
+    metadata: {
+      type: Object as PropType<NavieRpc.V1.Metadata.Response | undefined>,
+      default: undefined,
+    },
   },
   data() {
     return {
@@ -90,8 +104,17 @@ export default {
     };
   },
   computed: {
+    commands(): NavieRpc.V1.Metadata.Command[] {
+      return this.metadata?.commands ?? [];
+    },
+    placeholderOverride(): string | undefined {
+      return this.metadata?.inputPlaceholder ?? this.placeholder;
+    },
     hasInput() {
       return this.input !== '';
+    },
+    isSelectingCommand() {
+      return this.$refs.autocomplete.isVisible;
     },
   },
   methods: {
@@ -109,16 +132,18 @@ export default {
       this.input = input.innerText;
     },
     onKeyDown(e: Event) {
-      if (!(e instanceof KeyboardEvent)) return;
+      if (!(e instanceof KeyboardEvent));
 
       if (e.key === 'Enter' && !e.shiftKey) {
         e.preventDefault();
         this.send();
       }
     },
+    onAutoComplete(command: string) {
+      this.prefixNewMode(command);
+    },
     send() {
-      if (!this.hasInput) return;
-      if (this.isStopActive) return;
+      if (!this.hasInput || this.isSelectingCommand || this.isStopActive) return;
 
       this.$emit('send', this.input);
       this.input = '';
@@ -132,20 +157,19 @@ export default {
     },
     prefixNewMode(mode: string) {
       const currentInput = (this.$refs.input as HTMLSpanElement).innerText || '';
-      this.setInput(`${mode} ${currentInput.replace(/^\s*@(.+?)?(\s+?|$)/g, '')}`);
+      this.setInput(`${mode} ${currentInput.replace(/^\s*@[^\s]*\s*/g, '')}`);
     },
     setInput(input: string) {
       this.input = input;
-      (this.$refs.input as HTMLSpanElement).innerText = input;
+      const inputEl: HTMLInputElement = this.$refs.input;
+      inputEl.innerText = input;
+
+      const match = input.match(/\s+|$/);
+      const index = match ? match.index + match[0].length : input.length;
 
       // Move the cursor to the end of the input
-      const range = document.createRange();
       const selection = window.getSelection();
-      range.selectNodeContents(this.$refs.input);
-      range.collapse(false);
-      selection.removeAllRanges();
-      selection.addRange(range);
-
+      selection?.setPosition(this.$refs.input.lastChild, index);
       this.focus();
     },
   },

--- a/packages/components/src/components/chat/EventButton.vue
+++ b/packages/components/src/components/chat/EventButton.vue
@@ -1,0 +1,34 @@
+<template>
+  <v-button class="event-button" @click.native="emitEvent" size="small" kind="ghost">
+    <slot />
+  </v-button>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+import VButton from '../Button.vue';
+
+export default Vue.extend({
+  name: 'v-event-button',
+  components: {
+    VButton,
+  },
+  props: {
+    event: {
+      type: String,
+      required: true,
+    },
+  },
+  methods: {
+    emitEvent() {
+      this.$root.$emit('navie-ui-event', this.event);
+    },
+  },
+});
+</script>
+
+<style lang="scss" scoped>
+.event-button {
+  margin-right: 0.5rem;
+}
+</style>

--- a/packages/components/src/components/chat/WelcomeMessage.vue
+++ b/packages/components/src/components/chat/WelcomeMessage.vue
@@ -1,0 +1,49 @@
+<template>
+  <div class="welcome-message" data-cy="welcome-message" v-html="renderedMarkdown" v-if="message" />
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+import { marked } from 'marked';
+import DOMPurify from 'dompurify';
+
+export default Vue.extend({
+  name: 'v-welcome-message',
+
+  props: {
+    message: {
+      type: String,
+      default: '',
+    },
+  },
+
+  computed: {
+    renderedMarkdown(): string {
+      return DOMPurify.sanitize(marked.parse(this.message));
+    },
+  },
+});
+</script>
+
+<style lang="scss" scoped>
+.welcome-message {
+  line-height: 1.5;
+  color: $white;
+  background-color: rgba(black, 0.1);
+  border-radius: $border-radius;
+  border: 1px solid rgba(black, 0.1);
+  max-height: 100%;
+  overflow-y: auto;
+  padding: 0 1rem;
+
+  &::v-deep {
+    code {
+      background-color: rgba(black, 0.1);
+      border-radius: 6px;
+      border: 1px solid rgba(black, 0.05);
+      padding: 0.1rem 0.25rem;
+      padding-top: 0.2rem;
+    }
+  }
+}
+</style>

--- a/packages/components/src/lib/AppMapRPC.ts
+++ b/packages/components/src/lib/AppMapRPC.ts
@@ -230,4 +230,18 @@ export default class AppMapRPC {
       );
     });
   }
+
+  emitUiEvent(event: string): Promise<NavieRpc.V1.UIEvent.Response> {
+    return new Promise((resolve, reject) => {
+      this.client.request(
+        NavieRpc.V1.UIEvent.Method,
+        { event },
+        (err: any, error: any, result: NavieRpc.V1.UIEvent.Response) => {
+          if (err || error) return reportError(reject, err, error);
+
+          resolve(result);
+        }
+      );
+    });
+  }
 }

--- a/packages/components/src/lib/AppMapRPC.ts
+++ b/packages/components/src/lib/AppMapRPC.ts
@@ -1,4 +1,4 @@
-import { AppMapRpc, ConfigurationRpc } from '@appland/rpc';
+import { AppMapRpc, ConfigurationRpc, NavieRpc } from '@appland/rpc';
 import { browserClient, reportError } from './RPC';
 
 import { EventEmitter } from 'events';
@@ -212,6 +212,20 @@ export default class AppMapRPC {
           succeeded
             ? resolve()
             : reject(new Error(`Failed to update ${filePath}. Please try again.`));
+        }
+      );
+    });
+  }
+
+  metadata(): Promise<NavieRpc.V1.Metadata.Response> {
+    return new Promise((resolve, reject) => {
+      this.client.request(
+        NavieRpc.V1.Metadata.Method,
+        undefined,
+        (err: any, error: any, result: NavieRpc.V1.Metadata.Response) => {
+          if (err || error) return reportError(reject, err, error);
+
+          resolve(result);
         }
       );
     });

--- a/packages/components/src/pages/ChatSearch.vue
+++ b/packages/components/src/pages/ChatSearch.vue
@@ -13,8 +13,9 @@
         :send-message="sendMessage"
         :status-label="searchStatusLabel"
         :question="question"
-        @isChatting="setIsChatting"
         :input-placeholder="inputPlaceholder"
+        :metadata="metadata"
+        @isChatting="setIsChatting"
         @stop="onStop"
       >
         <v-llm-configuration
@@ -137,6 +138,7 @@ export default {
       contextResponse: undefined,
       pinnedItems: [] as PinItem[],
       projectDirectories: [] as string[],
+      metadata: undefined as NavieRpc.V1.Metadata.Response | undefined,
     };
   },
   provide() {
@@ -483,6 +485,10 @@ export default {
 
       this.configLoaded = true;
     },
+    async loadMetadata() {
+      const metadata = await this.rpcClient.metadata();
+      this.metadata = metadata;
+    },
   },
   async mounted() {
     if (this.$refs.vappmap && this.targetAppmap && this.targetAppmapFsPath) {
@@ -490,6 +496,7 @@ export default {
       await this.$refs.vappmap.loadData(this.targetAppmap);
     }
     this.loadNavieConfig();
+    this.loadMetadata();
     this.$root.$on('pin', (pin: PinEvent) => {
       const pinIndex = this.pinnedItems.findIndex((p) => p.handle === pin.handle);
       if (pin.pinned && pinIndex === -1) {

--- a/packages/components/src/pages/ChatSearch.vue
+++ b/packages/components/src/pages/ChatSearch.vue
@@ -507,19 +507,35 @@ export default {
     }
     this.loadNavieConfig();
     this.loadMetadata();
-    this.$root.$on('pin', (pin: PinEvent) => {
-      const pinIndex = this.pinnedItems.findIndex((p) => p.handle === pin.handle);
-      if (pin.pinned && pinIndex === -1) {
-        this.pinnedItems.push(pin);
-      } else if (!pin.pinned && pinIndex !== -1) {
-        this.pinnedItems.splice(pinIndex, 1);
-      }
-    });
-    this.$root.$on('jump-to', (handle: number) => {
-      document
-        .querySelector(`[data-handle="${handle}"]:not([data-reference])`)
-        ?.scrollIntoView({ behavior: 'smooth' });
-    });
+    this.$root
+      .$on('pin', (pin: PinEvent) => {
+        const pinIndex = this.pinnedItems.findIndex((p) => p.handle === pin.handle);
+        if (pin.pinned && pinIndex === -1) {
+          this.pinnedItems.push(pin);
+        } else if (!pin.pinned && pinIndex !== -1) {
+          this.pinnedItems.splice(pinIndex, 1);
+        }
+      })
+      .$on('jump-to', (handle: number) => {
+        document
+          .querySelector(`[data-handle="${handle}"]:not([data-reference])`)
+          ?.scrollIntoView({ behavior: 'smooth' });
+      })
+      .$on('navie-ui-event', async (event: string) => {
+        try {
+          const response = await this.rpcClient.emitUiEvent(event);
+          switch (response.action) {
+            case 'submit_prompt':
+              this.$refs.vchat.onSend(response.prompt);
+              this.$refs.vchat.scrollToBottom();
+              break;
+            default:
+              console.error(`Unknown action: ${response.action}`);
+          }
+        } catch (e) {
+          console.error(e);
+        }
+      });
   },
 };
 </script>

--- a/packages/components/src/pages/ChatSearch.vue
+++ b/packages/components/src/pages/ChatSearch.vue
@@ -24,6 +24,11 @@
           :base-url="baseUrl"
           :model="model"
         />
+        <template #not-chatting>
+          <div class="message-box__footer">
+            <v-welcome-message :message="welcomeMessage" />
+          </div>
+        </template>
       </v-chat>
     </div>
     <div
@@ -51,6 +56,7 @@ import AppMapRPC from '@/lib/AppMapRPC';
 import authenticatedClient from '@/components/mixins/authenticatedClient';
 import type { ITool, CodeSelection } from '@/components/chat/Chat.vue';
 import type { PinEvent } from '@/components/chat/PinEvent';
+import VWelcomeMessage from '@/components/chat/WelcomeMessage.vue';
 
 import debounce from '@/lib/debounce';
 
@@ -60,6 +66,7 @@ export default {
     VChat,
     VContext,
     VLlmConfiguration,
+    VWelcomeMessage,
   },
   mixins: [authenticatedClient],
   props: {
@@ -241,6 +248,9 @@ export default {
       return new AppMapRPC(
         this.appmapRpcFn ? { request: this.appmapRpcFn } : this.appmapRpcPort || 30101
       );
+    },
+    welcomeMessage(): string {
+      return this.metadata?.welcomeMessage ?? '';
     },
   },
   methods: {
@@ -533,6 +543,11 @@ $border-color: darken($gray4, 10%);
     display: flex;
     flex-direction: column;
     background-color: #292c39;
+
+    .message-box__footer {
+      padding: 2rem 2rem;
+      padding-top: 0;
+    }
 
     .navie-intro {
       padding: 1rem;

--- a/packages/components/src/stories/ChatSearch.stories.js
+++ b/packages/components/src/stories/ChatSearch.stories.js
@@ -310,6 +310,40 @@ function buildMockRpc(
         baseUrl,
         model: 'gpt-4-turbo',
       });
+    } else if (method === 'v1.navie.metadata') {
+      callback(null, null, {
+        welcomeMessage:
+          "### Hi, I'm Navie!\n\nI can help you answer questions about your codebase, plan solutions, and generate code. Enter `@` to see a list of commands.",
+        inputPlaceholder: "Ask a question or enter '@' for commands",
+        commands: [
+          {
+            name: '@explain',
+            description:
+              'Ask questions about the codebase, and Navie will respond with explanations, diagrams, code snippets, and more. This is the default mode.',
+          },
+          {
+            name: '@diagram',
+            description: 'Navie can generate Mermaid diagrams based on your request.',
+          },
+          {
+            name: '@plan',
+            description: 'Create a plan to implement a solution to a code issue or feature.',
+          },
+          {
+            name: '@generate',
+            description:
+              'Generate code based on the given instructions. This is particularly useful after a plan is created.',
+          },
+          {
+            name: '@help',
+            description: 'Get help with AppMap and Navie AI.',
+          },
+          {
+            name: '@test',
+            description: 'Write tests for your code.',
+          },
+        ],
+      });
     }
   };
 }

--- a/packages/components/src/stories/UserMessage.stories.js
+++ b/packages/components/src/stories/UserMessage.stories.js
@@ -137,3 +137,30 @@ erDiagram
 \`\`\``,
   complete: true,
 };
+
+export const Buttons = (args, { argTypes }) => ({
+  props: Object.keys(argTypes),
+  components: { VUserMessage },
+  template: `<v-user-message v-bind="$props"></v-user-message>`,
+});
+Buttons.args = {
+  id: 'system-message-id',
+  message: `To implement a login page, we need to ensure the following considerations:
+
+### Proposed Changes
+
+#### Frontend (UI Changes):
+1. **packages/client/src/components/LoginPage.jsx**
+   - Create a new component for the login page.
+   - Use input elements for the username and password fields.
+   - Implement a form submission function that validates inputs and communicates with the backend.
+   - Add state management for form inputs and potential error messages.
+   - Apply styles to the login form for proper layout and visual appeal.
+
+2. **packages/client/src/styles/LoginPage.css**
+   - Create styles specific to the login page to ensure a user-friendly and responsive design.
+
+[Generate code](event:generate-code) [Create a diagram](event:create-diagram)
+`,
+  complete: true,
+};

--- a/packages/components/tests/unit/chat/AutoComplete.spec.js
+++ b/packages/components/tests/unit/chat/AutoComplete.spec.js
@@ -1,0 +1,125 @@
+import VAutoComplete from '@/components/chat/AutoComplete.vue';
+import { mount } from '@vue/test-utils';
+
+describe('AutoComplete', () => {
+  let caretPosition = undefined;
+  const commands = [
+    {
+      name: '@one',
+      description: 'First description',
+    },
+    {
+      name: '@two',
+      description: 'Second description.',
+    },
+    {
+      name: '@three',
+      description: 'Third description.',
+    },
+  ];
+
+  beforeEach(() => {
+    document.getSelection = jest.fn().mockImplementation(() => ({ focusOffset: caretPosition }));
+  });
+
+  afterEach(() => {
+    caretPosition = undefined;
+    jest.resetAllMocks();
+  });
+
+  it('only shows if the input caret is on a completable command', async () => {
+    const input = '@ hello world';
+    caretPosition = input.length;
+    const wrapper = mount(VAutoComplete, { propsData: { input, commands } });
+    expect(wrapper.find('[data-cy="autocomplete"]').exists()).toBe(false);
+
+    caretPosition = 1;
+    document.dispatchEvent(new Event('selectionchange'));
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find('[data-cy="autocomplete"]').exists()).toBe(true);
+  });
+
+  it('only appears in valid cases', async () => {
+    const input = '@thre hello world';
+    const wrapper = mount(VAutoComplete, { propsData: { input, commands } });
+    expect(wrapper.find('[data-cy="autocomplete"]').exists()).toBe(false);
+
+    for (let i = 0; i < input.length; i++) {
+      caretPosition = i;
+      document.dispatchEvent(new Event('selectionchange'));
+      await wrapper.vm.$nextTick();
+      expect(wrapper.find('[data-cy="autocomplete"]').exists()).toBe(i > 0 && i <= 5);
+    }
+  });
+
+  it('does not autocomplete in the middle of an input', async () => {
+    const input = 'hello world @';
+    const wrapper = mount(VAutoComplete, { propsData: { input, commands } });
+    expect(wrapper.find('[data-cy="autocomplete"]').exists()).toBe(false);
+
+    caretPosition = input.length;
+    document.dispatchEvent(new Event('selectionchange'));
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find('[data-cy="autocomplete"]').exists()).toBe(false);
+  });
+
+  it('considers the full token as completable text', async () => {
+    const input = '@three hello world';
+    const wrapper = mount(VAutoComplete, { propsData: { input, commands } });
+    expect(wrapper.find('[data-cy="autocomplete"]').exists()).toBe(false);
+
+    caretPosition = 1;
+    document.dispatchEvent(new Event('selectionchange'));
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.find('[data-cy="autocomplete"]').exists()).toBe(false);
+  });
+
+  describe('when visible', () => {
+    let wrapper;
+
+    beforeEach(async () => {
+      caretPosition = 1;
+      wrapper = mount(VAutoComplete, { propsData: { input: '', commands } });
+      await wrapper.setProps({ input: '@' });
+      expect(wrapper.find('[data-cy="autocomplete"]').isVisible()).toBe(true);
+    });
+
+    it('navigates commands with arrow keys', async () => {
+      expect(wrapper.find('[data-active]').text()).toBe('@one');
+
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+      await wrapper.vm.$nextTick();
+      expect(wrapper.find('[data-active]').text()).toBe('@two');
+
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+      await wrapper.vm.$nextTick();
+      expect(wrapper.find('[data-active]').text()).toBe('@three');
+
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp' }));
+      await wrapper.vm.$nextTick();
+      expect(wrapper.find('[data-active]').text()).toBe('@two');
+
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp' }));
+      await wrapper.vm.$nextTick();
+      expect(wrapper.find('[data-active]').text()).toBe('@one');
+    });
+
+    it('navigates with mouse over', async () => {
+      expect(wrapper.find('[data-active]').text()).toBe('@one');
+
+      await wrapper.find('[data-cy="autocomplete"] li:nth-child(2)').trigger('mouseover');
+      expect(wrapper.find('[data-active]').text()).toBe('@two');
+    });
+
+    it('emits an event upon tab or enter', async () => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab' }));
+      await wrapper.vm.$nextTick();
+      expect(wrapper.emitted('submit')).toStrictEqual([['@one']]);
+
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+      await wrapper.vm.$nextTick();
+      expect(wrapper.emitted('submit')).toStrictEqual([['@one']]);
+    });
+  });
+});

--- a/packages/components/tests/unit/chat/ChatInput.spec.js
+++ b/packages/components/tests/unit/chat/ChatInput.spec.js
@@ -1,0 +1,52 @@
+import VChatInput from '@/components/chat/ChatInput.vue';
+import { mount } from '@vue/test-utils';
+
+describe('ChatInput', () => {
+  let caretPosition = undefined;
+  let wrapper;
+
+  beforeEach(() => {
+    document.getSelection = jest.fn().mockImplementation(() => ({ focusOffset: caretPosition }));
+    wrapper = mount(VChatInput, {
+      propsData: {
+        metadata: {
+          commands: [
+            {
+              name: '@example',
+              description: 'An example command',
+            },
+          ],
+        },
+      },
+    });
+  });
+
+  afterEach(() => {
+    caretPosition = undefined;
+    jest.resetAllMocks();
+  });
+
+  it('opens an autocomplete when "@" is typed', async () => {
+    expect(wrapper.find('[data-cy="autocomplete"]').exists()).toBe(false);
+
+    caretPosition = 1;
+    await wrapper.setData({ input: '@' });
+
+    expect(wrapper.find('[data-cy="autocomplete"]').isVisible()).toBe(true);
+  });
+
+  it('emits a send event if the user is not typing a command', async () => {
+    await wrapper.setData({ input: 'hello' });
+    wrapper.vm.send();
+
+    expect(wrapper.emitted('send')).toStrictEqual([['hello']]);
+  });
+
+  it('does not emit a send event when the user is typing a command', async () => {
+    caretPosition = 1;
+    await wrapper.setData({ input: '@' });
+    wrapper.vm.send();
+
+    expect(wrapper.emitted('send')).toBeUndefined();
+  });
+});

--- a/packages/components/tests/unit/chat/ChatSearch.spec.js
+++ b/packages/components/tests/unit/chat/ChatSearch.spec.js
@@ -42,6 +42,7 @@ describe('pages/ChatSearch.vue', () => {
     ],
   };
   const rpcNavieMetadata = () => [[null, null, navieMetadata]];
+  const rpcNavieMetadataEmpty = () => [[null, null, { commands: [] }]];
 
   const emptySearchResponse = {
     results: [],
@@ -520,5 +521,50 @@ describe('pages/ChatSearch.vue', () => {
     await wrapper.vm.$nextTick();
 
     expect(wrapper.find('[data-handle][data-reference]').exists()).toBe(true);
+  });
+
+  describe('metadata', () => {
+    beforeEach(() => {
+      document.getSelection = jest.fn().mockReturnValue({ focusOffset: 1 });
+    });
+
+    it('renders the metadata', async () => {
+      const wrapper = chatSearchWrapper({
+        'v2.configuration.get': noConfig(),
+        'v1.navie.metadata': rpcNavieMetadata(),
+      });
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.find('[data-cy="welcome-message"]').text()).toBe(navieMetadata.welcomeMessage);
+      expect(
+        wrapper
+          .find(`[data-cy="chat-input"][placeholder="${navieMetadata.inputPlaceholder}"]`)
+          .exists()
+      ).toBe(true);
+
+      const input = wrapper.findComponent(`.chat-input`);
+      await input.setData({ input: '@' });
+
+      expect(wrapper.find('[data-cy="autocomplete"]').exists()).toBe(true);
+      expect(wrapper.findAll('[data-cy="autocomplete-item"]').length).toBe(1);
+    });
+  });
+
+  it('renders default metadata when no metadata is available', async () => {
+    const wrapper = chatSearchWrapper({
+      'v2.configuration.get': noConfig(),
+      'v1.navie.metadata': rpcNavieMetadataEmpty(),
+    });
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.find('[data-cy="welcome-message"]').exists()).toBe(false);
+    expect(wrapper.find('[data-cy="chat-input"]').attributes('placeholder')).toBe(
+      'What are you working on today?'
+    );
+
+    const input = wrapper.findComponent(`.chat-input`);
+    await input.setData({ input: '@' });
+
+    expect(wrapper.find('[data-cy="autocomplete"]').exists()).toBe(false);
   });
 });

--- a/packages/components/tests/unit/chat/ChatSearch.spec.js
+++ b/packages/components/tests/unit/chat/ChatSearch.spec.js
@@ -30,12 +30,26 @@ describe('pages/ChatSearch.vue', () => {
   const userMessageId = 'the-user-message-id';
 
   const noConfig = () => [[null, null, { projectDirectories: [] }]];
+
+  const navieMetadata = {
+    welcomeMessage: 'Welcome to Navie!',
+    inputPlaceholder: 'Type something',
+    commands: [
+      {
+        name: '@example',
+        description: 'An example command',
+      },
+    ],
+  };
+  const rpcNavieMetadata = () => [[null, null, navieMetadata]];
+
   const emptySearchResponse = {
     results: [],
   };
 
   const buildComponent = (searchResponse, contextResponse, hasMetadata) => {
     const messagesCalled = {
+      'v1.navie.metadata': rpcNavieMetadata(),
       'v2.configuration.get': noConfig(),
       explain: [[null, null, { userMessageId, threadId }]],
       'explain.status': [
@@ -95,6 +109,7 @@ describe('pages/ChatSearch.vue', () => {
 
   it('can be resized', async () => {
     const wrapper = chatSearchWrapper({
+      'v1.navie.metadata': rpcNavieMetadata(),
       'v2.configuration.get': noConfig(),
     });
 
@@ -175,7 +190,7 @@ describe('pages/ChatSearch.vue', () => {
         const status = '[data-cy="tool-status"] [data-cy="status"]';
         const wrapper = chatSearchWrapper({
           'appmap.metadata': [[null, null, {}]],
-
+          'v1.navie.metadata': rpcNavieMetadata(),
           'v2.configuration.get': noConfig(),
           explain: [[null, null, { userMessageId, threadId }]],
           'explain.status': [
@@ -264,6 +279,7 @@ describe('pages/ChatSearch.vue', () => {
     it('does not render until the configuration is available', async () => {
       const wrapper = chatSearchWrapper({
         'v2.configuration.get': noConfig(),
+        'v1.navie.metadata': rpcNavieMetadata(),
       });
 
       expect(wrapper.find('[data-cy="llm-config"]').exists()).toBe(false);
@@ -275,6 +291,7 @@ describe('pages/ChatSearch.vue', () => {
 
     it('renders a local configuration', async () => {
       const wrapper = chatSearchWrapper({
+        'v1.navie.metadata': rpcNavieMetadata(),
         'v2.configuration.get': [
           [
             null,
@@ -294,6 +311,7 @@ describe('pages/ChatSearch.vue', () => {
 
     it('renders the default configuration', async () => {
       const wrapper = chatSearchWrapper({
+        'v1.navie.metadata': rpcNavieMetadata(),
         'v2.configuration.get': [[null, null, { projectDirectories: [] }]],
       });
 
@@ -307,6 +325,7 @@ describe('pages/ChatSearch.vue', () => {
 
     it('renders an azure configuration', async () => {
       const wrapper = chatSearchWrapper({
+        'v1.navie.metadata': rpcNavieMetadata(),
         'v2.configuration.get': [
           [
             null,
@@ -330,6 +349,7 @@ describe('pages/ChatSearch.vue', () => {
 
     it('renders an OpenAI configuration', async () => {
       const wrapper = chatSearchWrapper({
+        'v1.navie.metadata': rpcNavieMetadata(),
         'v2.configuration.get': [
           [
             null,
@@ -355,6 +375,7 @@ describe('pages/ChatSearch.vue', () => {
   describe('error handling', () => {
     async function simulateError(err, error) {
       const wrapper = chatSearchWrapper({
+        'v1.navie.metadata': rpcNavieMetadata(),
         'v2.configuration.get': noConfig(),
         explain: [[err, error]],
       });

--- a/packages/components/tests/unit/support/polyfills.js
+++ b/packages/components/tests/unit/support/polyfills.js
@@ -1,3 +1,6 @@
 import { TextEncoder, TextDecoder } from 'util';
 global.TextEncoder = TextEncoder;
 global.TextDecoder = TextDecoder;
+
+// Used by the AutoComplete component
+document.getSelection = jest.fn().mockReturnValue({ focusOffset: 0 });

--- a/packages/navie/src/lib/post-response-hook.ts
+++ b/packages/navie/src/lib/post-response-hook.ts
@@ -1,0 +1,7 @@
+import type InteractionHistory from '../interaction-history';
+
+export type PostResponseHookResult = string | undefined | Promise<string | undefined>;
+export default interface PostResponseHook {
+  condition(interactionHistory: InteractionHistory): boolean;
+  execute(interactionHistory: InteractionHistory): PostResponseHookResult;
+}

--- a/packages/navie/src/lib/post-response-hooks/post-diagram.ts
+++ b/packages/navie/src/lib/post-response-hooks/post-diagram.ts
@@ -1,0 +1,20 @@
+import type InteractionHistory from '../../interaction-history';
+import type { AgentSelectionEvent } from '../../interaction-history';
+import PostResponseHook from '../post-response-hook';
+
+/* eslint-disable class-methods-use-this */
+export default class PostDiagramHook implements PostResponseHook {
+  condition(interactionHistory: InteractionHistory): boolean {
+    const agentSelection = interactionHistory.events.find(
+      (e) => e.type === 'agentSelection'
+    ) as AgentSelectionEvent;
+    return agentSelection.agent === 'diagram';
+  }
+
+  execute() {
+    return `
+
+[Create an implementation plan](event:plan)`;
+  }
+}
+/* eslint-enable class-methods-use-this */

--- a/packages/navie/src/lib/post-response-hooks/post-generate.ts
+++ b/packages/navie/src/lib/post-response-hooks/post-generate.ts
@@ -1,0 +1,20 @@
+import type InteractionHistory from '../../interaction-history';
+import type { AgentSelectionEvent } from '../../interaction-history';
+import PostResponseHook from '../post-response-hook';
+
+/* eslint-disable class-methods-use-this */
+export default class PostGenerateHook implements PostResponseHook {
+  condition(interactionHistory: InteractionHistory): boolean {
+    const agentSelection = interactionHistory.events.find(
+      (e) => e.type === 'agentSelection'
+    ) as AgentSelectionEvent;
+    return agentSelection.agent === 'generate';
+  }
+
+  execute() {
+    return `
+
+[Write tests](event:test-cases)`;
+  }
+}
+/* eslint-enable class-methods-use-this */

--- a/packages/navie/src/lib/post-response-hooks/post-plan.ts
+++ b/packages/navie/src/lib/post-response-hooks/post-plan.ts
@@ -1,0 +1,20 @@
+import type InteractionHistory from '../../interaction-history';
+import type { AgentSelectionEvent } from '../../interaction-history';
+import PostResponseHook from '../post-response-hook';
+
+/* eslint-disable class-methods-use-this */
+export default class PostPlanHook implements PostResponseHook {
+  condition(interactionHistory: InteractionHistory): boolean {
+    const agentSelection = interactionHistory.events.find(
+      (e) => e.type === 'agentSelection'
+    ) as AgentSelectionEvent;
+    return agentSelection.agent === 'plan';
+  }
+
+  execute() {
+    return `
+
+[Generate code](event:generate-code) [Create a diagram](event:create-diagram)`;
+  }
+}
+/* eslint-enable class-methods-use-this */

--- a/packages/navie/src/lib/post-response-hooks/post-test.ts
+++ b/packages/navie/src/lib/post-response-hooks/post-test.ts
@@ -1,0 +1,20 @@
+import type InteractionHistory from '../../interaction-history';
+import type { AgentSelectionEvent } from '../../interaction-history';
+import PostResponseHook from '../post-response-hook';
+
+/* eslint-disable class-methods-use-this */
+export default class PostTestHook implements PostResponseHook {
+  condition(interactionHistory: InteractionHistory): boolean {
+    const agentSelection = interactionHistory.events.find(
+      (e) => e.type === 'agentSelection'
+    ) as AgentSelectionEvent;
+    return agentSelection.agent === 'test';
+  }
+
+  execute() {
+    return `
+
+[Create an implementation plan](event:plan)`;
+  }
+}
+/* eslint-enable class-methods-use-this */

--- a/packages/navie/src/prompt.ts
+++ b/packages/navie/src/prompt.ts
@@ -56,7 +56,8 @@ focused primarily on answering this question.
     content: `**The code generation task**
 
 This is a description of a code enhancement that the user wants you to help them with. Your response should be
-focused primarily on solving this issue via code generation.
+focused primarily on solving this issue via code generation. If this field is blank, the user expects you to use
+the conversation history to generate code.
 `,
     tagName: 'issue-description',
   },

--- a/packages/rpc/src/index.ts
+++ b/packages/rpc/src/index.ts
@@ -11,3 +11,4 @@ export * from './appmap';
 export * from './explain';
 export * from './configuration';
 export * from './file';
+export * from './navie';

--- a/packages/rpc/src/navie.ts
+++ b/packages/rpc/src/navie.ts
@@ -1,0 +1,20 @@
+export namespace NavieRpc {
+  export namespace V1 {
+    export namespace Metadata {
+      export type Command = {
+        name: string;
+        description: string;
+        referenceUrl?: string;
+        demoUrls?: string[];
+      };
+
+      export const Method = 'v1.navie.metadata';
+      export type Params = {};
+      export type Response = {
+        welcomeMessage?: string;
+        inputPlaceholder?: string;
+        commands: Command[];
+      };
+    }
+  }
+}

--- a/packages/rpc/src/navie.ts
+++ b/packages/rpc/src/navie.ts
@@ -16,5 +16,20 @@ export namespace NavieRpc {
         commands: Command[];
       };
     }
+
+    export namespace UIEvent {
+      export const Method = 'v1.navie.ui_event';
+      export type Params = {
+        event: string;
+      };
+      export type ResponseSubmitPrompt = Response & {
+        action: 'submit_prompt';
+        prompt: string;
+      };
+      export type Response = {
+        action: string;
+        [key: string]: any;
+      };
+    }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -152,7 +152,7 @@ __metadata:
     "@appland/models": "workspace:^2.10.2"
     "@appland/navie": ^1.19.0
     "@appland/openapi": "workspace:^1.8.0"
-    "@appland/rpc": "workspace:^1.9.0"
+    "@appland/rpc": "workspace:^1.11.0"
     "@appland/scanner": "workspace:^1.86.0"
     "@appland/sequence-diagram": "workspace:^1.12.0"
     "@craftamap/esbuild-plugin-html": ^0.4.0
@@ -500,7 +500,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@appland/rpc@workspace:^1.9.0, @appland/rpc@workspace:packages/rpc":
+"@appland/rpc@workspace:^1.11.0, @appland/rpc@workspace:^1.9.0, @appland/rpc@workspace:packages/rpc":
   version: 0.0.0-use.local
   resolution: "@appland/rpc@workspace:packages/rpc"
   dependencies:


### PR DESCRIPTION
This pull request adds the capability for Navie to render buttons in its response. A basic implementation exists to render buttons when a mode is selected, prompting the user to invoke another (separate) mode.

The basic implementation flow is as follows:
```mermaid
flowchart TD
    A["Plan"] --> B["Generate"]
    A --> C["Diagram"]
    B --> D["Test"]
    C --> B
    D --> A
```

### Key Changes

1. **UI Event Handling**
   - Added support for handling various UI events such as `generate-code`, `create-diagram`, `plan`, and `test-cases`.

2. **Command Buttons and Post-Response Hooks**
   - Implemented command buttons that appear following chat messages, allowing users to take next steps like generating code or creating diagrams.
   - Introduced post-response hooks for different actions (`plan`, `diagram`, `generate`, `test`).

3. **Auto-Completion for Commands**
   - Added an inline auto-completion feature for `@` commands to improve user experience during input.

4. **Welcome Message and Placeholder**
   - Added frontend support for rendering a welcome message and setting input placeholders dynamically based on metadata.

5. **Metadata RPC Endpoint**
   - Implemented the `v1.navie.metadata` endpoint to provide metadata such as welcome messages, input placeholders, and available commands.

### Improvements
- Improved user interaction flow with command buttons and auto-completion.
- Enhanced metadata handling to provide better contextual information to users.

### Fixes
- Fixed issues related to empty `@generate` commands by utilizing conversation history for code generation.