### PR TITLE
fix: Propagate code selection location to Navie

### DIFF
--- a/packages/components/src/components/chat/CodeSelection.ts
+++ b/packages/components/src/components/chat/CodeSelection.ts
@@ -1,0 +1,7 @@
+export type CodeSelection = {
+  path: string;
+  lineStart: number;
+  lineEnd: number;
+  code: string;
+  language: string;
+};

--- a/packages/components/src/stories/ChatInput.stories.js
+++ b/packages/components/src/stories/ChatInput.stories.js
@@ -15,6 +15,7 @@ const Template = (args, { argTypes }) => ({
     this.$nextTick(() => {
       const poppers = this.$el.querySelectorAll('.popper');
       poppers.forEach((popper) => {
+        // eslint-disable-next-line no-underscore-dangle
         const popperComponent = popper.__vue__;
         if (popperComponent) {
           popperComponent.visibleOverride = args.showTooltip;

--- a/packages/components/tests/unit/chat/ChatComponent.spec.js
+++ b/packages/components/tests/unit/chat/ChatComponent.spec.js
@@ -195,7 +195,18 @@ describe('components/Chat.vue', () => {
 
       await wrapper.vm.$nextTick();
 
-      expect(sendMessage).toBeCalledWith('Hello from the user', [codeSelection.code], []);
+      expect(sendMessage).toBeCalledWith(
+        'Hello from the user',
+        [
+          {
+            code: '...',
+            lineEnd: 17,
+            lineStart: 6,
+            path: 'app/controllers/users_controller.rb',
+          },
+        ],
+        []
+      );
     });
 
     it('includes pending code snippets in the input area', async () => {


### PR DESCRIPTION
Fixes https://github.com/getappmap/appmap-js/issues/2188

## Explanation

Here's a sequence diagram that Navie generated for me, which I like.

```mermaid
sequenceDiagram
    participant User
    participant VChatInput
    participant VChat
    participant VChatSearch
    participant ExplainRpc
    participant Navie

    User->>VChatInput: Enter message with code selection
    VChatInput->>VChat: sendMessage(message, codeSelections)
    
    rect rgb(150, 150, 150)
        Note over VChat: Change: Parse code selection
        VChat->>VChat: Parse codeSelection
    end
    
    VChat->>VChatSearch: sendMessage(message, codeSelections, appmaps)
    
    rect rgb(150, 150, 150)
        Note over VChatSearch: Change: Handle CodeSelection objects
        VChatSearch->>VChatSearch: Process codeSelections
        VChatSearch->>VChatSearch: Create userProvidedContext
    end
    
    VChatSearch->>ExplainRpc: Create explainRequest
    
    rect rgb(150, 150, 150)
        Note over ExplainRpc: Change: Include code selection location
        ExplainRpc->>ExplainRpc: Add codeSelection to explainRequest
    end
    
    ExplainRpc->>Navie: Send explainRequest
    Navie-->>VChatSearch: Response
    VChatSearch-->>VChat: Update chat
    VChat-->>User: Display response

    rect rgb(150, 150, 150)
        Note over VChat,VChatSearch: New file: CodeSelection.ts
        Note over VChat,VChatSearch: Defines CodeSelection type
    end
```

This sequence diagram illustrates the following key changes and additions:

1. In VChat component:
   - The code selection parsing logic is updated to handle both string and object representations of code selections.
   - The `CodeSelection` type is now imported from a separate file instead of being defined inline.

2. In VChatSearch component:
   - The `sendMessage` method now accepts `CodeSelection` objects instead of strings.
   - The processing of code selections is updated to create more detailed `userProvidedContext` items.

3. A new file, `CodeSelection.ts`, is created to define the `CodeSelection` type, which is now used across components.

