### PR TITLE
feat: Report AppMap usage stats

### DIFF
--- a/.appmapignore
+++ b/.appmapignore
@@ -1,4 +1,4 @@
 node_modules
 test
 tests
-
+packages/cli/tmp/applandinc.github.io

--- a/packages/cli/src/cmds/archive/index.ts
+++ b/packages/cli/src/cmds/archive/index.ts
@@ -6,7 +6,7 @@ import { IndexResult } from '../index/IndexResult';
 import { basename, dirname, join } from 'path';
 import { readFile } from 'fs/promises';
 import { Metadata } from '@appland/models';
-import emitUsage from '../../lib/emitUsage';
+import writeUsage, { collectUsageData } from '../../lib/emitUsage';
 
 export async function index(
   workerPool: WorkerPool,
@@ -39,7 +39,14 @@ export async function index(
   );
 
   if (sampleMetadata) {
-    await emitUsage(appMapDir, totalEvents, result.numProcessed, sampleMetadata);
+    const outputDir = join('.appmap', 'run-stats');
+    const usageData = await collectUsageData(
+      appMapDir,
+      totalEvents,
+      result.numProcessed,
+      sampleMetadata
+    );
+    await writeUsage(usageData, outputDir);
   }
 
   const elapsed = new Date().getTime() - startTime;

--- a/packages/cli/src/fingerprint/fingerprintDirectoryCommand.ts
+++ b/packages/cli/src/fingerprint/fingerprintDirectoryCommand.ts
@@ -1,7 +1,7 @@
 import type { Metadata } from '@appland/models';
 import { findFiles, verbose } from '../utils';
 import FingerprintQueue from './fingerprintQueue';
-import emitUsage from '../lib/emitUsage';
+import writeUsage, { collectUsageData } from '../lib/emitUsage';
 
 class FingerprintDirectoryCommand {
   private appmaps = 0;
@@ -29,7 +29,13 @@ class FingerprintDirectoryCommand {
     });
     if (count > 0) await fpQueue.process();
 
-    emitUsage(this.directory, this.events, this.appmaps, this.metadata);
+    const usageData = await collectUsageData(
+      this.directory,
+      this.events,
+      this.appmaps,
+      this.metadata
+    );
+    await writeUsage(usageData, this.directory);
 
     return count;
   }

--- a/packages/cli/tests/unit/lib/emitUsage.spec.ts
+++ b/packages/cli/tests/unit/lib/emitUsage.spec.ts
@@ -1,23 +1,34 @@
-import emitUsage from '../../../src/lib/emitUsage';
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
 import { dir } from 'tmp';
 import { promisify } from 'node:util';
-import { mkdir as mkdirCb, readFile as readFileCb, rm as rmCb } from 'graceful-fs';
+import { readFile as readFileCb, rm as rmCb } from 'graceful-fs';
 import { chdir } from 'node:process';
-import { UsageUpdateDto } from '@appland/client';
+
+import { Usage, UsageUpdateDto } from '@appland/client';
+
+import writeUsageData, { collectUsageData, sendUsageData } from '../../../src/lib/emitUsage';
 import { Git } from '../../../src/telemetry';
 
 // Using graceful-fs should eliminate any risk of EBUSY errors on Windows.
