### PR TITLE
feat: Add `@observe` command for recording suggestions

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -31,7 +31,7 @@
     "@appland/diagrams": "workspace:^1.7.0",
     "@appland/models": "workspace:^2.10.2",
     "@appland/rpc": "workspace:^1.13.0",
-    "@appland/sequence-diagram": "workspace:^1.11.0",
+    "@appland/sequence-diagram": "^1.11.0",
     "@types/sax": "^1.2.7",
     "buffer": "^6.0.3",
     "d3": "^7.8.4",

--- a/packages/components/src/components/chat/UserMessage.vue
+++ b/packages/components/src/components/chat/UserMessage.vue
@@ -656,6 +656,10 @@ export default {
     }
   }
 
+  li > div {
+    margin: 0.5rem 0 1rem 0;
+  }
+
   div {
     hr {
       border: none;

--- a/packages/components/src/components/chat/UserMessage.vue
+++ b/packages/components/src/components/chat/UserMessage.vue
@@ -393,7 +393,7 @@ export default {
 }
 .message {
   display: grid;
-  grid-template-columns: 38px 1fr;
+  grid-template-columns: 38px calc(100% - 38px - 1rem);
   grid-template-rows: 16px 1fr;
   gap: 0.5rem 1rem;
   padding: 0 1rem;

--- a/packages/components/src/stories/ChatSearch.stories.js
+++ b/packages/components/src/stories/ChatSearch.stories.js
@@ -417,6 +417,11 @@ function buildMockRpc(
             description: 'Write tests for your code.',
           },
           {
+            name: '@observe',
+            description:
+              'Request recommendations for recording trace data of specific behaviors within your application. Beta feature.',
+          },
+          {
             name: '@help',
             description: 'Get help with AppMap and Navie AI.',
           },

--- a/packages/navie/src/command.ts
+++ b/packages/navie/src/command.ts
@@ -10,6 +10,7 @@ export enum CommandMode {
   TechStack = 'tech-stack',
   ListFiles = 'list-files',
   Suggest = 'suggest',
+  Observe = 'observe',
 }
 
 export interface CommandRequest extends ClientRequest {

--- a/packages/navie/src/commands/observe-command.ts
+++ b/packages/navie/src/commands/observe-command.ts
@@ -1,0 +1,253 @@
+import { z } from 'zod';
+
+import type Command from '../command';
+import type { CommandRequest } from '../command';
+import CompletionService from '../services/completion-service';
+import LookupContextService from '../services/lookup-context-service';
+import VectorTermsService from '../services/vector-terms-service';
+import { ContextV2 } from '../context';
+import { ExplainOptions } from './explain-command';
+import Message from '../message';
+import InteractionHistory, {
+  CompletionEvent,
+  PromptInteractionEvent,
+} from '../interaction-history';
+import { UserOptions } from '../lib/parse-options';
+import ProjectInfoService from '../services/project-info-service';
+
+const RelevantTest = z.object({
+  relevantTest: z
+    .object({
+      name: z.string().optional().describe('The name of the test case, if known'),
+      path: z.string().describe('The file path of the test file'),
+      language: z
+        .enum(['ruby', 'python', 'java', 'javascript', 'other'])
+        .describe('The programming language of the test file'),
+      framework: z.string().optional().describe('The test framework used'),
+    })
+    .optional()
+    .describe('A descriptor of the most relevant test to the requested behavior'),
+  installCommands: z
+    .array(
+      z.object({
+        command: z.string().describe('The command to execute'),
+        description: z.string().optional().describe('A description of the command'),
+      })
+    )
+    .optional()
+    .describe('An ordered list of terminal command(s) necessary to execute to install AppMap'),
+  testCommands: z
+    .array(
+      z.object({
+        command: z.string().describe('The command to execute'),
+        description: z.string().optional().describe('A description of the command'),
+      })
+    )
+    .optional()
+    .describe('The ordered list of terminal command(s) that can be executed to run the test'),
+});
+
+export default class ObserveCommand implements Command {
+  constructor(
+    private readonly options: ExplainOptions,
+    private readonly completionService: CompletionService,
+    private readonly lookupContextService: LookupContextService,
+    private readonly vectorTermsService: VectorTermsService,
+    private readonly interactionHistory: InteractionHistory,
+    private readonly projectInfoService: ProjectInfoService
+  ) {}
+
+  private async getLanguageDirective(userOptions: UserOptions): Promise<string> {
+    const language = userOptions.stringValue('language');
+    if (language) {
+      return `The language of the test must be ${language}.`;
+    }
+
+    const projectInfos = await this.projectInfoService.lookupProjectInfo();
+    if (projectInfos.length <= 1) {
+      const language = projectInfos?.[0]?.appmapConfig?.language;
+      return language
+        ? `The test case must be written in ${language}.`
+        : 'Ideally, the language of the test case should be Java, Ruby, Python, or JavaScript.';
+    }
+
+    const containsUnknownLanguage = projectInfos.some((info) => !info.appmapConfig?.language);
+    const languageTable = projectInfos.reduce((acc, info) => {
+      acc += `| ${info.directory} | ${info.appmapConfig?.language ?? 'unknown'} |\n`;
+      return acc;
+    }, '| Directory | Language |\n| --- | --- |\n');
+
+    return [
+      'The language of the test must be one of the following, associated by project directory:',
+      languageTable,
+      containsUnknownLanguage
+        ? 'If a language is flagged as "unknown", ideally the language of the test case should be Java, Ruby, Python, or JavaScript, but this is not guaranteed.'
+        : '',
+    ]
+      .join('\n')
+      .trim();
+  }
+
+  private getTestSnippets(
+    vectorTerms: string[],
+    tokenLimit: number
+  ): Promise<ContextV2.FileContextItem[]> {
+    return this.lookupContextService
+      .lookupContext(vectorTerms, tokenLimit, {
+        include: ['test', 'spec'],
+      })
+      .then((contextItems) =>
+        contextItems.filter(
+          (item): item is ContextV2.FileContextItem =>
+            item.type === ContextV2.ContextItemType.CodeSnippet
+        )
+      );
+  }
+
+  private async getMostRelevantTest(
+    userRequest: string,
+    userOptions: UserOptions,
+    fileContextItems: ContextV2.FileContextItem[]
+  ): Promise<z.infer<typeof RelevantTest> | undefined> {
+    const model = this.completionService.miniModelName;
+    const temperature = 0;
+    const context = fileContextItems.map(
+      ({ content, location }) =>
+        `<code-snippet location="${location}">\n${content}\n</code-snippet>`
+    );
+
+    const projectLanguageDirective = await this.getLanguageDirective(userOptions);
+    const messages: Message[] = [
+      {
+        role: 'system',
+        content: `Given the following code snippets, identify the single most relevant test to the user request.
+
+${projectLanguageDirective}
+
+<code-snippets>
+${context.join('\n')}
+</code-snippets>`,
+      },
+      {
+        role: 'user',
+        content: userRequest,
+      },
+    ];
+
+    messages.forEach(({ role, content }) => {
+      this.interactionHistory.addEvent(new PromptInteractionEvent('relevantTest', role, content));
+    });
+    this.interactionHistory.addEvent(new CompletionEvent(model, temperature));
+
+    const result = await this.completionService.json(messages, RelevantTest, {
+      model,
+      temperature,
+    });
+
+    this.interactionHistory.addEvent(
+      new PromptInteractionEvent('relevantTest', 'assistant', JSON.stringify(result, null, 2))
+    );
+
+    return result;
+  }
+
+  async *execute({ question: userRequest, userOptions }: CommandRequest): AsyncIterable<string> {
+    const vectorTerms = await this.vectorTermsService.suggestTerms(userRequest);
+    const tokenLimit = userOptions.numberValue('tokenlimit') || this.options.tokenLimit;
+    const testSnippets = await this.getTestSnippets(vectorTerms, tokenLimit);
+    const result = await this.getMostRelevantTest(userRequest, userOptions, testSnippets);
+    const { relevantTest, installCommands, testCommands } = result || {};
+    if (!relevantTest) {
+      yield 'Sorry, I could not find any relevant tests to record.';
+      return;
+    }
+
+    if (relevantTest.language === 'other') {
+      yield `I found a relevant test at \`${relevantTest.path}\`, but I'm unable to help you record it at this time. This language does not appear to be supported.`;
+      return;
+    }
+
+    const helpDocs = await this.lookupContextService.lookupHelp(
+      [relevantTest.language],
+      ['record', 'agent', 'tests', relevantTest.framework].filter(Boolean) as string[],
+      tokenLimit
+    );
+
+    const messages: ReadonlyArray<Message> = [
+      {
+        role: 'system',
+        content: `You are Navie, an AI assistant created by AppMap. Your job is to help the user identify a relevant test case and record AppMap trace data for that test case.`,
+      },
+      {
+        role: 'user',
+        content: `Identify the most relevant test case from the following string:
+\`\`\`
+${userRequest}
+\`\`\``,
+      },
+      {
+        role: 'assistant',
+        content: `Based on the request, the most relevant test case is:
+${relevantTest.name ? `**Name:** \`${relevantTest.name}\`` : ''}
+${relevantTest.framework ? `**Framework:** \`${relevantTest.framework}\`` : ''}
+${relevantTest.language ? `**Language:** \`${relevantTest.language}\`` : ''}
+**Path:** \`${relevantTest.path}\`
+
+${
+  installCommands?.length
+    ? `I've identified the following commands that you may need to run to install AppMap:
+<commands>
+${installCommands?.map((command) => `- \`${command.command}\`: ${command.description}`).join('\n')}
+</commands>
+`
+    : ''
+}
+${
+  testCommands?.length
+    ? `I've identified the following commands that you may need to run to execute the test:
+<commands>
+${testCommands?.map((command) => `- \`${command.command}\`: ${command.description}`).join('\n')}
+</commands>
+`
+    : ''
+}
+Documentation which may be relevant to recording this particular test case is provided below.
+<documentation>
+${helpDocs
+  .map(
+    (doc) =>
+      `<document file="${doc.filePath}" from="${doc.from}" to="${doc.to}">${doc.content}</document>`
+  )
+  .join('\n')}
+</documentation>`,
+      },
+      {
+        role: 'user',
+        content: `Restate the information you've provided to me, in standalone format, as a step by step guide outlining the steps required to record the single test case that you've identified.
+If possible, include the terminal command needed to run the test. Only specify test patterns that are guaranteed to match based on previous context. For example, do not include file ranges not supported by the test runner.
+In your response, please include the following:
+- The name of the test case (if known)
+- The path to the test file
+- Any steps and terminal commands required to install the AppMap recording agent
+- Any steps and terminal commands required to run the specific test case
+
+Do not include:
+- A title or introduction
+- A conclusion or closing statement
+- My original inquiry`,
+      },
+    ];
+    messages.forEach(({ role, content }) => {
+      this.interactionHistory.addEvent(new PromptInteractionEvent('observe', role, content));
+    });
+    const temperature = 0;
+    this.interactionHistory.addEvent(
+      new CompletionEvent(this.completionService.modelName, temperature)
+    );
+    const completion = this.completionService.complete(messages, { temperature });
+
+    for await (const token of completion) {
+      yield token;
+    }
+  }
+}

--- a/packages/navie/src/navie.ts
+++ b/packages/navie/src/navie.ts
@@ -36,6 +36,7 @@ import ComputeUpdateService from './services/compute-update-service';
 import createCompletionService from './services/completion-service-factory';
 import NextStepClassificationService from './services/next-step-classification-service';
 import SuggestCommand from './commands/suggest-command';
+import ObserveCommand from './commands/observe-command';
 
 export type ChatHistory = Message[];
 
@@ -162,6 +163,18 @@ export default function navie(
     return new SuggestCommand(nextStepService);
   };
 
+  const buildObserveCommand = () => {
+    const projectInfoService = new ProjectInfoService(interactionHistory, projectInfoProvider);
+    return new ObserveCommand(
+      options,
+      completionService,
+      lookupContextService,
+      vectorTermsService,
+      interactionHistory,
+      projectInfoService
+    );
+  };
+
   const commandBuilders: Record<CommandMode, () => Command> = {
     [CommandMode.Explain]: buildExplainCommand,
     [CommandMode.Classify]: buildClassifyCommand,
@@ -171,6 +184,7 @@ export default function navie(
     [CommandMode.TechStack]: buildTechStackCommand,
     [CommandMode.Context]: buildContextCommand,
     [CommandMode.Suggest]: buildSuggestCommand,
+    [CommandMode.Observe]: buildObserveCommand,
   };
 
   let { question } = clientRequest;

--- a/packages/navie/src/services/anthropic-completion-service.ts
+++ b/packages/navie/src/services/anthropic-completion-service.ts
@@ -10,7 +10,6 @@ import CompletionService, {
   convertToMessage,
   JsonOptions,
   mergeSystemMessages,
-  ModelType,
   Usage,
 } from './completion-service';
 
@@ -79,12 +78,12 @@ export default class AnthropicCompletionService implements CompletionService {
   // Construct a model with non-default options. There doesn't seem to be a way to configure
   // the model parameters at invocation time like with OpenAI.
   private buildModel(options?: {
-    model?: ModelType;
+    model?: string;
     temperature?: number;
     streaming?: boolean;
   }): ChatAnthropic {
     return new ChatAnthropic({
-      modelName: options?.model === ModelType.Mini ? this.miniModelName : this.modelName,
+      modelName: options?.model ?? this.modelName,
       temperature: options?.temperature ?? this.temperature,
       streaming: options?.streaming ?? true,
     });

--- a/packages/navie/src/services/completion-service.ts
+++ b/packages/navie/src/services/completion-service.ts
@@ -3,13 +3,8 @@ import { AIMessage, BaseMessage, HumanMessage, SystemMessage } from '@langchain/
 import { z } from 'zod';
 import Message from '../message';
 
-export enum ModelType {
-  Full, // slower, more intelligent
-  Mini, // faster, less intelligent
-}
-
 export type JsonOptions = {
-  model?: ModelType;
+  model?: string;
   temperature?: number;
   maxRetries?: number;
 };

--- a/packages/navie/src/services/next-step-classification-service.ts
+++ b/packages/navie/src/services/next-step-classification-service.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import Message from '../message';
 import { ChatHistory } from '../navie';
-import CompletionService, { ModelType } from './completion-service';
+import CompletionService from './completion-service';
 
 const scoreSchema = z.object({
   evaluation: z.string(),
@@ -61,7 +61,7 @@ export default class NextStepClassificationService {
 
   private async getCompletion(messages: Message[]): Promise<NextStepResponse> {
     const response = await this.completionService.json(messages, NextStepResponseFormat, {
-      model: ModelType.Mini,
+      model: this.completionService.miniModelName,
       temperature: 0.2,
     });
     return response?.nextSteps ?? [];

--- a/packages/navie/src/services/openai-completion-service.ts
+++ b/packages/navie/src/services/openai-completion-service.ts
@@ -11,7 +11,6 @@ import CompletionService, {
   convertToMessage,
   JsonOptions,
   mergeSystemMessages,
-  ModelType,
   Usage,
 } from './completion-service';
 
@@ -189,12 +188,6 @@ export default class OpenAICompletionService implements CompletionService {
     }
   }
 
-  // Resolve `full` or `mini` to the appropriate model name.
-  private resolveModel(modelType?: ModelType): string {
-    if (modelType === ModelType.Mini) return this.miniModelName;
-    return this.modelName;
-  }
-
   // Request a JSON object with a given JSON schema.
   async json<Schema extends z.ZodType>(
     messages: Message[],
@@ -216,7 +209,7 @@ export default class OpenAICompletionService implements CompletionService {
             )}`,
           },
         ]),
-        model: this.resolveModel(options?.model),
+        model: options?.model ?? this.modelName,
         stream: false,
         temperature: options?.temperature,
       });
@@ -226,7 +219,7 @@ export default class OpenAICompletionService implements CompletionService {
     const generateOpenAi = () =>
       this.model.completionWithRetry({
         messages: mergeSystemMessages(messages),
-        model: this.resolveModel(options?.model),
+        model: options?.model ?? this.miniModelName,
         stream: false,
         temperature: options?.temperature,
         response_format: zodResponseFormat(schema, 'requestedObject'),

--- a/packages/navie/test/commands/observe-command.spec.ts
+++ b/packages/navie/test/commands/observe-command.spec.ts
@@ -1,0 +1,319 @@
+/*
+  eslint
+  @typescript-eslint/unbound-method: 0,
+  @typescript-eslint/no-unsafe-assignment: 0,
+  @typescript-eslint/no-explicit-any: 0,
+  func-names: 0
+*/
+
+import ObserveCommand from '../../src/commands/observe-command';
+import InteractionHistory from '../../src/interaction-history';
+import { UserOptions } from '../../src/lib/parse-options';
+import CompletionService from '../../src/services/completion-service';
+import LookupContextService from '../../src/services/lookup-context-service';
+import ProjectInfoService from '../../src/services/project-info-service';
+import VectorTermsService from '../../src/services/vector-terms-service';
+
+interface ObserveCommandPrivate {
+  getLanguageDirective(userOptions: UserOptions): Promise<string>;
+}
+
+describe('ObserveCommand', () => {
+  let command: ObserveCommand;
+  let completionService: CompletionService;
+  let lookupContextService: LookupContextService;
+  let vectorTermsService: VectorTermsService;
+  let interactionHistory: InteractionHistory;
+  let projectInfoService: ProjectInfoService;
+  let suggestTerms: jest.Mock;
+  const tokenLimit = 1000;
+  const responseTokens = 1000;
+  const modelName = 'exampleModel';
+  const miniModelName = 'exampleMiniModel';
+  const exampleGeneration = 'example generation';
+  const exampleContext = [
+    {
+      type: 'code-snippet',
+      content: 'it("works", () => true);',
+      directory: '/home/user/projects/my-app',
+      path: 'test/assert_true.js',
+    },
+  ];
+  const exampleHelp = [
+    {
+      filePath: 'doc.md',
+      from: 1,
+      to: 23,
+      content: 'example help content',
+      score: 10,
+    },
+  ];
+  const read = async (input: AsyncIterable<string>) => {
+    let result = '';
+    for await (const item of input) {
+      result += item;
+    }
+    return result;
+  };
+
+  beforeEach(() => {
+    completionService = {
+      json: jest.fn().mockResolvedValue({}),
+      complete: jest.fn().mockImplementation(function* () {
+        yield exampleGeneration;
+      }),
+      modelName: modelName,
+      miniModelName: miniModelName,
+    } as any;
+    interactionHistory = new InteractionHistory();
+    lookupContextService = new LookupContextService(
+      interactionHistory,
+      jest.fn().mockResolvedValue(exampleContext),
+      jest.fn().mockResolvedValue(exampleHelp)
+    );
+    suggestTerms = jest.fn().mockResolvedValue(['example']);
+    vectorTermsService = { suggestTerms } as any;
+    projectInfoService = new ProjectInfoService(
+      interactionHistory,
+      jest.fn().mockResolvedValue([{ directory: 'test', appmapConfig: { language: 'ruby' } }])
+    );
+    command = new ObserveCommand(
+      { tokenLimit, responseTokens },
+      completionService,
+      lookupContextService,
+      vectorTermsService,
+      interactionHistory,
+      projectInfoService
+    );
+  });
+
+  afterEach(jest.resetAllMocks);
+
+  it('requests help docs if a test is identified', async () => {
+    completionService.json = jest
+      .fn()
+      .mockReturnValueOnce({ relevantTest: { name: 'true is true', path: 'spec/my_spec.rb' } });
+    lookupContextService.lookupHelp = jest.fn().mockReturnValueOnce([]);
+    const result = await read(
+      command.execute({
+        question: 'what?',
+        userOptions: new UserOptions(new Map()),
+      })
+    );
+
+    expect(result).toEqual(exampleGeneration);
+    expect(vectorTermsService.suggestTerms).toBeCalledTimes(1);
+    expect(completionService.json).toBeCalledTimes(1);
+    expect(lookupContextService.lookupHelp).toBeCalledTimes(1);
+  });
+
+  it('exits early if no test is identified', async () => {
+    lookupContextService.lookupContext = jest.fn().mockResolvedValue([]);
+    completionService.json = jest.fn().mockReturnValueOnce(undefined);
+    lookupContextService.lookupHelp = jest.fn();
+    const result = await read(
+      command.execute({
+        question: 'what?',
+        userOptions: new UserOptions(new Map()),
+      })
+    );
+    expect(result).toEqual('Sorry, I could not find any relevant tests to record.');
+    expect(lookupContextService.lookupHelp).not.toBeCalled();
+    expect(completionService.complete).not.toBeCalled();
+  });
+
+  it('exits early if the language is not supported', async () => {
+    lookupContextService.lookupHelp = jest.fn();
+    completionService.json = jest.fn().mockReturnValueOnce({
+      relevantTest: {
+        name: 'true is true',
+        path: 'tests/assert_true.c',
+        language: 'other',
+      },
+    });
+    const result = await read(
+      command.execute({
+        question: 'what?',
+        userOptions: new UserOptions(new Map([['language', 'unsupported']])),
+      })
+    );
+    expect(result).toEqual(
+      "I found a relevant test at `tests/assert_true.c`, but I'm unable to help you record it at this time. This language does not appear to be supported."
+    );
+    expect(lookupContextService.lookupHelp).not.toBeCalled();
+    expect(completionService.complete).not.toBeCalled();
+  });
+
+  it('yields the expected interaction history', async () => {
+    completionService.json = jest
+      .fn()
+      .mockReturnValueOnce({ relevantTest: { name: 'true is true', path: 'spec/my_spec.rb' } });
+    const question = 'hello?';
+    await read(command.execute({ question, userOptions: new UserOptions(new Map()) }));
+    expect(interactionHistory.events.map((e) => ({ ...e }))).toEqual([
+      /*
+        VectorTermsService.suggestTerms is stubbed.
+        It'd otherwise include a VectorTermsEvent here.
+      */
+      {
+        type: 'contextLookup',
+        context: exampleContext,
+      },
+      {
+        type: 'prompt',
+        name: 'relevantTest',
+        role: 'system',
+        prefix: undefined,
+        content: expect.stringContaining('Given the following code snippets'),
+      },
+      {
+        type: 'prompt',
+        name: 'relevantTest',
+        role: 'user',
+        prefix: undefined,
+        content: question,
+      },
+      {
+        type: 'completion',
+        model: miniModelName,
+        temperature: 0,
+      },
+      {
+        type: 'prompt',
+        name: 'relevantTest',
+        role: 'assistant',
+        prefix: undefined,
+        content: expect.stringContaining('true is true'),
+      },
+      {
+        type: 'helpLookup',
+        help: exampleHelp,
+      },
+      {
+        type: 'prompt',
+        name: 'observe',
+        role: 'system',
+        prefix: undefined,
+        content: expect.stringContaining('You are Navie'),
+      },
+      {
+        type: 'prompt',
+        name: 'observe',
+        role: 'user',
+        prefix: undefined,
+        content: expect.stringContaining(question),
+      },
+      {
+        type: 'prompt',
+        name: 'observe',
+        role: 'assistant',
+        prefix: undefined,
+        content: expect.stringContaining('the most relevant test case is:'),
+      },
+      {
+        type: 'prompt',
+        name: 'observe',
+        role: 'user',
+        prefix: undefined,
+        content: expect.stringContaining("Restate the information you've provided to me"),
+      },
+      {
+        type: 'completion',
+        model: modelName,
+        temperature: 0,
+      },
+    ]);
+  });
+
+  describe('getLanguageDirective', () => {
+    let privateCommand: ObserveCommandPrivate;
+    beforeEach(() => {
+      privateCommand = command as unknown as ObserveCommandPrivate;
+    });
+
+    it('returns a language directive', async () => {
+      const userOptions = new UserOptions(new Map([['language', 'ruby']]));
+      const result = await privateCommand.getLanguageDirective(userOptions);
+      expect(result).toEqual('The language of the test must be ruby.');
+    });
+
+    it('returns an empty string if the language is not found', async () => {
+      const userOptions = new UserOptions(new Map([['language', 'YAML']]));
+      const result = await privateCommand.getLanguageDirective(userOptions);
+      expect(result).toEqual('The language of the test must be YAML.');
+    });
+
+    it('returns ambiguous instructions if no config is provided and language is not set', async () => {
+      projectInfoService.projectInfoProvider = jest.fn().mockResolvedValue([]);
+      const userOptions = new UserOptions(new Map());
+      const result = await privateCommand.getLanguageDirective(userOptions);
+      expect(result).toEqual(
+        'Ideally, the language of the test case should be Java, Ruby, Python, or JavaScript.'
+      );
+    });
+
+    it('returns ambiguous instructions if a config does not have a language', async () => {
+      projectInfoService.projectInfoProvider = jest.fn().mockResolvedValue([
+        {
+          directory: 'test',
+          appmapConfig: { language: undefined },
+        },
+      ]);
+      const userOptions = new UserOptions(new Map());
+      const result = await privateCommand.getLanguageDirective(userOptions);
+      expect(result).toEqual(
+        'Ideally, the language of the test case should be Java, Ruby, Python, or JavaScript.'
+      );
+    });
+
+    it('renders a markdown table if more than one project is found', async () => {
+      projectInfoService.projectInfoProvider = jest.fn().mockResolvedValue([
+        {
+          directory: '/home/user/projects/my-app',
+          appmapConfig: { language: 'ruby' },
+        },
+        {
+          directory: '/home/user/projects/other-app',
+          appmapConfig: { language: 'javascript' },
+        },
+      ]);
+      const userOptions = new UserOptions(new Map());
+      const result = await privateCommand.getLanguageDirective(userOptions);
+      expect(result).toEqual(
+        [
+          'The language of the test must be one of the following, associated by project directory:',
+          '| Directory | Language |',
+          '| --- | --- |',
+          '| /home/user/projects/my-app | ruby |',
+          '| /home/user/projects/other-app | javascript |',
+        ].join('\n')
+      );
+    });
+
+    it('provides additional instructions if a language is unknown', async () => {
+      projectInfoService.projectInfoProvider = jest.fn().mockResolvedValue([
+        {
+          directory: '/home/user/projects/my-app',
+          appmapConfig: { language: undefined },
+        },
+        {
+          directory: '/home/user/projects/other-app',
+          appmapConfig: { language: 'javascript' },
+        },
+      ]);
+      const userOptions = new UserOptions(new Map());
+      const result = await privateCommand.getLanguageDirective(userOptions);
+      expect(result).toEqual(
+        [
+          'The language of the test must be one of the following, associated by project directory:',
+          '| Directory | Language |',
+          '| --- | --- |',
+          '| /home/user/projects/my-app | unknown |',
+          '| /home/user/projects/other-app | javascript |',
+          '',
+          'If a language is flagged as "unknown", ideally the language of the test case should be Java, Ruby, Python, or JavaScript, but this is not guaranteed.',
+        ].join('\n')
+      );
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -300,7 +300,7 @@ __metadata:
     "@appland/diagrams": "workspace:^1.7.0"
     "@appland/models": "workspace:^2.10.2"
     "@appland/rpc": "workspace:^1.13.0"
-    "@appland/sequence-diagram": "workspace:^1.11.0"
+    "@appland/sequence-diagram": ^1.11.0
     "@babel/core": ^7.22.5
     "@babel/node": ^7.22.5
     "@babel/preset-env": ^7.22.5
@@ -583,7 +583,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@appland/sequence-diagram@workspace:^1.11.0, @appland/sequence-diagram@workspace:^1.12.0, @appland/sequence-diagram@workspace:packages/sequence-diagram":
+"@appland/sequence-diagram@^1.11.0, @appland/sequence-diagram@workspace:^1.12.0, @appland/sequence-diagram@workspace:packages/sequence-diagram":
   version: 0.0.0-use.local
   resolution: "@appland/sequence-diagram@workspace:packages/sequence-diagram"
   dependencies:


### PR DESCRIPTION
This pull request introduces a new `@observe` command to facilitate recording of test cases based on user inquiry. The user can specify some behavior they'd like to record and Navie will suggest a test case to run with AppMap enabled.

**Changes**:
1. **New Features**:
   - Introduced an `@observe` command to identify and suggest the most relevant test cases for recording AppMap trace data.
   
2. **Bug Fixes**:
   - Fixed a versioning issue in the `storybook` by correctly specifying the required version of `lru-cache`.
   
3. **Configuration Updates**:
   - Updated `package.json` and `yarn.lock` to reflect the corrected version constraints for dependencies.

**Testing**:
- Added unit tests to cover the new `@observe` command functionality.
- All existing tests have been run to ensure no breakage in current functionality.

Once released, the CLI will need to bump the included version of `@appland/navie` and add a command completion for `@observe` returned by the `v1.navie.metadata` RPC method.