### PR TITLE
chore: Control concurrency of GitHub Actions jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,10 @@ on:
   schedule:
     - cron: '0 0 * * 0'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   yarn_install:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This change will automatically cancel any still running or pending jobs from previous commits on a new push to a branch.

As a bonus, it will also cancel pending releases if something new is pushed to main. This means if we merge a couple branches in quick succession it won't lead to multiple releases getting pushed.