-const mkdir = promisify(mkdirCb);
 const readFile = promisify(readFileCb);
 const rm = promisify(rmCb);
 
 describe('emitUsage', () => {
   let rootDirectory: string;
+  let appmapDir: string;
+
   const cwd = process.cwd();
+
+  const numEvents = 1;
+  const numAppMaps = 2;
+  const metadata = { app: 'test', foo: 'bar' };
 
   beforeEach(async () => {
     rootDirectory = await promisify(dir)();
     chdir(rootDirectory);
+
+    appmapDir = process.cwd();
   });
 
   afterEach(async () => {
@@ -26,46 +37,90 @@ describe('emitUsage', () => {
     jest.clearAllMocks();
   });
 
-  describe('when the .appmap directory does not exist', () => {
-    it('does not emit any run stats information', async () => {
-      const resultPath = await emitUsage(process.cwd(), 1, 2);
-      expect(resultPath).toBeUndefined();
+  describe('collectUsageData', () => {
+    it('returns the correct usage data when metadata is provided', async () => {
+      const usageData = await collectUsageData(appmapDir, numEvents, numAppMaps, metadata as any);
+      expect(usageData).toMatchObject({
+        events: numEvents,
+        appmaps: numAppMaps,
+        metadata: expect.any(Object),
+        ci: Boolean(process.env.CI),
+      });
+    });
+
+    it('returns the correct usage data when metadata is not provided', async () => {
+      const usageData = await collectUsageData(appmapDir, numEvents, numAppMaps);
+      expect(usageData).toMatchObject({
+        events: numEvents,
+        appmaps: numAppMaps,
+        metadata: undefined,
+        ci: Boolean(process.env.CI),
+      });
     });
   });
 
-  describe('when the .appmap directory exists', () => {
-    const repository = 'my-repository';
-    const branch = 'my-branch';
-    const commit = 'my-commit';
+  describe('writeUsageData', () => {
+    describe('when the output directory exists or can be created', () => {
+      const repository = 'my-repository';
+      const branch = 'my-branch';
+      const commit = 'my-commit';
+
+      beforeEach(() => {
+        jest.spyOn(Git, 'repository').mockResolvedValue(repository);
+        jest.spyOn(Git, 'branch').mockResolvedValue(branch);
+        jest.spyOn(Git, 'commit').mockResolvedValue(commit);
+      });
+
+      it('emits the expected run stats information', async () => {
+        const usageData = await collectUsageData(appmapDir, numEvents, numAppMaps, metadata as any);
+        const resultPath = await writeUsageData(usageData, appmapDir);
+        expect(resultPath).toBeDefined();
+        const dirName = rootDirectory.split('/').pop();
+        expect(resultPath?.split('/')).toContain('.run-stats');
+        expect(resultPath?.split('/')).toContain(dirName);
+
+        const dto = JSON.parse(await readFile(resultPath!, 'utf-8')) as UsageUpdateDto;
+        expect(dto).toMatchObject({
+          events: numEvents,
+          appmaps: numAppMaps,
+          ci: Boolean(process.env.CI),
+        });
+        expect(dto.metadata).toMatchObject({
+          app: metadata.app,
+          git: {
+            repository,
+            branch,
+            commit,
+          },
+        });
+      });
+    });
+  });
+
+  describe('sendUsageData', () => {
+    let usageData: UsageUpdateDto;
 
     beforeEach(async () => {
-      await mkdir('.appmap');
-      jest.spyOn(Git, 'repository').mockResolvedValue(repository);
-      jest.spyOn(Git, 'branch').mockResolvedValue(branch);
-      jest.spyOn(Git, 'commit').mockResolvedValue(commit);
+      usageData = await collectUsageData(appmapDir, numEvents, numAppMaps, metadata as any);
     });
 
-    it('emits the expected run stats information', async () => {
-      const numEvents = 1;
-      const numAppMaps = 2;
-      const metadata = { app: 'test', foo: 'bar' };
+    it('the usage data can be sent successfully', async () => {
+      jest.spyOn(Usage, 'update').mockResolvedValue(undefined);
 
-      const resultPath = await emitUsage(process.cwd(), numEvents, numAppMaps, metadata as any);
-      expect(resultPath).toBeDefined();
+      const response = await sendUsageData(usageData, appmapDir);
+      expect(response.sent).toBe(true);
+      expect(response.filePath).toBeUndefined();
+    });
 
-      const dto = JSON.parse(await readFile(resultPath!, 'utf-8')) as UsageUpdateDto;
-      expect(dto).toMatchObject({
-        events: numEvents,
-        appmaps: numAppMaps,
-        ci: Boolean(process.env.CI),
-      });
-      expect(dto.metadata).toMatchObject({
-        app: metadata.app,
-        git: {
-          repository,
-          branch,
-          commit,
-        },
+    describe('when the usage data is not sent successfully', () => {
+      it('falls back to writing data to file on failure', async () => {
+        jest.spyOn(Usage, 'update').mockImplementationOnce(() => {
+          throw new Error('Mock API failure');
+        });
+
+        const response = await sendUsageData(usageData, appmapDir);
+        expect(response.sent).toBe(false);
+        expect(response.filePath).toBeDefined();
       });
     });
   });

--- a/packages/client/src/usage.ts
+++ b/packages/client/src/usage.ts
@@ -50,12 +50,20 @@ export default class Usage {
     // Consider this to be a no-op if there's nothing to report.
     if (!dto.events && !dto.appmaps) return;
 
-    await makeRequest({
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const serializeDto: any = { ...dto };
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    if (serializeDto.metadata) serializeDto.metadata = JSON.stringify(serializeDto.metadata);
+
+    const response = await makeRequest({
       service: ServiceEndpoint.ServiceApi,
       path: this.usagePath,
       method: 'POST',
-      body: JSON.stringify(dto),
+      body: JSON.stringify(serializeDto),
       retry: false,
     });
+    if (!response.ok) {
+      throw new Error(`Failed to update usage: ${response.body.toString('utf-8')}`);
+    }
   }
 }


### PR DESCRIPTION
Report run stats as the fingerprint watch command runs.

1. **Refactoring `emitUsage` to `writeUsage`, `collectUsageData`, and `sendUsageData`:**
   - **writeUsage:** 
     Writes usage statistics for AppMap events and files to a JSON file.
   - **collectUsageData:** 
     Collects usage data including metadata, number of events, and number of AppMap files.
   - **sendUsageData:** 
     Sends the usage data to a remote server; if it fails, it logs the data locally.

2. **Updated various files to use the new functions:**
   - `packages/cli/src/cmds/archive/index.ts`
   - `packages/cli/src/fingerprint/fingerprintDirectoryCommand.ts`
   - `packages/cli/src/fingerprint/fingerprintWatchCommand.ts`
   
