### PR TITLE
feat: Add subscription check and proxy permission validation for Navie AI conversations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@ pnpm-debug.log*
 *.njsproj
 *.sln
 *.sw?
-
+.vscode
 *.eslintcache
 *.log
 

--- a/architecture/.gitignore
+++ b/architecture/.gitignore
@@ -1,0 +1,1 @@
+branches

--- a/architecture/navie-ai/check-proxy-permissions.md
+++ b/architecture/navie-ai/check-proxy-permissions.md
@@ -1,0 +1,90 @@
+## Check Proxy Permissions
+
+This feature is designed to ensure that proper permissions are adhered to during the conversation
+enrollment process. It involves checking the user's access rights to use the Navie AI proxy based on
+the organization's policy.
+
+```mermaid
+flowchart TD
+    B["Create Conversation Thread Request"] --> C["Receive Conversation Thread Details"]
+    C --> D["Check Proxy Permissions"]
+    D -->|Yes| E["Proceed with Conversation Interaction"]
+    D -->|No| F["Log Message and Inform User"]
+    E --> G["Complete: Permissions Check Process"]
+    F --> G
+```
+
+1. **Initiation of the Process**:
+
+   - The sequence begins with a user or system request to initiate a conversation. This serves as
+     the starting point, where necessary details for creating a conversation thread are gathered.
+
+2. **Request for Conversation Thread Creation**:
+
+   - The Navie API client formulates a request to create a new conversation thread. This request
+     includes relevant model parameters and the project's context to ensure the thread is correctly
+     configured.
+
+3. **Receiving Conversation Thread Details**:
+
+   - Once the request is processed by the Navie service, it responds with the conversation thread
+     details. This includes information such as permissions, usage metrics, and subs fption data.
+
+4. **Checking of Proxy Permissions**:
+
+   - The system checks the permissions associated with the newly created conversation thread,
+     specifically focusing on the use of the Navie AI proxy. This step determines if the
+     conversation can proceed according to organizational policies and user entitlements.
+
+5. **Decision on Permission Validity**:
+
+   - At this juncture, the system assesses whether the proxy permissions are valid. If the
+     permissions are satisfactory ("Yes" branch), the conversation can continue seamlessly.
+   - Conversely, if permissions are inadequate or restricted ("No" branch), a message is logged, and
+     the user is informed about the permission issue.
+
+6. **Completion of the Permissions Check Process**:
+   - Regardless of the permission outcome, the flow wraps up by completing the permissions check. If
+     permissions were valid, the interaction continues smoothly. If not, appropriate actions are
+     taken based on the logged messages and informed user feedback.
+
+### Internal Dependencies
+
+1. **Navie API Client**:
+
+   - The client is responsible for sending requests to create conversation threads and receiving
+     responses with thread details.
+
+2. **Permissions and Usage Types**:
+
+   - Types such as `Permissions`, `Usage`, and `ConversationThread` are used for handling permission
+     checks and usage metrics within the system.
+
+3. **Functions and Services**:
+
+   - Functions like `checkProxyPermissions` are essential for verifying if the user or organization
+     is allowed to use the Navie AI proxy feature.
+
+4. **Thread Management**:
+
+   - Components related to managing thread states, including enrolling and interacting with
+     conversation threads.
+
+5. **Report and Handle Errors**:
+   - Mechanisms to log and inform users about permission-related issues, possibly involving
+     functions like `reportFetchError`.
+
+### External Dependencies
+
+1. **AppMap Service**:
+
+   - External service for handling requests related to conversation thread management and enforcing
+     organizational policies.
+
+2. **Socket.IO**:
+
+   - Utilized for maintaining real-time communication between the Navie client and service.
+
+3. **Configured Models and APIs**:
+   - External models and APIs specified in the configuration, necessary for authenticating and
+     authorizing requests made by the client.

