### PR TITLE
feat: Ignore .appmap and .navie directories when selecting context

### DIFF
--- a/packages/cli/tests/unit/rpc/explain/pattern.spec.ts
+++ b/packages/cli/tests/unit/rpc/explain/pattern.spec.ts
@@ -1,0 +1,27 @@
+import {
+  EXCLUDE_DOT_APPMAP_DIR,
+  EXCLUDE_DOT_NAVIE_DIR,
+} from '../../../../src/rpc/explain/collectContext';
+
+describe('Regex patterns', () => {
+  const testCases = [
+    { path: '/path/to/.appmap/file', pattern: EXCLUDE_DOT_APPMAP_DIR, shouldMatch: true },
+    { path: '/path/.hidden/.appmap/file', pattern: EXCLUDE_DOT_APPMAP_DIR, shouldMatch: true },
+    { path: '/path/to/appmap/file', pattern: EXCLUDE_DOT_APPMAP_DIR, shouldMatch: false },
+    { path: '.appmap', pattern: EXCLUDE_DOT_APPMAP_DIR, shouldMatch: true },
+    { path: '/appmap/.appmap/', pattern: EXCLUDE_DOT_APPMAP_DIR, shouldMatch: true },
+    { path: '/path/to/.navie/file', pattern: EXCLUDE_DOT_NAVIE_DIR, shouldMatch: true },
+    { path: '/path/.hidden/.navie/file', pattern: EXCLUDE_DOT_NAVIE_DIR, shouldMatch: true },
+    { path: '/path/to/navie/file', pattern: EXCLUDE_DOT_NAVIE_DIR, shouldMatch: false },
+    { path: '.navie', pattern: EXCLUDE_DOT_NAVIE_DIR, shouldMatch: true },
+    { path: '_.navie', pattern: EXCLUDE_DOT_NAVIE_DIR, shouldMatch: false },
+    { path: '._navie', pattern: EXCLUDE_DOT_NAVIE_DIR, shouldMatch: false },
+    { path: '/navie/.navie/', pattern: EXCLUDE_DOT_NAVIE_DIR, shouldMatch: true },
+  ];
+
+  testCases.forEach(({ path, pattern, shouldMatch }) => {
+    it(`should ${shouldMatch ? '' : 'not '}match pattern for path: ${path}`, () => {
+      expect(pattern.test(path)).toEqual(shouldMatch);
+    });
+  });
+});


### PR DESCRIPTION
These can be used to store metadata and information used by Navie itself, such as prompts and snippets, without risk of that material being selected as context.