### PR TITLE
feat: Add custom headers to Navie requests servicing completions

### DIFF
--- a/packages/cli/src/lib/packageVersion.ts
+++ b/packages/cli/src/lib/packageVersion.ts
@@ -1,0 +1,17 @@
+import { sync as readPackageUpSync } from 'read-pkg-up';
+
+let PACKAGE_VERSION: string | undefined | null = null;
+
+/**
+ * Returns the version from package.json, or undefined if it cannot be found.
+ *
+ * This is a cached value, so it will only be calculated once.
+ */
+export default function getPackageVersion(): string | undefined {
+  if (PACKAGE_VERSION === null) {
+    // `null` indicates that we haven't yet attempted to resolve a version.
+    const result = readPackageUpSync({ cwd: __dirname });
+    PACKAGE_VERSION = result?.packageJson?.version;
+  }
+  return PACKAGE_VERSION;
+}

--- a/packages/cli/src/rpc/explain/navie/navie-local.ts
+++ b/packages/cli/src/rpc/explain/navie/navie-local.ts
@@ -18,6 +18,8 @@ import assert from 'assert';
 import { initializeHistory, loadThread } from './historyHelper';
 import { THREAD_ID_REGEX } from './history';
 import Trajectory from './trajectory';
+import detectCodeEditor from '../../../lib/detectCodeEditor';
+import getPackageVersion from '../../../lib/packageVersion';
 
 const OPTION_SETTERS: Record<
   string,
