### PR TITLE
fix: Handle empty prompts gracefully

### DIFF
--- a/packages/navie/package.json
+++ b/packages/navie/package.json
@@ -33,7 +33,7 @@
     "eslint-plugin-promise": "^6.0.1",
     "eslint-plugin-unicorn": "^39.0.0",
     "jest": "^29.5.0",
-    "ts-jest": "^29.0.5",
+    "ts-jest": "^29.2.5",
     "ts-node": "^10.4.0",
     "tsc": "^2.0.3",
     "typescript": "^5.3.2"

--- a/packages/navie/src/lib/string-or-default.ts
+++ b/packages/navie/src/lib/string-or-default.ts
@@ -1,0 +1,15 @@
+/**
+ * Checks if a string is empty (ie. all-whitespace) and applies fallback if so.
+ * @param str
+ * @param fallback
+ * @returns str or fallback
+ * @example
+ * stringOrDefault('', 'fallback') // 'fallback'
+ * stringOrDefault('  ', 'fallback') // 'fallback'
+ * stringOrDefault('hello', 'fallback') // 'hello'
+ * stringOrDefault('  hello  ', 'fallback') // '  hello  '
+ */
+export default function stringOrDefault(str: string, fallback: string): string {
+  if (str.trim() === '') return fallback;
+  else return str;
+}

--- a/packages/navie/test/navie.spec.ts
+++ b/packages/navie/test/navie.spec.ts
@@ -1,0 +1,45 @@
+import ExplainCommand from '../src/commands/explain-command';
+import { ContextV2 } from '../src/context';
+import { HelpProvider } from '../src/help';
+import { ClientRequest, NavieOptions, default as navie } from '../src/navie';
+import { ProjectInfoProvider } from '../src/project-info';
+
+describe('Navie Function', () => {
+  let clientRequest: ClientRequest;
+  let contextProvider: ContextV2.ContextProvider;
+  let projectInfoProvider: ProjectInfoProvider;
+  let helpProvider: HelpProvider;
+  let options: NavieOptions;
+
+  beforeEach(() => {
+    clientRequest = { question: '' };
+    contextProvider = jest.fn().mockResolvedValue({});
+    projectInfoProvider = jest.fn().mockResolvedValue({});
+    helpProvider = jest.fn().mockResolvedValue({});
+    options = new NavieOptions();
+  });
+
+  test('uses default command if question is empty', async () => {
+    const instance = navie(
+      clientRequest,
+      contextProvider,
+      projectInfoProvider,
+      helpProvider,
+      options
+    );
+    const result = [];
+    for await (const chunk of instance.execute()) {
+      result.push(chunk);
+    }
+    expect(result).toBeTruthy();
+    expect(clientRequest.question).toEqual('explain');
+  });
+});
+
+jest.mock('../src/commands/explain-command');
+// eslint-disable-next-line @typescript-eslint/require-await
+ExplainCommand.prototype.execute = jest.fn().mockImplementation(async function* () {
+  yield 'This is a test response';
+});
+
+jest.mock('../src/services/openai-completion-service');

--- a/yarn.lock
+++ b/yarn.lock
@@ -476,7 +476,7 @@ __metadata:
     langchain: ^0.2.16
     mermaid: ^9
     openai: ^4.56.0
-    ts-jest: ^29.0.5
+    ts-jest: ^29.2.5
     ts-node: ^10.4.0
     tsc: ^2.0.3
     typescript: ^5.3.2
@@ -16244,7 +16244,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bs-logger@npm:0.x":
+"bs-logger@npm:0.x, bs-logger@npm:^0.2.6":
   version: 0.2.6
   resolution: "bs-logger@npm:0.2.6"
   dependencies:
@@ -20208,6 +20208,17 @@ __metadata:
   version: 2.7.4
   resolution: "ejs@npm:2.7.4"
   checksum: a1d2bfc7d1f0b39e99ae19b20c9469a25aeddba1ffc225db098110b18d566f73772fcdcc740b108cfda7452276f67d7b64eb359f90285414c942f4ae70713371
+  languageName: node
+  linkType: hard
+
+"ejs@npm:^3.1.10":
+  version: 3.1.10
+  resolution: "ejs@npm:3.1.10"
+  dependencies:
+    jake: ^10.8.5
+  bin:
+    ejs: bin/cli.js
+  checksum: ce90637e9c7538663ae023b8a7a380b2ef7cc4096de70be85abf5a3b9641912dde65353211d05e24d56b1f242d71185c6d00e02cb8860701d571786d92c71f05
   languageName: node
   linkType: hard
 
