### PR TITLE
fix: pass desired SSO target

### DIFF
--- a/packages/components/src/components/SignIn.vue
+++ b/packages/components/src/components/SignIn.vue
@@ -33,7 +33,7 @@
           class="btn btn-primary"
           data-cy="github-activation-button"
           href="/"
-          @click.prevent="signIn"
+          @click.prevent="signIn('github')"
         >
           Activate with <span><GitHubLogo class="small-logo" /> GitHub</span>
         </a>
@@ -41,7 +41,7 @@
           class="btn btn-primary"
           data-cy="gitlab-activation-button"
           href="/"
-          @click.prevent="signIn"
+          @click.prevent="signIn('gitlab')"
         >
           Activate with <span><GitLabLogo class="small-logo" /> GitLab</span>
         </a>
@@ -165,8 +165,8 @@ export default {
         }
       }
     },
-    signIn() {
-      this.$root.$emit('sign-in');
+    signIn(target) {
+      this.$root.$emit('sign-in', target);
     },
     reset() {
       this.email = '';


### PR DESCRIPTION
Send the SSO target when emitting the sign-in event.

Fixes https://github.com/getappmap/board/issues/338 .