### PR TITLE
fix: Prevent LLM from generating special characters in class names

### DIFF
--- a/packages/navie/src/agents/diagram-agent.ts
+++ b/packages/navie/src/agents/diagram-agent.ts
@@ -33,7 +33,7 @@ export default class DiagramAgent implements Agent {
     return new MermaidFilter(this.history, this.mermaidFixerService);
   }
 
-  async perform(options: AgentOptions, tokensAvailable: () => number): Promise<AgentResponse> {
+  async perform(options: AgentOptions, tokensAvailable: () => number): Promise<void> {
     const agentPrompt = [DIAGRAM_AGENT_PROMPT];
     // With the /noformat option, the user will explain the desired output format in their message.
     if (options.userOptions.isEnabled('format', true)) {
@@ -50,8 +50,6 @@ export default class DiagramAgent implements Agent {
     );
 
     await this.contextService.searchContext(options, tokensAvailable);
-
-    return { response: 'Rendering diagram...\n', abort: false };
   }
 
   applyQuestionPrompt(question: string): void {

--- a/packages/navie/src/agents/explain-agent.ts
+++ b/packages/navie/src/agents/explain-agent.ts
@@ -191,19 +191,23 @@ sequenceDiagram
 
 DO use Mermaid class diagram syntax.
 
+DO NOT use characters other than alphanumeric characters, underscores, or
+dashes (-) in the class names. If you need to use other special characters, you
+MUST use labels in square brackets or put the class name in backticks.
+
 <example format="class-diagram">
 \`\`\`mermaid
 classDiagram
   direction LR
 
-  class PartnerStrategy {
-      +fetch_for_product(product: Product) : PurchaseInfo
-      +fetch_for_line(line: Line, stockrecord: StockRecord) : PurchaseInfo
-      +select_stockrecord(product: Product) : StockRecord
+  class PartnerStrategy["Partner Strategy"] {
+      +fetch_for_product(product: Product): PurchaseInfo
+      +fetch_for_line(line: Line, stockrecord: StockRecord): PurchaseInfo
+      +select_stockrecord(product: Product): StockRecord
   }
 
-  class PurchaseInfo {
-      +price: PricingPolicy
+  class PurchaseInfo["Purchase::Info"] {
+      +price: \`Pricing::Policy\`
       +availability: AvailabilityPolicy
       +stockrecord: StockRecord
   }
@@ -234,7 +238,7 @@ classDiagram
       +upc: str
   }
 
-  class PricingPolicy {
+  class \`Pricing::Policy\` {
   }
 
   class AvailabilityPolicy {
@@ -253,7 +257,7 @@ classDiagram
   PartnerStrategy --> Basket
   PartnerStrategy --> Order
   PurchaseInfo --> StockRecord
-  PurchaseInfo --> PricingPolicy
+  PurchaseInfo --> \`Pricing::Policy\`
   PurchaseInfo --> AvailabilityPolicy
   PartnerStrategy --> PurchaseInfo
   PartnerStrategy --> Product

--- a/packages/navie/test/agents/diagram-agent.spec.ts
+++ b/packages/navie/test/agents/diagram-agent.spec.ts
@@ -72,6 +72,6 @@ describe('@diagram agent', () => {
     );
 
     // Verify that the result returned by the perform method is as expected
-    expect(result).toEqual({ response: 'Rendering diagram...\n', abort: false });
+    expect(result).toBeUndefined();
   });
 });

--- a/packages/navie/test/agents/diagram-agent.spec.ts
+++ b/packages/navie/test/agents/diagram-agent.spec.ts
@@ -1,7 +1,6 @@
 import InteractionHistory, { PromptInteractionEvent } from '../../src/interaction-history';
 import { AgentOptions } from '../../src/agent';
 import ContextService from '../../src/services/context-service';
-import CompletionService from '../../src/services/completion-service';
 import DiagramAgent, { DIAGRAM_AGENT_PROMPT } from '../../src/agents/diagram-agent';
 import { UserOptions } from '../../src/lib/parse-options';
 import MermaidFixerService from '../../src/services/mermaid-fixer-service';
@@ -21,13 +20,18 @@ describe('@diagram agent', () => {
     [
       {
         directory: 'twitter',
-        appmapConfig: { language: 'ruby' } as unknown as any,
-        appmapStats: { numAppMaps: 1 } as unknown as any,
+        appmapConfig: {
+          language: 'ruby',
+          name: 'test',
+          appmap_dir: 'tmp/appmap',
+          packages: undefined,
+        },
+        appmapStats: { numAppMaps: 1, packages: [], routes: [], tables: [] },
       },
     ]
   );
 
-  beforeEach(async () => {
+  beforeEach(() => {
     tokensAvailable = 1000;
     interactionHistory = new InteractionHistory();
     contextService = {
@@ -41,10 +45,6 @@ describe('@diagram agent', () => {
   afterEach(() => jest.restoreAllMocks());
 
   it('should perform the diagram agent task', async () => {
-    const completionService = {
-      perform: jest.fn(),
-    } as unknown as CompletionService;
-
     const diagramAgent = new DiagramAgent(interactionHistory, contextService, mermaidFixerService);
     const result = await diagramAgent.perform(initialQuestionOptions, () => tokensAvailable);
 
@@ -65,6 +65,7 @@ describe('@diagram agent', () => {
     );
 
     // Verify that the context service's perform method is called with the expected options
+    // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(contextService.searchContext).toHaveBeenCalledWith(
       initialQuestionOptions,
       expect.any(Function)


### PR DESCRIPTION
Fixes #2070 

![image](https://github.com/user-attachments/assets/03ab6ec1-f09c-4d2f-835e-a7be1d17c83b)

Note I told it how to quote, but it chose to use underscores anyway (this is copilot, other models might do better).