### PR TITLE
fix: Truncate largest message if max tokens are exceeded

### DIFF
--- a/packages/navie/src/lib/trim-largest-user-message.ts
+++ b/packages/navie/src/lib/trim-largest-user-message.ts
@@ -1,0 +1,31 @@
+import type Message from '../message';
+
+// Reduces the size of the largest user message by the given percentage of all messages content length
+export default function trimLargestUserMessage(
+  messages: readonly Message[],
+  reduceBy = 0.15
+): Message[] {
+  let largestMessageIndex = -1;
+  let contentLength = 0;
+  messages.forEach((message, index) => {
+    contentLength += message.content.length;
+
+    const maxLength = messages[largestMessageIndex]?.content?.length ?? -1;
+    if (message.role === 'user' && message.content.length > maxLength) {
+      largestMessageIndex = index;
+    }
+  });
+
+  if (largestMessageIndex === -1) return [...messages];
+
+  const largestMessage = messages[largestMessageIndex];
+  const charsToRemove = Math.ceil(contentLength * reduceBy);
+  const updatedMessage = { ...messages[largestMessageIndex] };
+  updatedMessage.content = largestMessage.content.slice(0, -charsToRemove);
+
+  return [
+    ...messages.slice(0, largestMessageIndex),
+    updatedMessage,
+    ...messages.slice(largestMessageIndex + 1),
+  ];
+}

--- a/packages/navie/test/lib/trim-largest-user-message.spec.ts
+++ b/packages/navie/test/lib/trim-largest-user-message.spec.ts
@@ -1,0 +1,55 @@
+import trimLargestMessage from '../../src/lib/trim-largest-user-message';
+import type Message from '../../src/message';
+
+describe('trimLargestMessage', () => {
+  it('returns the original messages if there are no messages', () => {
+    const messages: Message[] = [];
+    const result = trimLargestMessage(messages, 0.2);
+    expect(result).toEqual(messages);
+  });
+
+  it('trims the largest message by the default percentage', () => {
+    const messages: Message[] = [
+      { content: 'Hello world!', role: 'system' },
+      { content: 'This is the largest message.', role: 'user' },
+      { content: 'Short message.', role: 'assistant' },
+    ];
+    const result = trimLargestMessage(messages);
+    const expected = [
+      { content: 'Hello world!', role: 'system' },
+      { content: 'This is the largest', role: 'user' },
+      { content: 'Short message.', role: 'assistant' },
+    ];
+    expect(result).toEqual(expected);
+  });
+
+  it('trims the largest message by a specified percentage', () => {
+    const messages: Message[] = [
+      { content: 'Hello world!', role: 'system' },
+      { content: 'This is the largest message.', role: 'user' },
+      { content: 'Short message.', role: 'assistant' },
+    ];
+    const result = trimLargestMessage(messages, 0.44);
+    const expected = [
+      { content: 'Hello world!', role: 'system' },
+      { content: 'This', role: 'user' },
+      { content: 'Short message.', role: 'assistant' },
+    ];
+    expect(result).toEqual(expected);
+  });
+
+  it('does not trim the largest message if the role is not user', () => {
+    const messages: Message[] = [
+      { content: 'This is the largest message.', role: 'system' },
+      { content: 'Hello world!', role: 'user' },
+      { content: 'Short message.', role: 'assistant' },
+    ];
+    const result = trimLargestMessage(messages, 0.12);
+    const expected = [
+      { content: 'This is the largest message.', role: 'system' },
+      { content: 'Hello', role: 'user' },
+      { content: 'Short message.', role: 'assistant' },
+    ];
+    expect(result).toEqual(expected);
+  });
+});


### PR DESCRIPTION
Upon exceeding the max token limit, the completion will be retried, where the largest **user message** will be truncated by 15% of the **total content length**.

Resolves https://github.com/getappmap/appmap-js/issues/2007