### PR TITLE
fix: Normalize text before keyword splitting

### DIFF
--- a/packages/cli/src/fulltext/FileIndex.ts
+++ b/packages/cli/src/fulltext/FileIndex.ts
@@ -52,7 +52,7 @@ export class FileIndex {
   search(keywords: string[], limit = 10): FileIndexMatch[] {
     const query = `SELECT directory, file_name, (rank * -1) score FROM files WHERE files MATCH ? ORDER BY rank LIMIT ?`;
 
-    const searchExpr = queryKeywords(keywords).join(' OR ');
+    const searchExpr = queryKeywords(keywords.map((keyword) => keyword.toLowerCase())).join(' OR ');
     const rows = this.database.prepare(query).all(searchExpr, limit);
     if (debug.enabled)
       for (const row of rows) {

--- a/packages/cli/tests/unit/fixtures/fulltext/HTTPServer.ts
+++ b/packages/cli/tests/unit/fixtures/fulltext/HTTPServer.ts
@@ -1,0 +1,3 @@
+export default class HTTPServer {
+  constructor(public port: number) {}
+}

--- a/packages/cli/tests/unit/fulltext/FileIndex.spec.ts
+++ b/packages/cli/tests/unit/fulltext/FileIndex.spec.ts
@@ -144,6 +144,22 @@ describe('FileIndex', () => {
 
     /* eslint-enable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument */
   });
+
+  describe('ranking', () => {
+    const fixtureDir = join(__dirname, '..', 'fixtures', 'fulltext');
+
+    beforeEach(() => {
+      fileIndex = new FileIndex(database);
+      fileIndex.indexFile(fixtureDir, 'HTTPServer.ts');
+    });
+    afterEach(() => fileIndex.close());
+
+    it('case insensitive matches are ranked equally', () => {
+      const [caseMatch] = fileIndex.search(['HTTPServer'], 1);
+      const [nonCaseMatch] = fileIndex.search(['httpserver'], 1);
+      expect(caseMatch).toEqual(nonCaseMatch);
+    });
+  });
 });
 
 describe(filterFiles, () => {


### PR DESCRIPTION
This guarantees the full text search remains case insensitive. E.g., `HTTPServer` would split into `http server httpserver` Where `httpserver` would split into `httpserver`.

This does affect ranking in that the case sensitive match would have produced a higher score due to the additional matches.

Resolves #2067