### PR TITLE
feat: Add support for links to files

### DIFF
--- a/packages/components/src/components/chat/UserMessage.vue
+++ b/packages/components/src/components/chat/UserMessage.vue
@@ -154,6 +154,18 @@ customRenderer.code = (code: string, language: string, escaped: boolean, sourceP
   ].join('');
 };
 
+const linkRenderer = customRenderer.link;
+customRenderer.link = (href: string, title: string, text: string) => {
+  const linkHtml = linkRenderer(href, title, text);
+  const isWebsite = href.match(/^https?:\/\//);
+  if (isWebsite) {
+    // Links to external websites should always open in a new tab.
+    return linkHtml.replace('<a', '<a target="_blank" rel="noopener noreferrer"');
+  }
+
+  return linkHtml.replace(/<a/, '<a emit-event');
+};
+
 const marked = new Marked({
   renderer: customRenderer,
   extensions: [
@@ -315,9 +327,9 @@ export default {
           'modified',
           'original',
         ],
-        ADD_ATTR: ['language', 'location', 'command', 'prompt'],
+        ADD_ATTR: ['language', 'location', 'command', 'prompt', 'target', 'emit-event'],
         ALLOWED_URI_REGEXP:
-          /^(?:(?:(?:f|ht)tps?|mailto|event):|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i,
+          /^(?:(?:(?:f|ht)tps?|mailto|event|file):|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i,
       });
     },
     hasClipboardAPI() {

--- a/packages/components/src/stories/UserMessage.stories.js
+++ b/packages/components/src/stories/UserMessage.stories.js
@@ -179,3 +179,24 @@ Buttons.args = {
 `,
   complete: true,
 };
+
+export const Links = (args, { argTypes }) => ({
+  props: Object.keys(argTypes),
+  components: { VUserMessage },
+  template: `<v-user-message v-bind="$props"></v-user-message>`,
+  mounted() {
+    this.$nextTick(() => {
+      this.$root.$on('click-link', (href) => {
+        console.log('click-link', href);
+      });
+    });
+  },
+});
+Links.args = {
+  id: 'system-message-id',
+  message: `Here is some relevant information:
+- [AppMap Documentation](https://appmap.io/docs)
+- [packages/client/src/components/LoginPage.jsx](packages/client/src/components/LoginPage.jsx)
+`,
+  complete: true,
+};


### PR DESCRIPTION
This change:
- Always opens http(s) links in a new tab (this fixes an issue in JetBrains IDEs where a link would open in the current tab as well as in an external browser source).
- Emits `click-link` events for non-http(s) links, sending along the href in the event
- Allows `file:` protocol hrefs

Fixes https://github.com/getappmap/appmap-js/issues/2085
Resolves https://github.com/getappmap/appmap-js/issues/2018