### PR TITLE
feat: Support for file exclusion patterns in Navie

### DIFF
--- a/packages/cli/src/rpc/explain/ContentRestrictions.ts
+++ b/packages/cli/src/rpc/explain/ContentRestrictions.ts
@@ -1,0 +1,159 @@
+import { readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+import { type IMinimatch, Minimatch } from 'minimatch';
+
+export default class ContentRestrictions {
+  localRequired = false;
+  #global?: IMinimatch[];
+  #local = new Map<string, IMinimatch[]>();
+
+  constructor() {
+    this.loadDefaults();
+  }
+
+  public setGlobalRestrictions(restrictions: string[]) {
+    this.#global = restrictions.map(makePattern);
+  }
+
+  public setLocalRestrictions(root: string, restrictions: string[]) {
+    this.#local.set(normalizeAbsolute(root), restrictions.map(makePattern));
+  }
+
+  public safeRestricted(root: string, path: string): boolean;
+  public safeRestricted(absolutePath: string): boolean;
+  public safeRestricted(rootOrAbsolute: string, relative?: string): boolean {
+    try {
+      return this.isRestricted(rootOrAbsolute, relative);
+    } catch (e) {
+      console.error(e);
+      return true;
+    }
+  }
+
+  public isRestricted(root: string, path: string): boolean;
+  public isRestricted(absolutePath: string): boolean;
+  public isRestricted(rootOrAbsolute: string, relative?: string): boolean;
+
+  public isRestricted(rootOrAbsolute: string, relative?: string): boolean {
+    const normalized = normalizeAbsolute(rootOrAbsolute);
+    if (relative) return this.isRestrictedImpl(normalized, relative);
+    else {
+      const root = [...this.#local.keys()].find((r) => normalized.startsWith(r));
+      if (root) return this.isRestrictedImpl(root, normalized.slice(root.length + 1));
+      else if (this.localRequired) throw new Error(`No local restrictions for path ${normalized}`);
+      else return this.isRestrictedImpl('', normalized);
+    }
+  }
+
+  private isRestrictedImpl(root: string, path: string): boolean {
+    let normalized = path.replaceAll('\\', '/');
+    if (normalized.startsWith('/')) normalized = normalized.slice(1);
+
+    if (this.#global) {
+      for (const matcher of this.#global) {
+        if (matcher.match(normalized)) return true;
+      }
+    }
+
+    const localRestrictions = this.#local.get(root);
+    if (localRestrictions) {
+      for (const matcher of localRestrictions) {
+        if (matcher.match(normalized)) return true;
+      }
+    } else if (this.localRequired) throw new Error(`No local restrictions for root ${root}`);
+
+    return false;
+  }
+
+  reset() {
+    this.#global = undefined;
+    this.#local.clear();
+  }
+
+  loadDefaults() {
+    this.setGlobalRestrictions(getDefaultPatterns());
+  }
+
+  static get instance(): ContentRestrictions {
+    if (!this.#instance) this.#instance = new ContentRestrictions();
+    return this.#instance;
+  }
+
+  static #instance: ContentRestrictions;
+}
+
+function makePattern(pattern: string): IMinimatch {
+  let pat = pattern;
+
+  // patterns starting with a slash are relative to the project root
+  if (pat.startsWith('/')) pat = pat.slice(1);
+  // others can be anywhere
+  else pat = '**/' + pat;
+
+  return new Minimatch(pat, { dot: true, matchBase: true });
+}
+
+function normalizeAbsolute(path: string): string {
+  let normalized = path;
+  // lower case the first character so windows drives are all lower case
+  if (normalized[0] >= 'A' && normalized[0] <= 'Z')
+    normalized = normalized[0].toLowerCase() + normalized.slice(1);
+  return normalized.replaceAll('\\', '/');
+}
+
+/*
+ * tries to read the global patterns from a
+ * config file or fall back to hardcoded list
+ */
+function getDefaultPatterns(): string[] {
+  // TODO: is there a better place to put this code?
+  const configPath = join(homedir(), '.appmap', 'navie', 'global-ignore');
+  try {
+    return readFileSync(configPath, 'utf-8')
+      .split('\n')
+      .map((s) => s.trim());
+  } catch (e) {
+    console.warn(`Using default content restriction list, you can override it in ${configPath}`);
+    return DEFAULT_PATTERNS;
+  }
+}
+
+const DEFAULT_PATTERNS = [
+  'config/**',
+  'db_config/**',
+  'db-scripts/**',
+  'backups/**',
+  '.vscode/**',
+  'config*.json',
+  'db_config*.json',
+  'application*.properties',
+  'web*.config',
+  'app*.config',
+  '*.pem',
+  '*.key',
+  '*.crt',
+  '*.log',
+  'config*.yaml',
+  'application*.yaml',
+  'application*.yml',
+  'config*.yml',
+  'database*.yml',
+  'config*.groovy',
+  'config*.py',
+  'config*.js',
+  'hibernate.cfg*.yml',
+  'pom.xml',
+  'settings*.js',
+  'settings*.py',
+  '*.ini',
+  '*.env',
+  '**/SWIFT/*.xml',
+  '*.csv',
+  '**/src/main/resources/*.properties',
+  '**/src/main/resources/*.yaml',
+  '**/src/main/resources/*.yml',
+  '**/src/main/resources/*.json',
+  '**/src/main/resources/*.xml',
+];

--- a/packages/cli/src/rpc/explain/index/project-file-index.ts
+++ b/packages/cli/src/rpc/explain/index/project-file-index.ts
@@ -18,6 +18,8 @@ import { fileNameMatchesFilterPatterns } from './filter-patterns';
 
 import buildIndexInTempDir, { CloseableIndex } from './build-index-in-temp-dir';
 
+import ContentRestrictions from '../ContentRestrictions';
+
 const debug = makeDebug('appmap:index:project-files');
 
 function fileFilter(
@@ -33,6 +35,11 @@ function fileFilter(
 
     const includeFile = fileNameMatchesFilterPatterns(path, includePatterns, excludePatterns);
     if (!includeFile) return false;
+
+    if (ContentRestrictions.instance.safeRestricted(path)) {
+      debug('Skipping restricted file: %s', path);
+      return false;
+    }
 
     const isData = isDataFile(path);
     if (isData && (await isLargeFile(path))) {

--- a/packages/cli/tests/unit/rpc/explain/ContentRestrictions.spec.ts
+++ b/packages/cli/tests/unit/rpc/explain/ContentRestrictions.spec.ts
@@ -1,0 +1,107 @@
+import ContentRestrictions from '../../../../src/rpc/explain/ContentRestrictions';
+
+describe('ContentRestrictions', () => {
+  let contentRestrictions: ContentRestrictions;
+
+  beforeEach(() => {
+    contentRestrictions = new ContentRestrictions();
+  });
+
+  it('should set restrictions', () => {
+    const root = '/project';
+    contentRestrictions.setGlobalRestrictions(['**/.env']);
+    contentRestrictions.setLocalRestrictions(root, local);
+
+    expect(contentRestrictions.isRestricted(root, '.env')).toBe(true);
+    expect(contentRestrictions.isRestricted(root, 'src/.env')).toBe(true);
+    expect(contentRestrictions.isRestricted(root, 'src/some-dir/kernel.rs')).toBe(true);
+    expect(contentRestrictions.isRestricted(root, 'some-subdir/secrets.json')).toBe(true);
+    expect(contentRestrictions.isRestricted(root, 'src/secret-file.txt')).toBe(true);
+    expect(contentRestrictions.isRestricted(root, 'src/file.cfg')).toBe(true);
+    expect(contentRestrictions.isRestricted(root, 'scripts/deeper/file.txt')).toBe(true);
+    expect(contentRestrictions.isRestricted(root, 'tests/file.txt')).toBe(true);
+    expect(contentRestrictions.isRestricted(root, 'tests/deeper/file.txt')).toBe(false);
+    expect(contentRestrictions.isRestricted(root, 'src/deeper/temp.rb')).toBe(true);
+    expect(contentRestrictions.isRestricted(root, 'src/temp.rb')).toBe(true);
+    expect(contentRestrictions.isRestricted(root, 'main_test.go')).toBe(true);
+    expect(contentRestrictions.isRestricted(root, 'some/where/server.js')).toBe(true);
+    expect(contentRestrictions.isRestricted(root, 'server_config.rs')).toBe(true);
+    expect(contentRestrictions.isRestricted(root, 'some/where/session.js')).toBe(true);
+    expect(contentRestrictions.isRestricted(root, 'some/where/temp.mk')).toBe(true);
+    expect(contentRestrictions.isRestricted(root, 'some/where/temp.md')).toBe(true);
+    expect(contentRestrictions.isRestricted(root, 'some/where/packages/file.txt')).toBe(true);
+    expect(contentRestrictions.isRestricted(root, 'some/packages/deeper/file.txt')).toBe(false);
+    expect(contentRestrictions.isRestricted(root, 'some/where/packaged/file.txt')).toBe(true);
+    expect(contentRestrictions.isRestricted(root, 'some/packaged/deeper/file.txt')).toBe(false);
+    expect(contentRestrictions.isRestricted(root, 'some/security/deeper/file.txt')).toBe(true);
+    expect(contentRestrictions.isRestricted(root, 'some/where/security/file.txt')).toBe(true);
+    expect(contentRestrictions.isRestricted(root, 'src/ok.py')).toBe(false);
+
+    expect(contentRestrictions.isRestricted('/project/test.js')).toBe(false);
+    expect(contentRestrictions.isRestricted('/project/src/test.js')).toBe(false);
+    expect(contentRestrictions.isRestricted('/project/src/ok.py')).toBe(false);
+    expect(contentRestrictions.isRestricted('/project/main_test.go')).toBe(true);
+    expect(contentRestrictions.isRestricted('/some/.env')).toBe(true);
+  });
+
+  it('should handle windows paths', () => {
+    const root = 'C:\\project';
+    contentRestrictions.setGlobalRestrictions(['**/.env']);
+    contentRestrictions.setLocalRestrictions(root, local);
+
+    expect(contentRestrictions.isRestricted(root, 'src\\some-dir\\kernel.rs')).toBe(true);
+    expect(contentRestrictions.isRestricted(root, 'some-subdir\\secrets.json')).toBe(true);
+    expect(contentRestrictions.isRestricted(root, 'src\\secret-file.txt')).toBe(true);
+    expect(contentRestrictions.isRestricted(root, 'src\\file.cfg')).toBe(true);
+    expect(contentRestrictions.isRestricted(root, 'scripts\\deeper\\file.txt')).toBe(true);
+    expect(contentRestrictions.isRestricted(root, 'tests\\file.txt')).toBe(true);
+    expect(contentRestrictions.isRestricted(root, 'tests\\deeper\\file.txt')).toBe(false);
+    expect(contentRestrictions.isRestricted(root, 'src\\deeper\\temp.rb')).toBe(true);
+
+    expect(contentRestrictions.isRestricted('C:\\project\\test.js')).toBe(false);
+    expect(contentRestrictions.isRestricted('C:\\project\\src\\test.js')).toBe(false);
+    expect(contentRestrictions.isRestricted('C:\\project\\src\\ok.py')).toBe(false);
+    expect(contentRestrictions.isRestricted('C:\\project\\main_test.go')).toBe(true);
+    expect(contentRestrictions.isRestricted('c:\\project\\main_test.go')).toBe(true);
+    expect(contentRestrictions.isRestricted('D:\\user\\.env')).toBe(true);
+  });
+
+  it('should throw an error if local restrictions are required but not set', () => {
+    contentRestrictions.localRequired = true;
+    expect(() => contentRestrictions.isRestricted('/project', 'test.js')).toThrow(
+      'No local restrictions for root /project'
+    );
+    expect(contentRestrictions.safeRestricted('/project', 'test.js')).toBe(true);
+  });
+
+  it('should not throw an error if local restrictions are not required and not set', () => {
+    expect(contentRestrictions.isRestricted('/project', 'test.js')).toBe(false);
+  });
+});
+
+const local = [
+  // Ignore the `/src/some-dir/kernel.rs` file in this repository.
+  '/src/some-dir/kernel.rs',
+  // Ignore files called `secrets.json` anywhere in this repository.
+  'secrets.json',
+  // Ignore all files whose names begin with `secret` anywhere in this repository.
+  'secret*',
+  // Ignore files whose names end with `.cfg` anywhere in this repository.
+  '*.cfg',
+  // Ignore all files in or below the `/scripts` directory of this repository.
+  '/scripts/**',
+  // Ignore any files in the `/tests` directory.
+  '/tests/*',
+  // Ignore files called `temp.rb` in or below the `/src` directory.
+  '/src/**/temp.rb',
+  // Ignore the `/main_test.go` file.
+  '/main_test.go',
+  // Ignore any files with names beginning with `server` or `session` anywhere in this repository.
+  '{server,session}*',
+  // Ignore any files with names ending with `.md` or `.mk` anywhere in this repository.
+  '*.m[dk]',
+  // Ignore files directly within directories such as `packages` or `packaged` anywhere in this repository.
+  '**/package?/*',
+  // Ignore files in or below any `security` directories, anywhere in this repository.
+  '**/security/**',
+];

--- a/packages/cli/tests/unit/rpc/explain/index/project-file-index.spec.ts
+++ b/packages/cli/tests/unit/rpc/explain/index/project-file-index.spec.ts
@@ -1,0 +1,37 @@
+import { writeFileSync } from 'node:fs';
+import { dir, type DirectoryResult } from 'tmp-promise';
+
+import { buildProjectFileIndex } from '../../../../../src/rpc/explain/index/project-file-index';
+import ContentRestrictions from '../../../../../src/rpc/explain/ContentRestrictions';
+import { join } from 'node:path';
+
+describe('project-file-index', () => {
+  const contentRestrictions = ContentRestrictions.instance;
+  let project: DirectoryResult;
+
+  beforeEach(async () => {
+    ContentRestrictions.instance.reset();
+    project = await dir({ unsafeCleanup: true });
+    writeFileSync(join(project.path, 'restricted-file.js'), 'restricted');
+    writeFileSync(join(project.path, 'allowed-file.js'), 'allowed');
+  });
+
+  it('should skip restricted files during indexing', async () => {
+    contentRestrictions.setGlobalRestrictions(['**/restricted-file.js']);
+
+    const sourceDirectories = [project.path];
+    const includePatterns = undefined;
+    const excludePatterns = undefined;
+
+    const index = await buildProjectFileIndex(sourceDirectories, includePatterns, excludePatterns);
+    const files = index.index.search('session', 'file');
+
+    expect(files.filter((f) => f.filePath.includes('restricted-file.js')).length).toBe(0);
+    expect(files.filter((f) => f.filePath.includes('allowed-file.js')).length).toBe(1);
+  });
+
+  afterEach(() => {
+    void project.cleanup();
+    ContentRestrictions.instance.reset();
+  });
+});


### PR DESCRIPTION
This pull request introduces a new `ContentRestrictions` class to manage and enforce file access restrictions based on global and local patterns. The changes include adding the `ContentRestrictions` class, integrating it into existing modules, and adding tests to ensure its functionality.

Key changes:

### New Feature: ContentRestrictions Class
* [`packages/cli/src/rpc/explain/ContentRestrictions.ts`](diffhunk://#diff-eaf89054e06a974f6aa074c060639ff54572496c15f713e1a6a5eecb7dec4204R1-R159): Introduced the `ContentRestrictions` class to handle global and local file access restrictions. The class includes methods to set restrictions, check if a path is restricted, and load default patterns.

### Integration with Existing Modules
* [`packages/cli/src/rpc/explain/collect-location-context.ts`](diffhunk://#diff-d7f5141d81d7f3bafdbeabf3a4340ec108839cd6579cbdff09855f7f9b17c741R9): Integrated `ContentRestrictions` to skip restricted locations during the collection of location context. [[1]](diffhunk://#diff-d7f5141d81d7f3bafdbeabf3a4340ec108839cd6579cbdff09855f7f9b17c741R9) [[2]](diffhunk://#diff-d7f5141d81d7f3bafdbeabf3a4340ec108839cd6579cbdff09855f7f9b17c741L65-L70)
* [`packages/cli/src/rpc/explain/index/project-file-index.ts`](diffhunk://#diff-d1cd4a947766a671a76ff9b1fc5746714356941bb66451a4d0254b2616ea3499R21-R22): Modified the file filter function to skip restricted files based on `ContentRestrictions`. [[1]](diffhunk://#diff-d1cd4a947766a671a76ff9b1fc5746714356941bb66451a4d0254b2616ea3499R21-R22) [[2]](diffhunk://#diff-d1cd4a947766a671a76ff9b1fc5746714356941bb66451a4d0254b2616ea3499R39-R43)

### Tests for ContentRestrictions
* [`packages/cli/tests/unit/rpc/explain/ContentRestrictions.spec.ts`](diffhunk://#diff-8693b54369e02c98931f50e498004ad8c86b64add1f75cccb9f020a769344faeR1-R107): Added unit tests for the `ContentRestrictions` class to verify setting restrictions, handling Windows paths, and error handling when local restrictions are required but not set.
* [`packages/cli/tests/unit/rpc/explain/collect-location-context.spec.ts`](diffhunk://#diff-ec7adf01eeda1db3ea5156092b8de08bdbbe28bb88fa2dac1489bbacc071334aR7): Updated tests to reset `ContentRestrictions` state and added tests to ensure restricted locations are skipped. [[1]](diffhunk://#diff-ec7adf01eeda1db3ea5156092b8de08bdbbe28bb88fa2dac1489bbacc071334aR7) [[2]](diffhunk://#diff-ec7adf01eeda1db3ea5156092b8de08bdbbe28bb88fa2dac1489bbacc071334aL15-R19) [[3]](diffhunk://#diff-ec7adf01eeda1db3ea5156092b8de08bdbbe28bb88fa2dac1489bbacc071334aL25-R33) [[4]](diffhunk://#diff-ec7adf01eeda1db3ea5156092b8de08bdbbe28bb88fa2dac1489bbacc071334aR81-R112)
* [`packages/cli/tests/unit/rpc/explain/index/project-file-index.spec.ts`](diffhunk://#diff-e144d3fe276778391242e76c0f937271bc5af9224f08a5301fb47e93c3b53aceR1-R37): Added tests to verify that restricted files are skipped during project file indexing.

## Notes and future work
- Fixes #2226.
- The global exclusion list is read from `~/.appmap/navie/global-ignore`. If reading this file fails, a hardcoded list is used.
- There is support for per-directory exclusion lists but it's not currently wired up.
- Potential future work includes:
  - allowing setting per-directory and per-repository (by upstream URL) exclusion lists,
  - exposing exclusion list setting so it can be dynamically fetched by client.