### PR TITLE
fix: remove click handler from ChatSearch info

### DIFF
--- a/packages/components/src/pages/ChatSearch.vue
+++ b/packages/components/src/pages/ChatSearch.vue
@@ -44,7 +44,7 @@
       <div class="search-header">
         <h1>Navie's Context Sources</h1>
         <v-popper class="infoHelp" ref="infoPopper" placement="none">
-          <div class="info" @click.prevent="onMouseEnter">
+          <div class="info">
             <InfoIcon />
           </div>
           <template #content>


### PR DESCRIPTION
Get rid of a click handler on the info popper. It was added for debugging, and left in by mistake.