### PR TITLE
feat: Ignore more directories of vendored code

### DIFF
--- a/packages/cli/src/rpc/explain/collectContext.ts
+++ b/packages/cli/src/rpc/explain/collectContext.ts
@@ -8,9 +8,12 @@ import LocationContextCollector from './LocationContextCollector';
 import queryKeywords from '../../fulltext/queryKeywords';
 import { warn } from 'console';
 
-export const EXCLUDE_DOT_APPMAP_DIR = /(^|[/\\])\.appmap([/\\]|$)/;
+export const buildExclusionPattern = (dirName: string): RegExp => {
+  const dirNamePattern = dirName.replace('.', '\\.');
+  return new RegExp(`(^|[/\\\\])${dirNamePattern}([/\\\\]|$)`);
+};
 
-export const EXCLUDE_DOT_NAVIE_DIR = /(^|[/\\])\.navie([/\\]|$)/;
+const EXCLUDE_DIRS = ['.appmap', '.navie', '.yarn', 'venv', '.venv', 'node_modules', 'vendor'];
 
 export function textSearchResultToRpcSearchResult(
   eventResult: EventSearchResult
@@ -162,8 +165,7 @@ export default async function collectContext(
     return patterns;
   };
 
-  appendIfNotExists(excludePatterns, EXCLUDE_DOT_APPMAP_DIR);
-  appendIfNotExists(excludePatterns, EXCLUDE_DOT_NAVIE_DIR);
+  for (const dir of EXCLUDE_DIRS) appendIfNotExists(excludePatterns, buildExclusionPattern(dir));
 
   contextCollector.excludePatterns = excludePatterns;
 

--- a/packages/cli/tests/unit/rpc/explain/pattern.spec.ts
+++ b/packages/cli/tests/unit/rpc/explain/pattern.spec.ts
@@ -1,9 +1,9 @@
-import {
-  EXCLUDE_DOT_APPMAP_DIR,
-  EXCLUDE_DOT_NAVIE_DIR,
-} from '../../../../src/rpc/explain/collectContext';
+import { buildExclusionPattern } from '../../../../src/rpc/explain/collectContext';
 
 describe('Regex patterns', () => {
+  const EXCLUDE_DOT_APPMAP_DIR = buildExclusionPattern('.appmap');
+  const EXCLUDE_DOT_NAVIE_DIR = buildExclusionPattern('.navie');
+
   const testCases = [
     { path: '/path/to/.appmap/file', pattern: EXCLUDE_DOT_APPMAP_DIR, shouldMatch: true },
     { path: '/path/.hidden/.appmap/file', pattern: EXCLUDE_DOT_APPMAP_DIR, shouldMatch: true },


### PR DESCRIPTION
Ignore directories such as:

* .yarn
* venv
* .venv
* vendor
* node_modules

Most of these should not be in Git though, so maybe this isn’t needed? 
