### PR TITLE
fix: More verbose errors from Anthropic completion service

### DIFF
--- a/packages/navie/package.json
+++ b/packages/navie/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "@tsconfig/node-lts": "^20.1.3",
     "@types/jest": "^29.4.1",
-    "@types/node": "^17.0.2",
+    "@types/node": "20.1.0",
     "@typescript-eslint/eslint-plugin": "^5.51.0",
     "@typescript-eslint/parser": "^5.7.0",
     "eslint": "^8.4.1",

--- a/packages/navie/package.json
+++ b/packages/navie/package.json
@@ -19,6 +19,7 @@
   "author": "AppLand, Inc.",
   "license": "MIT + Commons Clause",
   "devDependencies": {
+    "@tsconfig/node-lts": "^20.1.3",
     "@types/jest": "^29.4.1",
     "@types/node": "^17.0.2",
     "@typescript-eslint/eslint-plugin": "^5.51.0",
@@ -37,7 +38,7 @@
     "ts-jest": "^29.0.5",
     "ts-node": "^10.4.0",
     "tsc": "^2.0.3",
-    "typescript": "^4.9.5"
+    "typescript": "^5.3.2"
   },
   "dependencies": {
     "@langchain/anthropic": "^0.2.14",

--- a/packages/navie/src/services/anthropic-completion-service.ts
+++ b/packages/navie/src/services/anthropic-completion-service.ts
@@ -132,9 +132,15 @@ export default class AnthropicCompletionService implements CompletionService {
 
       warn(usage.toString());
       return usage;
-    } catch (e) {
-      // throw a new error so we have stack from here instead of deep within the callback jungle
-      throw new Error(`Failed to complete: ${isNativeError(e) ? e.message : String(e)}`);
+    } catch (cause) {
+      throw new Error(`Failed to complete: ${errorMessage(cause)}`, {
+        cause,
+      });
     }
   }
+}
+
+function errorMessage(err: unknown): string {
+  if (isNativeError(err)) return err.cause ? errorMessage(err.cause) : err.message;
+  return String(err);
 }

--- a/packages/navie/src/services/openai-completion-service.ts
+++ b/packages/navie/src/services/openai-completion-service.ts
@@ -1,7 +1,7 @@
 import { isNativeError } from 'node:util/types';
 
 import { ChatOpenAI } from '@langchain/openai';
-import type { ChatCompletion, ChatCompletionChunk } from 'openai/resources';
+import type { ChatCompletion, ChatCompletionChunk } from 'openai/resources/index';
 import { z } from 'zod';
 import { zodResponseFormat } from 'openai/helpers/zod';
 import { warn } from 'console';

