### PR TITLE
fix: Punctuation in RTL text

### DIFF
--- a/packages/components/src/components/chat/ContextContainer.vue
+++ b/packages/components/src/components/chat/ContextContainer.vue
@@ -19,7 +19,7 @@
       :title="location"
     >
       <span class="context-container__title" data-cy="context-title">&#8206;{{ title }}</span>
-      <span class="context-container__button-group">
+      <span class="context-container__button-group" title="">
         <v-popper :time-to-display="250" text="Apply changes" align="right" placement="top">
           <span
             :class="{

--- a/packages/components/src/components/chat/ContextContainer.vue
+++ b/packages/components/src/components/chat/ContextContainer.vue
@@ -18,7 +18,7 @@
       @click="onClickHeader"
       :title="location"
     >
-      <span class="context-container__title" data-cy="context-title">{{ title }}</span>
+      <span class="context-container__title" data-cy="context-title">&#8206;{{ title }}</span>
       <span class="context-container__button-group">
         <v-popper :time-to-display="250" text="Apply changes" align="right" placement="top">
           <span

--- a/packages/components/src/stories/UserMessage.stories.js
+++ b/packages/components/src/stories/UserMessage.stories.js
@@ -30,6 +30,16 @@ def hello_world
 end
 \`\`\`
 
+<!-- file: /absolute/path.txt -->
+\`\`\`txt
+This is a text file, it should render as an absolute path.
+\`\`\`
+
+<!-- file: /really-really-really-really-really-really-really-really-really-really-really-really-really-really-really-really/long/absolute/path.txt -->
+\`\`\`txt
+This is a text file, it should render as an absolute path.
+\`\`\`
+
 \`\`\`html
 <!--
 here's

--- a/packages/components/tests/unit/chat/MarkdownCodeSnippet.spec.js
+++ b/packages/components/tests/unit/chat/MarkdownCodeSnippet.spec.js
@@ -88,6 +88,6 @@ describe('components/MarkdownCodeSnippet.vue', () => {
       provide: { projectDirectories: ['/home/user/my-project'] },
     });
 
-    expect(wrapper.find('[data-cy="context-title"]').text()).toBe('app/models/user.rb');
+    expect(wrapper.find('[data-cy="context-title"]').text()).toContain('app/models/user.rb');
   });
 });

--- a/packages/components/tests/unit/chat/UserMessage.spec.js
+++ b/packages/components/tests/unit/chat/UserMessage.spec.js
@@ -258,7 +258,7 @@ describe('components/UserMessage.vue', () => {
       });
 
       const title = wrapper.find('[data-cy="code-snippet"] [data-cy="context-title"]');
-      expect(title.text()).toEqual(path);
+      expect(title.text()).toContain(path);
     });
 
     it('renders code snippets with Unix paths', async () => {
@@ -270,7 +270,7 @@ describe('components/UserMessage.vue', () => {
       });
 
       const title = wrapper.find('[data-cy="code-snippet"] [data-cy="context-title"]');
-      expect(title.text()).toEqual(path);
+      expect(title.text()).toContain(path);
     });
 
     it('renders code snippet paths with a preceding file directive', async () => {
@@ -284,7 +284,7 @@ describe('components/UserMessage.vue', () => {
 
       const title = wrapper.find('[data-cy="code-snippet"] [data-cy="context-title"]');
       const codeSnippet = wrapper.find('[data-cy="code-snippet"] [data-cy="content"]');
-      expect(title.text()).toEqual(path);
+      expect(title.text()).toContain(path);
       expect(codeSnippet.text()).toEqual(sourceText);
     });
 
@@ -299,7 +299,7 @@ describe('components/UserMessage.vue', () => {
 
       const title = wrapper.find('[data-cy="code-snippet"] [data-cy="context-title"]');
       const codeSnippet = wrapper.find('[data-cy="code-snippet"] [data-cy="content"]');
-      expect(title.text()).toEqual(path);
+      expect(title.text()).toContain(path);
       expect(codeSnippet.text()).toEqual(sourceText);
     });
 
@@ -313,7 +313,7 @@ describe('components/UserMessage.vue', () => {
 
       const title = wrapper.find('[data-cy="code-snippet"] [data-cy="context-title"]');
       const codeSnippet = wrapper.find('[data-cy="code-snippet"] [data-cy="content"]');
-      expect(title.text()).toEqual('js');
+      expect(title.text()).toContain('js');
       expect(codeSnippet.text()).toEqual(sourceText);
     });
   });


### PR DESCRIPTION
This change fixes punctuation rendering on the wrong side of the title. The `UserMessage` story is updated to validate this change.
![image](https://github.com/user-attachments/assets/760b3976-3284-4fab-9d9f-bb0d7962f033)

It also removes the file tooltip from the buttons:
![image](https://github.com/user-attachments/assets/2e7e302b-1e7e-4c11-b384-71e61ca53384)

Resolves https://github.com/getappmap/appmap-js/issues/2036