### PR TITLE
Strip non-XML fences on changesets

### DIFF
--- a/packages/navie/src/agents/generate-agent.ts
+++ b/packages/navie/src/agents/generate-agent.ts
@@ -4,6 +4,7 @@ import { PromptType, buildPromptDescriptor, buildPromptValue } from '../prompt';
 import ContextService from '../services/context-service';
 import FileChangeExtractorService from '../services/file-change-extractor-service';
 import FileContentFetcher from '../services/file-content-fetcher';
+import splitOn from '../lib/split-on';
 
 export const GENERATE_AGENT_PROMPT = `**Task: Generation of Code**
 
@@ -216,34 +217,6 @@ export default class GenerateAgent implements Agent {
   filter = filterXmlFencesAroundChangesets;
 }
 
-/**
- * Split haystack on the first occurence of needle (or partial needle at the suffix)
- * @example splitOn("abc---def", "---") // ["abc", "---", "def"]
- * @example splitOn("abc--", "---") // ["abc", "--", ""]
- * @example splitOn("abc", "---") // ["abc", "", ""]
- * @example splitOn("abc---def---ghi", "---") // ["abc", "---", "def---ghi"]
- * @example splitOn("abc---def---ghi", "--") // ["abc", "--", "-def---ghi"]
- * @example splitOn("abc-def-ghi", "---") // ["abc-def-ghi", "", ""]
- * @example splitOn("abc-def-ghi", "def") // ["abc-", "def", "-ghi"]
- * @param haystack the string to split
- * @param needle the string to split on
- * @returns an array of strings
- */
-export function splitOn(haystack: string, needle: string): [string, string, string] {
-  let needleIdx = 0;
-  let haystackIdx = 0;
-  while (needleIdx < needle.length && haystackIdx < haystack.length) {
-    if (haystack[haystackIdx] === needle[needleIdx]) needleIdx++;
-    else needleIdx = 0;
-    haystackIdx++;
-  }
-  return [
-    haystack.slice(0, haystackIdx - needleIdx),
-    haystack.slice(haystackIdx - needleIdx, haystackIdx),
-    haystack.slice(haystackIdx),
-  ];
-}
-
 // Some models (looking at you Gemini) REALLY like markdown fences.
 // Let's make sure to filter them out around the changesets.
 export async function* filterXmlFencesAroundChangesets(
@@ -251,13 +224,12 @@ export async function* filterXmlFencesAroundChangesets(
 ): AsyncIterable<string> {
   let buffer = '';
   let outside = true;
+  const fenceRegex = /```[a-z]*?\n<change>/;
+  const endFenceRegex = /<\/change>\n```/;
   for await (const chunk of stream) {
     buffer += chunk;
     while (buffer) {
-      const [before, fence, after] = splitOn(
-        buffer,
-        outside ? '```xml\n<change>' : '</change>\n```'
-      );
+      const [before, fence, after] = splitOn(buffer, outside ? fenceRegex : endFenceRegex);
       yield before;
       if (fence) {
         if (after) {

--- a/packages/navie/src/lib/split-on.ts
+++ b/packages/navie/src/lib/split-on.ts
@@ -1,0 +1,76 @@
+/**
+ * Split haystack on the first occurence of needle (or partial needle at the suffix)
+ * @example splitOn("abc---def", "---") // ["abc", "---", "def"]
+ * @example splitOn("abc--", "---") // ["abc", "--", ""]
+ * @example splitOn("abc", "---") // ["abc", "", ""]
+ * @example splitOn("abc---def---ghi", "---") // ["abc", "---", "def---ghi"]
+ * @example splitOn("abc---def---ghi", "--") // ["abc", "--", "-def---ghi"]
+ * @example splitOn("abc-def-ghi", "---") // ["abc-def-ghi", "", ""]
+ * @example splitOn("abc-def-ghi", "def") // ["abc-", "def", "-ghi"]
+ * @example splitOn("abc-def-ghi", /-.*-/) // ["abc", "-def-", "ghi"]
+ * @example splitOn("abc-de", /-.*-/) // ["abc", "-de", ""]
+ * @param haystack the string to split
+ * @param needle the string or regex to split on
+ * @note only some regex features are supported
+ * @returns an array of strings
+ */
+export default function splitOn(
+  haystack: string,
+  needle: string | RegExp
+): [string, string, string] {
+  const re = new RegExp(`^(.*?)(${toPrefixRegexSource(needle)})(.*)$`, 's');
+  const match = re.exec(haystack);
+  if (!match) return [haystack, '', ''];
+  return [match[1], match[2], match[3]];
+}
+
+/** Return a regex matching the needle or any nonempty prefix.
+ * @note this is done by parsing the regex and currently only some regex features are supported.
+ */
+function toPrefixRegexSource(needle: string | RegExp): string {
+  const re = (typeof needle === 'string' ? regexpQuote(needle) : needle).source;
+
+  let result = '';
+
+  for (let i = 0; i < re.length; i++) {
+    let literal = re[i];
+    switch (literal) {
+      case '\\':
+        literal += re[++i];
+        break;
+      case '[': {
+        // note: this is naive and will break on escaped ]
+        const end = re.indexOf(']', i);
+        if (end === -1) throw new Error('Missing ]');
+        literal = re.slice(i, end + 1);
+        i = end;
+        break;
+      }
+      case '+':
+      case '*':
+      case '?':
+      case '^':
+      case '$':
+        result += literal;
+        continue;
+      case '(':
+      case ')':
+      case ']':
+      case '{':
+      case '}':
+      case '|':
+        throw new Error(`Unsupported regex feature: ${literal}`);
+      case '.':
+      default:
+      // pass
+    }
+    result += `(?:${literal}|$)`;
+  }
+
+  return result;
+}
+
+/** Make a regex matching the given literal string. */
+function regexpQuote(literal: string): RegExp {
+  return new RegExp(literal.replaceAll(/[-[\]{}()*+!<=:?.\/\\^$|#\s,]/g, '\\$&'));
+}

--- a/packages/navie/test/lib/split-on.spec.ts
+++ b/packages/navie/test/lib/split-on.spec.ts
@@ -1,0 +1,48 @@
+import splitOn from '../../src/lib/split-on';
+
+describe('splitOn', () => {
+  it('splits on exact match', () => {
+    const result = splitOn('abc---def', '---');
+    expect(result).toEqual(['abc', '---', 'def']);
+  });
+
+  it('splits on partial match at suffix', () => {
+    const result = splitOn('abc--', '---');
+    expect(result).toEqual(['abc', '--', '']);
+  });
+
+  it('splits when needle is not found', () => {
+    const result = splitOn('abc', '---');
+    expect(result).toEqual(['abc', '', '']);
+  });
+
+  it('splits on first occurrence of needle', () => {
+    const result = splitOn('abc---def---ghi', '---');
+    expect(result).toEqual(['abc', '---', 'def---ghi']);
+  });
+
+  it('splits on match within string', () => {
+    const result = splitOn('abc---def---ghi', '--');
+    expect(result).toEqual(['abc', '--', '-def---ghi']);
+  });
+
+  it('returns entire string if needle is not found', () => {
+    const result = splitOn('abc-def-ghi', '---');
+    expect(result).toEqual(['abc-def-ghi', '', '']);
+  });
+
+  it('splits on exact match within string', () => {
+    const result = splitOn('abc-def-ghi', 'def');
+    expect(result).toEqual(['abc-', 'def', '-ghi']);
+  });
+
+  it('splits on regex match', () => {
+    const result = splitOn('abc-def-ghi', /-[def]+-/);
+    expect(result).toEqual(['abc', '-def-', 'ghi']);
+  });
+
+  it('splits on partial regex match', () => {
+    const result = splitOn('abc-de', /-.*-/);
+    expect(result).toEqual(['abc', '-de', '']);
+  });
+});


### PR DESCRIPTION
Models that mix languages sometimes generate non-XML fences around changesets. This update filters out these fences to ensure proper rendering.

Fixes #2248