### PR TITLE
Show LLM errors

### DIFF
--- a/packages/components/src/lib/AppMapRPC.ts
+++ b/packages/components/src/lib/AppMapRPC.ts
@@ -84,7 +84,7 @@ export class ExplainRequest extends EventEmitter {
       this.client.request(
         'explain.status',
         { userMessageId },
-        (err: any, error: any, statusResponse: any) => {
+        (err: any, error: any, statusResponse: ExplainRpc.ExplainStatusResponse) => {
           // Stop polling if the user message is no longer available from the server,
           // for example if the RPC service has been restarted.
           if (error && error.code === 404) this.stopPolling();
@@ -100,6 +100,8 @@ export class ExplainRequest extends EventEmitter {
             for (const token of newTokens) this.onToken(token, userMessageId);
           }
           numTokens = explanation.length;
+
+          if (statusResponse.step === 'error') this.onError(statusResponse.err);
 
           if (['complete', 'error'].includes(statusResponse.step)) {
             this.stopPolling();

--- a/packages/navie/src/agents/generate-agent.ts
+++ b/packages/navie/src/agents/generate-agent.ts
@@ -79,6 +79,10 @@ Ensure that all lines of the original and modified code are indented correctly.
 
 If you want to create a new file, skip the <original> part.
 
+DO NOT put the generated XML in Markdown code fences (\`\`\`).
+
+If the output is too long, present only some changes and offer the user an option to continue with others.
+
 ## Example output
 
 <change>


### PR DESCRIPTION
Turns out the error was lost in the UI RPC layer. It took ages to go through all the layers to figure out where the leak was, but fortunately once found the fix was trivial.

![image](https://github.com/user-attachments/assets/d20b3346-3192-4b66-a02e-cb94473b62ff)
(Note this is copilot which has heavy off-topic filters.)

Error messages could use better styling, but I think this is outside of scope and this change should be merged ASAP because even this is better than silence.


(I also added another small commit adjusting the generate prompt; it helps prevent XML fencing (fixes #2012 hopefully) and tells the model to chunk response when required; this doesn't work best yet since `@generate` only looks at the last message to extract paths, so continuation requests won't have full required file contents, but I feel it's still better than stopping mid-chunk due to response size limits.)