@@ -30448,7 +30459,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"make-error@npm:1.x, make-error@npm:^1.1.1":
+"make-error@npm:1.x, make-error@npm:^1.1.1, make-error@npm:^1.3.6":
   version: 1.3.6
   resolution: "make-error@npm:1.3.6"
   checksum: b86e5e0e25f7f777b77fabd8e2cbf15737972869d852a22b7e73c17623928fccb826d8e46b9951501d3f20e51ad74ba8c59ed584f610526a48f8ccf88aaec402
@@ -40140,53 +40151,22 @@ resolve@1.1.7:
   languageName: node
   linkType: hard
 
-"ts-jest@npm:^29.0.5":
-  version: 29.0.5
-  resolution: "ts-jest@npm:29.0.5"
+"ts-jest@npm:^29.0.5, ts-jest@npm:^29.1.1, ts-jest@npm:^29.2.5":
+  version: 29.2.5
+  resolution: "ts-jest@npm:29.2.5"
   dependencies:
-    bs-logger: 0.x
-    fast-json-stable-stringify: 2.x
+    bs-logger: ^0.2.6
+    ejs: ^3.1.10
+    fast-json-stable-stringify: ^2.1.0
     jest-util: ^29.0.0
     json5: ^2.2.3
-    lodash.memoize: 4.x
-    make-error: 1.x
-    semver: 7.x
-    yargs-parser: ^21.0.1
+    lodash.memoize: ^4.1.2
+    make-error: ^1.3.6
+    semver: ^7.6.3
+    yargs-parser: ^21.1.1
   peerDependencies:
     "@babel/core": ">=7.0.0-beta.0 <8"
-    "@jest/types": ^29.0.0
-    babel-jest: ^29.0.0
-    jest: ^29.0.0
-    typescript: ">=4.3"
-  peerDependenciesMeta:
-    "@babel/core":
-      optional: true
-    "@jest/types":
-      optional: true
-    babel-jest:
-      optional: true
-    esbuild:
-      optional: true
-  bin:
-    ts-jest: cli.js
-  checksum: f60f129c2287f4c963d9ee2677132496c5c5a5d39c27ad234199a1140c26318a7d5bda34890ab0e30636ec42a8de28f84487c09e9dcec639c9c67812b3a38373
-  languageName: node
-  linkType: hard
-
-"ts-jest@npm:^29.1.1":
-  version: 29.1.1
-  resolution: "ts-jest@npm:29.1.1"
-  dependencies:
-    bs-logger: 0.x
-    fast-json-stable-stringify: 2.x
-    jest-util: ^29.0.0
-    json5: ^2.2.3
-    lodash.memoize: 4.x
-    make-error: 1.x
-    semver: ^7.5.3
-    yargs-parser: ^21.0.1
-  peerDependencies:
-    "@babel/core": ">=7.0.0-beta.0 <8"
+    "@jest/transform": ^29.0.0
     "@jest/types": ^29.0.0
     babel-jest: ^29.0.0
     jest: ^29.0.0
@@ -40194,6 +40174,8 @@ resolve@1.1.7:
   peerDependenciesMeta:
     "@babel/core":
       optional: true
+    "@jest/transform":
+      optional: true
     "@jest/types":
       optional: true
     babel-jest:
@@ -40202,7 +40184,7 @@ resolve@1.1.7:
       optional: true
   bin:
     ts-jest: cli.js
-  checksum: a8c9e284ed4f819526749f6e4dc6421ec666f20ab44d31b0f02b4ed979975f7580b18aea4813172d43e39b29464a71899f8893dd29b06b4a351a3af8ba47b402
+  checksum: d60d1e1d80936f6002b1bb27f7e062408bc733141b9d666565503f023c340a3196d506c836a4316c5793af81a5f910ab49bb9c13f66e2dc66de4e0f03851dbca
   languageName: node
   linkType: hard
 
@@ -42858,7 +42840,7 @@ typescript@~4.4.3:
   languageName: node
   linkType: hard
 
-"yargs-parser@npm:^21.0.1, yargs-parser@npm:^21.1.1":
+"yargs-parser@npm:^21.1.1":
   version: 21.1.1
   resolution: "yargs-parser@npm:21.1.1"
   checksum: ed2d96a616a9e3e1cc7d204c62ecc61f7aaab633dcbfab2c6df50f7f87b393993fe6640d017759fe112d0cb1e0119f2b4150a87305cc873fd90831c6a58ccf1c


### PR DESCRIPTION
Some models (notably copilot) don't like empty user messages. Use the command name if there's no question.