### PR TITLE
fix: Prevent a case where tokens would appear out of order

### DIFF
--- a/packages/cli/src/rpc/explain/navie/navie-remote.ts
+++ b/packages/cli/src/rpc/explain/navie/navie-remote.ts
@@ -157,9 +157,8 @@ export default class RemoteNavie extends EventEmitter implements INavie {
     };
 
     const onToken = async (token: string, messageId: string): Promise<void> => {
-      await callbackHandler.onToken(token, messageId);
-
       this.emit('token', token, messageId);
+      await callbackHandler.onToken(token, messageId);
     };
 
     const onRequestContext = async (


### PR DESCRIPTION
The async call before emitting a token would sometimes cause tokens to be emitted out of order.