### PR TITLE
fix: Hide AppMap subscription status in Copilot indicator

### DIFF
--- a/packages/components/src/components/chat-search/CopilotNotice.vue
+++ b/packages/components/src/components/chat-search/CopilotNotice.vue
@@ -5,8 +5,14 @@
         class="subscription-status"
         :subscription="subscription"
         :email="email"
+        v-if="displaySubscription"
       />
-      <div class="copilot-notice__notification">
+      <div
+        :class="{
+          'copilot-notice__notification': 1,
+          'copilot-notice__notification--no-subscription': !displaySubscription,
+        }"
+      >
         <div class="copilot-notice__notification-icon">
           <v-shield-icon />
         </div>
@@ -40,6 +46,11 @@ export default Vue.extend({
     },
     email: {
       type: String,
+    },
+  },
+  inject: {
+    displaySubscription: {
+      default: true,
     },
   },
 });
@@ -84,6 +95,10 @@ export default Vue.extend({
       svg {
         width: 24px;
       }
+    }
+
+    &--no-subscription {
+      border-top: none;
     }
   }
 

--- a/packages/components/tests/unit/chat/LlmConfiguration.spec.js
+++ b/packages/components/tests/unit/chat/LlmConfiguration.spec.js
@@ -137,19 +137,19 @@ describe('components/LlmConfiguration.vue', () => {
   });
 
   describe('subscription status', () => {
-    it('is not displayed when displaySubscription feature flag is false', async () => {
-      const wrapper = mount(LlmConfiguration, {
-        propsData: {
-          subscription: {},
-        },
-        provide: {
-          displaySubscription: false,
-        },
-      });
-      expect(wrapper.find('[data-cy="plan-status-free"]').exists()).toBeFalsy();
-    });
-
     describe('default', () => {
+      it('is not displayed when displaySubscription feature flag is false', async () => {
+        const wrapper = mount(LlmConfiguration, {
+          propsData: {
+            subscription: {},
+          },
+          provide: {
+            displaySubscription: false,
+          },
+        });
+        expect(wrapper.find('[data-cy="plan-status-free"]').exists()).toBeFalsy();
+      });
+
       it('shows the free plan', async () => {
         const wrapper = mount(LlmConfiguration, {
           propsData: {
@@ -174,6 +174,22 @@ describe('components/LlmConfiguration.vue', () => {
     });
 
     describe('copilot', () => {
+      it('is not displayed when displaySubscription feature flag is false', async () => {
+        const wrapper = mount(LlmConfiguration, {
+          propsData: {
+            model: 'gpt-4o',
+            baseUrl: 'http://localhost:11434/vscode/copilot',
+            subscription: {
+              subscriptions: [],
+            },
+          },
+          provide: {
+            displaySubscription: false,
+          },
+        });
+        expect(wrapper.find('[data-cy="plan-status-free"]').exists()).toBeFalsy();
+      });
+
       it('shows the free plan', async () => {
         const wrapper = mount(LlmConfiguration, {
           propsData: {


### PR DESCRIPTION
With the default subscription status feature flag (off):

Before
![image](https://github.com/user-attachments/assets/976e167b-e64f-4976-844f-b5068e78159d)


After
![image](https://github.com/user-attachments/assets/f13adc83-a975-4ed0-840c-41af08e920cf)
