### PR TITLE
fix: Retry on Claude overload error

### DIFF
--- a/packages/navie/package.json
+++ b/packages/navie/package.json
@@ -41,7 +41,7 @@
     "typescript": "^5.3.2"
   },
   "dependencies": {
-    "@langchain/anthropic": "^0.2.14",
+    "@langchain/anthropic": "^0.3.1",
     "@langchain/core": "^0.2.27",
     "@langchain/openai": "^0.2.7",
     "fast-xml-parser": "^4.4.0",

--- a/packages/navie/src/services/anthropic-completion-service.ts
+++ b/packages/navie/src/services/anthropic-completion-service.ts
@@ -7,6 +7,7 @@ import { z } from 'zod';
 import Message from '../message';
 import CompletionService, {
   Completion,
+  CompletionRetries,
   convertToMessage,
   JsonOptions,
   mergeSystemMessages,
@@ -161,7 +162,7 @@ export default class AnthropicCompletionService implements CompletionService {
     const tokens = new Array<string>();
     for (const message of sentMessages) this.trajectory.logSentMessage(message);
 
-    const maxAttempts = 5;
+    const maxAttempts = CompletionRetries;
     for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
       try {
         // eslint-disable-next-line no-await-in-loop

--- a/packages/navie/src/services/anthropic-completion-service.ts
+++ b/packages/navie/src/services/anthropic-completion-service.ts
@@ -8,6 +8,7 @@ import Message from '../message';
 import CompletionService, {
   Completion,
   CompletionRetries,
+  CompletionRetryDelay,
   convertToMessage,
   JsonOptions,
   mergeSystemMessages,
@@ -188,7 +189,7 @@ export default class AnthropicCompletionService implements CompletionService {
         if (attempt < maxAttempts - 1 && tokens.length === 0) {
           const sseError = getSseError(cause);
           if (sseError) {
-            const nextAttempt = 1000 * 2 ** attempt;
+            const nextAttempt = CompletionRetryDelay * 2 ** attempt;
             warn(`Received ${JSON.stringify(sseError.error)}, retrying in ${nextAttempt}ms`);
 
             // eslint-disable-next-line no-await-in-loop

--- a/packages/navie/src/services/completion-service.ts
+++ b/packages/navie/src/services/completion-service.ts
@@ -97,3 +97,15 @@ export const CompletionRetries = (() => {
   return 5;
 })();
 
+// Base delay between retries in milliseconds, before exponential backoff
+export const CompletionRetryDelay = (() => {
+  const env = process.env.APPMAP_NAVIE_COMPLETION_RETRY_DELAY;
+  if (env) {
+    const value = parseInt(env, 10);
+    if (Number.isInteger(value) && value > 0) {
+      return value;
+    }
+  }
+
+  return 1000;
+})();

--- a/packages/navie/src/services/completion-service.ts
+++ b/packages/navie/src/services/completion-service.ts
@@ -83,3 +83,17 @@ export function convertToMessage(message: Message): BaseMessage {
   }
   return new Cons({ content });
 }
+
+// Number of retries to attempt a completion before giving up
+export const CompletionRetries = (() => {
+  const env = process.env.APPMAP_NAVIE_COMPLETION_RETRIES;
+  if (env) {
+    const value = parseInt(env, 10);
+    if (Number.isInteger(value) && value > 0) {
+      return value;
+    }
+  }
+
+  return 5;
+})();
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -31,9 +31,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@anthropic-ai/sdk@npm:^0.25.2":
-  version: 0.25.2
-  resolution: "@anthropic-ai/sdk@npm:0.25.2"
+"@anthropic-ai/sdk@npm:^0.27.3":
+  version: 0.27.3
+  resolution: "@anthropic-ai/sdk@npm:0.27.3"
   dependencies:
     "@types/node": ^18.11.18
     "@types/node-fetch": ^2.6.4
@@ -42,7 +42,7 @@ __metadata:
     form-data-encoder: 1.7.2
     formdata-node: ^4.3.2
     node-fetch: ^2.6.7
-  checksum: b38f6a43f6f678e49f1b53226cc55654c23cf0fd1902cf3fcf98c0ae78f4c229518964f4cb31bc39da41925c806e7f4cc7ec14c511d387f07db3136b111bc744
+  checksum: 8000fc5a4e545057d8711f978a0de59c9a174398a81f700c9d279213790aaa4b2c100f96f2ef79447b8f1f3a04b8f094d60db66a06df8df96b31a3240d69cb5a
   languageName: node
   linkType: hard
 
@@ -454,7 +454,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@appland/navie@workspace:packages/navie"
   dependencies:
-    "@langchain/anthropic": ^0.2.14
+    "@langchain/anthropic": ^0.3.1
     "@langchain/core": ^0.2.27
     "@langchain/openai": ^0.2.7
     "@tsconfig/node-lts": ^20.1.3
@@ -6988,16 +6988,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@langchain/anthropic@npm:^0.2.14":
-  version: 0.2.15
-  resolution: "@langchain/anthropic@npm:0.2.15"
+"@langchain/anthropic@npm:^0.3.1":
+  version: 0.3.1
+  resolution: "@langchain/anthropic@npm:0.3.1"
   dependencies:
-    "@anthropic-ai/sdk": ^0.25.2
-    "@langchain/core": ">=0.2.21 <0.3.0"
+    "@anthropic-ai/sdk": ^0.27.3
     fast-xml-parser: ^4.4.1
     zod: ^3.22.4
     zod-to-json-schema: ^3.22.4
-  checksum: 06e36bee0451884be2e53c06942666f32701568fa83b329634169f4a1dd409f1659761c6255ac3b042f20f2ff5e63e7d4f04110fc1e908b00c3136c900474ba0
+  peerDependencies:
+    "@langchain/core": ">=0.2.21 <0.4.0"
+  checksum: 397dc1b114e48c312f8627e6a3a2dd1b28e91b11d3e1c08e6679a4087b3535665da8ea330fcd73ff95e8b87393347d5e112d6ca073b54bef2980625f0ec34217
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This pull request addresses an issue with the AnthropicCompletionService where requests would fail due to an overload error from Claude's API. The following changes have been implemented to resolve this issue:

- **Retry Mechanism for SSE Errors:** 
  - Introduced a method to parse SSE errors from error messages.
  - Implemented a retry mechanism within the `complete` method to handle overload errors by retrying up to a maximum of five attempts with exponential backoff.
  
- **Unit Tests:**
  - Enhanced the existing test suite to include a test that verifies the retry behavior when an overload error occurs.
  - Updated mocks and test utilities to support the new retry logic.

- **Dependency Updates:**
  - Updated the version of `@langchain/anthropic` to v0.3.1.

#### Testing

- **Automated Tests:** 
  - Added a new test case to ensure that the service retries requests on overload errors and ultimately throws an appropriate error if all retries fail.
  - All existing tests have been updated and validated to ensure compatibility with the changes.

- **Manual Testing:** 
  - Verified through manual testing that the retry mechanism works as expected, with appropriate logging and error handling.

#### Impact

These changes improve the robustness of the `AnthropicCompletionService` by handling API overload errors more gracefully, ensuring a more resilient interaction with the Claude API. The dependency updates also bring in the latest improvements and fixes from the updated libraries.

Fixes https://github.com/getappmap/appmap-js/issues/2002
