### PR TITLE
fix: Listen on localhost for IPv4 and IPv6

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,11 @@
 {
   "editor.rulers": [100],
   "editor.formatOnSave": true,
-  "editor.defaultFormatter": "esbenp.prettier-vscode"
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "jest.virtualFolders": [
+    {
+      "name": "cli",
+      "rootPath": "packages/cli"
+    }
+  ],
 }

--- a/packages/cli/src/lib/shadowLocalhost.ts
+++ b/packages/cli/src/lib/shadowLocalhost.ts
@@ -1,0 +1,45 @@
+import { Server } from 'node:http';
+
+export default function shadowLocalhost(server: Server): Promise<Server> {
+  if (server.listening) return createShadow(server);
+  else
+    return new Promise((resolve, reject) =>
+      server.on('listening', () => {
+        try {
+          resolve(createShadow(server));
+        } catch (e) {
+          reject(e);
+        }
+      })
+    );
+}
+
+function createShadow(server: Server): Promise<Server> {
+  const address = server.address();
+  if (address === null) {
+    throw new Error('Server has no address');
+  } else if (typeof address === 'string') {
+    throw new Error('Server is not IP');
+  } else {
+    const host = otherHost(address);
+    const shadow = new Server((...args) => server.emit('request', ...args)).unref();
+    return new Promise((resolve, reject) =>
+      shadow
+        .listen(address.port, host, () => {
+          server.on('close', () => shadow.close());
+          resolve(shadow);
+        })
+        .on('error', reject)
+    );
+  }
+}
+
+function otherHost(address: { port: number; family: string; address: string }): string {
+  if (!['127.0.0.1', '::1', 'localhost'].includes(address.address))
+    throw new Error(`Server is not localhost: ${address.address}`);
+  if (address.family === 'IPv6') {
+    return '127.0.0.1';
+  } else {
+    return '::1';
+  }
+}

--- a/packages/cli/tests/unit/lib/shadowLocalhost.spec.ts
+++ b/packages/cli/tests/unit/lib/shadowLocalhost.spec.ts
@@ -1,0 +1,52 @@
+import assert from 'node:assert';
+import { get, Server } from 'node:http';
+
+import shadowLocalhost from '../../../src/lib/shadowLocalhost';
+
+describe('shadowLocalhost', () => {
+  it('should start server on localhost for both IPv4 and IPv6', async () => {
+    expect.assertions(4);
+    const server = new Server((req, res) => {
+      res.writeHead(200, { 'Content-Type': 'text/plain' });
+      res.end('OK');
+    });
+    server.listen(0, 'localhost');
+    const shadow = await shadowLocalhost(server);
+
+    const address = server.address();
+    assert(address !== null && typeof address === 'object');
+    const port = address.port;
+
+    expect(await httpGet(`http://127.0.0.1:${port}`)).toBe('OK');
+    expect(await httpGet(`http://[::1]:${port}`)).toBe('OK');
+
+    const shadowClosed = new Promise<void>((resolve, reject) => {
+      shadow.on('close', resolve);
+      shadow.on('error', reject);
+    });
+    server.close();
+
+    await shadowClosed;
+
+    expect(server.listening).toBeFalsy();
+    expect(shadow.listening).toBeFalsy();
+  });
+});
+
+function httpGet(url: string): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    get(url, (res) => {
+      if (res.statusCode !== 200) {
+        reject(new Error(`HTTP error ${res.statusCode}`));
+        return;
+      }
+      let data = '';
+      res.on('data', (chunk) => {
+        data += chunk;
+      });
+      res.on('end', () => {
+        resolve(data);
+      });
+    }).on('error', reject);
+  });
+}


### PR DESCRIPTION
In some environments 'localhost' may resolve to either IPv4 or IPv6 depending on the runtime; if the client and the server differ, this could lead to connection problems.

To avoid this issue, attempt to start a server on both localhosts.