### PR TITLE
Visual adjustments to signup form

### DIFF
--- a/packages/components/src/components/SignIn.vue
+++ b/packages/components/src/components/SignIn.vue
@@ -2,7 +2,7 @@
   <div class="signin-sidebar">
     <AppMapLogo width="120" />
     <div v-if="!submitted" class="content-wrap">
-      <div class="sidebar-title" data-cy="title">Activate AppMap</div>
+      <div data-cy="title">Activate AppMap</div>
 
       <div class="signin-buttons">
         <p v-if="error" class="error">{{ error }}</p>
@@ -20,7 +20,7 @@
           data-cy="email-activation-button"
           @click.prevent="activateWithEmail"
         >
-          Activate with<span><EmailIcon class="small-logo" /> Email</span>
+          Get activation code by <span><EmailIcon class="small-logo" /> Email</span>
         </a>
 
         <div class="or-divider-container">
@@ -250,6 +250,10 @@ export default {
   padding: 1.5rem;
   line-height: 1.4rem;
 
+  .content-wrap {
+    max-width: 500px;
+  }
+
   a.link {
     color: $brightblue;
     text-decoration: none;
@@ -384,7 +388,6 @@ export default {
   .your-data {
     display: flex;
     flex-direction: row;
-    align-items: center;
     gap: 1rem;
     padding: 1rem;
     border: 1px solid $gray3;
@@ -395,6 +398,10 @@ export default {
       width: 100%;
       max-width: 33px;
       height: 42px;
+    }
+
+    .your-data-text {
+      font-size: 0.85rem;
     }
   }
 


### PR DESCRIPTION
This is part of the [Get New Users Into Chat](https://github.com/getappmap/board/issues/335) epic. Along with updates to the UI of adjacent components, this contributes to conveying a sense of organization and stability to new users. It also aims to drive more email activations but being clearer about how lightweight that process is.

Updates the button label on email signup, the visual design of the 'your data is your data' message, and the responsive behavior of the form at large sizes.

New View:

<img width="392" alt="image" src="https://github.com/user-attachments/assets/ee8bce77-c3aa-4f4c-a272-39fe1d1257de">

<img width="1366" alt="image" src="https://github.com/user-attachments/assets/aac20ffd-e2ac-4ca6-8ced-ad6f7f5cd586">


Existing View:

<img width="326" alt="image" src="https://github.com/user-attachments/assets/40786273-f36c-43af-b71d-bcfae0582ba4">

![image](https://github.com/user-attachments/assets/82f32058-d49c-40a4-b8c9-654de6396b86)
