### PR TITLE
fix: Split compound terms via VectorTermsService

### DIFF
--- a/packages/navie/src/services/vector-terms-service.ts
+++ b/packages/navie/src/services/vector-terms-service.ts
@@ -22,6 +22,8 @@ The developer asks a question using natural language. This question must be conv
 4) Optionally choose a small number of search terms which are MOST SELECTIVE. The MOST SELECTIVE match terms should
   be words that will match a feature or domain model object in the code base. They should be the most
   distinctive words in the question. You will prefix the MOST SELECTIVE terms with a '+'.
+5) In order for keywords to match optimally, compound words MUST additionally be segmented into individual search terms. This is additionally very important for compound words containing acronyms.
+  E.g., "httpserver" would become "http", "server", "httpserver". "xmlserializer" -> "xml", "serializer", "xmlserializer". "jsonserializer" -> "json", "serializer", "jsonserializer". etc. 
 
   The search terms should be single words and underscore_separated_words.`;
 
@@ -75,7 +77,7 @@ const promptExamples: Message[] = [
     content: JSON.stringify({
       context: 'logContext jest test case',
       instructions: 'Create test cases, following established patterns for mocking with jest.',
-      terms: ['test', 'cases', '+logContext', 'jest'],
+      terms: ['test', 'cases', '+logContext', 'log', 'context', 'jest'],
     }),
     role: 'assistant',
   },


### PR DESCRIPTION
The LLM is now instructed to split compound words into individual search terms. This will improve search performance among lower case search terms that cannot be split by word boundary without a word list.

E.g., given the input
```
@vector-terms htmlconsumer phpclient llmconfiguration
```

The following vector terms are generated
```
html consumer php client llm configuration +htmlconsumer +phpclient +llmconfiguration
```

This is preferred over the current behavior, which outputs the following:
```
htmlconsumer phpclient llmconfiguration +htmlconsumer +phpclient +llmconfiguration
```

Without proper casing, these outputs will not be split on word boundary, resulting in lower quality search results. This previously created a disparity between two inputs like `HTTPServer`, `httpserver`.

Resolves https://github.com/getappmap/appmap-js/issues/2067