### PR TITLE
feat: navie --ui

### DIFF
--- a/packages/cli/esbuild.html.ts
+++ b/packages/cli/esbuild.html.ts
@@ -73,3 +73,40 @@ esbuild
     console.warn(err);
     process.exit(1);
   });
+esbuild
+  .build({
+    minify: true,
+    sourcemap: true,
+    target: 'es2021',
+    metafile: true,
+    outdir: 'built/html',
+    bundle: true,
+    logLevel: 'info',
+    define: {
+      'process.env': '{}',
+      'process.env.NODE_ENV': '"production"',
+      global: 'window',
+    },
+    // inject: [require.resolve('process/browser')],
+    alias: {
+      http: require.resolve('stream-http'),
+      https: require.resolve('https-browserify'),
+    },
+    entryPoints: ['src/html/navie.js'],
+    plugins: [
+      htmlPlugin({
+        files: [
+          {
+            entryPoints: ['src/html/navie.js'],
+            filename: 'navie.html',
+            title: 'AppMap Navie',
+            htmlTemplate: '<div id="app"></div>',
+          },
+        ],
+      }),
+    ],
+  })
+  .catch((err) => {
+    console.warn(err);
+    process.exit(1);
+  });

--- a/packages/cli/src/cmds/index/rpcServer.ts
+++ b/packages/cli/src/cmds/index/rpcServer.ts
@@ -41,7 +41,7 @@ export default class RPCServer {
     this.bindPort = port;
   }
 
-  start() {
+  start(portCb?: (port: number) => void) {
     assert(this.app === undefined, 'RPC server already started');
 
     const rpcMethods: Record<string, MethodLike> = this.rpcHandlers.reduce((acc, handler) => {
@@ -84,6 +84,7 @@ export default class RPCServer {
       } else {
         this.port = address.port;
         log(`Running JSON-RPC server on port: ${this.port}`);
+        if (portCb) portCb(this.port);
       }
     });
     this.app = listener;

--- a/packages/cli/src/html/navie.js
+++ b/packages/cli/src/html/navie.js
@@ -1,0 +1,30 @@
+import Vue from 'vue';
+import Vuex from 'vuex';
+import plugin, { VChatSearch } from '@appland/components';
+
+import '@appland/diagrams/dist/style.css';
+
+Vue.use(Vuex);
+Vue.use(plugin);
+
+async function initializeApp() {
+  const params = new URL(document.location).searchParams;
+  const rpcPort = params.get('rpcPort');
+  const question = params.get('question');
+
+  const props = {};
+
+  if (rpcPort) props.appmapRpcPort = parseInt(rpcPort);
+  if (question) props.question = question;
+
+  return new Vue({
+    el: '#app',
+    render: (h) =>
+      h(VChatSearch, {
+        ref: 'ui',
+        props,
+      }),
+  });
+}
+
+initializeApp();

--- a/packages/cli/src/rpc/explain/explain.ts
+++ b/packages/cli/src/rpc/explain/explain.ts
@@ -11,7 +11,7 @@ import { ContextV2, Help, ProjectInfo, UserContext } from '@appland/navie';
 import { ExplainRpc } from '@appland/rpc';
 import { warn } from 'console';
 import EventEmitter from 'events';
-import { basename, join } from 'path';
+import { basename } from 'path';
 
 import { LRUCache } from 'lru-cache';
 import detectAIEnvVar from '../../cmds/index/aiEnvVar';


### PR DESCRIPTION
Add a --ui flag to the navie command which:

- Starts an RPC server on an open port
- Opens the Navie UI in the system browser configured to connect to that port

This is useful for using / debugging the UI while the UI and RPC/Navie are both in development at the same time.

```
./built/cli.js navie --ui -d $(pwd)/../..
Setting RPC configuration: {"projectDirectories":["/Users/kgilpin/source/appland/appmap-js/packages/cli/../.."],"appmapConfigFiles":["/Users/kgilpin/source/appland/appmap-js/appmap.yml"]}
No output specified, writing to stdout
Detected code editor: vscode
Opening navie.html
```

<img width="1023" alt="Screenshot 2025-01-09 at 5 01 54 PM" src="https://github.com/user-attachments/assets/a52f6d1d-8518-4337-a7d8-eb4af4dee893" />

## Note

This branch is proposed to merge into `develop`, along with the other fix branches that I will be pushing.
