### PR TITLE
fix: Allow 'low' classification score

### DIFF
--- a/packages/navie/src/context.ts
+++ b/packages/navie/src/context.ts
@@ -106,6 +106,8 @@ export namespace ContextV2 {
     High = 'high',
     // The label is somewhat relevant to the request.
     Medium = 'medium',
+    // The label is probably not relevant to the request.
+    Low = 'low',
   }
 
   // A label that describes the nature of the user's request.

--- a/packages/navie/src/services/classification-service.ts
+++ b/packages/navie/src/services/classification-service.ts
@@ -48,6 +48,8 @@ const SCORES = {
   low: 'The question is unlikely to be of this type.',
 };
 
+void assertNever<TypeDifference<keyof typeof SCORES, `${ContextV2.ContextLabelWeight}`>>();
+
 const SYSTEM_PROMPT = `**Question classifier**
 
 A software developer is asking a question about a project. Your task is to classify their MOST RECENT
@@ -173,7 +175,7 @@ export default class ClassificationService {
 
     const schema = z.record(
       z.enum(Object.keys(LABELS) as [string, ...string[]]),
-      z.enum(['high', 'medium'])
+      z.enum(Object.keys(SCORES) as [string, ...string[]])
     );
 
     const response = await this.completion.json(messages, schema, {


### PR DESCRIPTION
I've encountered a query that led OpenAI to insist on classifying something with 'low' score, leading to a parse error and retrying.

This change allows 'low' scores in the response schema. (An alternative approach would have been to remove 'low' score from the prompt, but it can be valuable to collect these low scores.)