### PR TITLE
Pin files to context

### DIFF
--- a/packages/components/src/components/chat-search/Context.vue
+++ b/packages/components/src/components/chat-search/Context.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="context" data-cy="context">
-    <template v-if="!contextResponse">
+    <template v-if="!contextResponse && !hasPinnedItems">
       <div class="context__notice-container">
         <div class="context__notice" data-cy="context-notice">
           <h2>Navie's context</h2>
@@ -15,7 +15,7 @@
     <template v-else>
       <div class="context__body">
         <h2>Context</h2>
-        <template v-if="pinnedItems && pinnedItems.length">
+        <template v-if="hasPinnedItems">
           <h3>Pinned Items</h3>
           <div class="context__body__table">
             <component
@@ -54,6 +54,7 @@
 <script lang="ts">
 //@ts-nocheck
 import VContextItem from '@/components/chat-search/ContextItem.vue';
+import VFile from '@/components/chat/File.vue';
 import VMarkdownCodeSnippet from '@/components/chat/MarkdownCodeSnippet.vue';
 import VMermaidDiagram from '@/components/chat/MermaidDiagram.vue';
 import VButton from '@/components/Button.vue';
@@ -61,14 +62,16 @@ import VButton from '@/components/Button.vue';
 const PinnedContextComponents = {
   'code-snippet': VMarkdownCodeSnippet,
   mermaid: VMermaidDiagram,
+  file: VFile,
 };
 
 export default {
   name: 'v-context',
 
   components: {
-    VContextItem,
     VButton,
+    VContextItem,
+    VFile,
     VMarkdownCodeSnippet,
     VMermaidDiagram,
   },
@@ -102,11 +105,14 @@ export default {
     contextTypeKeys() {
       return Object.keys(this.contextTypes);
     },
+    hasPinnedItems() {
+      return this.pinnedItems?.length > 0;
+    },
   },
 
   methods: {
     hasContext(type: string) {
-      return this.contextResponse.some((context) => context.type === type);
+      return this.contextResponse?.some((context) => context.type === type);
     },
     contextItems(type: string) {
       return this.contextResponse.filter((context) => context.type === type);

--- a/packages/components/src/components/chat/File.vue
+++ b/packages/components/src/components/chat/File.vue
@@ -1,0 +1,51 @@
+<template>
+  <v-context-container
+    :title="header"
+    :handle="handle"
+    :location="decodedLocation"
+    :is-pinnable="isPinnable"
+    :content-type="text"
+    :is-appliable="false"
+    @pin="onPin"
+  >
+  </v-context-container>
+</template>
+<script lang="ts">
+import VContextContainer from '@/components/chat/ContextContainer.vue';
+import ContextItemMixin from '@/components/mixins/contextItem';
+import Vue from 'vue';
+import type { PinEvent } from './PinEvent';
+
+export default Vue.extend({
+  name: 'v-file',
+
+  props: {
+    title: String,
+    location: String,
+    isPinnable: {
+      type: Boolean,
+      default: true,
+    },
+  },
+  mixins: [ContextItemMixin],
+  components: {
+    VContextContainer,
+  },
+  computed: {
+    header(): string | undefined {
+      return this.decodedLocation.split(/[\\/]/).at(-1);
+    },
+    decodedLocation(): string {
+      // The location may be URI encoded to avoid issues with special characters.
+      return decodeURIComponent(this.location);
+    },
+  },
+  methods: {
+    onPin(evt: PinEvent) {
+      // Receiving a "pin" here means that the user is unpinning the file, so evt.pinned is always
+      // false.
+      this.$root.$emit('pin', evt);
+    },
+  },
+});
+</script>

--- a/packages/components/src/components/chat/Handle.ts
+++ b/packages/components/src/components/chat/Handle.ts
@@ -1,0 +1,4 @@
+let Handle = 0;
+export function getNextHandle() {
+  return Handle++;
+}

--- a/packages/components/src/components/chat/PinEvent.ts
+++ b/packages/components/src/components/chat/PinEvent.ts
@@ -19,4 +19,9 @@ export type PinCodeSnippet = PinItem & {
   content: string;
 };
 
-export type PinEvents = PinEvent & (PinMermaid | PinCodeSnippet);
+export type PinFile = PinItem & {
+  type: 'file';
+  content: string;
+};
+
+export type PinEvents = PinEvent & (PinMermaid | PinCodeSnippet | PinFile);

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -17,3 +17,4 @@ const plugin = {
 export default plugin;
 export * as FeatureFlags from '@/lib/featureFlags';
 export * from '@/componentExports';
+export * from '@/lib/PinFileRequest';

--- a/packages/components/src/lib/PinFileRequest.ts
+++ b/packages/components/src/lib/PinFileRequest.ts
@@ -1,0 +1,11 @@
+export class PinFileRequest {
+  name: string; // the name of the file being pinned
+  uri?: string; // if available, a URI for the file
+  content?: string; // if the URI isn't available, the content for the file
+
+  constructor(arg: PinFileRequest) {
+    this.name = arg.name;
+    this.uri = arg.uri;
+    this.content = arg.content;
+  }
+}

--- a/packages/components/tests/e2e/specs/chat/chatSearch.spec.js
+++ b/packages/components/tests/e2e/specs/chat/chatSearch.spec.js
@@ -12,4 +12,60 @@ context('Chat search', () => {
     cy.get('[data-cy="stop-response"]').click();
     cy.get('[data-cy="stop-response"]').should('not.exist');
   });
+
+  describe('when a file is dropped', () => {
+    const listenForFetch = ($div) => {
+      const root = $div[0].__vue__.$root;
+      return new Cypress.Promise((resolve) => {
+        root.$on('fetch-pinned-files', (requests) => {
+          resolve(requests);
+        });
+      });
+    };
+
+    it('handles the VS Code Explorer as the source', () => {
+      cy.get('[data-cy="chat-search"]').then(($div) => {
+        const p = listenForFetch($div);
+        cy.wrap($div).trigger('drop', {
+          dataTransfer: {
+            items: [
+              {
+                kind: 'string',
+                type: 'application/vnd.code.uri-list',
+                getAsString: (cb) => {
+                  cb('file://src/stories/data/scenario.json');
+                },
+              },
+            ],
+          },
+        });
+
+        cy.wrap(p).then(async (requests) => {
+          expect(requests.length).to.eq(1);
+          expect(requests[0]).to.have.keys('name', 'uri', 'content');
+        });
+      });
+    });
+
+    it('handles a source outside VS Code', () => {
+      cy.get('[data-cy="chat-search"]').then(($div) => {
+        const p = listenForFetch($div);
+
+        cy.wrap($div).selectFile('src/stories/data/scenario.json', {
+          action: 'drag-drop',
+        });
+
+        cy.wrap(p).then(async (requests) => {
+          expect(requests.length).to.eq(1);
+          expect(requests[0]).to.have.keys('name', 'uri', 'content');
+
+          // NB: writing this expectation as
+          //   expect(requests[0].content).to.satisfy((s) => s.startsWith('{\n  "events": ['));
+          // works fine when it passes, but **hangs Cypress** when it fails.
+          // So, do this instead:
+          expect(requests[0].content.slice(0, 15)).to.eq('{\n  "events": [');
+        });
+      });
+    });
+  });
 });

--- a/packages/components/tests/unit/chat/ContextContainer.spec.js
+++ b/packages/components/tests/unit/chat/ContextContainer.spec.js
@@ -1,5 +1,5 @@
 import VContextContainer from '@/components/chat/ContextContainer.vue';
-import { mount } from '@vue/test-utils';
+import { createWrapper, mount } from '@vue/test-utils';
 
 describe('components/chat/ContextContainer.vue', () => {
   it('renders pinned state', async () => {
@@ -16,5 +16,24 @@ describe('components/chat/ContextContainer.vue', () => {
 
     const events = wrapper.emitted().pin;
     expect(events).toStrictEqual([[{ pinned: true, handle: wrapper.vm.valueHandle }]]);
+  });
+
+  it('opens a non-collapsible file item', async () => {
+    const location = '/home/user/my-project/app/models/user.rb';
+    const wrapper = mount(VContextContainer, {
+      propsData: {
+        language: 'javascript',
+        location,
+        isFile: true,
+        isCollapsible: false,
+      },
+    });
+
+    const rootWrapper = createWrapper(wrapper.vm.$root);
+    await wrapper.find('[data-cy="open"]').trigger('click');
+
+    const actual = rootWrapper.emitted()['open-location'];
+    expect(actual).toHaveLength(1);
+    expect(actual[0][0]).toStrictEqual(location);
   });
 });

--- a/packages/components/tests/unit/chat/File.spec.js
+++ b/packages/components/tests/unit/chat/File.spec.js
@@ -1,0 +1,19 @@
+import VFile from '@/components/chat/File.vue';
+import { createWrapper, mount } from '@vue/test-utils';
+
+describe('components/chat/File.vue', () => {
+  it('can open a file', async () => {
+    const location = '/home/user/my-project/app/models/user.rb';
+    const wrapper = mount(VFile, {
+      propsData: {
+        location,
+      },
+    });
+    const rootWrapper = createWrapper(wrapper.vm.$root);
+
+    await wrapper.find('[data-cy="open"]').trigger('click');
+    const actual = rootWrapper.emitted()['open-location'];
+    expect(actual).toHaveLength(1);
+    expect(actual[0][0]).toStrictEqual(location);
+  });
+});


### PR DESCRIPTION
Give the user the ability to pin files to the Chat context, including through drag-and-drop.

There are a couple of tests here, but this will be further tested by the e2e tests in the vscode-appland changes that use it.