### PR TITLE
feat: Display @command in next step suggestions

### DIFF
--- a/packages/components/src/components/chat/UserMessage.vue
+++ b/packages/components/src/components/chat/UserMessage.vue
@@ -68,7 +68,7 @@
               :command="i.command"
               :prompt="i.prompt"
             >
-              {{ i.label }}
+              {{ nextStepSuggestionText(i) }}
             </v-next-prompt-button>
           </v-popper>
         </div>
@@ -394,6 +394,11 @@ export default {
         threadId: this.threadId,
         content: this.message,
       });
+    },
+    nextStepSuggestionText(suggestion) {
+      return suggestion.command !== 'explain'
+        ? `@${suggestion.command} ${suggestion.label}`
+        : suggestion.label;
     },
   },
 

--- a/packages/components/tests/unit/chat/UserMessage.spec.js
+++ b/packages/components/tests/unit/chat/UserMessage.spec.js
@@ -373,7 +373,7 @@ describe('components/UserMessage.vue', () => {
       });
       expect(
         wrapper.findAll('[data-cy="next-step-button"]').wrappers.map((w) => w.text())
-      ).toStrictEqual(['Do this', 'Do that']);
+      ).toStrictEqual(['@do Do this', '@that Do that']);
     });
 
     it('automatically fetches next steps once the message is complete', async () => {


### PR DESCRIPTION
When suggesting a next step in the conversation, prepend the suggestion "pill" (button) with the command prefix, unless the command prefix is `@explain`.

For example, this button will show `@test Generate Test Cases` rather than `Generate Test Cases` (which could be construed as `@test` or `@generate` otherwise).

## Previous behavior

<img width="727" alt="Screenshot 2025-01-19 at 9 56 03 AM" src="https://github.com/user-attachments/assets/00324edc-cc02-4c44-bd08-01c53ba8b128" />

## New behavior

<img width="1179" alt="Screenshot 2025-01-21 at 12 04 07 PM" src="https://github.com/user-attachments/assets/36404a5a-824b-41cf-8cd4-44d5624a4193" />

## TODO

- [x] Suggestions are displayed in All Caps. It seems more natural if the questions are lower case or mixed case, as a user would type the words.

-- 

Fixes #2198