@@ -38,7 +40,13 @@ const OPTION_SETTERS: Record<
 };
 
 export default class LocalNavie extends EventEmitter implements INavie {
-  public navieOptions = new Navie.NavieOptions();
+  public navieOptions = new Navie.NavieOptions({
+    metadata: {
+      product: 'AppMap Navie',
+      version: getPackageVersion(),
+      codeEditor: detectCodeEditor(),
+    },
+  });
   public trajectory: Trajectory | undefined;
 
   assignedThreadId: string | undefined;

--- a/packages/navie/src/context.ts
+++ b/packages/navie/src/context.ts
@@ -77,12 +77,24 @@ export namespace ContextV2 {
     location: string;
   };
 
+  export type AppMapContextItem = ContextItem & {
+    type: ContextItemType.DataRequest | ContextItemType.SequenceDiagram;
+    directory: string;
+    location: string;
+  };
+
   export function isFileContextItem(contextItem: ContextItem): contextItem is FileContextItem {
     return (
       contextItem.type === ContextItemType.CodeSnippet ||
       contextItem.type === ContextItemType.SequenceDiagram ||
       contextItem.type === ContextItemType.DataRequest ||
       contextItem.type === ContextItemType.DirectoryListing
+    );
+  }
+
+  export function isAppMapContextItem(contextItem: ContextItem): contextItem is AppMapContextItem {
+    return [ContextItemType.DataRequest, ContextItemType.SequenceDiagram].includes(
+      contextItem.type
     );
   }
 

--- a/packages/navie/src/lib/navie-headers.ts
+++ b/packages/navie/src/lib/navie-headers.ts
@@ -1,0 +1,65 @@
+import { randomUUID } from 'crypto';
+import { NavieOptions } from '../navie';
+import { CommandMode } from '../command';
+import InteractionHistory, { ContextLookupEvent, InteractionEvent } from '../interaction-history';
+import { ContextV2 } from '../context';
+
+export interface NavieRequestMetadata {
+  // The name of the product making the request, e.g. "AppMap".
+  product?: string;
+
+  // The version of the product making the request, e.g. "1.0.0".
+  version?: string;
+
+  // The code editor which owns the process making the request, e.g. "vscode".
+  codeEditor?: string;
+
+  // Information about the model used to generate the response.
+  model?: {
+    name?: string;
+  };
+
+  // The @-command requested by the user.
+  command?: string;
+}
+
+export class NavieHeaders {
+  public readonly requestId = randomUUID();
+  private readonly metadata: NavieRequestMetadata;
+  private appmapReferences = new Set<string>();
+
+  constructor(interactionHistory: InteractionHistory, options: NavieOptions, command: CommandMode) {
+    this.metadata = options.metadata ?? {};
+    this.metadata.model ||= {};
+    this.metadata.model.name = options.modelName;
+    this.metadata.command = command;
+
+    interactionHistory.on('event', (event: InteractionEvent) => {
+      if (event.type === 'contextLookup') {
+        const contextLookupEvent = event as ContextLookupEvent;
+        contextLookupEvent.context?.filter(ContextV2.isAppMapContextItem).forEach((contextItem) => {
+          this.appmapReferences.add(contextItem.location);
+        });
+      }
+    });
+  }
+
+  buildHeaders(): Record<string, string> {
+    const platform = `${process.platform}-${process.arch}`;
+    const nodeVersion = `${process.release.name} ${process.versions.node}`;
+    const product = [this.metadata.product, this.metadata.version].filter(Boolean).join('/');
+    const userAgent = [product, `(${platform}; ${nodeVersion})`, this.metadata.codeEditor]
+      .filter(Boolean)
+      .join(' ');
+
+    return Object.entries({
+      'user-agent': userAgent,
+      'x-appmap-navie-request-id': this.requestId,
+      'x-appmap-navie-model': this.metadata.model?.name,
+      'x-appmap-navie-runtime-refs': this.appmapReferences.size,
+      'x-appmap-navie-command': this.metadata.command,
+    })
+      .filter((e): e is [string, string] => e[1] !== undefined)
+      .reduce((acc, [key, value]) => ({ ...acc, [key]: String(value) }), {});
+  }
+}

--- a/packages/navie/src/lib/navie-headers.ts
+++ b/packages/navie/src/lib/navie-headers.ts
@@ -21,6 +21,10 @@ export interface NavieRequestMetadata {
 
   // The @-command requested by the user.
   command?: string;
+
+  // Navie's token limit when serving the request. Not necessarily the same as the model's
+  // maximum token limit.
+  tokenLimit?: number;
 }
 
 export class NavieHeaders {
@@ -33,6 +37,7 @@ export class NavieHeaders {
     this.metadata.model ||= {};
     this.metadata.model.name = options.modelName;
     this.metadata.command = command;
+    this.metadata.tokenLimit = options.tokenLimit;
 
     interactionHistory.on('event', (event: InteractionEvent) => {
       if (event.type === 'contextLookup') {
@@ -56,8 +61,9 @@ export class NavieHeaders {
       'user-agent': userAgent,
       'x-appmap-navie-request-id': this.requestId,
       'x-appmap-navie-model': this.metadata.model?.name,
-      'x-appmap-navie-runtime-refs': this.appmapReferences.size,
+      'x-appmap-navie-appmap-count': this.appmapReferences.size,
       'x-appmap-navie-command': this.metadata.command,
+      'x-appmap-navie-token-limit': this.metadata.tokenLimit,
     })
       .filter((e): e is [string, string] => e[1] !== undefined)
       .reduce((acc, [key, value]) => ({ ...acc, [key]: String(value) }), {});

--- a/packages/navie/src/services/anthropic-completion-service.ts
+++ b/packages/navie/src/services/anthropic-completion-service.ts
@@ -16,6 +16,7 @@ import CompletionService, {
 } from './completion-service';
 import Trajectory from '../lib/trajectory';
 import MessageTokenReducerService from './message-token-reducer-service';
+import { NavieHeaders } from '../lib/navie-headers';
 
 /*
   Generated on https://docs.anthropic.com/en/docs/about-claude/models with
@@ -110,7 +111,8 @@ export default class AnthropicCompletionService implements CompletionService {
     public readonly modelName: string,
     public readonly temperature: number,
     private trajectory: Trajectory,
-    private readonly messageTokenReducerService: MessageTokenReducerService
+    private readonly messageTokenReducerService: MessageTokenReducerService,
+    private readonly headers: NavieHeaders
   ) {
     this.model = this.buildModel({ temperature });
   }
@@ -127,6 +129,9 @@ export default class AnthropicCompletionService implements CompletionService {
       modelName: options?.model ?? this.modelName,
       temperature: options?.temperature ?? this.temperature,
       streaming: options?.streaming ?? true,
+      clientOptions: {
+        defaultHeaders: this.headers.buildHeaders(),
+      },
     });
   }
 

--- a/packages/navie/src/services/completion-service-factory.ts
+++ b/packages/navie/src/services/completion-service-factory.ts
@@ -6,11 +6,13 @@ import AnthropicCompletionService from './anthropic-completion-service';
 import CompletionService from './completion-service';
 import Trajectory from '../lib/trajectory';
 import MessageTokenReducerService from './message-token-reducer-service';
+import { NavieHeaders } from '../lib/navie-headers';
 
 interface Options {
   modelName: string;
   temperature: number;
   trajectory: Trajectory;
+  headers: NavieHeaders;
   backend?: Backend;
 }
 
@@ -43,9 +45,16 @@ export default function createCompletionService({
   modelName,
   temperature,
   trajectory,
+  headers,
   backend = determineCompletionBackend(),
 }: Options): CompletionService {
   const messageTokenReducerService = new MessageTokenReducerService();
   warn(`Using completion service ${backend}`);
-  return new BACKENDS[backend](modelName, temperature, trajectory, messageTokenReducerService);
+  return new BACKENDS[backend](
+    modelName,
+    temperature,
+    trajectory,
+    messageTokenReducerService,
+    headers
+  );
 }

--- a/packages/navie/test/lib/navie-headers.spec.ts
+++ b/packages/navie/test/lib/navie-headers.spec.ts
@@ -1,0 +1,133 @@
+import { ContextV2 } from '../../src';
+import { CommandMode } from '../../src/command';
+import InteractionHistory, { ContextLookupEvent } from '../../src/interaction-history';
+import { NavieHeaders } from '../../src/lib/navie-headers';
+import { NavieOptions } from '../../src/navie';
+
+describe('NavieHeaders', () => {
+  describe('x-appmap-navie-runtime-refs', () => {
+    it('collects appmap data references', () => {
+      const history = new InteractionHistory();
+      const headers = new NavieHeaders(history, new NavieOptions(), CommandMode.Explain);
+      history.addEvent(
+        new ContextLookupEvent([
+          {
+            type: ContextV2.ContextItemType.SequenceDiagram,
+            location: 'same.appmap.json',
+            directory: '/home/user',
+            content: '---',
+          },
+          {
+            type: ContextV2.ContextItemType.DataRequest,
+            location: 'same.appmap.json',
+            directory: '/home/user',
+            content: '---',
+          },
+          {
+            type: ContextV2.ContextItemType.SequenceDiagram,
+            location: 'different.appmap.json',
+            directory: '/home/user',
+            content: '---',
+          },
+        ])
+      );
+      const result = headers.buildHeaders();
+      expect(result['x-appmap-navie-runtime-refs']).toEqual('2');
+    });
+
+    it('is zero when no appmap data references are found', () => {
+      const history = new InteractionHistory();
+      const headers = new NavieHeaders(history, new NavieOptions(), CommandMode.Explain);
+      const result = headers.buildHeaders();
+      expect(result['x-appmap-navie-runtime-refs']).toEqual('0');
+    });
+  });
+
+  describe('x-appmap-navie-request-id', () => {
+    const history = new InteractionHistory();
+
+    it('is a uuid', () => {
+      const headers = new NavieHeaders(history, new NavieOptions(), CommandMode.Explain);
+      const result = headers.buildHeaders();
+      expect(result['x-appmap-navie-request-id']).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+      );
+    });
+  });
+
+  describe('x-appmap-navie-model', () => {
+    const history = new InteractionHistory();
+
+    it('is the model name', () => {
+      const modelName = 'gpt-4o';
+      const headers = new NavieHeaders(
+        history,
+        new NavieOptions({ modelName }),
+        CommandMode.Explain
+      );
+      const result = headers.buildHeaders();
+      expect(result['x-appmap-navie-model']).toEqual(modelName);
+    });
+  });
+
+  describe('x-appmap-navie-command', () => {
+    const history = new InteractionHistory();
+
+    it('is the command name', () => {
+      const headers = new NavieHeaders(history, new NavieOptions(), CommandMode.Review);
+      const result = headers.buildHeaders();
+      expect(result['x-appmap-navie-command']).toEqual(CommandMode.Review);
+    });
+  });
+
+  describe('user-agent', () => {
+    const history = new InteractionHistory();
+
+    it('includes the product name', () => {
+      const product = 'AppMap Navie';
+      const headers = new NavieHeaders(
+        history,
+        new NavieOptions({ metadata: { product } }),
+        CommandMode.Explain
+      );
+      const result = headers.buildHeaders();
+      expect(result['user-agent']).toContain(product);
+    });
+
+    it('includes the version', () => {
+      const version = '1.2.3';
+      const headers = new NavieHeaders(
+        history,
+        new NavieOptions({ metadata: { version } }),
+        CommandMode.Explain
+      );
+      const result = headers.buildHeaders();
+      expect(result['user-agent']).toContain(version);
+    });
+
+    it('includes the code editor', () => {
+      const codeEditor = 'vscode';
+      const headers = new NavieHeaders(
+        history,
+        new NavieOptions({ metadata: { codeEditor } }),
+        CommandMode.Explain
+      );
+      const result = headers.buildHeaders();
+      expect(result['user-agent']).toContain(codeEditor);
+    });
+
+    it('includes the operating system and architecture', () => {
+      const headers = new NavieHeaders(history, new NavieOptions(), CommandMode.Explain);
+      const result = headers.buildHeaders();
+      expect(result['user-agent']).toContain(process.platform);
+      expect(result['user-agent']).toContain(process.arch);
+    });
+
+    it('includes the runtime and version', () => {
+      const headers = new NavieHeaders(history, new NavieOptions(), CommandMode.Explain);
+      const result = headers.buildHeaders();
+      expect(result['user-agent']).toContain(process.release.name);
+      expect(result['user-agent']).toContain(process.versions.node);
+    });
+  });
+});

--- a/packages/navie/test/lib/navie-headers.spec.ts
+++ b/packages/navie/test/lib/navie-headers.spec.ts
@@ -5,7 +5,7 @@ import { NavieHeaders } from '../../src/lib/navie-headers';
 import { NavieOptions } from '../../src/navie';
 
 describe('NavieHeaders', () => {
-  describe('x-appmap-navie-runtime-refs', () => {
+  describe('x-appmap-navie-appmap-count', () => {
     it('collects appmap data references', () => {
       const history = new InteractionHistory();
       const headers = new NavieHeaders(history, new NavieOptions(), CommandMode.Explain);
@@ -32,14 +32,14 @@ describe('NavieHeaders', () => {
         ])
       );
       const result = headers.buildHeaders();
-      expect(result['x-appmap-navie-runtime-refs']).toEqual('2');
+      expect(result['x-appmap-navie-appmap-count']).toEqual('2');
     });
 
     it('is zero when no appmap data references are found', () => {
       const history = new InteractionHistory();
       const headers = new NavieHeaders(history, new NavieOptions(), CommandMode.Explain);
       const result = headers.buildHeaders();
-      expect(result['x-appmap-navie-runtime-refs']).toEqual('0');
+      expect(result['x-appmap-navie-appmap-count']).toEqual('0');
     });
   });
 

--- a/packages/navie/test/services/anthropic-completion-service.spec.ts
+++ b/packages/navie/test/services/anthropic-completion-service.spec.ts
@@ -7,12 +7,16 @@ import { z } from 'zod';
 import { RunnableBinding } from '@langchain/core/runnables';
 import Trajectory, { TrajectoryEvent } from '../../src/lib/trajectory';
 import MessageTokenReducerService from '../../src/services/message-token-reducer-service';
+import { NavieHeaders } from '../../src/lib/navie-headers';
+import { NavieOptions } from '../../src/navie';
+import { CommandMode } from '../../src/command';
 
 describe('AnthropicCompletionService', () => {
   let interactionHistory: InteractionHistory;
   let messageTokenReducerService: MessageTokenReducerService;
   let trajectory: Trajectory;
   let service: AnthropicCompletionService;
+  let headers: NavieHeaders;
   const modelName = 'anthropic-model';
   const temperature = 0.3;
 
@@ -23,11 +27,19 @@ describe('AnthropicCompletionService', () => {
     interactionHistory = new InteractionHistory();
     messageTokenReducerService = new MessageTokenReducerService();
     trajectory = new Trajectory();
+    headers = new NavieHeaders(
+      interactionHistory,
+      new NavieOptions({
+        metadata: { product: 'navie-test', version: '0.0.0', codeEditor: 'vscode' },
+      }),
+      CommandMode.Explain
+    );
     service = new AnthropicCompletionService(
       modelName,
       temperature,
       trajectory,
-      messageTokenReducerService
+      messageTokenReducerService,
+      headers
     );
   });
 

--- a/packages/navie/test/services/completion-service-factory.spec.ts
+++ b/packages/navie/test/services/completion-service-factory.spec.ts
@@ -2,6 +2,10 @@ import createCompletionService from '../../src/services/completion-service-facto
 import OpenAICompletionService from '../../src/services/openai-completion-service';
 import AnthropicCompletionService from '../../src/services/anthropic-completion-service';
 import Trajectory from '../../src/lib/trajectory';
+import { NavieHeaders } from '../../src/lib/navie-headers';
+import InteractionHistory from '../../src/interaction-history';
+import { NavieOptions } from '../../src/navie';
+import { CommandMode } from '../../src/command';
 
 describe('CompletionServiceFactory', () => {
   const originalEnv = process.env;
@@ -13,14 +17,24 @@ describe('CompletionServiceFactory', () => {
   it('creates an OpenAICompletionService by default', () => {
     process.env.OPENAI_API_KEY = 'openai-key';
     const trajectory: Trajectory = jest.genMockFromModule<Trajectory>('../../src/lib/trajectory');
-    const service = createCompletionService({ modelName: 'test', temperature: 1, trajectory });
+    const service = createCompletionService({
+      modelName: 'test',
+      temperature: 1,
+      trajectory,
+      headers: new NavieHeaders(new InteractionHistory(), new NavieOptions(), CommandMode.Explain),
+    });
     expect(service).toBeInstanceOf(OpenAICompletionService);
   });
 
   it('creates an AnthropicCompletionService when ANTHROPIC_API_KEY is set', () => {
     process.env.ANTHROPIC_API_KEY = 'anthropic-key';
     const trajectory: Trajectory = jest.genMockFromModule<Trajectory>('../../src/lib/trajectory');
-    const service = createCompletionService({ modelName: 'test', temperature: 1, trajectory });
+    const service = createCompletionService({
+      modelName: 'test',
+      temperature: 1,
+      trajectory,
+      headers: new NavieHeaders(new InteractionHistory(), new NavieOptions(), CommandMode.Explain),
+    });
     expect(service).toBeInstanceOf(AnthropicCompletionService);
   });
 });

--- a/packages/navie/test/services/openai-completion-service.spec.ts
+++ b/packages/navie/test/services/openai-completion-service.spec.ts
@@ -300,7 +300,8 @@ describe('OpenAICompletionService', () => {
               'x-appmap-navie-command': 'explain',
               'x-appmap-navie-model': 'gpt-4o',
               'x-appmap-navie-request-id': headers.requestId,
-              'x-appmap-navie-runtime-refs': '0',
+              'x-appmap-navie-appmap-count': '0',
+              'x-appmap-navie-token-limit': '8000',
             },
           }
         );


### PR DESCRIPTION
This PR adds detailed request headers to Navie API calls to improve observability and tracking of Navie usage.

**Changes by package:**

*packages/cli*
- Added package version detection utility
- Added code editor detection integration
- Enhanced NavieOptions to include product metadata

*packages/navie*
- Added new `NavieHeaders` class for header management
- Integrated request tracking headers:
  - `user-agent`: Product, version, and platform info
  - `x-appmap-navie-request-id`: Unique request identifier, stable across multiple completions for a single request
  - `x-appmap-navie-model`: The name of the model requested
  - `x-appmap-navie-runtime-refs`: A count of unique AppMap traces referenced in context during completion
  - `x-appmap-navie-command`: The command mode used to service the request
- Updated completion services to include custom headers
- Added tests for header generation and integration
