### PR TITLE
test: emit an event when ChatSearch is loaded

### DIFF
--- a/packages/components/src/pages/ChatSearch.vue
+++ b/packages/components/src/pages/ChatSearch.vue
@@ -589,6 +589,9 @@ export default {
           this.$root.$emit('pin', eventData);
         });
       });
+    this.$nextTick(() => {
+      this.$root.$emit('chat-search-loaded');
+    });
   },
 };
 </script>


### PR DESCRIPTION
Emit an event when the ChatSearch component is completely loaded. This allows tests that use it to insure it's completely initialized before continuing.

Fixes #1994