### PR TITLE
feat: Report subscription status on thread creation

### DIFF
--- a/packages/cli/tests/integration/rpc.explain.spec.ts
+++ b/packages/cli/tests/integration/rpc.explain.spec.ts
@@ -17,6 +17,8 @@ jest.mock('@appland/navie');
 if (process.env.VERBOSE === 'true') verbose(true);
 
 describe('RPC', () => {
+  const enrollmentDate = new Date();
+
   describe('explain', () => {
     let navieProvider: INavieProvider;
     let rpcTest: RPCTest;
@@ -167,6 +169,10 @@ describe('RPC', () => {
               id: threadId,
               permissions: { useNavieAIProxy: true },
               usage: { conversationCounts: [] },
+              subscription: {
+                enrollmentDate: enrollmentDate,
+                subscriptions: [],
+              },
             })
           );
 

--- a/packages/cli/tests/unit/rpc/explain/Explain.spec.ts
+++ b/packages/cli/tests/unit/rpc/explain/Explain.spec.ts
@@ -60,6 +60,7 @@ describe('Explain', () => {
           id: 'the-conversation-thread-id',
           permissions: { useNavieAIProxy: true },
           usage: { conversationCounts: [] },
+          subscription: { enrollmentDate: new Date(), subscriptions: [] },
         });
 
         jest.spyOn(AIEnvVar, 'default').mockReturnValue(undefined);
@@ -101,6 +102,7 @@ describe('Explain', () => {
           id: 'the-conversation-thread-id',
           permissions: { useNavieAIProxy: true },
           usage: { conversationCounts: [] },
+          subscription: { enrollmentDate: new Date(), subscriptions: [] },
         });
 
         jest.spyOn(AIEnvVar, 'default').mockReturnValue('THE_AI_KEY');
@@ -137,6 +139,7 @@ describe('Explain', () => {
           id: 'the-conversation-thread-id',
           permissions: { useNavieAIProxy: true },
           usage: { conversationCounts: [] },
+          subscription: { enrollmentDate: new Date(), subscriptions: [] },
         };
         jest.spyOn(explain, 'enrollConversationThread').mockResolvedValue(conversationThread);
       });

--- a/packages/client/src/ai.ts
+++ b/packages/client/src/ai.ts
@@ -32,6 +32,15 @@ export type ProjectParameters = {
   directories: ProjectDirectory[];
 };
 
+export type SubscriptionItem = {
+  productName: string;
+};
+
+export type Subscription = {
+  enrollmentDate: Date;
+  subscriptions: SubscriptionItem[];
+};
+
 export type CreateConversationThread = {
   modelParameters: ModelParameters;
   projectParameters: ProjectParameters;
@@ -41,6 +50,7 @@ export type ConversationThread = {
   id: string;
   permissions: Permissions;
   usage: Usage;
+  subscription: Subscription;
 };
 
 export type UserMessage = {


### PR DESCRIPTION
Proposed updates to provide user subscription info on thread creation.

We can use this information to determine:

* How long the user has been a subscriber for (and therefore, are they still in a free trial period?)
* To which products the user has an active subscription. Currently, there's only one: "AppMap Pro".

```javascript
export type SubscriptionItem = {
  productName: string;
};

export type Subscription = {
  enrollmentDate: Date;
  subscriptions: SubscriptionItem[];
};

export type ConversationThread = {
  id: string;
  permissions: Permissions;
  usage: Usage;
  subscription: Subscription; <-- new
};
```

See Issue https://github.com/getappmap/appmap-services/issues/38
See PR https://github.com/getappmap/appmap-services/pull/83
