### PR TITLE
fix: Symlinks fall back to copying files on Windows

### DIFF
--- a/packages/cli/src/rpc/explain/explain.ts
+++ b/packages/cli/src/rpc/explain/explain.ts
@@ -22,7 +22,7 @@ import detectAIEnvVar from '../../cmds/index/aiEnvVar';
 import reportFetchError from './navie/report-fetch-error';
 import { LRUCache } from 'lru-cache';
 import { initializeHistory } from './navie/historyHelper';
-import { ThreadAccessError } from './navie/history';
+import { ThreadAccessError } from './navie/ihistory';
 import Thread from './navie/thread';
 
 const searchStatusByUserMessageId = new Map<string, ExplainRpc.ExplainStatusResponse>();

--- a/packages/cli/src/rpc/explain/navie/historyHelper.ts
+++ b/packages/cli/src/rpc/explain/navie/historyHelper.ts
@@ -1,19 +1,22 @@
 import { homedir } from 'os';
 import { mkdirSync, existsSync } from 'fs';
-import History, { ThreadAccessError } from './history';
+import History from './history';
 import Thread from './thread';
 import { join } from 'path';
 import { warn } from 'console';
 import configuration from '../../configuration';
+import IHistory, { ThreadAccessError } from './ihistory';
+import HistoryWindows from './historyWindows';
 
-export function initializeHistory(): History {
+export function initializeHistory(): IHistory {
   const historyDir = join(homedir(), '.appmap', 'navie', 'history');
   if (!existsSync(historyDir)) {
     mkdirSync(historyDir, { recursive: true });
   }
-  return new History(historyDir);
+  return process.platform === 'win32' ? new HistoryWindows(historyDir) : new History(historyDir);
 }
-export async function loadThread(history: History, threadId: string): Promise<Thread> {
+
+export async function loadThread(history: IHistory, threadId: string): Promise<Thread> {
   let thread: Thread;
 
   try {

--- a/packages/cli/src/rpc/explain/navie/historyWindows.ts
+++ b/packages/cli/src/rpc/explain/navie/historyWindows.ts
@@ -1,0 +1,21 @@
+import { ThreadAccessError } from './ihistory';
+import IHistory from './ihistory';
+import Thread from './thread';
+
+export default class HistoryWindows implements IHistory {
+  constructor(public readonly directory: string) {
+    console.warn('History is currently disabled. It is not yet implemented on Windows.');
+  }
+
+  token(): void {
+    // Do nothing
+  }
+
+  question(): void {
+    // Do nothing
+  }
+
+  load(threadId: string): Thread {
+    throw new ThreadAccessError(threadId, 'load', new Error('Not implemented on Windows'));
+  }
+}

--- a/packages/cli/src/rpc/explain/navie/ihistory.ts
+++ b/packages/cli/src/rpc/explain/navie/ihistory.ts
@@ -1,0 +1,47 @@
+import Thread from './thread';
+
+export class ThreadAccessError extends Error {
+  constructor(public readonly threadId: string, public action: string, public cause?: Error) {
+    super(ThreadAccessError.errorMessage(threadId, action, cause));
+  }
+
+  static errorMessage(threadId: string, action: string, cause?: Error): string {
+    const messages = [`Failed to ${action} thread ${threadId}`];
+    if (cause) messages.push(cause.message);
+    return messages.join(': ');
+  }
+}
+
+export enum QuestionField {
+  Question = 'question',
+  CodeSelection = 'codeSelection',
+  Prompt = 'prompt',
+}
+
+export enum ResponseField {
+  AssistantMessageId = 'assistantMessageId',
+  Answer = 'answer',
+}
+
+export default interface IHistory {
+  readonly directory: string;
+
+  token(
+    threadId: string,
+    userMessageId: string,
+    assistantMessageId: string,
+    token: string,
+    extensions?: Record<ResponseField, string>
+  ): void | Promise<void>;
+
+  question(
+    threadId: string,
+    userMessageId: string,
+    question: string,
+    codeSelection: string | undefined,
+    prompt: string | undefined,
+    extensions?: Record<QuestionField, string>
+  ): void | Promise<void>;
+
+  load(threadId: string): Thread | Promise<Thread>;
+}

--- a/packages/cli/src/rpc/explain/navie/navie-remote.ts
+++ b/packages/cli/src/rpc/explain/navie/navie-remote.ts
@@ -8,7 +8,7 @@ import { default as INavie } from './inavie';
 import assert from 'assert';
 import { initializeHistory, loadThread } from './historyHelper';
 import Thread from './thread';
-import History from './history';
+import IHistory from './ihistory';
 
 export class RemtoteCallbackHandler {
   thread: Thread | undefined;
@@ -17,7 +17,7 @@ export class RemtoteCallbackHandler {
   tokens: string[] = [];
 
   constructor(
-    private readonly history: History,
+    private readonly history: IHistory,
     private readonly contextProvider: ContextV2.ContextProvider,
     private readonly projectInfoProvider: ProjectInfo.ProjectInfoProvider,
     private readonly helpProvider: Help.HelpProvider


### PR DESCRIPTION
This pull request addresses the issue of handling history on Windows by disabling the history functionality. Non-Administrator accounts cannot create symlinks by default on Windows, which is necessary for the current implementation of history.

#### Details:
- Introduced an `IHistory` interface to standardize history operations.
- Moved existing history-related functionality to the `History` class which implements `IHistory`.
- Created a `HistoryWindows` class that implements `IHistory` with no-op methods and throws a `ThreadAccessError` for unimplemented functionalities.
- Updated the initialization logic to conditionally use `HistoryWindows` on Windows platforms.
- Refactored references to `History` to use the new `IHistory` interface across the project.