### PR TITLE
fix: Normalize Windows path locations

### DIFF
--- a/packages/cli/tests/unit/rpc/explain/location.spec.ts
+++ b/packages/cli/tests/unit/rpc/explain/location.spec.ts
@@ -1,81 +1,125 @@
 import Location from '../../../../src/rpc/explain/location';
 
+let platform = 'linux';
+jest.mock('node:os', () => ({ platform: () => platform }));
+
 describe('Location', () => {
-  it('parses a location without line numbers', () => {
-    const location = Location.parse('path/to/file.rb');
-    expect(location).toEqual(new Location('path/to/file.rb'));
+  afterAll(() => {
+    jest.resetModules();
   });
 
-  it('parses a location with a single line number', () => {
-    const location = Location.parse('path/to/file.rb:1');
-    expect(location).toEqual(new Location('path/to/file.rb', '1'));
+  describe('posix', () => {
+    beforeEach(() => {
+      platform = 'linux';
+    });
+
+    it('parses a location without line numbers', () => {
+      const location = Location.parse('path/to/file.rb');
+      expect(location).toEqual(new Location('path/to/file.rb'));
+    });
+
+    it('parses a location with a single line number', () => {
+      const location = Location.parse('path/to/file.rb:1');
+      expect(location).toEqual(new Location('path/to/file.rb', '1'));
+    });
+
+    it('parses a location with a line range', () => {
+      const location = Location.parse('path/to/file.rb:1-2');
+      expect(location).toEqual(new Location('path/to/file.rb', '1-2'));
+    });
+
+    it('returns the correct snippet for a given content', () => {
+      const location = new Location('path/to/file.rb', '2-3');
+      const content = 'line1\nline2\nline3\nline4';
+      expect(location.snippet(content)).toEqual('line2\nline3');
+    });
+
+    it('returns the full content if no line range is specified', () => {
+      const location = new Location('path/to/file.rb');
+      const content = 'line1\nline2\nline3\nline4';
+      expect(location.snippet(content)).toEqual(content);
+    });
+
+    it('converts to string correctly', () => {
+      const location = new Location('path/to/file.rb', '1-2');
+      expect(location.toString()).toEqual('path/to/file.rb:1-2');
+    });
+
+    it('converts to string correctly without line range', () => {
+      const location = new Location('path/to/file.rb');
+      expect(location.toString()).toEqual('path/to/file.rb');
+    });
+
+    it('parses a Unix style full path', () => {
+      const location = Location.parse('/path/to/file.rb');
+      expect(location).toEqual(new Location('/path/to/file.rb'));
+    });
+
+    it('parses a Unix style path with a line range', () => {
+      const location = Location.parse('/path/to/file.rb:1-2');
+      expect(location).toEqual(new Location('/path/to/file.rb', '1-2'));
+    });
+
+    it('ignores invalid characters in line range', () => {
+      const location = Location.parse('path/to/file.rb:1-2a');
+      expect(location).toEqual(new Location('path/to/file.rb:1-2a'));
+    });
+
+    it('parses a location with a single line number and invalid characters', () => {
+      const location = Location.parse('path/to/file.rb:1a');
+      expect(location).toEqual(new Location('path/to/file.rb:1a'));
+    });
+
+    it('passes through an invalid location', () => {
+      const location = Location.parse('c:/invalid:location:foo:1-2');
+      expect(location).toEqual(new Location('c:/invalid:location:foo', '1-2'));
+    });
   });
 
-  it('parses a location with a line range', () => {
-    const location = Location.parse('path/to/file.rb:1-2');
-    expect(location).toEqual(new Location('path/to/file.rb', '1-2'));
-  });
+  describe('windows', () => {
+    beforeEach(() => {
+      platform = 'win32';
+    });
 
-  it('returns the correct snippet for a given content', () => {
-    const location = new Location('path/to/file.rb', '2-3');
-    const content = 'line1\nline2\nline3\nline4';
-    expect(location.snippet(content)).toEqual('line2\nline3');
-  });
+    it('parses a location with a drive letter', () => {
+      const location = Location.parse('C:\\path\\to\\file.rb:1');
+      expect(location).toEqual(new Location('C:\\path\\to\\file.rb', '1'));
+    });
 
-  it('returns the full content if no line range is specified', () => {
-    const location = new Location('path/to/file.rb');
-    const content = 'line1\nline2\nline3\nline4';
-    expect(location.snippet(content)).toEqual(content);
-  });
+    it('passes through an invalid location', () => {
+      const location = Location.parse('C:\\invalid:location:foo:1-2');
+      expect(location).toEqual(new Location('C:\\invalid:location:foo', '1-2'));
+    });
 
-  it('converts to string correctly', () => {
-    const location = new Location('path/to/file.rb', '1-2');
-    expect(location.toString()).toEqual('path/to/file.rb:1-2');
-  });
+    it('parses a Windows path with a line range', () => {
+      const location = Location.parse('C:\\path\\to\\file.rb:1-2');
+      expect(location).toEqual(new Location('C:\\path\\to\\file.rb', '1-2'));
+    });
 
-  it('converts to string correctly without line range', () => {
-    const location = new Location('path/to/file.rb');
-    expect(location.toString()).toEqual('path/to/file.rb');
-  });
+    it('parses a Windows path with a single line number', () => {
+      const location = Location.parse('C:\\path\\to\\file.rb:1');
+      expect(location).toEqual(new Location('C:\\path\\to\\file.rb', '1'));
+    });
 
-  it('parses a location with a drive letter', () => {
-    const location = Location.parse('c:/path/to/file.rb:1');
-    expect(location).toEqual(new Location('c:/path/to/file.rb', '1'));
-  });
+    it('normalizes Windows path containing leading back slashes', () => {
+      const location = Location.parse('\\C:\\path\\to\\file.rb:1');
+      expect(location).toEqual(new Location('C:\\path\\to\\file.rb', '1'));
+    });
 
-  it('passes through an invalid location', () => {
-    const location = Location.parse('c:/invalid:location:foo:1-2');
-    expect(location).toEqual(new Location('c:/invalid:location:foo', '1-2'));
-  });
+    it('normalizes Windows path containing leading forward slashes', () => {
+      const location = Location.parse('/C:\\path\\to\\file.rb:1');
+      expect(location).toEqual(new Location('C:\\path\\to\\file.rb', '1'));
+    });
 
-  it('parses a Windows path with a line range', () => {
-    const location = Location.parse('C:\\path\\to\\file.rb:1-2');
-    expect(location).toEqual(new Location('C:\\path\\to\\file.rb', '1-2'));
-  });
+    it('normalizes Windows drive letter casing', () => {
+      const location = Location.parse('c:\\path\\to\\file.rb:1');
+      expect(location).toEqual(new Location('C:\\path\\to\\file.rb', '1'));
+    });
 
-  it('parses a Windows path with a single line number', () => {
-    const location = Location.parse('C:\\path\\to\\file.rb:1');
-    expect(location).toEqual(new Location('C:\\path\\to\\file.rb', '1'));
-  });
-
-  it('parses a Unix style full path', () => {
-    const location = Location.parse('/path/to/file.rb');
-    expect(location).toEqual(new Location('/path/to/file.rb'));
-  });
-
-  it('parses a Unix style path with a line range', () => {
-    const location = Location.parse('/path/to/file.rb:1-2');
-    expect(location).toEqual(new Location('/path/to/file.rb', '1-2'));
-  });
-
-  it('ignores invalid characters in line range', () => {
-    const location = Location.parse('path/to/file.rb:1-2a');
-    expect(location).toEqual(new Location('path/to/file.rb:1-2a'));
-  });
-
-  it('parses a location with a single line number and invalid characters', () => {
-    const location = Location.parse('path/to/file.rb:1a');
-    expect(location).toEqual(new Location('path/to/file.rb:1a'));
+    it('normalizes Windows path separators', () => {
+      const location = Location.parse('C:/path/to/file.rb:1');
+      expect(location).toEqual(new Location('C:\\path\\to\\file.rb', '1'));
+    });
   });
 
   it('handles zero starting line correctly', () => {


### PR DESCRIPTION
In practice, Windows paths are represented in many different forms. Path separators are interchangable and paths are case insensitive. Additionally, paths constructed via a file scheme URI may contain a leading slash, similar to an absolute path in POSIX.

This was preventing pinned items from being picked up in Windows. A pinned file path may be something like:
```
/c:/Users/Administrator/Project/app.rb:2-24
```

This is problematic for a few reasons:
1. The leading slash corrupts the path and it is not usable. Ideally clients would not send us paths formatted in this manner, but it's already happening. This behavior is observed both from JetBrains and Visual Studio Code.
2. The path separators are valid, but don't match other cases in our code, such as when we compare the absolute file path against known project directories. In this case, known project directories will use the default separator (\\), so [checks to see if a file starts with one of these paths will always fail](https://github.com/getappmap/appmap-js/blob/3e0f4ae7aabb3d7b1a27b8f54135d39a6e4b79d9/packages/cli/src/rpc/explain/collect-location-context.ts#L40).
3. A case inconsistency in the drive letter will also cause the above scenario to fail. Windows doesn't actually care, but our string comparisons obviously do.