### PR TITLE
fix: Return whole lines when looking up source code

### DIFF
--- a/packages/cli/src/rpc/explain/buildContext.ts
+++ b/packages/cli/src/rpc/explain/buildContext.ts
@@ -70,13 +70,13 @@ export default async function buildContext(
 
       codeSnippetLocations.add(event.location);
 
-      const snippets = await lookupSourceCode(result.directory, event.location);
-      if (snippets) {
+      const snippet = await lookupSourceCode(result.directory, event.location);
+      if (snippet) {
         codeSnippets.push({
           directory: result.directory,
           type: ContextV2.ContextItemType.CodeSnippet,
-          location: event.location,
-          content: snippets.join('\n'),
+          location: snippet.location,
+          content: snippet.content,
           score: event.score,
         });
       }

--- a/packages/cli/tests/unit/rpc/explain/buildContext.spec.ts
+++ b/packages/cli/tests/unit/rpc/explain/buildContext.spec.ts
@@ -36,7 +36,9 @@ describe('buildContext', () => {
 
   describe('function call', () => {
     it('is emitted with source code', async () => {
-      jest.mocked(lookupSourceCode).mockResolvedValue(['the code']);
+      jest
+        .mocked(lookupSourceCode)
+        .mockResolvedValue({ content: 'the code', location: 'app/models/user.rb:42-47' });
 
       const context = await buildContext([
         {
@@ -53,7 +55,7 @@ describe('buildContext', () => {
       ).toEqual([
         {
           directory: 'a',
-          location: 'app/models/user.rb',
+          location: 'app/models/user.rb:42-47',
           type: 'code-snippet',
           score: 1,
           content: 'the code',

--- a/packages/cli/tests/unit/rpc/explain/lookupSourceCode.spec.ts
+++ b/packages/cli/tests/unit/rpc/explain/lookupSourceCode.spec.ts
@@ -1,0 +1,52 @@
+import path from 'node:path';
+
+import { RecursiveCharacterTextSplitter } from 'langchain/text_splitter';
+import { fs, vol } from 'memfs';
+
+import lookupSourceCode from '../../../../src/rpc/explain/lookupSourceCode';
+
+describe('lookupSourceCode', () => {
+  const directory = '/project';
+  const fileName = 'example.rb';
+  const sourceCodeSnippet = 'module A\n  class B\n    def foo\n      pass\n    end\n  end\nend';
+  const filePath = path.join(directory, fileName);
+
+  it('returns the correct snippet object', async () => {
+    const snippet = await lookupSourceCode(directory, `${fileName}:3`);
+    expect(snippet).toEqual({
+      content: sourceCodeSnippet,
+      location: 'example.rb:1-7',
+    });
+  });
+
+  it('preserves indents even on a chunk boundary', async () => {
+    const smallSplitter = RecursiveCharacterTextSplitter.fromLanguage('ruby', {
+      chunkSize: 10,
+      chunkOverlap: 0,
+    });
+    jest.spyOn(RecursiveCharacterTextSplitter, 'fromLanguage').mockReturnValue(smallSplitter);
+    const snippet = await lookupSourceCode(directory, `${fileName}:4`);
+    expect(snippet).toEqual({
+      content: '      pass',
+      location: 'example.rb:4-4',
+    });
+  });
+
+  it('returns undefined for non-existent line', async () => {
+    const snippet = await lookupSourceCode(directory, `${fileName}:10`);
+    expect(snippet).toBeUndefined();
+  });
+
+  beforeEach(() => {
+    vol.mkdirSync(directory, { recursive: true });
+    vol.writeFileSync(filePath, sourceCodeSnippet);
+  });
+
+  afterEach(() => {
+    vol.reset();
+    jest.restoreAllMocks();
+  });
+});
+
+jest.mock('fs', () => fs);
+jest.mock('fs/promises', () => fs.promises);


### PR DESCRIPTION
This pull request includes several changes to improve the handling and testing of source code snippets in the `buildContext` and `lookupSourceCode` functions. The most important changes include modifying the `lookupSourceCode` function to return an object with content and location, updating the `buildContext` function to accommodate this change, and adding new unit tests for `lookupSourceCode`.

Improvements to `lookupSourceCode` function:

* [`packages/cli/src/rpc/explain/lookupSourceCode.ts`](diffhunk://#diff-626e77ca4eebdac8e17c8b86fd555197c5f97ff00a711e09f04ef090dfe8e08dL32-R32): Modified `lookupSourceCode` to return an object with `content` and `location` instead of an array of strings. This change ensures that the returned snippet includes both the content and its precise location. [[1]](diffhunk://#diff-626e77ca4eebdac8e17c8b86fd555197c5f97ff00a711e09f04ef090dfe8e08dL32-R32) [[2]](diffhunk://#diff-626e77ca4eebdac8e17c8b86fd555197c5f97ff00a711e09f04ef090dfe8e08dL80-R82) [[3]](diffhunk://#diff-626e77ca4eebdac8e17c8b86fd555197c5f97ff00a711e09f04ef090dfe8e08dL103-R128)
* Make sure to read and return whole lines when looking up the source code. The location returned corresponds to real file location and the computed line extent.

Updates to `buildContext` function:

* [`packages/cli/src/rpc/explain/buildContext.ts`](diffhunk://#diff-1eec0b1fbd3441feaea713bec9393e91d5b663586c61fdc11a34f59cce31708bL73-R79): Updated `buildContext` to handle the new object returned by `lookupSourceCode`, ensuring that the `codeSnippets` array contains the correct `content` and `location` fields.

Unit tests:

* [`packages/cli/tests/unit/rpc/explain/buildContext.spec.ts`](diffhunk://#diff-06a401b9d52a4b7a062f5556b741d27d63ceabd853918bb4a86dadddef710e26L39-R41): Updated existing tests to match the new return type of `lookupSourceCode`, ensuring that the `location` field includes line numbers. [[1]](diffhunk://#diff-06a401b9d52a4b7a062f5556b741d27d63ceabd853918bb4a86dadddef710e26L39-R41) [[2]](diffhunk://#diff-06a401b9d52a4b7a062f5556b741d27d63ceabd853918bb4a86dadddef710e26L56-R58)
* [`packages/cli/tests/unit/rpc/explain/lookupSourceCode.spec.ts`](diffhunk://#diff-31acc009cf204473b0817d442a6c2df7f4c9c6725f13ab0c6d394a5bfa5158b3R1-R35): Added new unit tests for `lookupSourceCode` to verify that it returns the correct snippet object and handles non-existent lines appropriately.