### PR TITLE
Provide default prompt for empty questions in PlanAgent

### DIFF
--- a/packages/navie/src/agents/plan-agent.ts
+++ b/packages/navie/src/agents/plan-agent.ts
@@ -71,6 +71,10 @@ Example:
 * DO NOT output code blocks or fenced code. Output only a text description of the suggested
   changes, along with the file names.
 `;
+
+/** Default problem statement used when the user hasn't provided any (for example relying on pinned content). */
+const DEFAULT_PROBLEM_STATEMENT = 'What is the best way to solve this problem?';
+
 export class PlanAgent implements Agent {
   public readonly temperature = undefined;
 
@@ -102,7 +106,7 @@ export class PlanAgent implements Agent {
       new PromptInteractionEvent(
         PromptType.ProblemStatement,
         'user',
-        buildPromptValue(PromptType.ProblemStatement, question)
+        buildPromptValue(PromptType.ProblemStatement, question.trim() || DEFAULT_PROBLEM_STATEMENT)
       )
     );
   }

--- a/packages/navie/test/agents/plan-agent.spec.ts
+++ b/packages/navie/test/agents/plan-agent.spec.ts
@@ -1,0 +1,27 @@
+import { PlanAgent } from '../../src/agents/plan-agent';
+
+import InteractionHistory from '../../src/interaction-history';
+
+describe('PlanAgent', () => {
+  let interactionHistory: InteractionHistory;
+
+  beforeEach(() => {
+    interactionHistory = new InteractionHistory();
+  });
+
+  it('should handle empty question', () => {
+    const planAgent = new PlanAgent(interactionHistory, null as never);
+    planAgent.applyQuestionPrompt('');
+    expect(interactionHistory.events[0]).toMatchInlineSnapshot(`
+      PromptInteractionEvent {
+        "content": "<problem-statement>
+      What is the best way to solve this problem?
+      </problem-statement>",
+        "name": "problemStatement",
+        "prefix": undefined,
+        "role": "user",
+        "type": "prompt",
+      }
+    `);
+  });
+});


### PR DESCRIPTION
Introduce a default problem statement for the PlanAgent when no user input is provided, ensuring a consistent response in such cases. Add a test to verify this behavior.