--- a/architecture/navie-ai/check-subscription.md
+++ b/architecture/navie-ai/check-subscription.md
@@ -1,0 +1,109 @@
+## Check Subscription Status
+
+This feature ensures that users adhere to subscription limits during the conversation enrollment
+process. It involves checking the user's subscription status and usage count to determine if they
+can continue using the Navie AI service.
+
+```
+flowchart TD
+    A["Start Conversation Enrollment"] --> B["Create Conversation Thread"]
+    B --> C["Thread Created?"]
+    C -->|No| D["Log Error and Continue"]
+    C -->|Yes| E["Check Subscription"]
+    E --> F["Subscription Active?"]
+    F -->|No| G["Check Usage Count"]
+    G --> H["Usage Count Below Limit?"]
+    H -->|No| I["Return Status False with Subscription Required Message"]
+    H -->|Yes| J["Usage Count at Warning Threshold?"]
+    J -->|Yes| K["Return Status True with Warning Message"]
+    J -->|No| L["Return Status True"]
+    F -->|Yes| L["Return Status True"]
+```
+
+1. **Initiation of the Process**:
+
+   - The sequence begins with a user or system request to initiate a conversation. This serves as
+     the starting point, where necessary details for creating a conversation thread are gathered.
+
+2. **Request for Conversation Thread Creation**:
+
+   - The Navie API client formulates a request to create a new conversation thread. This request
+     includes relevant model parameters and the project's context to ensure the thread is correctly
+     configured.
+
+3. **Receiving Conversation Thread Details**:
+
+   - Once the request is processed by the Navie service, it responds with the conversation thread
+     details. This includes information such as permissions, usage metrics, and subscription data.
+
+4. **Checking of Subscription**:
+
+   - The system checks the subscription status associated with the newly created conversation
+     thread. This step is used to determine if the conversation can proceed according to the user's
+     subscription plan and usage limits.
+
+5. **Decision on Subscription Validity**:
+
+   - At this juncture, the system assesses whether the subscription is active. If the subscription
+     is active ("Yes" branch), the conversation can continue seamlessly.
+   - If the subscription is inactive ("No" branch), the system checks the usage count to determine
+     if the user is within the free usage limit.
+
+6. **Checking Usage Count**:
+
+   - The system evaluates the usage count to see if it is below the free usage limit. If the usage
+     count is below the limit, the conversation can proceed.
+   - If the usage count is at the warning threshold, a warning message is returned, but the
+     conversation can still proceed.
+   - If the usage count exceeds the limit, a subscription required message is returned, and the
+     conversation cannot proceed.
+
+7. **Completion of the Subscription Check Process**:
+   - Regardless of the subscription outcome, the flow wraps up by completing the subscription check.
+     If the subscription and usage count are valid, the interaction continues smoothly. If not,
+     appropriate actions are taken based on the returned messages.
+
+### Internal Dependencies
+
+1. **Navie API Client**:
+
+   - The client is responsible for sending requests to create conversation threads and receiving
+     responses with thread details.
+
+2. **Subscription and Usage Types**:
+
+   - Types such as `Subscription`, `Usage`, and `ConversationThread` are used for handling
+     subscription checks and usage metrics within the system.
+
+3. **Functions and Services**:
+
+   - Functions like `checkSubscription` are essential for verifying if the user has an active
+     subscription and if their usage is within the allowed limits.
+
+4. **Thread Management**:
+
+   - Components related to managing thread states, including enrolling and interacting with
+     conversation threads.
+
+5. **Report and Handle Errors**:
+   - Mechanisms to log and inform users about subscription-related issues, possibly involving
+     functions like `reportFetchError`.
+
+### External Dependencies
+
+1. **AppMap Service**:
+
+   - External service for handling requests related to conversation thread management and enforcing
+     subscription policies.
+
+2. **Socket.IO**:
+
+   - Utilized for maintaining real-time communication between the Navie client and service.
+
+3. **Configured Models and APIs**:
+   - External models and APIs specified in the configuration, necessary for authenticating and
+     authorizing requests made by the client.
+
+```
+
+```

