### PR TITLE
Improve search performance by sniffing out and skipping binary files

### DIFF
--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "better-sqlite3": "^11.5.0",
+    "isbinaryfile": "^5.0.4",
     "yargs": "^17.7.2"
   }
 }

--- a/packages/search/src/build-file-index.ts
+++ b/packages/search/src/build-file-index.ts
@@ -26,14 +26,23 @@ type Context = {
 };
 
 async function indexFile(context: Context, filePath: string) {
+  debug('Indexing file: %s', filePath);
   const fileContents = await context.contentReader(filePath);
   if (!fileContents) return;
 
+  debug(
+    'Read file: %s, length: %d (%s...)',
+    filePath,
+    fileContents.length,
+    fileContents.slice(0, 40)
+  );
   const tokens = context.tokenizer(fileContents, filePath);
   const symbols = tokens.symbols.join(' ');
   const words = tokens.words.join(' ');
 
+  debug('Tokenized file: %s', filePath);
   context.fileIndex.indexFile(context.baseDirectory, filePath, symbols, words);
+  debug('Wrote file to index: %s', filePath);
 }
 
 async function indexDirectory(context: Context, directory: string) {

--- a/packages/search/src/file-type.ts
+++ b/packages/search/src/file-type.ts
@@ -1,6 +1,8 @@
 import { stat } from 'fs/promises';
 import makeDebug from 'debug';
 
+import { isBinaryFileSync } from 'isbinaryfile';
+
 const debug = makeDebug('appmap:search:file-type');
 
 const BINARY_FILE_EXTENSIONS: string[] = [
@@ -106,8 +108,15 @@ export const isLargeFile = async (fileName: string): Promise<boolean> => {
   return fileSize > largeFileThreshold();
 };
 
-export const isBinaryFile = (fileName: string): boolean => {
-  return BINARY_FILE_EXTENSIONS.some((ext) => fileName.endsWith(ext));
+export const isBinaryFile = (filePath: string): boolean => {
+  if (BINARY_FILE_EXTENSIONS.some((ext) => filePath.endsWith(ext))) return true;
+  try {
+    return isBinaryFileSync(filePath);
+  } catch (error) {
+    debug(`Error reading file: %s`, filePath);
+    debug(error);
+    return false;
+  }
 };
 
 export const isDataFile = (fileName: string): boolean => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -602,6 +602,7 @@ __metadata:
     eslint-plugin-jest: ^28.8.3
     eslint-plugin-prettier: ^5.2.1
     eslint-plugin-promise: ^7.1.0
+    isbinaryfile: ^5.0.4
     jest: ^29.7.0
     prettier: ^3.3.3
     ts-jest: ^29.2.5
@@ -26869,6 +26870,13 @@ __metadata:
   version: 2.0.5
   resolution: "isarray@npm:2.0.5"
   checksum: bd5bbe4104438c4196ba58a54650116007fa0262eccef13a4c55b2e09a5b36b59f1e75b9fcc49883dd9d4953892e6fc007eef9e9155648ceea036e184b0f930a
+  languageName: node
+  linkType: hard
+
+"isbinaryfile@npm:^5.0.4":
+  version: 5.0.4
+  resolution: "isbinaryfile@npm:5.0.4"
+  checksum: d88982a889369d83a5937b4b4d2288ed3b3dbbcee8fc74db40058f3c089a2c7beb9e5305b7177e82d87ff38fb62be8d60960f7a2d669ca08240ef31c1435b884
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Navie tried to index binary files in my project tree that didn't have extensions it knew to be binary (for example, executable binaries). This can be a problem with compiled languages such as rust, go, C(++), etc. which usually produce extensionless executables on non-Windows platforms.

To avoid this problem, use file sniffing (provided by isbinaryfile package) to skip binary files. This improves search time from 1m34.054s to 0m3.047s in my test project.

I've done a bunch of experiments (parsers, parallelization, dropping Unicode etc.) but in the end the solution turned out to be trivial. There is still room for improvement (searching my 58 MiB /usr/include takes about 15 s which is at the upper bound of acceptable) but with this simple change it's fast enough to fix #2126 