### PR TITLE
feat: Associate boost factor data with a session id

### DIFF
--- a/packages/cli/src/cmds/search/search.ts
+++ b/packages/cli/src/cmds/search/search.ts
@@ -4,7 +4,7 @@ import assert from 'assert';
 import { readFileSync } from 'fs';
 import { writeFile } from 'fs/promises';
 import { AppMap, AppMapFilter, buildAppMap, deserializeFilter } from '@appland/models';
-import { FileIndex } from '@appland/search';
+import { FileIndex, generateSessionId } from '@appland/search';
 
 import { handleWorkingDirectory } from '../../lib/handleWorkingDirectory';
 import { verbose } from '../../utils';
@@ -104,6 +104,8 @@ export const handler = async (argv: ArgumentTypes) => {
 
   handleWorkingDirectory(directory);
 
+  const sessionId = generateSessionId();
+
   function printResultsJSON(response: EventSearchResponse | DiagramsSearchResponse) {
     console.log(JSON.stringify(response, null, 2));
   }
@@ -190,7 +192,12 @@ export const handler = async (argv: ArgumentTypes) => {
       return fileIndex;
     });
 
-    const response = await search(index.index, query.split(/\s+/).join(' OR '), maxResults);
+    const response = await search(
+      index.index,
+      sessionId,
+      query.split(/\s+/).join(' OR '),
+      maxResults
+    );
     index.close();
 
     if (findEvents) {

--- a/packages/cli/src/rpc/explain/collect-search-context.ts
+++ b/packages/cli/src/rpc/explain/collect-search-context.ts
@@ -8,6 +8,7 @@ import { SearchResponse as AppMapSearchResponse } from './index/appmap-match';
 import { searchAppMapFiles } from './index/appmap-file-index';
 import { searchProjectFiles } from './index/project-file-index';
 import { buildProjectFileSnippetIndex } from './index/project-file-snippet-index';
+import { generateSessionId } from '@appland/search';
 
 export type SearchContextRequest = {
   appmaps?: string[];
@@ -26,6 +27,8 @@ export default async function collectSearchContext(
   searchResponse: SearchRpc.SearchResponse;
   context: ContextV2.ContextResponse;
 }> {
+  const sessionId = generateSessionId();
+
   let appmapSearchResponse: AppMapSearchResponse;
   if (request.appmaps) {
     const results = request.appmaps
@@ -53,6 +56,7 @@ export default async function collectSearchContext(
     };
   } else {
     const selectedAppMaps = await searchAppMapFiles(
+      sessionId,
       appmapDirectories,
       vectorTerms,
       DEFAULT_MAX_DIAGRAMS
@@ -69,6 +73,7 @@ export default async function collectSearchContext(
   }
 
   const fileSearchResults = await searchProjectFiles(
+    sessionId,
     sourceDirectories,
     request.includePatterns,
     request.excludePatterns,
@@ -76,6 +81,7 @@ export default async function collectSearchContext(
   );
 
   const snippetIndex = await buildProjectFileSnippetIndex(
+    sessionId,
     vectorTerms,
     appmapSearchResponse,
     fileSearchResults

--- a/packages/cli/src/rpc/explain/collect-snippets.ts
+++ b/packages/cli/src/rpc/explain/collect-snippets.ts
@@ -1,13 +1,23 @@
 import { ContextV2 } from '@appland/navie';
-import { parseFileChunkSnippetId, SnippetIndex, SnippetSearchResult } from '@appland/search';
+import {
+  parseFileChunkSnippetId,
+  SessionId,
+  SnippetIndex,
+  SnippetSearchResult,
+} from '@appland/search';
 import { CHARS_PER_SNIPPET } from './collect-context';
 
 export default function collectSnippets(
   snippetIndex: SnippetIndex,
+  sessionId: SessionId,
   query: string,
   charLimit: number
 ): ContextV2.ContextResponse {
-  const snippets = snippetIndex.searchSnippets(query, Math.round(charLimit / CHARS_PER_SNIPPET));
+  const snippets = snippetIndex.searchSnippets(
+    sessionId,
+    query,
+    Math.round(charLimit / CHARS_PER_SNIPPET)
+  );
 
   const buildLocation = (result: SnippetSearchResult) => {
     const snippetId = parseFileChunkSnippetId(result.snippetId);

--- a/packages/cli/src/rpc/explain/index/appmap-file-index.ts
+++ b/packages/cli/src/rpc/explain/index/appmap-file-index.ts
@@ -1,6 +1,6 @@
 import sqlite3 from 'better-sqlite3';
 
-import { FileIndex } from '@appland/search';
+import { FileIndex, SessionId } from '@appland/search';
 
 import buildIndexInTempDir, { CloseableIndex } from './build-index-in-temp-dir';
 import { buildAppMapIndex, search } from './appmap-index';
@@ -18,13 +18,14 @@ export async function buildAppMapFileIndex(
 }
 
 export async function searchAppMapFiles(
+  sessionId: SessionId,
   appmapDirectories: string[],
   vectorTerms: string[],
   maxDiagrams: number
 ): Promise<SearchResponse> {
   const index = await buildAppMapFileIndex(appmapDirectories);
   try {
-    return await search(index.index, vectorTerms.join(' OR '), maxDiagrams);
+    return await search(index.index, sessionId, vectorTerms.join(' OR '), maxDiagrams);
   } finally {
     index.close();
   }

--- a/packages/cli/src/rpc/explain/index/appmap-index.ts
+++ b/packages/cli/src/rpc/explain/index/appmap-index.ts
@@ -3,7 +3,7 @@ import { isNativeError } from 'util/types';
 import { log, warn } from 'console';
 import { readFile } from 'fs/promises';
 import { Metadata } from '@appland/models';
-import { buildFileIndex, FileIndex, fileTokens } from '@appland/search';
+import { buildFileIndex, FileIndex, fileTokens, SessionId } from '@appland/search';
 
 import { findFiles, isNodeError, verbose } from '../../../utils';
 import {
@@ -149,10 +149,11 @@ export async function buildAppMapIndex(fileIndex: FileIndex, directories: string
 
 export async function search(
   index: FileIndex,
+  sessionId: SessionId,
   search: string,
   maxResults: number
 ): Promise<SearchResponse> {
-  const searchMatches = index.search(search, maxResults);
+  const searchMatches = index.search(sessionId, search, maxResults);
   let matches: Match[] = searchMatches.map((match) => {
     let appmapId = match.filePath;
     if (appmapId.endsWith('.appmap.json'))

--- a/packages/cli/src/rpc/explain/index/project-file-index.ts
+++ b/packages/cli/src/rpc/explain/index/project-file-index.ts
@@ -12,6 +12,7 @@ import {
   isLargeFile,
   listProjectFiles,
   readFileSafe,
+  SessionId,
 } from '@appland/search';
 import { fileNameMatchesFilterPatterns } from './filter-patterns';
 
@@ -69,6 +70,7 @@ export async function buildProjectFileIndex(
 }
 
 export async function searchProjectFiles(
+  sessionId: SessionId,
   sourceDirectories: string[],
   includePatterns: RegExp[] | undefined,
   excludePatterns: RegExp[] | undefined,
@@ -76,7 +78,7 @@ export async function searchProjectFiles(
 ): Promise<FileSearchResult[]> {
   const index = await buildProjectFileIndex(sourceDirectories, includePatterns, excludePatterns);
   try {
-    return index.index.search(vectorTerms.join(' OR '));
+    return index.index.search(sessionId, vectorTerms.join(' OR '));
   } finally {
     index.close();
   }

--- a/packages/cli/src/rpc/explain/index/project-file-snippet-index.ts
+++ b/packages/cli/src/rpc/explain/index/project-file-snippet-index.ts
@@ -1,5 +1,5 @@
 import sqlite3 from 'better-sqlite3';
-import { FileSearchResult, SnippetIndex } from '@appland/search';
+import { FileSearchResult, SessionId, SnippetIndex } from '@appland/search';
 
 import buildIndexInTempDir, { CloseableIndex } from './build-index-in-temp-dir';
 import { SearchResponse as AppMapSearchResponse } from './appmap-match';
@@ -28,6 +28,7 @@ class ProjectFileSnippetIndexImpl implements ProjectFileSnippetIndex {
   constructor(
     private vectorTerms: string[],
     private index: CloseableIndex<SnippetIndex>,
+    private sessionId: SessionId,
     private eventsCollector: EventCollector
   ) {}
 
@@ -54,6 +55,7 @@ class ProjectFileSnippetIndexImpl implements ProjectFileSnippetIndex {
     const codeSnippetCharLimit = codeSnippetCount === 0 ? charLimit : charLimit / 4;
     const sourceContext = collectSnippets(
       this.index.index,
+      this.sessionId,
       this.vectorTerms.join(' OR '),
       codeSnippetCharLimit
     );
@@ -68,6 +70,7 @@ class ProjectFileSnippetIndexImpl implements ProjectFileSnippetIndex {
 }
 
 export async function buildProjectFileSnippetIndex(
+  sessionId: SessionId,
   vectorTerms: string[],
   appmapSearchResponse: AppMapSearchResponse,
   fileSearchResults: FileSearchResult[]
@@ -79,5 +82,5 @@ export async function buildProjectFileSnippetIndex(
 
   const eventsCollector = new EventCollector(vectorTerms.join(' '), appmapSearchResponse);
 
-  return new ProjectFileSnippetIndexImpl(vectorTerms, snippetIndex, eventsCollector);
+  return new ProjectFileSnippetIndexImpl(vectorTerms, snippetIndex, sessionId, eventsCollector);
 }

--- a/packages/cli/src/rpc/search/search.ts
+++ b/packages/cli/src/rpc/search/search.ts
@@ -1,6 +1,6 @@
 import { isAbsolute, join } from 'path';
 import sqlite3 from 'better-sqlite3';
-import { FileIndex } from '@appland/search';
+import { FileIndex, generateSessionId } from '@appland/search';
 import { SearchRpc } from '@appland/rpc';
 
 import { RpcHandler } from '../rpc';
@@ -27,6 +27,8 @@ export async function handler(
   options: HandlerOptions
 ): Promise<SearchRpc.SearchResponse> {
   const config = configuration();
+  const sessionId = generateSessionId();
+
   const appmapDirectories = await config.appmapDirectories();
   let appmapSearchResponse: SearchResponse;
   if (appmaps) {
@@ -71,6 +73,7 @@ export async function handler(
 
     appmapSearchResponse = await searchAppMaps(
       index.index,
+      sessionId,
       query.split(/\s+/).join(' OR '),
       maxResults
     );

--- a/packages/cli/tests/unit/rpc/explain/collect-search-context.spec.ts
+++ b/packages/cli/tests/unit/rpc/explain/collect-search-context.spec.ts
@@ -61,6 +61,7 @@ describe('collectSearchContext', () => {
     );
 
     expect(AppMapFileIndex.searchAppMapFiles as jest.Mock).toHaveBeenCalledWith(
+      expect.any(String),
       appmapDirectories,
       vectorTerms,
       expect.any(Number)
@@ -101,6 +102,7 @@ describe('collectSearchContext', () => {
     );
 
     expect(ProjectFileIndex.searchProjectFiles as jest.Mock).toHaveBeenCalledWith(
+      expect.any(String),
       sourceDirectories,
       undefined,
       undefined,

--- a/packages/cli/tests/unit/rpc/explain/index/appmap-index.search.spec.ts
+++ b/packages/cli/tests/unit/rpc/explain/index/appmap-index.search.spec.ts
@@ -2,7 +2,7 @@ import * as utils from '../../../../../src/utils';
 import UpToDate from '../../../../../src/lib/UpToDate';
 import { PathLike } from 'fs';
 import { join } from 'path';
-import { FileIndex, FileSearchResult } from '@appland/search';
+import { FileIndex, FileSearchResult, generateSessionId } from '@appland/search';
 import { search } from '../../../../../src/rpc/explain/index/appmap-index';
 import { SearchStats } from '../../../../../src/rpc/explain/index/appmap-match';
 
@@ -11,6 +11,7 @@ jest.mock('../../../../../src/lib/UpToDate');
 
 describe('AppMapIndex', () => {
   let mockAppmapIndex: FileIndex;
+  const sessionId = generateSessionId();
 
   afterEach(() => jest.resetAllMocks());
 
@@ -68,7 +69,7 @@ describe('AppMapIndex', () => {
       });
 
       it('downscores the out of date matches', async () => {
-        const searchResults = await search(mockAppmapIndex, 'login', 5);
+        const searchResults = await search(mockAppmapIndex, sessionId, 'login', 5);
         expect(searchResults.numResults).toEqual(5);
         expect(searchResults.results.map((r) => r.appmap)).toEqual([
           'appmap5',
@@ -82,7 +83,7 @@ describe('AppMapIndex', () => {
       });
 
       it('only computes downscore until maxResults is reached', async () => {
-        const searchResults = await search(mockAppmapIndex, 'login', 1);
+        const searchResults = await search(mockAppmapIndex, sessionId, 'login', 1);
         expect(searchResults.numResults).toEqual(5);
         expect(searchResults.results.map((r) => r.appmap)).toEqual(['appmap5']);
         expect(searchResults.results.map((r) => r.score)).toEqual([5]);
@@ -93,7 +94,7 @@ describe('AppMapIndex', () => {
     it(`reports statistics`, async () => {
       mockUpToDate();
 
-      const searchResults = await search(mockAppmapIndex, 'login', 10);
+      const searchResults = await search(mockAppmapIndex, sessionId, 'login', 10);
       expect(searchResults.numResults).toEqual(5);
       expect(searchResults.results.map((r) => r.score)).toEqual([5, 4, 3, 2, 1]);
 
@@ -115,7 +116,7 @@ describe('AppMapIndex', () => {
       mockAppmapIndex = {
         search: jest.fn().mockReturnValue([]),
       } as unknown as FileIndex;
-      const searchResults = await search(mockAppmapIndex, 'the search', 10);
+      const searchResults = await search(mockAppmapIndex, sessionId, 'the search', 10);
       expect(searchResults).toStrictEqual({
         type: 'appmap',
         results: [],
@@ -153,7 +154,7 @@ describe('AppMapIndex', () => {
     beforeEach(() => mockUpToDate());
 
     it(`removes the search result from the reported matches`, async () => {
-      const searchResults = await search(mockAppmapIndex, 'login', 10);
+      const searchResults = await search(mockAppmapIndex, sessionId, 'login', 10);
       expect(searchResults.numResults).toEqual(1);
       expect(searchResults.results).toEqual([
         { appmap: 'appmap1', directory: 'the-dir', score: 1 },

--- a/packages/search/README.md
+++ b/packages/search/README.md
@@ -33,6 +33,14 @@ The main goal of introducing a `session id` is to:
   over and impact the results of another session. This isolation is crucial in multi-user systems
   where search personalization is required.
 
+### Session Deletion
+
+The system provides a mechanism to delete all data associated with a specific session. This is
+achieved through the `deleteSession` method available in both the `FileIndex` and `SnippetIndex`
+classes. By invoking this method with a session id, all boost factors and related data tied to that
+session are removed from the database, ensuring that no residual data affects future search
+operations.
+
 ### Entity-Relationship Diagram
 
 ```mermaid

--- a/packages/search/README.md
+++ b/packages/search/README.md
@@ -1,0 +1,68 @@
+# `@appland/search`
+
+## session_id
+
+The `session id` parameter is an integral part of differentiating boost records in this system. Its
+intent is to make sure that the boost factors, which affect search results, remain specific to a
+particular search session and do not impact other concurrent search sessions.
+
+### Intent
+
+The main goal of introducing a `session id` is to:
+
+1. **Isolate Boost Factors**: By associating each boost record with a unique session id, different
+   sessions' boost factors are kept separate. This means that boosting done in one session doesn't
+   unintentionally affect another.
+
+2. **Maintain Contextual Relevance**: Boost factors should only influence the search results within
+   the scope of their intended search session. This ensures the search system remains contextually
+   aware and the results are relevant to the specific scenarios where the boosts were applied.
+
+### How It Works for Concurrency
+
+- **Storage**: When a boost factor is being stored in the system, it includes a `session id` in the
+  database schema for boost records. This ties the boost factor directly to the user's session that
+  triggered it.
+
+- **Filtering**: When search operations are performed, only boost factors associated with the
+  current session id are considered. This filtering ensures that only relevant boosts are applied to
+  the search results.
+
+- **Concurrent Use**: In environments where multiple users or sessions are interacting with the
+  search system simultaneously, the session id ensures that one session's boost factors don't spill
+  over and impact the results of another session. This isolation is crucial in multi-user systems
+  where search personalization is required.
+
+### Entity-Relationship Diagram
+
+```mermaid
+erDiagram
+  FILE_CONTENT {
+    TEXT directory
+    TEXT file_path
+    TEXT file_symbols
+    TEXT file_words
+  }
+  FILE_BOOST {
+    TEXT session_id
+    TEXT file_path
+    REAL boost_factor
+  }
+
+
+  SNIPPET_CONTENT {
+    TEXT snippet_id
+    TEXT directory
+    TEXT file_symbols
+    TEXT file_words
+    TEXT content
+  }
+  SNIPPET_BOOST {
+    TEXT session_id
+    TEXT snippet_id
+    REAL boost_factor
+  }
+
+  FILE_CONTENT ||--|| FILE_BOOST : "Is boosted by"
+  SNIPPET_CONTENT ||--|| SNIPPET_BOOST : "Is boosted by"
+```

--- a/packages/search/src/cli.ts
+++ b/packages/search/src/cli.ts
@@ -13,6 +13,7 @@ import buildSnippetIndex from './build-snippet-index';
 import { readFileSafe } from './ioutil';
 import { langchainSplitter } from './splitter';
 import assert from 'assert';
+import { generateSessionId } from './session-id';
 
 const debug = makeDebug('appmap:search:cli');
 const cli = yargs(hideBin(process.argv))
@@ -63,6 +64,7 @@ const cli = yargs(hideBin(process.argv))
 
       const db = new sqlite3(':memory:');
       const fileIndex = new FileIndex(db);
+      const sessionId = generateSessionId();
 
       await buildFileIndex(
         fileIndex,
@@ -85,7 +87,7 @@ const cli = yargs(hideBin(process.argv))
 
       console.log('File search results');
       console.log('-------------------');
-      const fileSearchResults = fileIndex.search(query as string);
+      const fileSearchResults = fileIndex.search(sessionId, query as string);
       for (const result of fileSearchResults) {
         const { filePath, score } = result;
         printResult('file', filePath, score);
@@ -102,7 +104,7 @@ const cli = yargs(hideBin(process.argv))
 
       const isNullOrUndefined = (value: unknown) => value === null || value === undefined;
 
-      const snippetSearchResults = snippetIndex.searchSnippets(query as string);
+      const snippetSearchResults = snippetIndex.searchSnippets(sessionId, query as string);
       for (const result of snippetSearchResults) {
         const { snippetId, score } = result;
         printResult(snippetId.type, snippetId.id, score);

--- a/packages/search/src/file-index.ts
+++ b/packages/search/src/file-index.ts
@@ -22,6 +22,8 @@ VALUES (?, ?, ?, ?)`;
 const UPDATE_BOOST_SQL = `INSERT OR REPLACE INTO file_boost (session_id, file_path, boost_factor)
 VALUES (?, ?, ?)`;
 
+const DELETE_SESSION_SQL = `DELETE FROM file_boost WHERE session_id LIKE ?`;
+
 const SEARCH_SQL = `SELECT
     file_content.directory,
     file_content.file_path,
@@ -72,6 +74,7 @@ export type FileSearchResult = {
 export default class FileIndex {
   #insert: sqlite3.Statement;
   #updateBoost: sqlite3.Statement;
+  #deleteSession: sqlite3.Statement<string>;
   #search: sqlite3.Statement<[string, string, number]>;
 
   constructor(public database: sqlite3.Database) {
@@ -81,6 +84,7 @@ export default class FileIndex {
     this.database.pragma('synchronous = OFF');
     this.#insert = this.database.prepare(INSERT_SQL);
     this.#updateBoost = this.database.prepare(UPDATE_BOOST_SQL);
+    this.#deleteSession = this.database.prepare(DELETE_SESSION_SQL);
     this.#search = this.database.prepare(SEARCH_SQL);
   }
 
@@ -96,6 +100,14 @@ export default class FileIndex {
    */
   boostFile(sessionId: SessionId, filePath: string, boostFactor: number): void {
     this.#updateBoost.run(sessionId, filePath, boostFactor);
+  }
+
+  /**
+   * Deletes all data associated with a specific session.
+   * @param sessionId - The session identifier to delete data for.
+   */
+  deleteSession(sessionId: string): void {
+    this.#deleteSession.run(sessionId);
   }
 
   /**

--- a/packages/search/src/index.ts
+++ b/packages/search/src/index.ts
@@ -1,4 +1,5 @@
 export { ContentReader, readFileSafe } from './ioutil';
+export { SessionId, generateSessionId } from './session-id';
 export { Splitter, langchainSplitter } from './splitter';
 export { ListFn, FilterFn, Tokenizer, default as buildFileIndex } from './build-file-index';
 export { File, default as buildSnippetIndex } from './build-snippet-index';

--- a/packages/search/src/session-id.ts
+++ b/packages/search/src/session-id.ts
@@ -1,0 +1,7 @@
+import { v4 as uuidv4 } from 'uuid';
+
+export type SessionId = string;
+
+export function generateSessionId(): SessionId {
+  return uuidv4();
+}

--- a/packages/search/src/snippet-index.ts
+++ b/packages/search/src/snippet-index.ts
@@ -22,6 +22,8 @@ const INSERT_SNIPPET_SQL = `INSERT INTO snippet_content
 (snippet_id, directory, file_symbols, file_words, content)
 VALUES (?, ?, ?, ?, ?)`;
 
+const DELETE_SESSION_SQL = `DELETE FROM snippet_boost WHERE session_id LIKE ?`;
+
 const UPDATE_SNIPPET_BOOST_SQL = `INSERT OR REPLACE INTO snippet_boost 
 (session_id, snippet_id, boost_factor)
 VALUES (?, ?, ?)`;
@@ -110,6 +112,7 @@ type SnippetSearchRow = {
 export default class SnippetIndex {
   #insertSnippet: sqlite3.Statement;
   #updateSnippetBoost: sqlite3.Statement;
+  #deleteSession: sqlite3.Statement<[string]>;
   #searchSnippet: sqlite3.Statement<[string, string, number]>;
 
   constructor(public database: sqlite3.Database) {
@@ -118,8 +121,17 @@ export default class SnippetIndex {
     this.database.pragma('journal_mode = OFF');
     this.database.pragma('synchronous = OFF');
     this.#insertSnippet = this.database.prepare(INSERT_SNIPPET_SQL);
+    this.#deleteSession = this.database.prepare(DELETE_SESSION_SQL);
     this.#updateSnippetBoost = this.database.prepare(UPDATE_SNIPPET_BOOST_SQL);
     this.#searchSnippet = this.database.prepare(SEARCH_SNIPPET_SQL);
+  }
+
+  /**
+   * Deletes all data associated with a specific session.
+   * @param sessionId - The session identifier to delete data for.
+   */
+  deleteSession(sessionId: string): void {
+    this.#deleteSession.run(sessionId);
   }
 
   /**

--- a/packages/search/test/file-index.spec.ts
+++ b/packages/search/test/file-index.spec.ts
@@ -1,15 +1,18 @@
 import { strict as assert } from 'assert';
 import sqlite3 from 'better-sqlite3';
 import FileIndex, { FileSearchResult } from '../src/file-index';
+import { generateSessionId, SessionId } from '../src/session-id';
 
 describe('FileIndex', () => {
   let db: sqlite3.Database;
   let index: FileIndex;
+  let sessionId: SessionId;
   const directory = 'src';
 
   beforeEach(() => {
     db = new sqlite3(':memory:');
     index = new FileIndex(db);
+    sessionId = generateSessionId();
   });
 
   afterEach(() => {
@@ -18,15 +21,25 @@ describe('FileIndex', () => {
 
   it('should insert and search a file', () => {
     index.indexFile(directory, 'test.txt', 'symbol1', 'word1');
-    const results = index.search('symbol1');
+    const results = index.search(sessionId, 'symbol1');
     assert.equal(results.length, 1);
     assert.equal(results[0].filePath, 'test.txt');
   });
 
   it('should update the boost factor of a file', () => {
     index.indexFile(directory, 'test2.txt', 'symbol2', 'word2');
-    index.boostFile('test2.txt', 2.0);
-    const results = index.search('symbol2');
+    index.boostFile(sessionId, 'test2.txt', -2.0);
+    const results = index.search(sessionId, 'symbol2');
+    expect(results.map((r: FileSearchResult) => r.directory)).toEqual([directory]);
+    expect(results.map((r: FileSearchResult) => r.filePath)).toEqual(['test2.txt']);
+    expect(results[0].score).toBeLessThan(0);
+  });
+
+  it('should apply the session id to the boost factors', () => {
+    index.indexFile(directory, 'test2.txt', 'symbol2', 'word2');
+    index.boostFile(sessionId, 'test2.txt', 2.0);
+    const otherSessionId = generateSessionId();
+    const results = index.search(otherSessionId, 'symbol2');
     expect(results.map((r: FileSearchResult) => r.directory)).toEqual([directory]);
     expect(results.map((r: FileSearchResult) => r.filePath)).toEqual(['test2.txt']);
     expect(results[0].score).toBeGreaterThan(0);
@@ -35,15 +48,15 @@ describe('FileIndex', () => {
   it('should return results ordered by score', () => {
     index.indexFile(directory, 'test3.txt', 'symbol1 symbol3', 'word1 word3');
     index.indexFile(directory, 'test4.txt', 'symbol2 symbol3', 'word1 word4');
-    index.boostFile('test4.txt', 2.0);
+    index.boostFile(sessionId, 'test4.txt', 2.0);
 
-    let results = index.search('word1');
+    let results = index.search(sessionId, 'word1');
     expect(results.map((r: FileSearchResult) => r.filePath)).toEqual(['test4.txt', 'test3.txt']);
 
-    results = index.search('symbol3');
+    results = index.search(sessionId, 'symbol3');
     expect(results.map((r: FileSearchResult) => r.filePath)).toEqual(['test4.txt', 'test3.txt']);
 
-    results = index.search('symbol2');
+    results = index.search(sessionId, 'symbol2');
     expect(results.map((r: FileSearchResult) => r.filePath)).toEqual(['test4.txt']);
   });
 });

--- a/packages/search/test/snippet-index.spec.ts
+++ b/packages/search/test/snippet-index.spec.ts
@@ -2,10 +2,12 @@ import { strict as assert } from 'assert';
 import sqlite3 from 'better-sqlite3';
 
 import SnippetIndex, { SnippetId } from '../src/snippet-index';
+import { generateSessionId, SessionId } from '../src/session-id';
 
 describe('SnippetIndex', () => {
   let db: sqlite3.Database;
   let index: SnippetIndex;
+  let sessionId: SessionId;
   const directory = 'src';
 
   const snippet1: SnippetId = { type: 'code-snippet', id: 'test.txt:1' };
@@ -16,6 +18,7 @@ describe('SnippetIndex', () => {
   beforeEach(() => {
     db = new sqlite3(':memory:');
     index = new SnippetIndex(db);
+    sessionId = generateSessionId();
   });
 
   afterEach(() => {
@@ -25,7 +28,7 @@ describe('SnippetIndex', () => {
   it('should insert and search a snippet', () => {
     const content = 'symbol1 word1';
     index.indexSnippet(snippet1, directory, 'symbol1', 'word1', content);
-    const results = index.searchSnippets('symbol1');
+    const results = index.searchSnippets(sessionId, 'symbol1');
     assert.equal(results.length, 1);
     assert.equal(JSON.stringify(results[0].snippetId), JSON.stringify(snippet1));
     assert.equal(results[0].content, content);
@@ -34,50 +37,66 @@ describe('SnippetIndex', () => {
   it('should update the boost factor of a snippet', () => {
     const content = 'symbol2 word2';
     index.indexSnippet(snippet2, directory, 'symbol2', 'word2', content);
-    index.boostSnippet(snippet2, 2.0);
-    const results = index.searchSnippets('symbol2');
+    index.boostSnippet(sessionId, snippet2, 2.0);
+    const results = index.searchSnippets(sessionId, 'symbol2');
     assert.equal(results.length, 1);
     assert.equal(JSON.stringify(results[0].snippetId), JSON.stringify(snippet2));
   });
 
-  it('should return results ordered by score', () => {
-    index.indexSnippet(
-      snippet3,
-      directory,
-      'symbol1 symbol3',
-      'word1 word3',
-      'symbol1 word1 symbol3 word3'
-    );
-    index.indexSnippet(
-      snippet4,
-      directory,
-      'symbol2 symbol3',
-      'word1 word4',
-      'symbol2 word1 symbol3 word4'
-    );
+  describe('boost factor', () => {
+    let unboostedScore: number;
 
-    let results = index.searchSnippets('word1 OR word4');
-    assert.equal(results.length, 2);
-    assert.equal(JSON.stringify(results[0].snippetId), JSON.stringify(snippet4));
-    assert.equal(JSON.stringify(results[1].snippetId), JSON.stringify(snippet3));
+    beforeEach(() => {
+      index.indexSnippet(
+        snippet3,
+        directory,
+        'symbol1 symbol3',
+        'word1 word3',
+        'symbol1 word1 symbol3 word3'
+      );
+      index.indexSnippet(
+        snippet4,
+        directory,
+        'symbol2 symbol3',
+        'word1 word4',
+        'symbol2 word1 symbol3 word4'
+      );
 
-    const unboostedScore = results[1].score;
+      const results = index.searchSnippets(sessionId, 'word1 OR word4');
+      assert.equal(results.length, 2);
+      assert.equal(JSON.stringify(results[0].snippetId), JSON.stringify(snippet4));
+      assert.equal(JSON.stringify(results[1].snippetId), JSON.stringify(snippet3));
 
-    index.boostSnippet(snippet3, 2.0);
+      unboostedScore = results[1].score;
+    });
 
-    results = index.searchSnippets('word1 OR word4');
-    assert.equal(results.length, 2);
-    assert.equal(JSON.stringify(results[0].snippetId), JSON.stringify(snippet3));
-    assert.equal(JSON.stringify(results[1].snippetId), JSON.stringify(snippet4));
+    it('applies to a session', () => {
+      index.boostSnippet(sessionId, snippet3, 2.0);
 
-    const boostedScore = results[0].score;
-    const scoreMultiple = boostedScore / unboostedScore;
-    expect(scoreMultiple).toBeGreaterThan(1.99);
-    expect(scoreMultiple).toBeLessThan(2.01);
+      let results = index.searchSnippets(sessionId, 'word1 OR word4');
+      assert.equal(results.length, 2);
+      assert.equal(JSON.stringify(results[0].snippetId), JSON.stringify(snippet3));
+      assert.equal(JSON.stringify(results[1].snippetId), JSON.stringify(snippet4));
 
-    results = index.searchSnippets('symbol3');
-    assert.equal(results.length, 2);
-    assert.equal(JSON.stringify(results[0].snippetId), JSON.stringify(snippet3));
-    assert.equal(JSON.stringify(results[1].snippetId), JSON.stringify(snippet4));
+      const boostedScore = results[0].score;
+      const scoreMultiple = boostedScore / unboostedScore;
+      expect(scoreMultiple).toBeGreaterThan(1.99);
+      expect(scoreMultiple).toBeLessThan(2.01);
+
+      results = index.searchSnippets(sessionId, 'symbol3');
+      assert.equal(results.length, 2);
+      assert.equal(JSON.stringify(results[0].snippetId), JSON.stringify(snippet3));
+      assert.equal(JSON.stringify(results[1].snippetId), JSON.stringify(snippet4));
+    });
+
+    it('is ignored on other sessions', () => {
+      const otherSessionId = generateSessionId();
+      const results = index.searchSnippets(otherSessionId, 'word1 OR word4');
+      assert.equal(results.length, 2);
+      assert.equal(JSON.stringify(results[0].snippetId), JSON.stringify(snippet4));
+      assert.equal(JSON.stringify(results[1].snippetId), JSON.stringify(snippet3));
+
+      expect(results[1].score).toBeCloseTo(unboostedScore);
+    });
   });
 });


### PR DESCRIPTION
This allows multiple jobs / sessions to be using the index concurrently, applying different boost factors according to their needs.

## Requirements

<!-- copilot:ignore -->

When searching for code and files, add a session id for the boost records.

When searching, the session id is a required argument, and it is used to select only the boost
records that are relevant to the current search session.

---

/include=search/src

Plan changes only in packages/search/src

## Navie Plan

**Add session id to search boost records in packages/search**

**Problem**
The search system needs to differentiate between boost records from different search sessions to ensure boost records only affect search results within their intended context. This change should be implemented within the `packages/search/src` directory.

**Analysis**
We need to modify the file index and search functionality to support session-specific boost records. This involves:

1. Adding session id to boost record storage
2. Filtering boost records by session id during search
3. Ensuring all boost operations include a session id

The core changes will be in the FileIndex class, which manages the SQLite database tables for file content and boost records.

**Proposed Changes**

1. `packages/search/src/file-index.ts`:
   - Update the `file_boost` table schema to include a `session_id` column
   - Modify the `boostFile` method to require a session id parameter
   - Update the search SQL query to filter boost records by session id
   - Add session id parameter to search method signature

2. `packages/search/src/types.ts` (new file):
   - Define interfaces for boost and search operations that include session id
   - Define types for search results and boost records

3. `packages/search/src/snippet-index.ts`:
   - Update the snippet boosting functionality to include session id
   - Modify snippet search to consider session-specific boost factors
   - Update the search query to filter boost records by session id

4. `packages/search/src/index.ts`:
   - Export the new session-aware interfaces and types
   - Update the public API to include session id in boost and search operations

This implementation focuses exclusively on the search package and maintains its core functionality while adding session-specific boost capabilities.

## Review

✅ Logical Changes

The changes introduce a session ID to associate boost factors with specific search sessions, ensuring that boosts are session-specific and do not interfere with other sessions. Additionally, the database schema for boost tables is modified to include session_id as part of the primary key, and tests are updated to reflect these changes. Documentation is also added to explain the purpose of the session ID.

✅ Possible Bugs to Investigate

## Notes

The initial review called out the lack of documentation for the session id feature.

<img width="662" alt="Screen Shot 2024-11-25 at 2 28 49 PM" src="https://github.com/user-attachments/assets/489b7e13-8806-4d8c-a55c-1366b91caa2f">




