### PR TITLE
fix: Migrate from better-sqlite3 to node-sqlite3-wasm

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -38,7 +38,6 @@
     "@eslint/js": "~8.57.0",
     "@octokit/types": "^11.1.0",
     "@swc/core": "^1.3.76",
-    "@types/better-sqlite3": "^7.6.11",
     "@types/cors": "^2.8.17",
     "@types/fs-extra": "^9.0.13",
     "@types/gitconfiglocal": "^2.0.1",
@@ -103,7 +102,6 @@
     "applicationinsights": "^2.1.4",
     "async": "^3.2.4",
     "axios": "^0.27.2",
-    "better-sqlite3": "^11.5.0",
     "body-parser": "^1.20.2",
     "boxen": "^5.0.1",
     "chalk": "^4.1.2",
@@ -131,6 +129,7 @@
     "lunr": "^2.3.9",
     "minimatch": "^5.1.2",
     "moo": "^0.5.1",
+    "node-sqlite3-wasm": "^0.8.34",
     "open": "^8.2.1",
     "openapi-diff": "^0.23.6",
     "openapi-types": "^12.1.3",
@@ -167,9 +166,7 @@
       "resources",
       "built/appmap.html",
       "built/sequenceDiagram.html",
-      "built/docs",
-      "../../node_modules/better-sqlite3/build/Release/better_sqlite3.node",
-      "node_modules/better-sqlite3/build/Release/better_sqlite3.node"
+      "built/docs"
     ],
     "outputPath": "dist"
   },

--- a/packages/cli/src/cmds/search/search.ts
+++ b/packages/cli/src/cmds/search/search.ts
@@ -1,5 +1,5 @@
+import sqlite3 from 'node-sqlite3-wasm';
 import yargs from 'yargs';
-import sqlite3 from 'better-sqlite3';
 import assert from 'assert';
 import { readFileSync } from 'fs';
 import { writeFile } from 'fs/promises';