--- a/architecture/navie-ai/enroll-conversation.openapi.yaml
+++ b/architecture/navie-ai/enroll-conversation.openapi.yaml
@@ -1,0 +1,108 @@
+openapi: 3.0.0
+info:
+  title: Navie Conversation Enrollment API
+  version: 1.0.0
+paths:
+  /conversations/enroll:
+    post:
+      summary: Enroll a new conversation thread
+      description: Creates a new conversation thread and returns the conversation details.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateConversationThreadRequest'
+      responses:
+        '200':
+          description: Successful enrollment of the conversation thread.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConversationThreadResponse'
+        '400':
+          description: Invalid request parameters.
+        '403':
+          description: Forbidden. The request cannot proceed due to lack of proxy permissions.
+components:
+  schemas:
+    CreateConversationThreadRequest:
+      type: object
+      properties:
+        modelParameters:
+          $ref: '#/components/schemas/ModelParameters'
+        projectParameters:
+          $ref: '#/components/schemas/ProjectParameters'
+      required:
+        - modelParameters
+        - projectParameters
+
+    ModelParameters:
+      type: object
+      properties:
+        baseUrl:
+          type: string
+        model:
+          type: string
+        aiKeyName:
+          type: string
+
+    ProjectParameters:
+      type: object
+      properties:
+        directoryCount:
+          type: integer
+        directories:
+          type: array
+          items:
+            type: object
+            properties:
+              hasAppMapConfig:
+                type: boolean
+              language:
+                type: string
+
+    ConversationThreadResponse:
+      type: object
+      properties:
+        id:
+          type: string
+        permissions:
+          $ref: '#/components/schemas/Permissions'
+        usage:
+          $ref: '#/components/schemas/Usage'
+        subscription:
+          $ref: '#/components/schemas/Subscription'
+
+    Permissions:
+      type: object
+      properties:
+        useNavieAIProxy:
+          type: boolean
+
+    Usage:
+      type: object
+      properties:
+        conversationCounts:
+          type: array
+          items:
+            $ref: '#/components/schemas/ConversationCount'
+
+    Subscription:
+      type: object
+      properties:
+        enrollmentDate:
+          type: string
+          format: date-time
+        subscriptions:
+          type: array
+          items:
+            type: string
+
+    ConversationCount:
+      type: object
+      properties:
+        daysAgo:
+          type: integer
+        count:
+          type: integer

--- a/packages/cli/src/rpc/explain/enroll-conversation.ts
+++ b/packages/cli/src/rpc/explain/enroll-conversation.ts
@@ -1,0 +1,69 @@
+import { ConversationThread } from '@appland/client';
+import { warn } from 'console';
+import hardSubscriptionCheckEnabled from './hard-subscription-check-enabled';
+
+export const FREE_USAGE_DURATION = 7;
+export const FREE_USAGE_LIMIT = 3;
+
+const SUBSCRIPTION_INSTRUCTIONS = `To subscribe, visit https://getappmap.com. Sign in using your email,
+then click on the "Subscribe" button on your Account page.
+
+Pricing information is available at https://appmap.io/pricing, and details of the subscription
+process and features are available at https://appmap.io/docs/reference/subscription.
+
+For enterprise subscriptions, please contact support@appmap.io.
+`;
+
+const SUBSCRIPTION_WARNING_MESSAGE = `You have almost reached the usage limit of the free tier of Navie AI,
+which allows you to have up to ${FREE_USAGE_LIMIT} conversations in each ${FREE_USAGE_DURATION} day period.
+
+${SUBSCRIPTION_INSTRUCTIONS}
+`;
+
+const SUBSCRIPTION_REQUIRED_MESSAGE = `You have reached the usage limit of the free tier of Navie AI. Please subscribe to continue using Navie AI.
+
+${SUBSCRIPTION_INSTRUCTIONS}
+`;
+
+export type EnrollmentStatus = {
+  message?: string;
+  status: boolean;
+};
+
+export function checkProxyPermissions(thread: ConversationThread): EnrollmentStatus {
+  if (!thread.permissions.useNavieAIProxy) {
+    return {
+      message: `Use of Navie AI proxy is forbidden by your organization policy.\nYou can ignore this message if you're using your own AI API key or connecting to your own model.`,
+      status: false,
+    };
+  }
+
+  return { status: true };
+}
+
+export function checkSubscription(thread: ConversationThread): EnrollmentStatus {
+  if (!hardSubscriptionCheckEnabled()) return { status: true };
+
+  const { subscription, usage } = thread;
+
+  // If the user has a subscription, they can continue using Navie AI.
+  if (subscription.subscriptions.length > 0) return { status: true };
+
+  const usageItem = usage.conversationCounts.find((item) => item.daysAgo === FREE_USAGE_DURATION);
+  if (!usageItem) {
+    warn(`Failed to find usage item for ${FREE_USAGE_DURATION} days ago`);
+    return {
+      status: true,
+    };
+  }
+
+  if (usageItem.count < FREE_USAGE_LIMIT - 1) return { status: true };
+
+  if (usageItem.count == FREE_USAGE_LIMIT - 1)
+    return { message: SUBSCRIPTION_WARNING_MESSAGE, status: true };
+
+  return {
+    message: SUBSCRIPTION_REQUIRED_MESSAGE,
+    status: false,
+  };
+}

--- a/packages/cli/src/rpc/explain/hard-subscription-check-enabled.ts
+++ b/packages/cli/src/rpc/explain/hard-subscription-check-enabled.ts
@@ -1,0 +1,3 @@
+export default function hardSubscriptionCheckEnabled(): boolean {
+  return process.env.APPMAP_NAVIE_SUBSCRIPTION_CHECK === 'true';
+}

