### PR TITLE
fix: handle missing API key

### DIFF
--- a/packages/components/src/components/chat/Chat.vue
+++ b/packages/components/src/components/chat/Chat.vue
@@ -287,7 +287,10 @@ export default {
         this.messages.splice(messageIndex, 1);
       }
 
-      if (error.code === 401) {
+      if (
+        error.code === 401 ||
+        (error.code === 500 && error.message === 'Authentication required')
+      ) {
         this.setAuthorized(false);
       } else {
         this.addErrorMessage(error);


### PR DESCRIPTION
When the user hasn't provided an API key for Navie, the RPC client currently returns a 500 error code with a message, instead of a 401. Handle this error, so the UI will be updated appropriately.