### PR TITLE
fix: Update macos runners to macos-latest

### DIFF
--- a/.github/workflows/build-native-scanner.yml
+++ b/.github/workflows/build-native-scanner.yml
@@ -109,7 +109,7 @@ jobs:
           overwrite: true
 
   macos-x64:
-    runs-on: macos-12
+    runs-on: macos-latest
 
     if:
       ${{ contains(github.event.pull_request.labels.*.name, 'build native') ||
@@ -169,7 +169,7 @@ jobs:
           overwrite: true
 
   macos-arm:
-    runs-on: macos-14
+    runs-on: macos-latest
 
     if:
       ${{ contains(github.event.pull_request.labels.*.name, 'build native') ||

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -108,7 +108,7 @@ jobs:
           overwrite: true
 
   macos-x64:
-    runs-on: macos-12
+    runs-on: macos-latest
 
     if:
       ${{ contains(github.event.pull_request.labels.*.name, 'build native') ||
@@ -168,7 +168,7 @@ jobs:
           overwrite: true
 
   macos-arm:
-    runs-on: macos-14
+    runs-on: macos-latest
 
     if:
       ${{ contains(github.event.pull_request.labels.*.name, 'build native') ||


### PR DESCRIPTION
GitHub Actions is starting the deprecation process for macOS 12. While the image is being deprecated, You may experience longer queue times during peak usage hours.