### PR TITLE
feat: Ignore large data files

### DIFF
--- a/packages/cli/tests/unit/fulltext/FileIndex.spec.ts
+++ b/packages/cli/tests/unit/fulltext/FileIndex.spec.ts
@@ -155,16 +155,31 @@ describe(filterFiles, () => {
     jest.resetAllMocks();
   });
 
-  it('filters out files with binary extensions and non-files', async () => {
+  it('filters out binary files, non-files, and large data files', async () => {
     const dir = tmp.dirSync({ unsafeCleanup: true }).name;
     writeFileSync(join(dir, 'file.txt'), 'hello');
     writeFileSync(join(dir, 'file.zip'), 'hello');
     writeFileSync(join(dir, 'file.json'), 'hello');
     writeFileSync(join(dir, 'large.txt'), Buffer.alloc(100_000));
+    writeFileSync(join(dir, 'large.js'), Buffer.alloc(100_000));
+    writeFileSync(join(dir, 'large.ts'), Buffer.alloc(100_000));
+    writeFileSync(join(dir, 'large.haml'), Buffer.alloc(100_000));
+    writeFileSync(join(dir, 'large.java'), Buffer.alloc(100_000));
+    writeFileSync(join(dir, 'large.mjs'), Buffer.alloc(100_000));
+    writeFileSync(join(dir, 'large.pyc'), Buffer.alloc(100_000));
+    writeFileSync(join(dir, 'large.json'), Buffer.alloc(100_000));
     mkdirSync(join(dir, 'dir'));
 
     const fileList = readdirSync(dir);
     const filtered = await filterFiles(dir, fileList);
-    expect(filtered).toEqual(['file.json', 'file.txt', 'large.txt']);
+    expect(filtered).toEqual([
+      'file.json',
+      'file.txt',
+      'large.haml',
+      'large.java',
+      'large.js',
+      'large.ts',
+      'large.txt',
+    ]);
   });
 });

--- a/packages/cli/tests/unit/rpc/explain/pattern.spec.ts
+++ b/packages/cli/tests/unit/rpc/explain/pattern.spec.ts
@@ -17,6 +17,7 @@ describe('Regex patterns', () => {
     { path: '_.navie', pattern: EXCLUDE_DOT_NAVIE_DIR, shouldMatch: false },
     { path: '._navie', pattern: EXCLUDE_DOT_NAVIE_DIR, shouldMatch: false },
     { path: '/navie/.navie/', pattern: EXCLUDE_DOT_NAVIE_DIR, shouldMatch: true },
+    { path: '/non-matching/test/file', pattern: /some_other_regex/, shouldMatch: false },
   ];
 
   testCases.forEach(({ path, pattern, shouldMatch }) => {


### PR DESCRIPTION
### Logical Changes

- **Extended Binary File Extensions List**

  Added more file extensions to the list of `BINARY_FILE_EXTENSIONS`.

- **Introduced Data File Extensions List**

  Introduced a new list `DATA_FILE_EXTENSIONS`.

- **Refactored File Filtering Logic**
  
  Created helper functions `isBinaryFile` and `isDataFile` to streamline file filtering.

- **Updated File Filtering Method**

  Enhanced `filterFiles` function to exclude large data files.

- **Extended Unit Tests**

  Modified and added unit tests to cover new filtering logic for binary and data files.

- **Added Test Case for Regex Patterns**

  Added a new test case in the pattern matching tests.

### Possible Bugs to Investigate

Checked-off items have been reviewed by the developer and determined to be non-issues.

- [ ] **Missing Extensions:** There is a risk of missing certain binary or data file extensions that are not included in the current lists.
- [ ] **Hardcoded File Size Threshold:** The file size threshold (50,000 bytes) is hardcoded and may not be suitable for all scenarios.
- [ ] **Performance Impact:** Iterating through large arrays of file names and extensions could impact performance.
- [x] **Error Handling:** The catch block in `filterFiles` logs an error but continues processing. Ensure this behavior is intended.
- [x] **Test Coverage:** Ensure all edge cases are covered in unit tests, particularly for newly introduced file types and size-based exclusions.


Fixes https://github.com/getappmap/appmap-js/issues/2039
