### PR TITLE
fix: Don't cover the stop button with the tooltip

### DIFF
--- a/packages/components/src/components/chat/ChatInput.vue
+++ b/packages/components/src/components/chat/ChatInput.vue
@@ -66,7 +66,7 @@
           <v-send-icon />
         </button>
       </v-popper>
-      <v-popper v-if="isStopActive" text="Stop" placement="top" text-align="left">
+      <v-popper v-if="isStopActive" text="Stop" placement="top" text-align="left" align="right">
         <button
           class="control-button"
           data-cy="stop-response"

--- a/packages/components/src/stories/ChatInput.stories.js
+++ b/packages/components/src/stories/ChatInput.stories.js
@@ -1,0 +1,39 @@
+import VChatInput from '../components/chat/ChatInput.vue';
+import './scss/vscode.scss';
+
+export default {
+  title: 'Pages/Chat/Input',
+  component: VChatInput,
+};
+
+const Template = (args, { argTypes }) => ({
+  components: { VChatInput },
+  props: Object.keys(argTypes),
+  template: '<VChatInput v-bind="$props" />',
+  mounted() {
+    // Access the VPopper component and set the visibleOverride property
+    this.$nextTick(() => {
+      const poppers = this.$el.querySelectorAll('.popper');
+      poppers.forEach((popper) => {
+        const popperComponent = popper.__vue__;
+        if (popperComponent) {
+          popperComponent.visibleOverride = args.showTooltip;
+        }
+      });
+    });
+  },
+});
+
+export const Default = Template.bind({});
+Default.args = {
+  inputPlaceholder: 'Type your message here...',
+  isStopActive: false,
+  showTooltip: false,
+};
+
+export const WithStopButton = Template.bind({});
+WithStopButton.args = {
+  inputPlaceholder: 'Type your message here...',
+  isStopActive: true,
+  showTooltip: true,
+};


### PR DESCRIPTION
![obraz](https://github.com/user-attachments/assets/a1d6083d-4f2a-4718-a198-eb2f70ca1856)

Also, add a storybook story for this so we can see if the problem reoccurs.

(NB, the whole popper component is an abomination and should be nuked. A task for another day.)

Fixes #2048