--- a/packages/cli/tests/unit/rpc/explain/Explain.spec.ts
+++ b/packages/cli/tests/unit/rpc/explain/Explain.spec.ts
@@ -149,10 +149,31 @@ describe('Explain', () => {
           ask: jest.fn().mockResolvedValue('the-answer'),
           on: jest.fn(),
         } as unknown as INavie;
+        await explain.enrollConversation(navie);
         await explain.explain(navie);
 
         expect(explain.conversationThread).toEqual(conversationThread);
-        expect(status).toEqual({ step: ExplainRpc.Step.NEW, threadId: conversationThread.id });
+        expect(status).toEqual({
+          step: ExplainRpc.Step.NEW,
+          threadId: conversationThread.id,
+          explanation: [],
+        });
+      });
+
+      describe('but usage of the AI proxy is not allowed', () => {
+        beforeEach(() => {
+          conversationThread.permissions.useNavieAIProxy = false;
+        });
+
+        it('the conversation is stopped', async () => {
+          const navie = {
+            on: jest.fn(),
+          } as unknown as INavie;
+          await explain.enrollConversation(navie);
+
+          expect(status.explanation).toHaveLength(1);
+          expect(status.step).toEqual(ExplainRpc.Step.COMPLETE);
+        });
       });
     });
 
