### PR TITLE
fix: Strip options from chat history given to the LLM

### DIFF
--- a/packages/navie/src/navie.ts
+++ b/packages/navie/src/navie.ts
@@ -238,10 +238,26 @@ export default function navie(
     async *execute(): AsyncIterable<string> {
       assert(command, 'Command not specified');
 
-      for await (const chunk of command.execute({ ...clientRequest, userOptions }, chatHistory))
+      for await (const chunk of command.execute(
+        { ...clientRequest, userOptions },
+        cleanHistory(chatHistory)
+      ))
         yield chunk;
     }
   }
 
   return new Navie();
+}
+
+/**
+ * Remove options from the messages; the chat history is given to the LLM
+ * and it shouldn't see them lest they confuse it. Commands are ok.
+ */
+function cleanHistory(chatHistory?: ChatHistory): ChatHistory | undefined {
+  if (!chatHistory) return undefined;
+
+  return chatHistory.map((message) => ({
+    ...message,
+    content: parseOptions(message.content).question,
+  }));
 }

--- a/packages/navie/test/lib/parse-options.spec.ts
+++ b/packages/navie/test/lib/parse-options.spec.ts
@@ -101,4 +101,10 @@ describe('parseOptions', () => {
     expect(options.isEnabled('quiet', false)).toBe(true);
     expect(question).toBe('hello');
   });
+
+  it('leaves @commands intact', () => {
+    const { options, question } = parseOptions('@help /verbose hello');
+    expect(options.isEnabled('verbose', false)).toBe(true);
+    expect(question).toBe('@help hello');
+  });
 });


### PR DESCRIPTION
Giving options to the LLM tends to confuse it; for example seeing `@generate /format=xml` often leads to it suggesting things like `@generate a plan in XML format`. Since the options are a side channel meant for Navie, not the LLM, it should be safe to strip them.