### PR TITLE
fix: Retrieve pinned items via location context lookup

### DIFF
--- a/packages/navie/src/agent.ts
+++ b/packages/navie/src/agent.ts
@@ -29,15 +29,22 @@ export class AgentOptions {
     return this.projectInfo.some((info) => info.appmapStats && info.appmapStats?.numAppMaps > 0);
   }
 
+  get contextLocations(): string[] {
+    return this.codeSelection && typeof this.codeSelection !== 'string'
+      ? this.codeSelection.filter(UserContext.hasLocation).map((cs) => cs.location)
+      : [];
+  }
+
   buildContextFilters(): ContextV2.ContextFilters {
     const filters: ContextV2.ContextFilters = {};
     if (this.contextLabels) filters.labels = this.contextLabels;
-    if (this.codeSelection && typeof this.codeSelection !== 'string') {
-      filters.locations = this.codeSelection
-        .filter(UserContext.hasLocation)
-        .map((cs) => cs.location);
-    }
     this.userOptions.populateContextFilters(filters);
+    const contextLocations = this.contextLocations;
+    if (contextLocations.length > 0) {
+      filters.locations = contextLocations;
+      filters.exclude ||= [];
+      filters.exclude.push(...contextLocations);
+    }
     return filters;
   }
 }

--- a/packages/navie/src/agents/diagram-agent.ts
+++ b/packages/navie/src/agents/diagram-agent.ts
@@ -48,6 +48,7 @@ export default class DiagramAgent implements Agent {
       )
     );
 
+    await this.contextService.locationContextFromOptions(options);
     await this.contextService.searchContext(options, tokensAvailable);
   }
 

--- a/packages/navie/src/agents/explain-agent.ts
+++ b/packages/navie/src/agents/explain-agent.ts
@@ -302,6 +302,7 @@ export default class ExplainAgent implements Agent {
       )
     );
 
+    await this.contextService.locationContextFromOptions(options);
     await this.contextService.searchContext(options, tokensAvailable);
   }
 

--- a/packages/navie/src/agents/plan-agent.ts
+++ b/packages/navie/src/agents/plan-agent.ts
@@ -93,6 +93,7 @@ export class PlanAgent implements Agent {
       )
     );
 
+    await this.contextService.locationContextFromOptions(options);
     await this.contextService.searchContext(options, tokensAvailable);
   }
 

--- a/packages/navie/src/agents/search-agent.ts
+++ b/packages/navie/src/agents/search-agent.ts
@@ -56,6 +56,7 @@ export default class SearchAgent implements Agent {
       )
     );
 
+    await this.contextService.locationContextFromOptions(options);
     await this.contextService.searchContext(options, tokensAvailable);
   }
 

--- a/packages/navie/src/agents/test-agent.ts
+++ b/packages/navie/src/agents/test-agent.ts
@@ -79,6 +79,7 @@ export default class TestAgent implements Agent {
       await contentFetcher.applyFileContext(options, options.chatHistory);
     }
 
+    await this.contextService.locationContextFromOptions(options);
     await this.contextService.searchContext(options, tokensAvailable, ['test', 'spec']);
   }
 

--- a/packages/navie/src/services/context-service.ts
+++ b/packages/navie/src/services/context-service.ts
@@ -35,8 +35,9 @@ export default class ContextService {
         searchTerms.push(...additionalTerms);
       }
 
-      const filters = { ...options.buildContextFilters() };
-
+      // Locations are not considered when searching for context. Use the `locationContext` method
+      // to retrieve context for specific files.
+      const filters = { ...options.buildContextFilters(), locations: undefined };
       const tokenCount = tokensAvailable();
       let context = await this.lookupContextService.lookupContext(searchTerms, tokenCount, filters);
       context = ContextService.guardContextType(context);
@@ -73,6 +74,11 @@ export default class ContextService {
       this.history.addEvent(contextItem);
     }
     this.history.log(`[context-service] Added ${charsAdded} characters of file context`);
+  }
+
+  locationContextFromOptions(options: AgentOptions): Promise<void> {
+    const { locations } = options.buildContextFilters();
+    return locations && locations.length > 0 ? this.locationContext(locations) : Promise.resolve();
   }
 
   static guardContextType(

--- a/packages/navie/test/agent-options.spec.ts
+++ b/packages/navie/test/agent-options.spec.ts
@@ -16,5 +16,19 @@ describe('AgentOptions', () => {
         include: ['test'],
       });
     });
+
+    it('builds locations and excludes from code selection locations', () => {
+      const userOptions = new UserOptions(new Map());
+      const agentOptions = new AgentOptions(
+        question,
+        question,
+        userOptions,
+        [],
+        [],
+        [{ type: 'file', location: 'file1.md' }]
+      );
+      const filters = agentOptions.buildContextFilters();
+      expect(filters).toEqual({ locations: ['file1.md'], exclude: ['file1.md'] });
+    });
   });
 });

--- a/packages/navie/test/services/context-service.spec.ts
+++ b/packages/navie/test/services/context-service.spec.ts
@@ -1,4 +1,3 @@
-import { lookup } from 'dns';
 import { AgentOptions } from '../../src/agent';
 import ContextService from '../../src/services/context-service';
 import VectorTermsService from '../../src/services/vector-terms-service';


### PR DESCRIPTION
Pinned items are now retrieved via a location context lookup, otherwise they are susceptible to being dropped due to [context length constraints](https://github.com/getappmap/appmap-js/blob/main/packages/navie/src/lib/apply-context.ts#L75-L84).

Those locations are additionally added to the exclude list, ensuring that context search does not yield duplicated code snippets.

## Sequence Diagram

The following sequence diagram illustrates the flow of a request:

```mermaid
sequenceDiagram
    participant CLI as CLI (Client)
    box Navie Backend
    participant ExplainAgent as ExplainAgent
    participant ContextService as ContextService
    participant LookupContext as LookupContextService
    end

    CLI->>ExplainAgent: Send request with options
    ExplainAgent->>ContextService: locationContextFromOptions(options)
    ContextService->>LookupContext: lookupContext(keywords, tokenCount, filters)
    LookupContext->>CLI: collectContext
    CLI-->>LookupContext: Location context
    LookupContext-->>ContextService: ContextResponse
    ContextService-->>ExplainAgent: ContextResponse
    ExplainAgent->>ContextService: searchContext(options, tokensAvailable)
    ContextService->>LookupContext: searchContext(keywords, tokenCount, filters)
    LookupContext->>CLI: collectContext
    CLI-->>LookupContext: Search context
    LookupContext-->>ContextService: Updated ContextResponse
    ContextService-->>ExplainAgent: Updated ContextResponse
    ExplainAgent-->>CLI: Completions
```

## Key Components

- **CLI:** Initiates the request with specific options for context.
- **ExplainAgent:** The agent responsible for contextual and completion logic.
- **ContextService:** Handles the processing and application of context filters.
- **LookupContextService:** Responsible for retrieving specific contexts based on the search parameters.

## Enhancements Post-Diff

- Improved handling of location-based context with `contextLocations` filtering.
- Introduction of `locationContextFromOptions` in `ContextService` for file-specific context management.
- Agents now ensure the retrieval of location-specific context before executing general context searches.
- Transition from direct filtering to utilizing `contextLocations` in `AgentOptions`.
- Refactoring in `ContextService` to manage context retrieval more efficiently.
- Update to agent services to leverage new context handling methods.