@@ -166,6 +187,7 @@ describe('Explain', () => {
           ask: jest.fn().mockResolvedValue('the-answer'),
           on: jest.fn(),
         } as unknown as INavie;
+        await explain.enrollConversation(navie);
         await explain.explain(navie);
 
         expect(explain.conversationThread).toBeUndefined();

--- a/packages/cli/tests/unit/rpc/explain/enroll-conversation.spec.ts
+++ b/packages/cli/tests/unit/rpc/explain/enroll-conversation.spec.ts
@@ -1,0 +1,142 @@
+import { ConversationThread, SubscriptionItem } from '@appland/client';
+
+import * as hardSubscriptionCheckEnabled from '../../../../src/rpc/explain/hard-subscription-check-enabled';
+
+import { 
+  EnrollmentStatus,
+  checkProxyPermissions,
+  checkSubscription,
+  FREE_USAGE_LIMIT
+} from '../../../../src/rpc/explain/enroll-conversation';
+
+jest.mock('../../../../src/rpc/explain/hard-subscription-check-enabled');
+
+describe('checkProxyPermissions', () => {
+  function createThreadWithPermissions(useNavieAIProxy: boolean): ConversationThread {
+    return {
+      id: 'the-thread-id',
+      subscription: {
+        enrollmentDate: new Date('2021-01-01 00:00:00Z'),
+        subscriptions: [],
+      },
+      usage: {
+        conversationCounts: [],
+      },
+      permissions: {
+        useNavieAIProxy,
+      },
+    };
+  }
+
+  function mockSubscriptionCheckEnabled(enabled: boolean) {
+    jest.spyOn(hardSubscriptionCheckEnabled, 'default').mockReturnValue(enabled); 
+  };
+
+  afterEach(() => jest.resetAllMocks());
+
+  describe('when useNavieAIProxy is forbidden', () => {
+    it('should return status false', () => {
+      const thread = createThreadWithPermissions(false);
+      const result: EnrollmentStatus = checkProxyPermissions(thread);
+
+      expect(result.status).toBe(false);
+      expect(result.message).toContain(
+        'Use of Navie AI proxy is forbidden by your organization policy.'
+      );
+    });
+  });
+
+  describe('when useNavieAIProxy is allowed', () => {
+    it('should return status true', () => {
+      const thread = createThreadWithPermissions(true);
+      const result: EnrollmentStatus = checkProxyPermissions(thread);
+
+      expect(result.status).toBe(true);
+      expect(result.message).toBeUndefined();
+    });
+  });
+
+  describe('checkSubscription', () => {
+    function createThread(subscriptionCount: number, usageCount: number): ConversationThread {
+      return {
+        id: 'the-thread-id',
+        subscription: {
+          enrollmentDate: new Date('2021-01-01 00:00:00Z'),
+          subscriptions: Array(subscriptionCount).fill({
+            productName: 'Navie AI',
+          }) as SubscriptionItem[],
+        },
+        usage: {
+          conversationCounts: [{ daysAgo: 7, count: usageCount }],
+        },
+        permissions: {
+          useNavieAIProxy: true,
+        },
+      };
+    }
+
+    describe('when subscription check is enabled', () => {
+      beforeEach(() => mockSubscriptionCheckEnabled(true));
+
+      it('should return status true when user has an active subscription', () => {
+        const thread = createThread(1, FREE_USAGE_LIMIT + 1);
+        const result: EnrollmentStatus = checkSubscription(thread);
+
+        expect(result.status).toBe(true);
+        expect(result.message).toBeUndefined();
+      });
+
+      it('should return status true when usage item is not found', () => {
+        const thread = createThread(0, 0);
+        thread.usage.conversationCounts = [];
+        const result: EnrollmentStatus = checkSubscription(thread);
+
+        expect(result.status).toBe(true);
+        expect(result.message).toBeUndefined();
+      });
+
+      it('should return status true when usage count is below the free usage limit', () => {
+        const thread = createThread(0, FREE_USAGE_LIMIT - 2);
+        const result: EnrollmentStatus = checkSubscription(thread);
+
+        expect(result.status).toBe(true);
+        expect(result.message).toBeUndefined();
+      });
+
+      it('should return status true with a warning message when usage count is at the warning threshold', () => {
+        const thread = createThread(0, FREE_USAGE_LIMIT - 1);
+        const result: EnrollmentStatus = checkSubscription(thread);
+
+        expect(result.status).toBe(true);
+        expect(result.message).toContain(
+          'You have almost reached the usage limit of the free tier of Navie AI'
+        );
+      });
+
+      describe('when usage count exceeds the free usage limit', () => {
+        it('should return status false with a required subscription message', () => {
+          const thread = createThread(0, FREE_USAGE_LIMIT);
+          const result: EnrollmentStatus = checkSubscription(thread);
+          expect(result.status).toBe(false);
+          expect(result.message).toContain(
+            'You have reached the usage limit of the free tier of Navie AI. Please subscribe to continue using Navie AI.'
+          );
+        });
+      });
+    });
+
+    describe('when subscription check is disabled', () => {
+      beforeEach(() => mockSubscriptionCheckEnabled(false));
+
+      describe('when usage count exceeds the free usage limit', () => {
+        it('should return status true', () => {
+          const thread = createThread(0, FREE_USAGE_LIMIT);
+          const result: EnrollmentStatus = checkSubscription(thread);
+          
+          expect(result.status).toBe(true);
+          expect(result.message).toBeUndefined();
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
This change adds validation checks when enrolling a new conversation thread to ensure proper access
control and subscription enforcement for the Navie AI service. The key validations include:

1. Permission checks to verify if the user has access to use the Navie AI proxy based on their
   organization's policy
2. Subscription validation to ensure users haven't exceeded free trial usage limits or have an
   active subscription

Key implementation details:

- Introduces `enrollConversation` method in Explain class to orchestrate validation
- Adds `EnrollmentStatus` type to standardize validation responses
- Free tier usage limits defined as constants:
  - FREE_USAGE_DURATION: 7 days lookback period
  - FREE_USAGE_LIMIT: 3 conversations per period
- Helpful user messages for:
  - Subscription upgrade guidance
  - Free tier usage warnings
  - Proxy permission restrictions
- Ensures validation results are captured in conversation status

## Checklist

- [ ] Implement the subscription reference page at https://appmap.io/docs/reference/subscription
- [ ] Validate the end-to-end flow
- [x] Add proxy permission check
- [x] Add subscription status check
- [x] Add warning messages for usage limits
- [x] Integrate validation into conversation flow
- [x] Test the proxy permission check
- [x] Test the subscription status check

## Features

- navie-ai/subscription-validation
- navie-ai/proxy-permissions

## Dependencies

### Class Dependencies (internal)

- ExplainRpc
- Explain
- ConversationThread

### Library Dependencies (external)

- @appland/client
- Navie API service

The key additions are the subscription and permission validation logic, and user feedback messages
to guide users through proper subscription flows.

```mermaid
sequenceDiagram
    participant User as User
    participant Navie as Navie
    participant SubscriptionService as Subscription Service

    User->>Navie: Start Conversation Enrollment
    Navie->>SubscriptionService: Create Conversation Thread
    SubscriptionService-->>Navie: Thread Details
    Navie->>Navie: Check Subscription
    alt Subscription Active
        Navie-->>User: Status True
    else Subscription Inactive
        Navie->>Navie: Check Usage Count
        alt Usage Below Limit
            Navie-->>User: Status True
        else Usage At Warning Threshold
            Navie-->>User: Status True with Warning
        else Usage Exceeds Limit
            Navie-->>User: Status False with Subscription Required Message
        end
    end
```
