### PR TITLE
fix: Fix a typo in `/gather` option

### DIFF
--- a/packages/navie/src/commands/explain-command.ts
+++ b/packages/navie/src/commands/explain-command.ts
@@ -199,5 +199,5 @@ function gathererEnabled(
     [AgentMode.Generate, AgentMode.Test].includes(agentMode) ||
     !!contextLabels.find((l) => l.name === ContextV2.ContextLabelName.Overview);
 
-  return userOptions.isEnabled('gatherer', enabledByDefault);
+  return userOptions.isEnabled('gather', enabledByDefault);
 }


### PR DESCRIPTION
In refactoring the `/gather` flag somehow got changed to `/gatherer`. This change changes it back.