### PR TITLE
fix: Don't retry when hitting copilot content filter while generating JSON

### DIFF
--- a/packages/navie/src/services/openai-completion-service.ts
+++ b/packages/navie/src/services/openai-completion-service.ts
@@ -210,7 +210,7 @@ export default class OpenAICompletionService implements CompletionService {
 
   // Request a JSON object with a given JSON schema.
   async json<Schema extends z.ZodType>(
-    messages: Message[],
+    messages: readonly Message[],
     schema: Schema,
     options?: CompleteOptions
   ): Promise<z.infer<Schema> | undefined> {
@@ -272,6 +272,12 @@ export default class OpenAICompletionService implements CompletionService {
       } else {
         warn(`Unexpected response choice: ${JSON.stringify(choice)}`);
         continue; // eslint-disable-line no-continue
+      }
+
+      // Copilot tends to respond with this when hitting content filters.
+      if (completion.content === "Sorry, I can't assist with that.") {
+        warn('LLM refused to respond, probably hit a content filter.');
+        return;
       }
 
       if (completion && completion.content !== null && completion.content !== undefined) {

--- a/packages/navie/test/services/openai-completion-service.spec.ts
+++ b/packages/navie/test/services/openai-completion-service.spec.ts
@@ -41,41 +41,11 @@ describe('OpenAICompletionService', () => {
   });
 
   describe('when the completion service is used', () => {
-    const openAI = jest.mocked(OpenAI.ChatOpenAI);
-    const completionWithRetry = jest.mocked<
-      (
-        request: OpenAI.OpenAIClient.Chat.ChatCompletionCreateParamsStreaming,
-        options?: OpenAI.OpenAICoreRequestOptions
-      ) => Promise<AsyncIterable<OpenAI.OpenAIClient.Chat.Completions.ChatCompletionChunk>>
-    >(OpenAI.ChatOpenAI.prototype.completionWithRetry);
-
     beforeEach(() => {
       interactionHistory.addEvent(
         new PromptInteractionEvent(PromptType.Question, 'user', 'What is user management?')
       );
-
-      const generator =
-        async function* (): AsyncIterable<OpenAI.OpenAIClient.Chat.Completions.ChatCompletionChunk> {
-          yield {
-            choices: [
-              {
-                delta: {
-                  content: 'User management works by managing users.',
-                  role: 'assistant',
-                },
-                finish_reason: 'stop',
-                index: 0,
-                logprobs: null,
-              },
-            ],
-            id: 'the-id',
-            model: 'the-model',
-            created: 1234567890,
-            object: 'chat.completion.chunk',
-          };
-        };
-
-      completionWithRetry.mockImplementation(async () => generator());
+      mockCompletion('User management works by managing users.');
     });
 
     const complete = async (options: { temperature: number | undefined }) => {
@@ -114,32 +84,20 @@ describe('OpenAICompletionService', () => {
     });
 
     it('retries on server error with exponential backoff during response iteration', async () => {
-      let callCount = 0;
       // eslint-disable-next-line @typescript-eslint/require-await
-      const mockCompletionWithRetry = jest.fn().mockImplementation(async function* () {
-        if (callCount === 0) {
-          callCount += 1;
-          throw new APIError(
-            undefined,
-            {
-              message:
-                'The server had an error processing your request. Sorry about that! You can retry your request, or contact us through our help center at help.openai.com if you keep seeing this error.',
-              type: 'server_error',
-              param: null,
-              code: null,
-            },
-            undefined,
-            undefined
-          );
-        }
-
-        // This is the success case after retry
-        yield {
-          choices: [{ delta: { content: 'Hello' } }],
-        };
+      responseMock.mockImplementationOnce(() => {
+        throw new APIError(
+          undefined,
+          {
+            message:
+              'The server had an error processing your request. Sorry about that! You can retry your request, or contact us through our help center at help.openai.com if you keep seeing this error.',
+            type: 'server_error',
+          },
+          undefined,
+          undefined
+        );
       });
-
-      service.model.completionWithRetry = mockCompletionWithRetry;
+      mockCompletion('Hello');
 
       const messages = [{ role: 'user', content: 'Hello' }] as const;
       const result = [];
@@ -148,40 +106,31 @@ describe('OpenAICompletionService', () => {
       }
 
       expect(result).toEqual(['Hello']);
-      expect(mockCompletionWithRetry).toHaveBeenCalledTimes(2);
+      expect(completionWithRetry).toHaveBeenCalledTimes(2);
     });
 
     it('retries if token count exceeds limit', async () => {
-      let callCount = 0;
       // eslint-disable-next-line @typescript-eslint/require-await
-      const mockCompletionWithRetry = jest.fn().mockImplementation(async function* () {
-        if (callCount === 0) {
-          callCount += 1;
-          throw new APIError(
-            undefined,
-            {
-              message:
-                "This model's maximum context length is 128000 tokens. However, your messages resulted in 128001 tokens. Please reduce the length of the messages.",
-              type: 'invalid_request_error',
-              param: 'messages',
-              code: 'context_length_exceeded',
-            },
-            undefined,
-            undefined
-          );
-        }
-
-        // This is the success case after retry
-        yield {
-          choices: [{ delta: { content: 'Hello' } }],
-        };
+      responseMock.mockImplementationOnce(() => {
+        throw new APIError(
+          undefined,
+          {
+            message:
+              "This model's maximum context length is 128000 tokens. However, your messages resulted in 128001 tokens. Please reduce the length of the messages.",
+            type: 'invalid_request_error',
+            param: 'messages',
+            code: 'context_length_exceeded',
+          },
+          undefined,
+          undefined
+        );
       });
+      mockCompletion('Hello');
+
       const reduceMessageTokens = jest
         .spyOn(messageTokenReducerService, 'reduceMessageTokens')
         .mockResolvedValue([]);
 
-      service.model.completionWithRetry = mockCompletionWithRetry;
-
       const messages = [{ role: 'user', content: 'Hello' }] as const;
       const result = [];
       for await (const token of service.complete(messages)) {
@@ -189,7 +138,7 @@ describe('OpenAICompletionService', () => {
       }
 
       expect(result).toEqual(['Hello']);
-      expect(mockCompletionWithRetry).toHaveBeenCalledTimes(2);
+      expect(completionWithRetry).toHaveBeenCalledTimes(2);
       expect(reduceMessageTokens).toHaveBeenCalledTimes(1);
     });
 
@@ -205,9 +154,7 @@ describe('OpenAICompletionService', () => {
 
   describe('json', () => {
     it('returns the parsed JSON', async () => {
-      service.model.completionWithRetry = jest.fn().mockResolvedValue({
-        choices: [{ message: { content: '{"answer": "42"}' } }],
-      });
+      mockCompletion('{"answer": "42"}');
 
       const schema = z.object({ answer: z.string() });
       const result = await service.json([], schema);
@@ -215,9 +162,7 @@ describe('OpenAICompletionService', () => {
     });
 
     it('returns undefined if the JSON does not validate', async () => {
-      service.model.completionWithRetry = jest.fn().mockResolvedValue({
-        choices: [{ message: { content: '{"answer": 42}' } }],
-      });
+      mockCompletion('{"answer": 42}');
 
       const schema = z.object({ answer: z.string() });
       const result = await service.json([], schema);
@@ -225,9 +170,7 @@ describe('OpenAICompletionService', () => {
     });
 
     it('returns undefined if the JSON is not parsable', async () => {
-      service.model.completionWithRetry = jest.fn().mockResolvedValue({
-        choices: [{ message: { content: 'not JSON' } }],
-      });
+      mockCompletion('not JSON');
 
       const schema = z.object({ answer: z.string() });
       const result = await service.json([], schema);
@@ -242,7 +185,7 @@ describe('OpenAICompletionService', () => {
       const schema = z.object({ answer: z.string() });
       const options = { temperature: 1.0, model: service.miniModelName };
       await service.json(messages, schema, options);
-      expect(service.model.completionWithRetry).toHaveBeenCalledWith(
+      expect(completionWithRetry).toHaveBeenCalledWith(
         expect.objectContaining({
           messages: [
             // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
@@ -259,9 +202,7 @@ describe('OpenAICompletionService', () => {
       const trajectoryEvents = new Array<TrajectoryEvent>();
       trajectory.on('event', (event) => trajectoryEvents.push(event));
 
-      service.model.completionWithRetry = jest.fn().mockResolvedValue({
-        choices: [{ message: { content: '{"answer": "42"}' } }],
-      });
+      mockCompletion('{"answer": "42"}');
 
       const messages: Message[] = [
         { role: 'system', content: 'system prompt' },
@@ -273,11 +214,11 @@ describe('OpenAICompletionService', () => {
     });
 
     it('retries the expected number of times on failure', async () => {
-      service.model.completionWithRetry = jest.fn().mockResolvedValue({ choices: [] });
+      completionWithRetry.mockResolvedValue({ choices: [] } as never);
       const schema = z.object({ answer: z.string() });
       const maxRetries = 5;
       await service.json([], schema, { maxRetries });
-      expect(service.model.completionWithRetry).toHaveBeenCalledTimes(maxRetries);
+      expect(completionWithRetry).toHaveBeenCalledTimes(maxRetries);
     });
 
     describe('when running locally', () => {
@@ -296,17 +237,16 @@ describe('OpenAICompletionService', () => {
       });
 
       it('provides the JSON schema in the system prompt', async () => {
-        service.model.completionWithRetry = jest.fn().mockResolvedValue({
-          choices: [{ message: { content: '{"answer": "42"}' } }],
-        });
+        mockCompletion('{"answer": "42"}');
 
         const schema = z.object({ answer: z.string() });
         await service.json([], schema);
-        expect(service.model.completionWithRetry).toHaveBeenCalledWith(
+        expect(completionWithRetry).toHaveBeenCalledWith(
           expect.objectContaining({
             messages: [
               {
                 role: 'system',
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
                 content: expect.stringContaining(
                   JSON.stringify(
                     {
@@ -334,9 +274,7 @@ describe('OpenAICompletionService', () => {
         const trajectoryEvents = new Array<TrajectoryEvent>();
         trajectory.on('event', (event) => trajectoryEvents.push(event));
 
-        service.model.completionWithRetry = jest.fn().mockResolvedValue({
-          choices: [{ message: { content: '{"answer": "42"}' } }],
-        });
+        mockCompletion('{"answer": "42"}');
 
         const schema = z.object({ answer: z.string() });
         await service.json(
@@ -357,14 +295,7 @@ describe('OpenAICompletionService', () => {
       });
 
       it('handles Visual Studio Code Copilot responses', async () => {
-        service.model.completionWithRetry = jest.fn().mockResolvedValue({
-          choices: [
-            {
-              // Copilot will return a chunk even when streaming is disabled.
-              delta: { content: '{"answer": "42"}' },
-            },
-          ],
-        });
+        completionWithRetry.mockResolvedValue(chunk('{"answer": "42"}') as never);
 
         const schema = z.object({ answer: z.string() });
         const result = await service.json([], schema);
@@ -415,4 +346,63 @@ describe('OpenAICompletionService', () => {
       });
     });
   });
+
+  const openAI = jest.mocked(OpenAI.ChatOpenAI);
+
+  const responseMock = jest.fn<string, []>();
+  function mockCompletion(response: string) {
+    responseMock.mockReturnValue(response);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async function completionResp(request: OpenAI.OpenAIClient.Chat.ChatCompletionCreateParams) {
+    if (request.stream)
+      // eslint-disable-next-line @typescript-eslint/require-await
+      return (async function* () {
+        yield chunk(responseMock());
+      })();
+    else return completion(responseMock());
+  }
+
+  const completionWithRetry = jest.spyOn(OpenAI.ChatOpenAI.prototype, 'completionWithRetry');
+  beforeEach(() => completionWithRetry.mockImplementation(completionResp as never));
+  afterEach(jest.resetAllMocks);
 });
+
+function chunk(response: string): OpenAI.OpenAIClient.Chat.Completions.ChatCompletionChunk {
+  return {
+    choices: [
+      {
+        delta: {
+          content: response,
+          role: 'assistant',
+        },
+        finish_reason: 'stop',
+        index: 0,
+        logprobs: null,
+      },
+    ],
+    id: 'the-id',
+    model: 'the-model',
+    created: 1234567890,
+    object: 'chat.completion.chunk',
+  };
+}
+
+function completion(response: string): OpenAI.OpenAIClient.Chat.Completions.ChatCompletion {
+  return {
+    id: 'the-id',
+    model: 'the-model',
+    created: 1234567890,
+    object: 'chat.completion',
+    usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+    choices: [
+      {
+        message: { content: response, refusal: null, role: 'assistant' },
+        finish_reason: 'stop',
+        index: 0,
+        logprobs: null,
+      },
+    ],
+  };
+}

--- a/packages/navie/test/services/openai-completion-service.spec.ts
+++ b/packages/navie/test/services/openai-completion-service.spec.ts
@@ -221,6 +221,17 @@ describe('OpenAICompletionService', () => {
       expect(completionWithRetry).toHaveBeenCalledTimes(maxRetries);
     });
 
+    it('should handle content filter response', async () => {
+      const messages = [{ role: 'user', content: 'Hello' }] as const;
+      const schema = z.object({ key: z.string() });
+
+      mockCompletion("Sorry, I can't assist with that.");
+
+      const result = await service.json(messages, schema);
+      expect(result).toBeUndefined();
+      expect(completionWithRetry).toHaveBeenCalledTimes(1);
+    });
+
     describe('when running locally', () => {
       const originalBaseURL = process.env.OPENAI_BASE_URL;
 


### PR DESCRIPTION
Copilot likes to respond with `Sorry, I can't assist with that.` instead of throwing an error when hitting a content filter, which used to lead to useless retry in JSON generation. We special case this to avoid the delay.

Fixes #2089 