### PR TITLE
fix: Focus the chat input automatically

### DIFF
--- a/packages/components/src/components/chat/ChatInput.vue
+++ b/packages/components/src/components/chat/ChatInput.vue
@@ -40,8 +40,6 @@
         @submit="onAutoComplete"
         ref="autocomplete"
       />
-      <!-- See the comment in getappmap/vscode-appland/web/src/app.js for why `focus` is set on the
-        input -->
       <div
         :class="{ glow: useAnimation }"
         :contenteditable="isDisabled ? 'false' : 'plaintext-only'"
@@ -53,7 +51,6 @@
         tabindex="0"
         ref="input"
         data-cy="chat-input"
-        focus
       />
       <v-popper
         v-if="!isStopActive"
@@ -264,7 +261,7 @@ export default {
       this.input = this.question;
     }
 
-    this.focus();
+    window.onfocus = () => this.focus();
   },
 };
 </script>

--- a/packages/components/src/stories/ChatInput.stories.js
+++ b/packages/components/src/stories/ChatInput.stories.js
@@ -15,6 +15,7 @@ const Template = (args, { argTypes }) => ({
     this.$nextTick(() => {
       const poppers = this.$el.querySelectorAll('.popper');
       poppers.forEach((popper) => {
+        // eslint-disable-next-line no-underscore-dangle
         const popperComponent = popper.__vue__;
         if (popperComponent) {
           popperComponent.visibleOverride = args.showTooltip;

--- a/packages/components/tests/e2e/specs/chat/chatSearch.spec.js
+++ b/packages/components/tests/e2e/specs/chat/chatSearch.spec.js
@@ -13,6 +13,19 @@ context('Chat search', () => {
     cy.get('[data-cy="stop-response"]').should('not.exist');
   });
 
+  describe('focus', () => {
+    const input = '[data-cy="chat-input"]';
+    it('should focus on the input on page load', () => {
+      cy.get(input).should('be.focused');
+    });
+
+    it('regains focus when the user comes back to the chat', () => {
+      cy.get(input).blur().should('not.be.focused');
+      cy.window().trigger('focus');
+      cy.get(input).should('be.focused');
+    });
+  });
+
   describe('when a file is dropped', () => {
     const listenForFetch = ($div) => {
       const root = $div[0].__vue__.$root;


### PR DESCRIPTION
This drops the `focus` selector hackery in favor of using `HTMLElement` `focus` method and binding to the window's `onfocus` event handler property.

We can remove any existing code editor integration to handle focus.

Fixes https://github.com/getappmap/appmap-js/issues/2156