### PR TITLE
fix: Default the custom welcome message to ON

### DIFF
--- a/packages/cli/src/rpc/navie/isCustomWelcomeMessageEnabled.ts
+++ b/packages/cli/src/rpc/navie/isCustomWelcomeMessageEnabled.ts
@@ -1,15 +1,5 @@
-import INavie from '../explain/navie/inavie';
-
-export default function isCustomWelcomeMessageEnabled(_navie: INavie): boolean {
-  const disabledByEnvironmentVariable = () => process.env.NAVIE_CUSTOM_WELCOME_MESSAGE === 'false';
-  const enabledByEnvironmentVariable = () => process.env.NAVIE_CUSTOM_WELCOME_MESSAGE === 'true';
-  // TODO: This can be used to enable an incremental rollout of the feature.
-  // For now, we will go with the environment variables only.
-  // const disabledByUseOfLocalNavie = () => navie instanceof LocalNavie;
-  if (disabledByEnvironmentVariable()) return false;
-
-  if (enabledByEnvironmentVariable()) return true;
-
-  // return !disabledByUseOfLocalNavie();
-  return false;
+export default function isCustomWelcomeMessageEnabled(): boolean {
+  // This behavior is DEFAULT ON, but can be disabled by setting the environment variable
+  // NAVIE_CUSTOM_WELCOME_MESSAGE=false. Any other value will be treated as true.
+  return process.env.NAVIE_CUSTOM_WELCOME_MESSAGE !== 'false';
 }

--- a/packages/cli/src/rpc/navie/welcome-suggestion.ts
+++ b/packages/cli/src/rpc/navie/welcome-suggestion.ts
@@ -84,7 +84,7 @@ export async function getWelcomeMessage(
   const navie = navieProvider(NOP, NOP, NOP);
 
   // Case 1: Custom welcome message may not be enabled at all
-  if (!isCustomWelcomeMessageEnabled(navie)) {
+  if (!isCustomWelcomeMessageEnabled()) {
     return {
       message:
         'I can help you answer questions about your codebase, create diagrams, plan solutions, generate code and tests, and review code changes. Type `@` to see a list of commands.',


### PR DESCRIPTION
This change will enable the custom welcome message for everyone once released.

`NAVIE_CUSTOM_WELCOME_MESSAGE` can still be set to `false` to disable this behavior. Any other value will be leave the custom welcome message enabled.