--- a/packages/navie/tsconfig.json
+++ b/packages/navie/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "@tsconfig/node-lts/tsconfig.json",
   "compilerOptions": {
     "noEmit": true,
     "types": ["node", "jest"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -457,6 +457,7 @@ __metadata:
     "@langchain/anthropic": ^0.2.14
     "@langchain/core": ^0.2.27
     "@langchain/openai": ^0.2.7
+    "@tsconfig/node-lts": ^20.1.3
     "@types/jest": ^29.4.1
     "@types/node": ^17.0.2
     "@typescript-eslint/eslint-plugin": ^5.51.0
@@ -480,7 +481,7 @@ __metadata:
     ts-jest: ^29.0.5
     ts-node: ^10.4.0
     tsc: ^2.0.3
-    typescript: ^4.9.5
+    typescript: ^5.3.2
     zod: ^3.23.8
   languageName: unknown
   linkType: soft
@@ -10589,6 +10590,13 @@ __metadata:
   version: 2.0.0
   resolution: "@tootallnate/once@npm:2.0.0"
   checksum: ad87447820dd3f24825d2d947ebc03072b20a42bfc96cbafec16bff8bbda6c1a81fcb0be56d5b21968560c5359a0af4038a68ba150c3e1694fe4c109a063bed8
+  languageName: node
+  linkType: hard
+
+"@tsconfig/node-lts@npm:^20.1.3":
+  version: 20.1.3
+  resolution: "@tsconfig/node-lts@npm:20.1.3"
+  checksum: c6d62e2dbc32764414e9b865103348a04facbe14a1d9439013d01e6b1220265e3d1cfdaafedba0d5ab9adba8e6fb190fb4ce9a8195253e8ed97b427d943e5dab
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -459,7 +459,7 @@ __metadata:
     "@langchain/openai": ^0.2.7
     "@tsconfig/node-lts": ^20.1.3
     "@types/jest": ^29.4.1
-    "@types/node": ^17.0.2
+    "@types/node": 20.1.0
     "@typescript-eslint/eslint-plugin": ^5.51.0
     "@typescript-eslint/parser": ^5.7.0
     eslint: ^8.4.1
@@ -11318,6 +11318,13 @@ __metadata:
   version: 17.0.17
   resolution: "@types/node@npm:17.0.17"
   checksum: 8ddba2829acdf1684fbd8fd248ec13f033efb70ecd1085677b547c40ef8e936a006b95eac3bdc28c47939c62526f3f027afeb4a930e30e4394923bbae4626476
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:20.1.0":
+  version: 20.1.0
+  resolution: "@types/node@npm:20.1.0"
+  checksum: c6d9afa9aa78b4b4348c69ece94975be70346b144c278f1395694a10ef919d7db300018101b6f9245e6bdd76674a5327d2d14829092f3d5295e858cff5f22a66
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Before:
```
Error: Failed to complete: Connection error.
    at AnthropicCompletionService.complete_1 (/home/divide/projects/appmap-js/packages/navie/dist/services/anthropic-completion-service.js:170:23)
    at complete_1.throw (<anonymous>)
    at resume (/home/divide/projects/appmap-js/packages/navie/dist/services/anthropic-completion-service.js:24:44)
    at reject (/home/divide/projects/appmap-js/packages/navie/dist/services/anthropic-completion-service.js:27:30)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```
After:
```
Error: Failed to complete: FetchError: request to http://example.test/v1/messages failed, reason: getaddrinfo ENOTFOUND example.test
    at AnthropicCompletionService.complete (/home/divide/projects/appmap-js/packages/navie/dist/services/anthropic-completion-service.js:120:19)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async ClassificationService.classifyQuestion (/home/divide/projects/appmap-js/packages/navie/dist/services/classification-service.js:150:26)
    at async ExplainCommand.execute (/home/divide/projects/appmap-js/packages/navie/dist/commands/explain-command.js:41:31)
    at async Navie.execute (/home/divide/projects/appmap-js/packages/navie/dist/navie.js:150:30)
    at async LocalNavie.ask (/home/divide/projects/appmap-js/packages/cli/built/rpc/explain/navie/navie-local.js:130:85)
    at async Explain.explain (/home/divide/projects/appmap-js/packages/cli/built/rpc/explain/explain.js:78:9) {
  [cause]: APIConnectionError: Connection error.
      at Anthropic.makeRequest (/home/divide/projects/appmap-js/node_modules/@anthropic-ai/sdk/core.js:304:19)
      at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
      at async RetryOperation._fn (/home/divide/projects/appmap-js/node_modules/p-retry/index.js:50:12) {
    status: undefined,
    headers: undefined,
    request_id: undefined,
    error: undefined,
    cause: FetchError: request to http://example.test/v1/messages failed, reason: getaddrinfo ENOTFOUND example.test
        at ClientRequest.<anonymous> (/home/divide/projects/appmap-js/node_modules/node-fetch/lib/index.js:1491:11)
        at ClientRequest.emit (node:events:520:28)
        at emitErrorEvent (node:_http_client:103:11)
        at Socket.socketErrorListener (node:_http_client:506:5)
        at Socket.emit (node:events:532:35)
        at emitErrorNT (node:internal/streams/destroy:170:8)
        at emitErrorCloseNT (node:internal/streams/destroy:129:3)
        at process.processTicksAndRejections (node:internal/process/task_queues:82:21) {
      type: 'system',
      errno: 'ENOTFOUND',
      code: 'ENOTFOUND'
    },
    attemptNumber: 2,
    retriesLeft: 0
  }
}
```

Hopefully it will make it easier to debug those dreaded connections errors.