### PR TITLE
fix: Only try once in classifier, ignore classifier errors

### DIFF
--- a/packages/navie/src/commands/explain-command.ts
+++ b/packages/navie/src/commands/explain-command.ts
@@ -49,7 +49,12 @@ export default class ExplainCommand implements Command {
     let contextLabelsFn: Promise<ContextV2.ContextLabel[]> | undefined;
 
     if (classifyEnabled)
-      contextLabelsFn = this.classifierService.classifyQuestion(baseQuestion, chatHistory);
+      contextLabelsFn = this.classifierService
+        .classifyQuestion(baseQuestion, chatHistory)
+        .catch((err) => {
+          warn(`Error classifying question: ${err}`);
+          return [];
+        });
 
     let projectInfo: ProjectInfo[] = [];
     if (request.userOptions.isEnabled('projectinfo', true)) {

--- a/packages/navie/src/services/classification-service.ts
+++ b/packages/navie/src/services/classification-service.ts
@@ -180,6 +180,7 @@ export default class ClassificationService {
 
     const response = await this.completion.json(messages, schema, {
       model: this.completion.miniModelName,
+      maxRetries: 1,
     });
 
     debug('Classification response: %s', response);


### PR DESCRIPTION
This pull request includes improvements to error handling and configuration in the `navie` package. The most important changes involve adding error handling for the `classifyQuestion` method and configuring the maximum retries for the `completion.json` method.

Error handling improvements:

* [`packages/navie/src/commands/explain-command.ts`](diffhunk://#diff-8fc64b3b138b643930110c42f044e061bdc178fb607f1fbcf34bd30b7b13e95cL52-R57): Added a catch block to handle errors in the `classifyQuestion` method, logging a warning and returning an empty array if an error occurs.

Configuration updates:

* [`packages/navie/src/services/classification-service.ts`](diffhunk://#diff-b9faab5fe978dd5609f5f1675dd6a4aced72c85ef9ba20289c8225c5cc8ac540R183): Configured the `completion.json` method to have a maximum of one retry.