@@ -186,7 +186,7 @@ export const handler = async (argv: ArgumentTypes) => {
     };
 
     const index = await buildIndexInTempDir('appmaps', async (indexFile) => {
-      const db = new sqlite3(indexFile);
+      const db = new sqlite3.Database(indexFile);
       const fileIndex = new FileIndex(db);
       await buildAppMapIndex(fileIndex, [process.cwd()]);
       return fileIndex;

--- a/packages/cli/src/rpc/explain/index-files.ts
+++ b/packages/cli/src/rpc/explain/index-files.ts
@@ -1,4 +1,4 @@
-import sqlite3 from 'better-sqlite3';
+import type sqlite3 from 'node-sqlite3-wasm';
 
 import {
   buildFileIndex,

--- a/packages/cli/src/rpc/explain/index-snippets.ts
+++ b/packages/cli/src/rpc/explain/index-snippets.ts
@@ -1,3 +1,5 @@
+import sqlite3 from 'node-sqlite3-wasm';
+
 import {
   buildSnippetIndex,
   FileSearchResult,
@@ -6,7 +8,6 @@ import {
   readFileSafe,
   SnippetIndex,
 } from '@appland/search';
-import sqlite3 from 'better-sqlite3';
 
 export default async function indexSnippets(
   db: sqlite3.Database,

--- a/packages/cli/src/rpc/explain/index/appmap-file-index.ts
+++ b/packages/cli/src/rpc/explain/index/appmap-file-index.ts
@@ -1,4 +1,4 @@
-import sqlite3 from 'better-sqlite3';
+import sqlite3 from 'node-sqlite3-wasm';
 
 import { FileIndex, SessionId } from '@appland/search';
 
@@ -10,7 +10,7 @@ export async function buildAppMapFileIndex(
   appmapDirectories: string[]
 ): Promise<CloseableIndex<FileIndex>> {
   return await buildIndexInTempDir<FileIndex>('appmaps', async (indexFile) => {
-    const db = new sqlite3(indexFile);
+    const db = new sqlite3.Database(indexFile);
     const fileIndex = new FileIndex(db);
     await buildAppMapIndex(fileIndex, appmapDirectories);
     return fileIndex;

--- a/packages/cli/src/rpc/explain/index/project-file-index.ts
+++ b/packages/cli/src/rpc/explain/index/project-file-index.ts
@@ -1,5 +1,5 @@
-import sqlite3 from 'better-sqlite3';
 import makeDebug from 'debug';
+import sqlite3 from 'node-sqlite3-wasm';
 
 import {
   buildFileIndex,
@@ -71,7 +71,7 @@ export async function buildProjectFileIndex(
   excludePatterns: RegExp[] | undefined
 ): Promise<CloseableIndex<FileIndex>> {
   return await buildIndexInTempDir('files', async (indexFile) => {
-    const db = new sqlite3(indexFile);
+    const db = new sqlite3.Database(indexFile);
     return await indexFiles(db, sourceDirectories, includePatterns, excludePatterns);
   });
 }

--- a/packages/cli/src/rpc/explain/index/project-file-snippet-index.ts
+++ b/packages/cli/src/rpc/explain/index/project-file-snippet-index.ts
@@ -1,4 +1,5 @@
-import sqlite3 from 'better-sqlite3';
+import sqlite3 from 'node-sqlite3-wasm';
+
 import { FileSearchResult, SessionId, SnippetIndex } from '@appland/search';
 
 import buildIndexInTempDir, { CloseableIndex } from './build-index-in-temp-dir';
@@ -76,7 +77,7 @@ export async function buildProjectFileSnippetIndex(
   fileSearchResults: FileSearchResult[]
 ): Promise<ProjectFileSnippetIndex> {
   const snippetIndex = await buildIndexInTempDir('snippets', async (indexFile) => {
-    const db = new sqlite3(indexFile);
+    const db = new sqlite3.Database(indexFile);
     return await indexSnippets(db, fileSearchResults);
   });
 

--- a/packages/cli/src/rpc/search/search.ts
+++ b/packages/cli/src/rpc/search/search.ts
@@ -1,5 +1,7 @@
 import { isAbsolute, join } from 'path';
-import sqlite3 from 'better-sqlite3';
+
+import sqlite3 from 'node-sqlite3-wasm';
+
 import { FileIndex, generateSessionId } from '@appland/search';
 import { SearchRpc } from '@appland/rpc';
 
@@ -62,7 +64,7 @@ export async function handler(
     // Search across all AppMaps, creating a map from AppMap id to AppMapSearchResult
     const maxResults = options.maxDiagrams || options.maxResults || DEFAULT_MAX_DIAGRAMS;
     const index = await buildIndexInTempDir('appmaps', async (indexFile) => {
-      const db = new sqlite3(indexFile);
+      const db = new sqlite3.Database(indexFile);
       const fileIndex = new FileIndex(db);
       await buildAppMapIndex(
         fileIndex,

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -21,7 +21,6 @@
   "author": "AppLand, Inc",
   "license": "Commons Clause + MIT",
   "devDependencies": {
-    "@types/better-sqlite3": "^7.6.11",
     "@types/jest": "^29.5.4",
     "@types/node": "^16",
     "eslint": "^9",
@@ -39,8 +38,8 @@
     "typescript-eslint": "^8.11.0"
   },
   "dependencies": {
-    "better-sqlite3": "^11.5.0",
     "isbinaryfile": "^5.0.4",
+    "node-sqlite3-wasm": "^0.8.34",
     "yargs": "^17.7.2"
   }
 }

--- a/packages/search/src/cli.ts
+++ b/packages/search/src/cli.ts
@@ -1,7 +1,7 @@
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
-import sqlite3 from 'better-sqlite3';
 import makeDebug from 'debug';
+import sqlite3 from 'node-sqlite3-wasm';
 
 import { fileTokens } from './tokenize';
 import FileIndex from './file-index';
@@ -62,7 +62,7 @@ const cli = yargs(hideBin(process.argv))
         return !filterRE.test(path);
       };
 
-      const db = new sqlite3(':memory:');
+      const db = new sqlite3.Database(':memory:');
       const fileIndex = new FileIndex(db);
       const sessionId = generateSessionId();
 

--- a/packages/search/src/git.ts
+++ b/packages/search/src/git.ts
@@ -1,4 +1,4 @@
-import { exec as execCallback, spawn } from 'child_process';
+import { exec as execCallback, spawn } from 'node:child_process';
 import { PathLike } from 'fs';
 import { promisify } from 'util';
 

--- a/packages/search/src/snippet-index.ts
+++ b/packages/search/src/snippet-index.ts
@@ -1,5 +1,7 @@
 import assert from 'assert';
-import sqlite3 from 'better-sqlite3';
+
+import type sqlite3 from 'node-sqlite3-wasm';
+
 import { SessionId } from './session-id';
 
 const CREATE_SNIPPET_CONTENT_TABLE_SQL = `CREATE VIRTUAL TABLE snippet_content USING fts5(
@@ -115,14 +117,14 @@ type SnippetSearchRow = {
 export default class SnippetIndex {
   #insertSnippet: sqlite3.Statement;
   #updateSnippetBoost: sqlite3.Statement;
-  #deleteSession: sqlite3.Statement<[string]>;
-  #searchSnippet: sqlite3.Statement<[string, string, number]>;
+  #deleteSession: sqlite3.Statement;
+  #searchSnippet: sqlite3.Statement;
 
   constructor(public database: sqlite3.Database) {
     this.database.exec(CREATE_SNIPPET_CONTENT_TABLE_SQL);
     this.database.exec(CREATE_SNIPPET_BOOST_TABLE_SQL);
-    this.database.pragma('journal_mode = OFF');
-    this.database.pragma('synchronous = OFF');
+    this.database.exec('PRAGMA journal_mode = OFF');
+    this.database.exec('PRAGMA synchronous = OFF');
     this.#insertSnippet = this.database.prepare(INSERT_SNIPPET_SQL);
     this.#deleteSession = this.database.prepare(DELETE_SESSION_SQL);
     this.#updateSnippetBoost = this.database.prepare(UPDATE_SNIPPET_BOOST_SQL);
@@ -152,7 +154,7 @@ export default class SnippetIndex {
     words: string,
     content: string
   ): void {
-    this.#insertSnippet.run(encodeSnippetId(snippetId), directory, symbols, words, content);
+    this.#insertSnippet.run([encodeSnippetId(snippetId), directory, symbols, words, content]);
   }
 
   /**
@@ -162,11 +164,11 @@ export default class SnippetIndex {
    * @param boostFactor - The factor by which to boost the snippet's relevance.
    */
   boostSnippet(sessionId: SessionId, snippetId: SnippetId, boostFactor: number): void {
-    this.#updateSnippetBoost.run(sessionId, encodeSnippetId(snippetId), boostFactor);
+    this.#updateSnippetBoost.run([sessionId, encodeSnippetId(snippetId), boostFactor]);
   }
 
   searchSnippets(sessionId: SessionId, query: string, limit = 10): SnippetSearchResult[] {
-    const rows = this.#searchSnippet.all(sessionId, query, limit) as SnippetSearchRow[];
+    const rows = this.#searchSnippet.all([sessionId, query, limit]) as SnippetSearchRow[];
     return rows.map((row) => ({
       directory: row.directory,
       snippetId: parseSnippetId(row.snippet_id),

--- a/packages/search/test/file-index.spec.ts
+++ b/packages/search/test/file-index.spec.ts
@@ -1,5 +1,7 @@
 import { strict as assert } from 'assert';
-import sqlite3 from 'better-sqlite3';
+
+import sqlite3 from 'node-sqlite3-wasm';
+
 import FileIndex, { FileSearchResult } from '../src/file-index';
 import { generateSessionId, SessionId } from '../src/session-id';
 
@@ -16,7 +18,7 @@ describe('FileIndex', () => {
   const directory = 'src';
 
   beforeEach(() => {
-    db = new sqlite3(':memory:');
+    db = new sqlite3.Database(':memory:');
     index = new FileIndex(db);
     sessionId = generateSessionId();
   });

--- a/packages/search/test/snippet-index.spec.ts
+++ b/packages/search/test/snippet-index.spec.ts
@@ -1,5 +1,6 @@
 import { strict as assert } from 'assert';
-import sqlite3 from 'better-sqlite3';
+
+import sqlite3 from 'node-sqlite3-wasm';
 
 import SnippetIndex, {
   fileChunkSnippetId,
@@ -26,7 +27,7 @@ describe('SnippetIndex', () => {
   const snippet4: SnippetId = { type: 'code-snippet', id: 'test4.txt:31' };
 
   beforeEach(() => {
-    db = new sqlite3(':memory:');
+    db = new sqlite3.Database(':memory:');
     index = new SnippetIndex(db);
     sessionId = generateSessionId();
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -160,7 +160,6 @@ __metadata:
     "@octokit/types": ^11.1.0
     "@sidvind/better-ajv-errors": ^0.9.1
     "@swc/core": ^1.3.76
-    "@types/better-sqlite3": ^7.6.11
     "@types/cors": ^2.8.17
     "@types/fs-extra": ^9.0.13
     "@types/gitconfiglocal": ^2.0.1
@@ -182,7 +181,6 @@ __metadata:
     applicationinsights: ^2.1.4
     async: ^3.2.4
     axios: ^0.27.2
-    better-sqlite3: ^11.5.0
     body-parser: ^1.20.2
     boxen: ^5.0.1
     chalk: ^4.1.2
@@ -221,6 +219,7 @@ __metadata:
     minimatch: ^5.1.2
     moo: ^0.5.1
     node-fetch: 2.6.7
+    node-sqlite3-wasm: ^0.8.34
     open: ^8.2.1
     openapi-diff: ^0.23.6
     openapi-types: ^12.1.3
@@ -592,10 +591,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@appland/search@workspace:packages/search"
   dependencies:
-    "@types/better-sqlite3": ^7.6.11
     "@types/jest": ^29.5.4
     "@types/node": ^16
-    better-sqlite3: ^11.5.0
     eslint: ^9
     eslint-config-prettier: ^9
     eslint-plugin-eslint-comments: ^3.2.0
@@ -605,6 +602,7 @@ __metadata:
     eslint-plugin-promise: ^7.1.0
     isbinaryfile: ^5.0.4
     jest: ^29.7.0
+    node-sqlite3-wasm: ^0.8.34
     prettier: ^3.3.3
     ts-jest: ^29.2.5
     tsc: ^2.0.4
@@ -10670,15 +10668,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/better-sqlite3@npm:^7.6.11":
-  version: 7.6.11
-  resolution: "@types/better-sqlite3@npm:7.6.11"
-  dependencies:
-    "@types/node": "*"
-  checksum: 981740c78f97961bf1d8e78ed8bc841792cb25695afd9d920769d5b890d40ddf3724ace8a4db1adbf634c2f05c6efe3491ce9bf66818bacd93629ea060493546
-  languageName: node
-  linkType: hard
-
 "@types/body-parser@npm:*":
   version: 1.19.2
   resolution: "@types/body-parser@npm:1.19.2"
@@ -15898,17 +15887,6 @@ __metadata:
   dependencies:
     open: ^8.0.4
   checksum: 1471552fa7f733561e7f49e812be074b421153006ca744de985fb6d38939807959fc5fe9cb819cf09f864782e294704fd3b31711ea14c115baf3330a2f1135de
-  languageName: node
-  linkType: hard
-
-"better-sqlite3@npm:^11.5.0":
-  version: 11.5.0
-  resolution: "better-sqlite3@npm:11.5.0"
-  dependencies:
-    bindings: ^1.5.0
-    node-gyp: latest
-    prebuild-install: ^7.1.1
-  checksum: 37acef8d4272ad57fe211aa5a2e177f95443eafb794c7db6c2d0dae0a4fe4c2ef508b8b970d82f1d9744d009677d82067279f45e27d4155a5e68a578f5c5c051
   languageName: node
   linkType: hard
 
@@ -32664,6 +32642,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"node-sqlite3-wasm@npm:^0.8.34":
+  version: 0.8.34
+  resolution: "node-sqlite3-wasm@npm:0.8.34"
+  checksum: c6c9b2c75d714badaa41ac66a9ed6a30a718252d9259268bb96d899308aa9024c8766a0995c10e5225e7c57cc8c1483ef9279c3b6e97ddd45b6dba3af3e6e551
+  languageName: node
+  linkType: hard
+
 "non-layered-tidy-tree-layout@npm:^2.0.2":
   version: 2.0.2
   resolution: "non-layered-tidy-tree-layout@npm:2.0.2"
@@ -35373,28 +35358,6 @@ __metadata:
   bin:
     prebuild-install: bin.js
   checksum: dbf96d0146b6b5827fc8f67f72074d2e19c69628b9a7a0a17d0fad1bf37e9f06922896972e074197fc00a52eae912993e6ef5a0d471652f561df5cb516f3f467
-  languageName: node
-  linkType: hard
-
-"prebuild-install@npm:^7.1.1":
-  version: 7.1.2
-  resolution: "prebuild-install@npm:7.1.2"
-  dependencies:
-    detect-libc: ^2.0.0
-    expand-template: ^2.0.3
-    github-from-package: 0.0.0
-    minimist: ^1.2.3
-    mkdirp-classic: ^0.5.3
-    napi-build-utils: ^1.0.1
-    node-abi: ^3.3.0
-    pump: ^3.0.0
-    rc: ^1.2.7
-    simple-get: ^4.0.0
-    tar-fs: ^2.0.0
-    tunnel-agent: ^0.6.0
-  bin:
-    prebuild-install: bin.js
-  checksum: 543dadf8c60e004ae9529e6013ca0cbeac8ef38b5f5ba5518cb0b622fe7f8758b34e4b5cb1a791db3cdc9d2281766302df6088bd1a225f206925d6fee17d6c5c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This pull request replaces the `better-sqlite3` library with `node-sqlite3-wasm`.

Benefits:
- no need to recompile across Node versions and platforms,
- allows creating a single js bundle distribution in the future,
- avoids dynamic linking of the unsigned sqlite DLL which might trip up antivirus software.

Dependency updates:

* [`packages/cli/package.json`](diffhunk://#diff-6e2e2a1851648938b325ba84de634407a4e69a644ea61102df15ca4a8a7a9758L106): Removed `better-sqlite3` and added `node-sqlite3-wasm` as a dependency. [[1]](diffhunk://#diff-6e2e2a1851648938b325ba84de634407a4e69a644ea61102df15ca4a8a7a9758L106) [[2]](diffhunk://#diff-6e2e2a1851648938b325ba84de634407a4e69a644ea61102df15ca4a8a7a9758R133)
* [`packages/search/package.json`](diffhunk://#diff-a8d004b220907f6de1d22d818ca06350516584cd248956e8bdd5f169aefd342fL42-R43): Removed `better-sqlite3` and added `node-sqlite3-wasm` as a dependency.

Code modifications:

* Updated import statements to use `node-sqlite3-wasm` instead of `better-sqlite3` in multiple files. [[1]](diffhunk://#diff-d8fd67903cdfc50fe74d3f7d256d8ad4552b187ae1677ce4976352a0ce7a88f6R1-L2) [[2]](diffhunk://#diff-3c8bb5ef056f56cda3443680b7fa51dffa76fd2442238d60dbdb252428b19207L1-R1) [[3]](diffhunk://#diff-0d52e9e2650143c485d81d3d340977813be94a779de7d0480991a7a6d2d76239R1-R2) [[4]](diffhunk://#diff-b7e58484bf7f63109ff4ca97ea6459fbddde14ef6c7fa88f56334c6c6de887edL1-R1) [[5]](diffhunk://#diff-d1cd4a947766a671a76ff9b1fc5746714356941bb66451a4d0254b2616ea3499L1-R2) [[6]](diffhunk://#diff-9abb25909d7b6fffee5de3188ff44fe2b7274e60166d2466af119115a7f10378L1-R2) [[7]](diffhunk://#diff-7a0eae5ac20d49798f3ee375e322078243b313e4058e37498203b231b4c6c59bL2-R4) [[8]](diffhunk://#diff-940de0c3b853587c4f73e1e9a70765dcadaa994d79a8a9738a98a66f466401c5L3-R4) [[9]](diffhunk://#diff-7613ce73fb9c6ef1241cfc7440ca305f2d85d752545fcbd5ec5b6e637831e13dL1-R2) [[10]](diffhunk://#diff-f9101babe675011ce7d8dc59c9e632866dd70641140285c6402d4b8b4bb9324aL2-R4)
* Changed the instantiation of the SQLite database from `new sqlite3(indexFile)` to `new sqlite3.Database(indexFile)` in several functions. [[1]](diffhunk://#diff-d8fd67903cdfc50fe74d3f7d256d8ad4552b187ae1677ce4976352a0ce7a88f6L189-R189) [[2]](diffhunk://#diff-b7e58484bf7f63109ff4ca97ea6459fbddde14ef6c7fa88f56334c6c6de887edL13-R13) [[3]](diffhunk://#diff-d1cd4a947766a671a76ff9b1fc5746714356941bb66451a4d0254b2616ea3499L74-R74) [[4]](diffhunk://#diff-9abb25909d7b6fffee5de3188ff44fe2b7274e60166d2466af119115a7f10378L79-R80) [[5]](diffhunk://#diff-7a0eae5ac20d49798f3ee375e322078243b313e4058e37498203b231b4c6c59bL65-R67) [[6]](diffhunk://#diff-940de0c3b853587c4f73e1e9a70765dcadaa994d79a8a9738a98a66f466401c5L65-R65)
* Adjusted method calls and parameters to match the new library's API, including changes to `prepare` and `run` methods in `FileIndex` and `SnippetIndex` classes. [[1]](diffhunk://#diff-7613ce73fb9c6ef1241cfc7440ca305f2d85d752545fcbd5ec5b6e637831e13dL77-R93) [[2]](diffhunk://#diff-7613ce73fb9c6ef1241cfc7440ca305f2d85d752545fcbd5ec5b6e637831e13dL102-R103) [[3]](diffhunk://#diff-7613ce73fb9c6ef1241cfc7440ca305f2d85d752545fcbd5ec5b6e637831e13dL121-R122) [[4]](diffhunk://#diff-f9101babe675011ce7d8dc59c9e632866dd70641140285c6402d4b8b4bb9324aL118-R127) [[5]](diffhunk://#diff-f9101babe675011ce7d8dc59c9e632866dd70641140285c6402d4b8b4bb9324aL155-R157) [[6]](diffhunk://#diff-f9101babe675011ce7d8dc59c9e632866dd70641140285c6402d4b8b4bb9324aL165-R171)

These changes ensure compatibility with the new SQLite library and maintain the functionality of the existing codebase.