### PR TITLE
fix: Use git attributes to identify binary files

### DIFF
--- a/packages/cli/src/fulltext/FileIndex.ts
+++ b/packages/cli/src/fulltext/FileIndex.ts
@@ -259,11 +259,9 @@ const DATA_FILE_EXTENSIONS: string[] = [
   'xml',
 ].map((ext) => '.' + ext);
 
-const isBinaryFile = (fileName: string, gitAttributes?: ReturnType<typeof getGitAttributes>) => {
-  if (BINARY_FILE_EXTENSIONS.some((ext) => fileName.endsWith(ext))) return true;
-  if (gitAttributes?.some((attr) => attr.binary && minimatch(fileName, attr.pattern))) return true;
-  return false;
-};
+const isBinaryFile = (fileName: string, gitAttributes?: ReturnType<typeof getGitAttributes>) =>
+  BINARY_FILE_EXTENSIONS.some((ext) => fileName.endsWith(ext)) ||
+  gitAttributes?.some((attr) => attr.binary && minimatch(fileName, attr.pattern, { dot: true }));
 
 const isDataFile = (fileName: string) => {
   return DATA_FILE_EXTENSIONS.some((ext) => fileName.endsWith(ext));

--- a/packages/cli/tests/unit/fulltext/FileIndex.spec.ts
+++ b/packages/cli/tests/unit/fulltext/FileIndex.spec.ts
@@ -190,6 +190,7 @@ describe(filterFiles, () => {
     writeFileSync(join(dir, 'file.txt'), 'hello');
     writeFileSync(join(dir, 'file.my-extension'), 'hello');
     writeFileSync(join(dir, 'file.bin'), 'hello');
+    writeFileSync(join(dir, '.file.bin'), 'hello');
 
     const fileList = readdirSync(dir);
     const gitAttributes = getGitAttributes(dir);


### PR DESCRIPTION
Fixes #2042

Add support for identifying binary files using git attributes in addition to file extensions.

* Add `getGitAttributes` function to read and parse the `.gitattributes` file in `packages/cli/src/fulltext/FileIndex.ts`.
* Update `isBinaryFile` function to check git attributes information in addition to file extensions in `packages/cli/src/fulltext/FileIndex.ts`.
* Update `filterFiles` function to use the `getGitAttributes` function to determine if a file is binary based on git attributes in `packages/cli/src/fulltext/FileIndex.ts`.
* Add tests to verify that the context search/lookup/collector correctly identifies binary files using git attributes information in `packages/cli/tests/unit/fulltext/FileIndex.spec.ts`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/getappmap/appmap-js/issues/2042?shareId=7a68523a-affa-44f8-80f9-d10a1d5a1e10).