### PR TITLE
Improving generation consistency

### DIFF
--- a/packages/cli/src/rpc/explain/explain.ts
+++ b/packages/cli/src/rpc/explain/explain.ts
@@ -27,6 +27,7 @@ import INavie, { INavieProvider } from './navie/inavie';
 import reportFetchError from './navie/report-fetch-error';
 import Thread from './navie/thread';
 import handleReview from './review';
+import { normalizePath } from './location';
 
 const searchStatusByUserMessageId = new Map<string, ExplainRpc.ExplainStatusResponse>();
 
@@ -388,7 +389,7 @@ const explainHandler: (
           userContext = options.codeSelection.map((cs) => {
             return {
               type: cs.type,
-              location: cs.location,
+              location: cs.location ? normalizePath(cs.location) : undefined,
               content: cs.content,
             } as UserContext.ContextItem;
           });

--- a/packages/cli/src/rpc/explain/location.ts
+++ b/packages/cli/src/rpc/explain/location.ts
@@ -1,7 +1,7 @@
 import { warn } from 'node:console';
 import { platform } from 'node:os';
 
-function normalizePath(location: string): string {
+export function normalizePath(location: string): string {
   if (platform() !== 'win32') return location;
 
   // This fixes up a few issues observed with Windows paths:

--- a/packages/navie/src/agents/diagram-agent.ts
+++ b/packages/navie/src/agents/diagram-agent.ts
@@ -1,7 +1,7 @@
 import { Agent, AgentOptions } from '../agent';
 import InteractionHistory, { PromptInteractionEvent } from '../interaction-history';
 import MermaidFilter from '../lib/mermaid-filter';
-import { PROMPTS, PromptType } from '../prompt';
+import { buildPromptValue, PROMPTS, PromptType } from '../prompt';
 import ContextService from '../services/context-service';
 import MermaidFixerService from '../services/mermaid-fixer-service';
 import { DIAGRAM_FORMAT_PROMPT } from './explain-agent';
@@ -17,6 +17,8 @@ Your job is to generate software diagrams based on a description provided by the
 The user is an experienced software developer who will review the diagrams you generate, and use them
 to understand the code and design code solutions. You can expect the user to be proficient in software development.
 `;
+
+const DEFAULT_QUESTION = 'Create a diagram from the information available.';
 
 export default class DiagramAgent implements Agent {
   public temperature = undefined;
@@ -53,6 +55,8 @@ export default class DiagramAgent implements Agent {
   }
 
   applyQuestionPrompt(question: string): void {
-    this.history.addEvent(new PromptInteractionEvent(PromptType.Question, 'user', question));
+    this.history.addEvent(
+      new PromptInteractionEvent(PromptType.Question, 'user', question.trim() || DEFAULT_QUESTION)
+    );
   }
 }

--- a/packages/navie/src/agents/generate-agent.ts
+++ b/packages/navie/src/agents/generate-agent.ts
@@ -4,6 +4,7 @@ import { PromptType, buildPromptDescriptor, buildPromptValue } from '../prompt';
 import ContextService from '../services/context-service';
 import FileChangeExtractorService from '../services/file-change-extractor-service';
 import FileContentFetcher from '../services/file-content-fetcher';
+import splitOn from '../lib/split-on';
 
 export const GENERATE_AGENT_PROMPT = `**Task: Generation of Code**
 
@@ -216,34 +217,6 @@ export default class GenerateAgent implements Agent {
   filter = filterXmlFencesAroundChangesets;
 }
 
-/**
- * Split haystack on the first occurence of needle (or partial needle at the suffix)
- * @example splitOn("abc---def", "---") // ["abc", "---", "def"]
- * @example splitOn("abc--", "---") // ["abc", "--", ""]
- * @example splitOn("abc", "---") // ["abc", "", ""]
- * @example splitOn("abc---def---ghi", "---") // ["abc", "---", "def---ghi"]
- * @example splitOn("abc---def---ghi", "--") // ["abc", "--", "-def---ghi"]
- * @example splitOn("abc-def-ghi", "---") // ["abc-def-ghi", "", ""]
- * @example splitOn("abc-def-ghi", "def") // ["abc-", "def", "-ghi"]
- * @param haystack the string to split
- * @param needle the string to split on
- * @returns an array of strings
- */
-export function splitOn(haystack: string, needle: string): [string, string, string] {
-  let needleIdx = 0;
-  let haystackIdx = 0;
-  while (needleIdx < needle.length && haystackIdx < haystack.length) {
-    if (haystack[haystackIdx] === needle[needleIdx]) needleIdx++;
-    else needleIdx = 0;
-    haystackIdx++;
-  }
-  return [
-    haystack.slice(0, haystackIdx - needleIdx),
-    haystack.slice(haystackIdx - needleIdx, haystackIdx),
-    haystack.slice(haystackIdx),
-  ];
-}
-
 // Some models (looking at you Gemini) REALLY like markdown fences.
 // Let's make sure to filter them out around the changesets.
 export async function* filterXmlFencesAroundChangesets(
@@ -251,13 +224,12 @@ export async function* filterXmlFencesAroundChangesets(
 ): AsyncIterable<string> {
   let buffer = '';
   let outside = true;
+  const fenceRegex = /```[a-z]*?\n<change>/;
+  const endFenceRegex = /<\/change>\n```/;
   for await (const chunk of stream) {
     buffer += chunk;
     while (buffer) {
-      const [before, fence, after] = splitOn(
-        buffer,
-        outside ? '```xml\n<change>' : '</change>\n```'
-      );
+      const [before, fence, after] = splitOn(buffer, outside ? fenceRegex : endFenceRegex);
       yield before;
       if (fence) {
         if (after) {

--- a/packages/navie/src/agents/plan-agent.ts
+++ b/packages/navie/src/agents/plan-agent.ts
@@ -73,6 +73,10 @@ Example:
 * DO NOT output code blocks or fenced code. Output only a text description of the suggested
   changes, along with the file names.
 `;
+
+/** Default problem statement used when the user hasn't provided any (for example relying on pinned content). */
+const DEFAULT_PROBLEM_STATEMENT = 'What is the best way to solve this problem?';
+
 export class PlanAgent implements Agent {
   public readonly temperature = undefined;
 
@@ -104,7 +108,7 @@ export class PlanAgent implements Agent {
       new PromptInteractionEvent(
         PromptType.ProblemStatement,
         'user',
-        buildPromptValue(PromptType.ProblemStatement, question)
+        buildPromptValue(PromptType.ProblemStatement, question.trim() || DEFAULT_PROBLEM_STATEMENT)
       )
     );
   }

--- a/packages/navie/src/agents/plan-agent.ts
+++ b/packages/navie/src/agents/plan-agent.ts
@@ -46,10 +46,10 @@ For a bug, explain the root cause of the bug, and how the logic should be change
 
 For a feature, describe the components of the new functionality, and the role of each one.
 
-* **Proposed Changes** This section suggests which files and components should be changed in order to
+* **Proposed Changes** This section suggests which files should be changed in order to
 solve the issue.
 
-With reference to files and / or modules, explain how the code should be modified to solve the issue.
+With reference to files, explain how the code should be modified to solve the issue.
 
 DO NOT generate code.
 
@@ -63,6 +63,8 @@ Example:
 
 * DO provide a detailed description of the necessary changes.
 * DO suggest changes to existing, non-test code files.
+* DO enumerate the changes per file, providing a path relative to the project root.
+* DO NOT reference files without their path.
 * DO NOT include a code snippet.
 * DO NOT GENERATE CODE.
 * DO NOT design changes to test cases.

--- a/packages/navie/src/commands/explain-command.ts
+++ b/packages/navie/src/commands/explain-command.ts
@@ -108,7 +108,9 @@ export default class ExplainCommand implements Command {
     ];
     if (codeSelection) {
       const rendered =
-        typeof codeSelection !== 'string' ? UserContext.renderItems(codeSelection) : codeSelection;
+        typeof codeSelection !== 'string'
+          ? UserContext.renderItems(codeSelection, { interactionHistory: this.interactionHistory })
+          : codeSelection;
       aggregateQuestion.push(rendered);
     }
 

--- a/packages/navie/src/interaction-history.ts
+++ b/packages/navie/src/interaction-history.ts
@@ -256,6 +256,12 @@ export class ContextItemEvent extends InteractionEvent {
   }
 
   updateState(state: InteractionState) {
+    if (this.requestor === ContextItemRequestor.PinnedFile) {
+      // There's no need to include the content of pinned files in the system prompt.
+      // It'll automatically be included in the user prompt.
+      return;
+    }
+
     const content = [
       [
         `<${this.promptPrefix}`,

--- a/packages/navie/src/lib/split-on.ts
+++ b/packages/navie/src/lib/split-on.ts
@@ -1,0 +1,76 @@
+/**
+ * Split haystack on the first occurence of needle (or partial needle at the suffix)
+ * @example splitOn("abc---def", "---") // ["abc", "---", "def"]
+ * @example splitOn("abc--", "---") // ["abc", "--", ""]
+ * @example splitOn("abc", "---") // ["abc", "", ""]
+ * @example splitOn("abc---def---ghi", "---") // ["abc", "---", "def---ghi"]
+ * @example splitOn("abc---def---ghi", "--") // ["abc", "--", "-def---ghi"]
+ * @example splitOn("abc-def-ghi", "---") // ["abc-def-ghi", "", ""]
+ * @example splitOn("abc-def-ghi", "def") // ["abc-", "def", "-ghi"]
+ * @example splitOn("abc-def-ghi", /-.*-/) // ["abc", "-def-", "ghi"]
+ * @example splitOn("abc-de", /-.*-/) // ["abc", "-de", ""]
+ * @param haystack the string to split
+ * @param needle the string or regex to split on
+ * @note only some regex features are supported
+ * @returns an array of strings
+ */
+export default function splitOn(
+  haystack: string,
+  needle: string | RegExp
+): [string, string, string] {
+  const re = new RegExp(`^(.*?)(${toPrefixRegexSource(needle)})(.*)$`, 's');
+  const match = re.exec(haystack);
+  if (!match) return [haystack, '', ''];
+  return [match[1], match[2], match[3]];
+}
+
+/** Return a regex matching the needle or any nonempty prefix.
+ * @note this is done by parsing the regex and currently only some regex features are supported.
+ */
+function toPrefixRegexSource(needle: string | RegExp): string {
+  const re = (typeof needle === 'string' ? regexpQuote(needle) : needle).source;
+
+  let result = '';
+
+  for (let i = 0; i < re.length; i++) {
+    let literal = re[i];
+    switch (literal) {
+      case '\\':
+        literal += re[++i];
+        break;
+      case '[': {
+        // note: this is naive and will break on escaped ]
+        const end = re.indexOf(']', i);
+        if (end === -1) throw new Error('Missing ]');
+        literal = re.slice(i, end + 1);
+        i = end;
+        break;
+      }
+      case '+':
+      case '*':
+      case '?':
+      case '^':
+      case '$':
+        result += literal;
+        continue;
+      case '(':
+      case ')':
+      case ']':
+      case '{':
+      case '}':
+      case '|':
+        throw new Error(`Unsupported regex feature: ${literal}`);
+      case '.':
+      default:
+      // pass
+    }
+    result += `(?:${literal}|$)`;
+  }
+
+  return result;
+}
+
+/** Make a regex matching the given literal string. */
+function regexpQuote(literal: string): RegExp {
+  return new RegExp(literal.replaceAll(/[-[\]{}()*+!<=:?.\/\\^$|#\s,]/g, '\\$&'));
+}

--- a/packages/navie/src/services/code-selection-service.ts
+++ b/packages/navie/src/services/code-selection-service.ts
@@ -17,7 +17,9 @@ export default class CodeSelectionService {
 
   applyCodeSelection(userContext: string | UserContext.ContextItem[]) {
     const renderedContext: string =
-      typeof userContext !== 'string' ? UserContext.renderItems(userContext) : userContext;
+      typeof userContext !== 'string'
+        ? UserContext.renderItems(userContext, { interactionHistory: this.interactionHistory })
+        : userContext;
 
     this.interactionHistory.addEvent(
       new PromptInteractionEvent(

--- a/packages/navie/src/services/file-change-extractor-service.ts
+++ b/packages/navie/src/services/file-change-extractor-service.ts
@@ -137,7 +137,7 @@ ${content}
     if (clientRequest.codeSelection) {
       const codeSelection =
         typeof clientRequest.codeSelection !== 'string'
-          ? UserContext.renderItems(clientRequest.codeSelection, false)
+          ? UserContext.renderItems(clientRequest.codeSelection, { includeContent: false })
           : clientRequest.codeSelection;
 
       history.push({

--- a/packages/navie/test/agents/plan-agent.spec.ts
+++ b/packages/navie/test/agents/plan-agent.spec.ts
@@ -1,0 +1,27 @@
+import { PlanAgent } from '../../src/agents/plan-agent';
+
+import InteractionHistory from '../../src/interaction-history';
+
+describe('PlanAgent', () => {
+  let interactionHistory: InteractionHistory;
+
+  beforeEach(() => {
+    interactionHistory = new InteractionHistory();
+  });
+
+  it('should handle empty question', () => {
+    const planAgent = new PlanAgent(interactionHistory, null as never);
+    planAgent.applyQuestionPrompt('');
+    expect(interactionHistory.events[0]).toMatchInlineSnapshot(`
+      PromptInteractionEvent {
+        "content": "<problem-statement>
+      What is the best way to solve this problem?
+      </problem-statement>",
+        "name": "problemStatement",
+        "prefix": undefined,
+        "role": "user",
+        "type": "prompt",
+      }
+    `);
+  });
+});

--- a/packages/navie/test/integration/pinned-items.spec.ts
+++ b/packages/navie/test/integration/pinned-items.spec.ts
@@ -1,0 +1,125 @@
+import { mkdtemp, readFile, rm, writeFile } from 'fs/promises';
+import { ContextV2, Message, UserContext } from '../../src';
+import { default as navieFactory, NavieOptions } from '../../src/navie';
+import { dirname, join } from 'path';
+import { tmpdir } from 'os';
+import * as completionServiceFactory from '../../src/services/completion-service-factory';
+
+jest.mock('../../src/services/completion-service-factory', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock('console', () => ({
+  warn: jest.fn(),
+  log: jest.fn(),
+  error: jest.fn(),
+}));
+
+describe('Pinned items', () => {
+  let contextProvider: jest.Mock;
+  let projectInfoProvider: jest.Mock;
+  let helpProvider: jest.Mock;
+  let completionService: { model: string; json: jest.Mock; complete: jest.Mock };
+  let tmpDir: string;
+  let pinnedFilePath: string;
+  const pinnedFileContent = 'Hello from a pinned file';
+
+  beforeEach(async () => {
+    jest.resetAllMocks();
+    completionService = {
+      model: 'mock',
+      json: jest.fn().mockResolvedValue({}),
+      complete: jest.fn().mockImplementation(function* () {
+        yield 'completion';
+      }),
+    };
+    (completionServiceFactory.default as jest.Mock).mockReturnValue(completionService);
+    contextProvider = jest.fn().mockImplementation(async (req: ContextV2.ContextRequest) => {
+      if (req.locations) {
+        const fullTextLocations = await Promise.all(
+          req.locations.map(async (location) => {
+            const filePath = location.replace(':0', '');
+            if (!filePath) return undefined;
+
+            const content = await readFile(filePath, 'utf8');
+            return {
+              type: ContextV2.ContextItemType.CodeSnippet,
+              content,
+              location,
+              directory: dirname(location),
+            };
+          })
+        );
+        return fullTextLocations.filter(Boolean);
+      }
+      return [];
+    });
+    projectInfoProvider = jest.fn();
+    helpProvider = jest.fn();
+    tmpDir = await mkdtemp(join(tmpdir(), 'pinned-items-spec-'));
+    pinnedFilePath = join(tmpDir, 'pinned-file.ts');
+    await writeFile(pinnedFilePath, pinnedFileContent);
+
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  const invokeNavie = async (
+    question: string,
+    pinnedItems: UserContext.FileItem[] = [],
+    chatHistory: Message[] = []
+  ) => {
+    const completion = navieFactory(
+      { question, codeSelection: pinnedItems },
+      contextProvider,
+      projectInfoProvider,
+      helpProvider,
+      new NavieOptions(),
+      chatHistory
+    ).execute();
+    let buffer = '';
+    for await (const chunk of completion) buffer += chunk;
+    return buffer;
+  };
+
+  const expectMessageContains = (role: 'user' | 'assistant' | 'system', partialContent: string) =>
+    expect(completionService.complete).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({
+          role,
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          content: expect.stringContaining(partialContent),
+        }),
+      ]),
+      expect.anything()
+    );
+
+  const expectMessageNotContains = (
+    role: 'user' | 'assistant' | 'system',
+    partialContent: string
+  ) =>
+    completionService.complete.mock.calls.forEach(([messages]: Message[][]) =>
+      messages.forEach((message: Message) => {
+        if (message.role === role) {
+          expect(message.content).not.toContain(partialContent);
+        }
+      })
+    );
+  describe('@explain', () => {
+    // eslint-disable-next-line jest/expect-expect
+    it('renders pinned items to the user message', async () => {
+      const question = 'analyze this';
+      await invokeNavie(question, [{ type: 'file', location: pinnedFilePath }]);
+      expectMessageContains('user', pinnedFileContent);
+      expectMessageContains('user', pinnedFilePath);
+      expectMessageContains('user', question);
+      expectMessageNotContains('system', pinnedFileContent);
+    });
+  });
+});

--- a/packages/navie/test/lib/split-on.spec.ts
+++ b/packages/navie/test/lib/split-on.spec.ts
@@ -1,0 +1,48 @@
+import splitOn from '../../src/lib/split-on';
+
+describe('splitOn', () => {
+  it('splits on exact match', () => {
+    const result = splitOn('abc---def', '---');
+    expect(result).toEqual(['abc', '---', 'def']);
+  });
+
+  it('splits on partial match at suffix', () => {
+    const result = splitOn('abc--', '---');
+    expect(result).toEqual(['abc', '--', '']);
+  });
+
+  it('splits when needle is not found', () => {
+    const result = splitOn('abc', '---');
+    expect(result).toEqual(['abc', '', '']);
+  });
+
+  it('splits on first occurrence of needle', () => {
+    const result = splitOn('abc---def---ghi', '---');
+    expect(result).toEqual(['abc', '---', 'def---ghi']);
+  });
+
+  it('splits on match within string', () => {
+    const result = splitOn('abc---def---ghi', '--');
+    expect(result).toEqual(['abc', '--', '-def---ghi']);
+  });
+
+  it('returns entire string if needle is not found', () => {
+    const result = splitOn('abc-def-ghi', '---');
+    expect(result).toEqual(['abc-def-ghi', '', '']);
+  });
+
+  it('splits on exact match within string', () => {
+    const result = splitOn('abc-def-ghi', 'def');
+    expect(result).toEqual(['abc-', 'def', '-ghi']);
+  });
+
+  it('splits on regex match', () => {
+    const result = splitOn('abc-def-ghi', /-[def]+-/);
+    expect(result).toEqual(['abc', '-def-', 'ghi']);
+  });
+
+  it('splits on partial regex match', () => {
+    const result = splitOn('abc-de', /-.*-/);
+    expect(result).toEqual(['abc', '-de', '']);
+  });
+});


### PR DESCRIPTION
1. Pinned items are now presented solely in the user context. Previously they were split between user and system context, where a path to the file would be presented in user context but the actual contents were written to the system context. It'd be up to the LLM to make the association.
2. Some changes to the `@plan` prompt to nudge it more towards presenting relative file paths in the plan output. With gpt-4o, plan would often only include a basename or an identifier found in the code.
3. User selected context paths are now normalized on ingress so that they don't need to be spot fixed where ever we're comparing paths internally.
4. Some additional logging is added to help troubleshoot cases where Navie becomes unresponsive
5. `@diagram` now has a default prompt. Without user input, some models would tend to completely ignore the system prompt.