### PR TITLE
feat: Replace LLM configuration with model selector

### DIFF
--- a/packages/cli/src/cmds/index/rpc.ts
+++ b/packages/cli/src/cmds/index/rpc.ts
@@ -34,6 +34,11 @@ import { join } from 'path';
 import { homedir } from 'os';
 import { navieWelcomeV2 } from '../../rpc/navie/welcome';
 import { navieRegisterV1 } from '../../rpc/navie/register';
+import ModelRegistry from '../../rpc/navie/models/registry';
+import { navieModelsAddV1 } from '../../rpc/navie/models/handlers/add';
+import { navieModelsListV1 } from '../../rpc/navie/models/handlers/list';
+import { navieModelsSelectV1 } from '../../rpc/navie/models/handlers/select';
+import { navieModelsGetConfigV1 } from '../../rpc/navie/models/handlers/getConfig';
 
 export const command = 'rpc';
 export const describe = 'Run AppMap JSON-RPC server';
@@ -77,12 +82,20 @@ export function rpcMethods(navie: INavieProvider, codeEditor?: string): RpcHandl
     navieSuggestHandlerV1(navie),
     navieWelcomeV2(navie),
     navieRegisterV1(codeEditor),
+    navieModelsAddV1(),
+    navieModelsListV1(),
+    navieModelsSelectV1(),
+    navieModelsGetConfigV1(),
   ];
 }
 
 export const handler = async (argv: HandlerArguments) => {
   observePerformance();
   verbose(argv.verbose);
+
+  ModelRegistry.instance.refresh().catch((e) => {
+    console.error(`failed to intialize model registry: ${String(e)}`);
+  });
 
   const navie = buildNavieProvider(argv);
   let codeEditor: string | undefined = argv.codeEditor;

--- a/packages/cli/src/rpc/explain/navie/navie-local.ts
+++ b/packages/cli/src/rpc/explain/navie/navie-local.ts
@@ -18,6 +18,7 @@ import assert from 'assert';
 import { initializeHistory, loadThread } from './historyHelper';
 import { THREAD_ID_REGEX } from './history';
 import Trajectory from './trajectory';
+import ModelRegistry from '../../navie/models/registry';
 
 const OPTION_SETTERS: Record<
   string,
@@ -147,7 +148,8 @@ export default class LocalNavie extends EventEmitter implements INavie {
         this.projectInfoProvider,
         this.helpProvider,
         this.navieOptions,
-        thread.messages
+        thread.messages,
+        ModelRegistry.instance.selectedModel
       );
 
       let agentName: string | undefined;

--- a/packages/cli/src/rpc/navie/isCustomWelcomeMessageEnabled.ts
+++ b/packages/cli/src/rpc/navie/isCustomWelcomeMessageEnabled.ts
@@ -1,5 +1,18 @@
+import ModelRegistry from './models/registry';
+
 export default function isCustomWelcomeMessageEnabled(): boolean {
   // This behavior is DEFAULT ON, but can be disabled by setting the environment variable
-  // NAVIE_CUSTOM_WELCOME_MESSAGE=false. Any other value will be treated as true.
-  return process.env.NAVIE_CUSTOM_WELCOME_MESSAGE !== 'false';
+  // NAVIE_CUSTOM_WELCOME_MESSAGE=false.
+  if (process.env.NAVIE_CUSTOM_WELCOME_MESSAGE === 'false') {
+    return false;
+  }
+
+  // If the model selector is available, the custom message can only be rendered if a model is
+  // selected.
+  if (process.env.APPMAP_NAVIE_MODEL_SELECTOR) {
+    return ModelRegistry.instance.selectedModel !== undefined;
+  }
+
+  // Otherwise, default on.
+  return true;
 }

--- a/packages/cli/src/rpc/navie/models/handlers/add.ts
+++ b/packages/cli/src/rpc/navie/models/handlers/add.ts
@@ -1,0 +1,23 @@
+import { NavieRpc } from '@appland/rpc';
+import { RpcHandler } from '../../../rpc';
+import ModelRegistry from '../registry';
+import { verbose } from '../../../../utils';
+
+export function navieModelsAddV1(): RpcHandler<
+  NavieRpc.V1.Models.Add.Params,
+  NavieRpc.V1.Models.Add.Response
+> {
+  return {
+    name: NavieRpc.V1.Models.Add.Method,
+    handler: (models) => {
+      if (verbose()) {
+        console.log(
+          `Adding client models to registry: ${models
+            .map((model) => `${model.provider.toLowerCase()}:${model.id.toLowerCase()}`)
+            .join(', ')}`
+        );
+      }
+      models.forEach((model) => ModelRegistry.instance.add(model));
+    },
+  };
+}

--- a/packages/cli/src/rpc/navie/models/handlers/getConfig.ts
+++ b/packages/cli/src/rpc/navie/models/handlers/getConfig.ts
@@ -1,0 +1,38 @@
+import { NavieRpc } from '@appland/rpc';
+import { RpcHandler } from '../../../rpc';
+
+/**
+ * This function is used to print a secret value as asterisks. If the value doesn't exists,
+ * it returns undefined.
+ * @param value the secret value
+ * @returns the secret value as asterisks or undefined
+ */
+const formatSecret = (value?: string) => (value?.length ? '*'.repeat(value.length) : undefined);
+
+export function navieModelsGetConfigV1(): RpcHandler<
+  NavieRpc.V1.Models.GetConfig.Params,
+  NavieRpc.V1.Models.GetConfig.Response
+> {
+  return {
+    name: NavieRpc.V1.Models.GetConfig.Method,
+    handler: () => [
+      {
+        provider: 'openai',
+        apiKey: formatSecret(process.env.OPENAI_API_KEY),
+        endpoint: process.env.OPENAI_BASE_URL,
+      },
+      {
+        provider: 'anthropic',
+        apiKey: formatSecret(process.env.ANTHROPIC_API_KEY),
+      },
+      {
+        provider: 'google',
+        apiKey: formatSecret(process.env.GOOGLE_WEB_CREDENTIALS),
+      },
+      {
+        provider: 'ollama',
+        endpoint: process.env.OLLAMA_BASE_URL,
+      },
+    ],
+  };
+}

--- a/packages/cli/src/rpc/navie/models/handlers/list.ts
+++ b/packages/cli/src/rpc/navie/models/handlers/list.ts
@@ -1,0 +1,13 @@
+import { NavieRpc } from '@appland/rpc';
+import { RpcHandler } from '../../../rpc';
+import ModelRegistry from '../registry';
+
+export function navieModelsListV1(): RpcHandler<
+  NavieRpc.V1.Models.List.Params,
+  NavieRpc.V1.Models.List.Response
+> {
+  return {
+    name: NavieRpc.V1.Models.List.Method,
+    handler: () => ModelRegistry.instance.list(),
+  };
+}

--- a/packages/cli/src/rpc/navie/models/handlers/select.ts
+++ b/packages/cli/src/rpc/navie/models/handlers/select.ts
@@ -1,0 +1,13 @@
+import { NavieRpc } from '@appland/rpc';
+import { RpcHandler } from '../../../rpc';
+import ModelRegistry from '../registry';
+
+export function navieModelsSelectV1(): RpcHandler<
+  NavieRpc.V1.Models.Select.Params,
+  NavieRpc.V1.Models.Select.Response
+> {
+  return {
+    name: NavieRpc.V1.Models.Select.Method,
+    handler: (model) => ModelRegistry.instance.select(model.id),
+  };
+}

--- a/packages/cli/src/rpc/navie/models/providers/anthropic.ts
+++ b/packages/cli/src/rpc/navie/models/providers/anthropic.ts
@@ -1,0 +1,61 @@
+import { NavieRpc } from '@appland/rpc';
+import { normalizeDate } from '../util';
+
+interface AnthropicModelResponse {
+  data: {
+    type: 'model';
+    id: string;
+    display_name: string;
+    created_at: string;
+  }[];
+  has_more: boolean;
+  first_id: string;
+  last_id: string;
+}
+
+export async function fetchAnthropicModels(apiKey: string): Promise<NavieRpc.V1.Models.Model[]> {
+  const models: NavieRpc.V1.Models.Model[] = [];
+  const params = new URLSearchParams({ limit: '100' });
+  let nextId: string | undefined;
+
+  for (;;) {
+    if (nextId) {
+      params.set('after_id', nextId);
+    }
+
+    try {
+      const res = await fetch(`https://api.anthropic.com/v1/models?${params.toString()}`, {
+        headers: {
+          'content-type': 'application/json',
+          'x-api-key': apiKey,
+          'anthropic-version': '2023-06-01',
+        },
+      });
+
+      if (!res.ok) {
+        throw new Error(`recieved unexpected response ${res.status} ${res.statusText}`);
+      }
+
+      const json = (await res.json()) as AnthropicModelResponse;
+      models.push(
+        ...json.data.map((model) => ({
+          id: model.id,
+          name: model.display_name,
+          provider: 'Anthropic',
+          createdAt: normalizeDate(model.created_at),
+        }))
+      );
+
+      if (!json.has_more) {
+        break;
+      }
+
+      nextId = json.last_id;
+    } catch (e) {
+      console.error(`failed to fetch anthropic models: ${String(e)}`);
+      break;
+    }
+  }
+
+  return models;
+}

--- a/packages/cli/src/rpc/navie/models/providers/ollama.ts
+++ b/packages/cli/src/rpc/navie/models/providers/ollama.ts
@@ -1,0 +1,41 @@
+import { OLLAMA_URL } from '@appland/navie';
+import { NavieRpc } from '@appland/rpc';
+import { verbose } from '../../../../utils';
+import { normalizeDate } from '../util';
+
+interface OllamaModelResponse {
+  models: {
+    name: string;
+    modified_at: string;
+  }[];
+}
+
+export async function fetchOllamaModels(): Promise<NavieRpc.V1.Models.Model[]> {
+  const models: NavieRpc.V1.Models.Model[] = [];
+  try {
+    const res = await fetch(`${OLLAMA_URL}/api/tags`, {
+      headers: {
+        'content-type': 'application/json',
+      },
+    });
+
+    if (!res.ok) {
+      throw new Error(`received unexpected response ${res.status} ${res.statusText}`);
+    }
+
+    const json = (await res.json()) as OllamaModelResponse;
+    models.push(
+      ...json.models.map((model) => ({
+        id: model.name,
+        name: model.name,
+        provider: 'Ollama',
+        createdAt: normalizeDate(model.modified_at),
+      }))
+    );
+  } catch (e) {
+    if (verbose()) {
+      console.error(`failed to fetch ollama models: ${String(e)}`);
+    }
+  }
+  return models;
+}

--- a/packages/cli/src/rpc/navie/models/providers/openai.ts
+++ b/packages/cli/src/rpc/navie/models/providers/openai.ts
@@ -1,0 +1,51 @@
+import { NavieRpc } from '@appland/rpc';
+import { normalizeDate } from '../util';
+
+interface OpenAiModelResponse {
+  object: 'list';
+  data: {
+    id: string;
+    object: 'model';
+    created: number;
+    owned_by: string;
+  }[];
+}
+
+export async function fetchOpenAIModels(apiKey: string): Promise<NavieRpc.V1.Models.Model[]> {
+  const models: NavieRpc.V1.Models.Model[] = [];
+  try {
+    const res = await fetch('https://api.openai.com/v1/models', {
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${apiKey}`,
+      },
+    });
+
+    if (!res.ok) {
+      throw new Error(`recieved unexpected response ${res.status} ${res.statusText}`);
+    }
+
+    const nonInternalModel = (model: OpenAiModelResponse['data'][number]) =>
+      !['openai-internal', 'openai'].includes(model.owned_by);
+
+    const isRelevantModel = (model: OpenAiModelResponse['data'][number]) =>
+      model.owned_by !== 'system' ||
+      !model.id.match(/preview|embedding|tts|moderation|dall-e|chatgpt|transcribe|\d{3,}/g);
+
+    const json = (await res.json()) as OpenAiModelResponse;
+    models.push(
+      ...json.data
+        .filter((model) => nonInternalModel(model) && isRelevantModel(model))
+        .map((model) => ({
+          id: model.id,
+          name: model.id,
+          provider: 'OpenAI',
+          createdAt: normalizeDate(model.created),
+        }))
+    );
+  } catch (e) {
+    console.error(`failed to fetch openai models: ${String(e)}`);
+  }
+
+  return models;
+}

--- a/packages/cli/src/rpc/navie/models/registry.ts
+++ b/packages/cli/src/rpc/navie/models/registry.ts
@@ -1,0 +1,131 @@
+import { NavieRpc } from '@appland/rpc';
+import { verbose } from '../../../utils';
+import { fetchAnthropicModels } from './providers/anthropic';
+import { fetchOllamaModels } from './providers/ollama';
+import { fetchOpenAIModels } from './providers/openai';
+
+const findModel = (
+  arr: NavieRpc.V1.Models.Model[],
+  id: string,
+  provider?: string
+): NavieRpc.V1.Models.Model | undefined => {
+  const lowerId = id.toLowerCase();
+  const lowerProvider = provider?.toLowerCase();
+  return arr.find(
+    (model) =>
+      model.id.toLowerCase() === lowerId &&
+      (!provider || model.provider.toLowerCase() === lowerProvider)
+  );
+};
+
+export default class ModelRegistry {
+  private readonly recommendedModels = [/claude-3[-.]5-sonnet/, /gpt-4o/];
+  private readonly notRecommendedModels = [/^o1-?.*$/, /^o3-?.*$/, /^claude-3[-.]7-sonnet-?.*$/];
+  private clientModels = new Map<string, NavieRpc.V1.Models.ClientModel>();
+  private apiModels: NavieRpc.V1.Models.Model[] = [];
+  private _selectedModel?: NavieRpc.V1.Models.Model;
+
+  static readonly instance = new ModelRegistry();
+
+  private constructor() {
+    // no-op
+  }
+
+  select(modelId: string | undefined) {
+    if (!modelId) {
+      if (verbose()) console.log(`[ModelRegistry] Unselecting active model`);
+      this._selectedModel = undefined;
+      return;
+    }
+
+    let provider: string | undefined;
+    let id: string;
+    const lowerModelId = modelId.toLowerCase();
+    const delimiterIndex = lowerModelId.indexOf(':');
+    if (delimiterIndex === -1) {
+      id = decodeURIComponent(lowerModelId.toLowerCase());
+    } else {
+      id = decodeURIComponent(lowerModelId.slice(delimiterIndex + 1));
+      provider = decodeURIComponent(lowerModelId.slice(0, delimiterIndex));
+    }
+
+    let model = findModel(this.apiModels, id, provider);
+    model = model ?? findModel(Array.from(this.clientModels.values()), id, provider);
+    if (model) {
+      console.log(`[ModelRegistry] Selecting model "${modelId}"`);
+    } else if (!model) {
+      console.warn(`[ModelRegistry] Model ${modelId} not found`);
+    }
+
+    this._selectedModel = model;
+  }
+
+  get selectedModel(): NavieRpc.V1.Models.Model | undefined {
+    return this._selectedModel;
+  }
+
+  add(model: NavieRpc.V1.Models.ClientModel) {
+    const key = `${model.provider.toLowerCase()}:${model.id.toLowerCase()}`;
+    this.clientModels.set(key, model);
+  }
+
+  list(): NavieRpc.V1.Models.ListModel[] {
+    const listModels: NavieRpc.V1.Models.ListModel[] = Array.from(this.clientModels.values())
+      .map((m) => {
+        const model = {
+          id: m.id,
+          name: m.name,
+          provider: m.provider,
+          createdAt: m.createdAt,
+        } as NavieRpc.V1.Models.Model;
+        if (m.maxInputTokens !== undefined) {
+          model.maxInputTokens = m.maxInputTokens;
+        }
+        return model;
+      })
+      .concat(this.apiModels)
+      .map((m) => ({ ...m })); // shallow copy to avoid mutating the original objects
+
+    const recommendation = this.recommendedModels.find((regex) =>
+      listModels.some((m) => regex.test(m.id))
+    );
+    for (const model of listModels) {
+      if (recommendation?.test(model.id)) {
+        model.tags = ['recommended'];
+      }
+      if (model.id === this.selectedModel?.id) {
+        if (model.tags) model.tags.push('primary');
+        else model.tags = ['primary'];
+      }
+      if (this.notRecommendedModels.some((regex) => regex.test(model.id))) {
+        if (model.tags) model.tags.push('alpha');
+        else model.tags = ['alpha'];
+      }
+    }
+
+    return listModels;
+  }
+
+  async refresh() {
+    const promises: Promise<NavieRpc.V1.Models.Model[]>[] = [];
+    const { ANTHROPIC_API_KEY, OPENAI_API_KEY, OPENAI_BASE_URL } = process.env;
+
+    if (ANTHROPIC_API_KEY) {
+      promises.push(fetchAnthropicModels(ANTHROPIC_API_KEY));
+    }
+
+    if (OPENAI_API_KEY && (!OPENAI_BASE_URL || OPENAI_BASE_URL === 'https://api.openai.com')) {
+      promises.push(fetchOpenAIModels(OPENAI_API_KEY));
+    }
+
+    promises.push(fetchOllamaModels());
+
+    const results = await Promise.allSettled(promises);
+    this.apiModels = results
+      .filter(
+        (result): result is PromiseFulfilledResult<NavieRpc.V1.Models.Model[]> =>
+          result.status === 'fulfilled'
+      )
+      .flatMap((result) => result.value); // eslint-disable-line @typescript-eslint/no-unsafe-return
+  }
+}

--- a/packages/cli/src/rpc/navie/models/util.ts
+++ b/packages/cli/src/rpc/navie/models/util.ts
@@ -1,0 +1,6 @@
+export function normalizeDate(date: string | number) {
+  if (typeof date === 'number') {
+    return new Date(date * 1000).toISOString();
+  }
+  return new Date(date).toISOString();
+}

--- a/packages/cli/tests/unit/rpc/navie/models/registry.spec.ts
+++ b/packages/cli/tests/unit/rpc/navie/models/registry.spec.ts
@@ -1,0 +1,220 @@
+import ModelRegistry from '../../../../../src/rpc/navie/models/registry';
+
+describe(ModelRegistry, () => {
+  let modelRegistry: ModelRegistry;
+
+  beforeEach(() => {
+    // The model registry is a singleton, typically accessed via `ModelRegistry.instance`. However,
+    // for testing purposes, we create a new instance to avoid side effects. The cast here is used
+    // to avoid exposing the private constructor of the class.
+    /*
+      eslint-disable-next-line @typescript-eslint/no-unsafe-assignment,
+                               @typescript-eslint/no-unsafe-call,
+                               @typescript-eslint/no-explicit-any
+    */
+    modelRegistry = new (ModelRegistry as any)();
+  });
+
+  describe('select', () => {
+    const models = [
+      { id: 'small', name: 'Model 1', provider: 'one', createdAt: '2023-01-01' },
+      { id: 'medium', name: 'Model 2', provider: 'two', createdAt: '2023-01-02' },
+      { id: 'large', name: 'Model 3', provider: 'three', createdAt: '2023-01-03' },
+      { id: 'extra-large', name: 'Model 4', provider: 'two', createdAt: '2023-01-04' },
+    ];
+
+    beforeEach(() => {
+      models.forEach((model) => {
+        modelRegistry.add(model);
+      });
+    });
+
+    it('selects a model by id', () => {
+      modelRegistry.select('medium');
+      expect(modelRegistry.selectedModel).toStrictEqual(models[1]);
+    });
+
+    it('selects a model scoped by provider', () => {
+      modelRegistry.select('two:extra-large');
+      expect(modelRegistry.selectedModel).toStrictEqual(models[3]);
+    });
+
+    it('is case insensitive', () => {
+      modelRegistry.select('TWO:EXTRA-LARGE');
+      expect(modelRegistry.selectedModel).toStrictEqual(models[3]);
+    });
+  });
+
+  describe('add', () => {
+    it('adds a model', () => {
+      const model = { id: '1', name: 'Model 1', provider: 'example;com', createdAt: '2023-01-01' };
+      modelRegistry.add(model);
+      expect(modelRegistry.list()).toEqual([model]);
+    });
+    it("doesn't add duplicate models", () => {
+      const model = { id: '1', name: 'Model 1', provider: 'example;com', createdAt: '2023-01-01' };
+      modelRegistry.add(model);
+      modelRegistry.add(model);
+      expect(modelRegistry.list()).toEqual([model]);
+    });
+  });
+
+  describe('list', () => {
+    it('inclues both client and api models', () => {
+      const clientModel = {
+        id: '1',
+        name: 'client model',
+        provider: 'example;com',
+        createdAt: '2023-01-01',
+      };
+      const apiModel = {
+        id: '2',
+        name: 'api model',
+        provider: 'example;com',
+        createdAt: '2023-01-01',
+      };
+      modelRegistry.add(clientModel);
+      modelRegistry['apiModels'] = [apiModel]; // eslint-disable-line @typescript-eslint/dot-notation
+      expect(modelRegistry.list()).toEqual([clientModel, apiModel]);
+    });
+    it('does not include endpoint information', () => {
+      const endpoint = {
+        baseUrl: 'http://example.com',
+        apiKey: 'example',
+      };
+      const clientModel = {
+        id: 'example',
+        name: 'example',
+        provider: 'example',
+        createdAt: '2023-01-01',
+        maxInputTokens: 1000,
+      };
+      modelRegistry.add({ ...clientModel, ...endpoint });
+      const models = modelRegistry.list();
+      expect(models).toStrictEqual([clientModel]);
+    });
+    it('tags the primary model', () => {
+      const model = {
+        id: 'example',
+        name: 'Model 1',
+        provider: 'example;com',
+        createdAt: '2023-01-01',
+      };
+      modelRegistry.add(model);
+      modelRegistry.select(model.id);
+      expect(modelRegistry.list()).toStrictEqual([{ ...model, tags: ['primary'] }]);
+    });
+    it('tags recommended models in priority order', () => {
+      const model = {
+        id: 'claude-3-5-sonnet-latest',
+        name: 'Model 1',
+        provider: 'example;com',
+        createdAt: '2023-01-01',
+      };
+      modelRegistry.add(model);
+      expect(modelRegistry.list()).toStrictEqual([{ ...model, tags: ['recommended'] }]);
+    });
+    it('tags models that are not recommended', () => {
+      const model = {
+        id: 'o1-thinking-extended-plus',
+        name: 'Model 1',
+        provider: 'example;com',
+        createdAt: '2023-01-01',
+      };
+      modelRegistry.add(model);
+      expect(modelRegistry.list()).toStrictEqual([{ ...model, tags: ['alpha'] }]);
+    });
+    it('can provide more than one tag', () => {
+      const model = {
+        id: 'claude-3-5-sonnet-latest',
+        name: 'Model 1',
+        provider: 'example;com',
+        createdAt: '2023-01-01',
+      };
+      modelRegistry.add(model);
+      modelRegistry.select(model.id);
+      expect(modelRegistry.list()).toStrictEqual([{ ...model, tags: ['recommended', 'primary'] }]);
+    });
+  });
+
+  describe('refresh', () => {
+    let fetchMock: jest.SpyInstance;
+    const originalEnv = process.env;
+
+    beforeEach(() => {
+      const timestamp = new Date().toISOString();
+      fetchMock = jest.spyOn(global, 'fetch').mockImplementation((url) => {
+        // This mocks a union response of Ollama, Anthropic, and OpenAI
+        const models = [
+          {
+            id: 'example',
+            name: 'example',
+            display_name: 'example',
+            provider: url,
+            modified_at: timestamp,
+            created: timestamp,
+            created_at: timestamp,
+          },
+        ];
+        return Promise.resolve({
+          json: () => ({
+            models,
+            data: models,
+          }),
+          ok: true,
+        } as unknown as Response);
+      });
+    });
+    afterEach(() => {
+      jest.restoreAllMocks();
+      process.env = { ...originalEnv };
+    });
+
+    it('always attempts to fetch ollama models', async () => {
+      delete process.env.ANTHROPIC_API_KEY;
+      delete process.env.OPENAI_API_KEY;
+      await modelRegistry.refresh();
+      expect(fetchMock).toHaveBeenCalledWith('http://localhost:11434/api/tags', expect.anything());
+      expect(modelRegistry.list()).toStrictEqual(
+        expect.arrayContaining([expect.objectContaining({ provider: 'Ollama' })])
+      );
+    });
+
+    it('fetches anthropic models when ANTHROPIC_API_KEY is set', async () => {
+      process.env.ANTHROPIC_API_KEY = 'dummy';
+      delete process.env.OPENAI_API_KEY;
+      await modelRegistry.refresh();
+      expect(fetchMock).toHaveBeenCalledWith('http://localhost:11434/api/tags', expect.anything());
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://api.anthropic.com/v1/models?limit=100',
+        expect.anything()
+      );
+      expect(modelRegistry.list()).toStrictEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ provider: 'Anthropic' }),
+          expect.objectContaining({ provider: 'Ollama' }),
+        ])
+      );
+    });
+
+    it('fetches openai models when OPENAI_API_KEY is set', async () => {
+      process.env.OPENAI_API_KEY = 'dummy';
+      delete process.env.ANTHROPIC_API_KEY;
+      await modelRegistry.refresh();
+      expect(fetchMock).toHaveBeenCalledWith('http://localhost:11434/api/tags', expect.anything());
+      expect(fetchMock).toHaveBeenCalledWith('https://api.openai.com/v1/models', expect.anything());
+      expect(modelRegistry.list()).toStrictEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ provider: 'OpenAI' }),
+          expect.objectContaining({ provider: 'Ollama' }),
+        ])
+      );
+    });
+
+    it('gracefully handles fetch errors', async () => {
+      fetchMock.mockImplementation(() => Promise.reject(new Error('Fetch failed')));
+      await modelRegistry.refresh();
+      expect(modelRegistry.list()).toStrictEqual([]);
+    });
+  });
+});

--- a/packages/components/src/components/Badge.vue
+++ b/packages/components/src/components/Badge.vue
@@ -12,8 +12,8 @@ export default {
 
 <style lang="scss" scoped>
 .badge {
-  background-color: $brightblue;
-  color: $white;
+  background-color: $color-highlight;
+  color: $color-foreground-light;
   padding: 0.125rem 0.25rem;
   border-radius: 0.25rem;
   font-size: 0.65rem;

--- a/packages/components/src/components/chat-search/ModelSelector.vue
+++ b/packages/components/src/components/chat-search/ModelSelector.vue
@@ -1,0 +1,486 @@
+<template>
+  <div class="model-selector">
+    <v-popper ref="config" :hoverable="false" class="popper" placement="bottom" align="left">
+      <v-cog-solid
+        @click.prevent.stop="showPopper($refs.config)"
+        class="model-selector__config-button"
+      />
+      <template #content>
+        <div class="model-selector-config">
+          <h2>Configuration</h2>
+          <div class="model-selector-config__group">
+            <h3>OpenAI</h3>
+            <div class="model-selector-config__item">
+              <span class="model-selector-config__item--title">API Key</span>
+              <input
+                class="model-selector-config__text-input"
+                type="password"
+                @click.prevent.stop
+                @input="onInput"
+                @change="onChangeValue($event, 'OPENAI_API_KEY')"
+                @focus="selectAll($event.target)"
+                placeholder="OpenAI API Key"
+                data-secret
+                :data-clear="Boolean(configMap.openai && configMap.openai.apiKey)"
+                :value="configMap.openai && configMap.openai.apiKey"
+              />
+            </div>
+            <div class="model-selector-config__item">
+              <span class="model-selector-config__item--title">API URL</span>
+              <input
+                class="model-selector-config__text-input"
+                @click.prevent.stop
+                placeholder="http://api.openai.com/v1"
+                @change="onChangeValue($event, 'OPENAI_BASE_URL')"
+                :value="configMap.openai && configMap.openai.endpoint"
+              />
+            </div>
+          </div>
+          <div class="model-selector-config__group">
+            <h3>Anthropic</h3>
+            <div class="model-selector-config__item">
+              <span class="model-selector-config__item--title">API Key</span>
+              <input
+                class="model-selector-config__text-input"
+                type="password"
+                @click.prevent.stop
+                @input="onInput"
+                @change="onChangeValue($event, 'ANTHROPIC_API_KEY')"
+                @focus="selectAll($event.target)"
+                placeholder="Anthropic API Key"
+                data-secret
+                :data-clear="Boolean(configMap.anthropic && configMap.anthropic.apiKey)"
+                :value="configMap.anthropic && configMap.anthropic.apiKey"
+              />
+            </div>
+          </div>
+          <div class="model-selector-config__group">
+            <h3>Ollama</h3>
+            <div class="model-selector-config__item">
+              <span class="model-selector-config__item--title">Ollama Host URL</span>
+              <input
+                class="model-selector-config__text-input"
+                @click.prevent.stop
+                @change="onChangeValue($event, 'OLLAMA_BASE_URL')"
+                placeholder="http://localhost:11434"
+                :value="configMap.ollama && configMap.ollama.endpoint"
+              />
+            </div>
+          </div>
+        </div>
+      </template>
+    </v-popper>
+    <v-popper ref="dropdown" :hoverable="false" class="popper" placement="bottom" align="left">
+      <div
+        class="model-selector__dropdown"
+        @click.prevent.stop="showPopper($refs.dropdown)"
+        data-cy="model-selector"
+      >
+        <span class="model-selector__title" data-cy="selected-model">
+          <template v-if="selectedModel">
+            {{ selectedModel.name }}
+          </template>
+          <template v-else> Select a model </template>
+          <v-chevron-down class="model-selector__chevron" />
+        </span>
+      </div>
+      <template #content>
+        <div class="model-selector-list" v-if="sortedModels.length">
+          <div
+            class="model-selector-list__item"
+            data-cy="model-selector-item"
+            v-for="model in sortedModels"
+            :key="`${model.provider}:${model.id}`"
+            @click="onSelect(model)"
+          >
+            <span class="model-selector-list__item--title">
+              {{ model.name }}
+              <v-badge v-for="tag in filterTags(model)" :key="tag" :class="badgeClass(tag)">
+                {{ tag }}
+              </v-badge>
+            </span>
+            <span class="model-selector-list__item--description">{{ model.provider }}</span>
+          </div>
+        </div>
+        <div class="model-selector-config" v-else>
+          <div class="model-selector__no-models">
+            <h2>No models are available</h2>
+            <p>
+              To get started, click the gear icon <v-cog-solid class="icon-inline" /> to configure
+              your API keys for:
+            </p>
+            <ul>
+              <li>OpenAI</li>
+              <li>Anthropic</li>
+            </ul>
+            <p>
+              If you're using Ollama, make sure it is running. If your Ollama service runs on a
+              non-default port, change the Ollama Host URL in the configuration menu.
+            </p>
+            <p>
+              <strong>Alternatively</strong>, install and sign in to GitHub Copilot. Models provided
+              by GitHub Copilot will be automatically become available.
+            </p>
+          </div>
+        </div>
+      </template>
+    </v-popper>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue, { PropType } from 'vue';
+import VPopper from '@/components/Popper.vue';
+import VChevronDown from '@/assets/fa-solid_chevron-down.svg';
+import VCogSolid from '@/assets/cog-solid.svg';
+import VBadge from '@/components/Badge.vue';
+import type { NavieRpc } from '@appland/rpc';
+
+export default Vue.extend({
+  components: {
+    VPopper,
+    VChevronDown,
+    VCogSolid,
+    VBadge,
+  },
+
+  props: {
+    models: {
+      type: Array as PropType<NavieRpc.V1.Models.ListModel[]>,
+      default: () => [],
+    },
+    selectedModel: {
+      type: Object as PropType<NavieRpc.V1.Models.ListModel | undefined>,
+    },
+    modelConfigs: {
+      type: Array as PropType<NavieRpc.V1.Models.Config[]>,
+      default: () => [],
+    },
+  },
+
+  data() {
+    return {
+      hidePoppers: (() => {}) as () => void,
+      clearedInputs: new Set<HTMLInputElement>(),
+    };
+  },
+
+  computed: {
+    configMap(): Record<string, NavieRpc.V1.Models.Config> {
+      return this.modelConfigs.reduce((map, config) => {
+        map[config.provider] = config;
+        return map;
+      }, {} as Record<string, NavieRpc.V1.Models.Config>);
+    },
+    sortedModels(): NavieRpc.V1.Models.Model[] {
+      return [...this.models].sort((a, b) => {
+        const provider = a.provider.localeCompare(b.provider);
+        if (provider !== 0) return provider;
+        return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+      });
+    },
+  },
+
+  methods: {
+    filterTags(model: NavieRpc.V1.Models.ListModel) {
+      return model.tags?.filter((tag) => !['primary', 'secondary'].includes(tag)) ?? [];
+    },
+    badgeClass(tag: string) {
+      return {
+        badge: true,
+        'badge--recommended': tag === 'recommended',
+        'badge--alpha': tag === 'alpha',
+      };
+    },
+    onSelect(model: NavieRpc.V1.Models.Model) {
+      this.$emit('select', model.provider, model.id);
+      if (this.$refs.popper) {
+        const popper = this.$refs.popper as any;
+        popper.hide();
+      }
+    },
+    _hidePoppers() {
+      window.removeEventListener('click', this.hidePoppers);
+      [this.$refs.dropdown, this.$refs.config].forEach((popper: any) => {
+        if (popper && popper.isVisible) {
+          popper.hide();
+        }
+      });
+    },
+    showPopper(popper: any) {
+      if (popper.isVisible) {
+        popper.hide();
+        return;
+      }
+
+      // Make sure only one popper is visible at a time
+      this.hidePoppers();
+
+      popper.show();
+      window.addEventListener('click', this.hidePoppers);
+    },
+    selectAll(element: EventTarget | null) {
+      if (element instanceof HTMLInputElement) {
+        element.select();
+      }
+    },
+    // If an input contains an asterisk'd value, fully clear it.
+    // We don't want the user expecting the real value to be there.
+    onInput(event: Event) {
+      if (!(event instanceof InputEvent)) {
+        return;
+      }
+
+      const input = event.target as HTMLInputElement;
+      if (input.getAttribute('data-clear') === null) {
+        return;
+      }
+
+      if (this.clearedInputs.has(input)) {
+        return;
+      }
+
+      input.value = event.data ?? '';
+      this.clearedInputs.add(input);
+    },
+    onChangeValue(event: Event, key: string) {
+      const input = event.target;
+      if (!(input instanceof HTMLInputElement)) {
+        return;
+      }
+
+      const isSecret = input.getAttribute('data-secret') !== null;
+
+      this.$root.$emit('change-model-config', {
+        key,
+        value: input.value,
+        secret: isSecret,
+      });
+    },
+  },
+  mounted() {
+    this.hidePoppers = this._hidePoppers.bind(this);
+  },
+});
+</script>
+
+<style lang="scss" scoped>
+.popper {
+  ::v-deep {
+    .popper__text {
+      padding: 0;
+      background-color: $color-background;
+      border: none;
+      max-width: unset;
+      border-radius: $border-radius;
+      pointer-events: all;
+
+      &--align-left {
+        left: 0;
+        transform: none;
+      }
+    }
+  }
+}
+
+.badge {
+  margin: 0 0.25em;
+  line-height: 1.6;
+
+  &--recommended {
+    background-color: $color-highlight;
+    color: $color-foreground-light;
+  }
+  &--alpha {
+    background-color: $color-background-light !important;
+    color: $color-background !important;
+  }
+}
+
+.model-selector {
+  display: flex;
+  flex-direction: row;
+  gap: 0.5rem;
+  padding: 1rem 1rem 0.5rem 1rem;
+  position: relative;
+
+  &__drop-down {
+    padding: 0;
+  }
+
+  &__config-button {
+    cursor: pointer;
+    width: 1.2em;
+    height: 1.2em;
+
+    path {
+      fill: $color-foreground;
+      transform-origin: center;
+      transition: all 0.1s ease-in;
+    }
+
+    &:hover {
+      path {
+        fill: $color-highlight;
+      }
+    }
+
+    &:active {
+      path {
+        fill: $color-highlight;
+        transform: rotate(60deg);
+      }
+    }
+  }
+
+  &__title {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+    font-weight: 600;
+    font-size: 1rem;
+    color: $color-foreground;
+    cursor: pointer;
+
+    svg path {
+      fill: $color-foreground;
+    }
+
+    &:hover {
+      color: $color-highlight;
+      svg path {
+        fill: $color-highlight;
+      }
+    }
+  }
+
+  &__chevron {
+    width: 0.8em;
+    height: 0.8em;
+    padding-top: 3px;
+  }
+}
+
+.model-selector__no-models {
+  padding-top: 0.5em;
+  max-width: 32em;
+
+  p {
+    font-size: 1em;
+    margin: 0.5em 0;
+  }
+
+  ul {
+    margin-top: 0.5em;
+    margin-left: 0;
+    padding-left: 1.5em;
+  }
+}
+
+.icon-inline {
+  width: 1.2em;
+  height: 1.2em;
+}
+
+.model-selector-config {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem 1rem 1rem;
+  background-color: $color-background-light;
+  min-width: 32em;
+  border-radius: $border-radius;
+  border: 1px solid $color-border;
+  max-height: calc(100vh - 6em);
+  overflow-y: auto;
+
+  h2 {
+    margin: 0;
+  }
+
+  &__group {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    gap: 0.5rem;
+    border-top: 1px solid $color-border;
+    padding-top: 0.5em;
+
+    h3 {
+      margin: 0;
+      padding-bottom: 0.25em;
+    }
+  }
+
+  &__item {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  &__item--title {
+    padding-left: 0.65em;
+    font-weight: 400;
+    font-size: 0.9em;
+    color: $color-foreground-light;
+  }
+
+  &__text-input {
+    border-radius: $border-radius;
+    font-size: 1.2em;
+    height: 2em;
+    border: 1px solid $color-border;
+    border-radius: $border-radius;
+    background-color: $color-input-bg;
+    color: $color-input-fg;
+    padding: 0 0.5em;
+    user-select: all;
+
+    &:focus {
+      outline: none;
+      border-color: $color-highlight;
+    }
+  }
+}
+
+.model-selector-list {
+  display: flex;
+  overflow-y: auto;
+  max-height: 30rem;
+  pointer-events: all;
+  flex-direction: column;
+  gap: 1px;
+  border-radius: $border-radius;
+  border: 1px solid $color-border;
+  background-color: $color-background-light;
+  max-height: calc(100vh - 6em);
+  overflow-y: auto;
+
+  &__item {
+    display: flex;
+    flex-direction: row;
+    gap: 0.5rem;
+    align-items: center;
+    padding: 0.5rem;
+    place-content: space-between;
+
+    cursor: pointer;
+
+    &:hover {
+      background-color: $color-button-bg-hover;
+    }
+
+    &--title {
+      font-weight: 600;
+      font-size: 1rem;
+      color: $color-foreground-light;
+    }
+
+    &--description {
+      font-size: 0.8rem;
+      opacity: 0.8;
+      color: $color-foreground-dark;
+    }
+  }
+}
+</style>

--- a/packages/components/src/components/chat/Chat.vue
+++ b/packages/components/src/components/chat/Chat.vue
@@ -66,7 +66,7 @@
       :input-placeholder="inputPlaceholder"
       :commands="commands"
       :use-animation="useAnimation"
-      :is-disabled="isInputDisabled"
+      :is-disabled="isInputDisabled || selectedModel === undefined"
       :usage="usage"
       :subscription="subscription"
       :email="email"
@@ -77,7 +77,7 @@
 
 <script lang="ts">
 //@ts-nocheck
-import Vue from 'vue';
+import Vue, { PropType } from 'vue';
 import VUserMessage from '@/components/chat/UserMessage.vue';
 import VChatInput from '@/components/chat/ChatInput.vue';
 import VAppMapNavieLogo from '@/assets/appmap-full-logo.svg';
@@ -188,6 +188,9 @@ export default {
     },
     email: {
       type: String,
+    },
+    selectedModel: {
+      type: Object as PropType<NavieRpc.V1.Models.ListModel>,
     },
   },
   data() {

--- a/packages/components/src/lib/AppMapRPC.ts
+++ b/packages/components/src/lib/AppMapRPC.ts
@@ -318,4 +318,50 @@ export default class AppMapRPC {
       );
     });
   }
+
+  listModels(): Promise<NavieRpc.V1.Models.Model[]> {
+    return new Promise((resolve, reject) => {
+      this.client.request(
+        NavieRpc.V1.Models.List.Method,
+        {},
+        (err: any, error: any, result: NavieRpc.V1.Models.Model[]) => {
+          if (err || error) return reportError(reject, err, error);
+
+          resolve(result);
+        }
+      );
+    });
+  }
+
+  selectModel(model: { provider?: string | undefined; id: string }): Promise<void> {
+    let serializedId: string | undefined;
+    if (model) {
+      serializedId = [model.provider, model.id]
+        .filter((part): part is string => Boolean(part))
+        .map((part) => encodeURIComponent(part))
+        .join(':');
+    }
+
+    return new Promise((resolve, reject) => {
+      this.client.request(NavieRpc.V1.Models.Select.Method, { id: serializedId }, (err: any) => {
+        if (err) return reportError(reject, err, err);
+
+        resolve();
+      });
+    });
+  }
+
+  getModelConfig(): Promise<NavieRpc.V1.Models.Config[]> {
+    return new Promise((resolve, reject) => {
+      this.client.request(
+        NavieRpc.V1.Models.GetConfig.Method,
+        {},
+        (err: any, error: any, result: NavieRpc.V1.Models.Config[]) => {
+          if (err || error) return reportError(reject, err, error);
+
+          resolve(result);
+        }
+      );
+    });
+  }
 }

--- a/packages/components/tests/e2e/specs/chat/chatSearch.spec.js
+++ b/packages/components/tests/e2e/specs/chat/chatSearch.spec.js
@@ -6,13 +6,6 @@ context('Chat search', () => {
     cy.viewport(1280, 720);
   });
 
-  it('assistant response can be stopped', () => {
-    cy.get('[data-cy="chat-input"]', { timeout: 25000 }).clear().type('Hello world{enter}');
-    cy.get('[data-cy="stop-response"]').should('exist');
-    cy.get('[data-cy="stop-response"]').click();
-    cy.get('[data-cy="stop-response"]').should('not.exist');
-  });
-
   describe('focus', () => {
     const input = '[data-cy="chat-input"]';
     it('should focus on the input on page load', () => {

--- a/packages/components/tests/unit/chat/ModelSelector.spec.js
+++ b/packages/components/tests/unit/chat/ModelSelector.spec.js
@@ -1,0 +1,38 @@
+import VModelSelector from '@/components/chat-search/ModelSelector.vue';
+import { mount } from '@vue/test-utils';
+
+describe('ModelSelector.vue', () => {
+  let wrapper;
+  const models = [
+    { id: 'gpt-3.5-turbo', name: 'GPT-3.5 Turbo', provider: 'OpenAI', createdAt: '2023-03-14' },
+    { id: 'gpt-4', name: 'GPT-4', provider: 'OpenAI', createdAt: '2023-03-14' },
+    { id: 'deekseek-r1:8b', name: 'deepseek-r1:8b', provider: 'Ollama', createdAt: '2025-01-20' },
+  ];
+  beforeEach(() => {
+    wrapper = mount(VModelSelector, {
+      propsData: {
+        models,
+        selectedModel: models[0],
+      },
+    });
+  });
+
+  it('lists available models', async () => {
+    // Click to view models
+    await wrapper.find('[data-cy="model-selector"]').trigger('click');
+    expect(wrapper.findAll('[data-cy="model-selector-item"]').length).toBe(models.length);
+  });
+
+  it('emits an event when a model is selected', async () => {
+    // Click to view models
+    await wrapper.find('[data-cy="model-selector"]').trigger('click');
+
+    // Models are sorted by provider, then by createdAt
+    wrapper.find('[data-cy="model-selector-item"]:nth-child(1)').trigger('click');
+    expect(wrapper.emitted().select).toStrictEqual([['Ollama', 'deekseek-r1:8b']]);
+  });
+
+  it('displays the selected model', () => {
+    expect(wrapper.find('[data-cy="selected-model"]').text()).toBe('GPT-3.5 Turbo');
+  });
+});

--- a/packages/navie/src/index.ts
+++ b/packages/navie/src/index.ts
@@ -16,3 +16,4 @@ export * as InteractionHistory from './interaction-history';
 export { SELECTED_BACKEND } from './services/completion-service-factory';
 export { UserOptions, default as parseOptions } from './lib/parse-options';
 export { REVIEW_DIFF_LOCATION } from './commands/review-command';
+export { OLLAMA_URL } from './services/ollama-completion-service';

--- a/packages/navie/src/services/completion-service.ts
+++ b/packages/navie/src/services/completion-service.ts
@@ -2,11 +2,20 @@ import type { BaseLanguageModelInterface, TokenUsage } from '@langchain/core/lan
 import { AIMessage, BaseMessage, HumanMessage, SystemMessage } from '@langchain/core/messages';
 import { z } from 'zod';
 import Message from '../message';
+import type Trajectory from '../lib/trajectory';
+import type MessageTokenReducerService from './message-token-reducer-service';
 
 export type CompleteOptions = {
   model?: string;
   temperature?: number;
   maxRetries?: number;
+};
+
+export type CompletionServiceOptions = {
+  modelName: string;
+  temperature: number;
+  trajectory: Trajectory;
+  messageTokenReducerService: MessageTokenReducerService;
 };
 
 export default interface CompletionService {

--- a/packages/navie/src/services/ollama-completion-service.ts
+++ b/packages/navie/src/services/ollama-completion-service.ts
@@ -1,0 +1,40 @@
+import Trajectory from '../lib/trajectory';
+import MessageTokenReducerService from './message-token-reducer-service';
+import OpenAICompletionService from './openai-completion-service';
+
+function getOllamaUrl(): string {
+  let ollamaApiUrl = 'http://localhost:11434';
+  const { OLLAMA_BASE_URL } = process.env;
+  if (OLLAMA_BASE_URL) {
+    try {
+      const url = new URL(OLLAMA_BASE_URL);
+      ollamaApiUrl = url.toString();
+      console.warn(`OLLAMA_BASE_URL is set to ${OLLAMA_BASE_URL}`);
+    } catch {
+      console.warn(
+        `invalid OLLAMA_BASE_URL: "${OLLAMA_BASE_URL}", using default API URL ${ollamaApiUrl}`
+      );
+    }
+  }
+  return ollamaApiUrl;
+}
+
+export const OLLAMA_URL = getOllamaUrl();
+
+export default class OllamaCompletionService extends OpenAICompletionService {
+  constructor(
+    modelName: string,
+    temperature: number,
+    trajectory: Trajectory,
+    messageTokenReducerService: MessageTokenReducerService
+  ) {
+    super(
+      modelName,
+      temperature,
+      trajectory,
+      messageTokenReducerService,
+      `${OLLAMA_URL}/v1`,
+      'dummy'
+    );
+  }
+}

--- a/packages/navie/test/services/completion-service-factory.spec.ts
+++ b/packages/navie/test/services/completion-service-factory.spec.ts
@@ -1,6 +1,8 @@
 import createCompletionService from '../../src/services/completion-service-factory';
-import OpenAICompletionService from '../../src/services/openai-completion-service';
 import AnthropicCompletionService from '../../src/services/anthropic-completion-service';
+import GoogleVertexAICompletionService from '../../src/services/google-vertexai-completion-service';
+import OllamaCompletionService from '../../src/services/ollama-completion-service';
+import OpenAICompletionService from '../../src/services/openai-completion-service';
 import Trajectory from '../../src/lib/trajectory';
 
 describe('CompletionServiceFactory', () => {
@@ -12,15 +14,35 @@ describe('CompletionServiceFactory', () => {
 
   it('creates an OpenAICompletionService by default', () => {
     process.env.OPENAI_API_KEY = 'openai-key';
-    const trajectory: Trajectory = jest.genMockFromModule<Trajectory>('../../src/lib/trajectory');
+    const trajectory = new Trajectory();
     const service = createCompletionService({ modelName: 'test', temperature: 1, trajectory });
     expect(service).toBeInstanceOf(OpenAICompletionService);
   });
 
   it('creates an AnthropicCompletionService when ANTHROPIC_API_KEY is set', () => {
     process.env.ANTHROPIC_API_KEY = 'anthropic-key';
-    const trajectory: Trajectory = jest.genMockFromModule<Trajectory>('../../src/lib/trajectory');
+    const trajectory = new Trajectory();
     const service = createCompletionService({ modelName: 'test', temperature: 1, trajectory });
     expect(service).toBeInstanceOf(AnthropicCompletionService);
+  });
+
+  it("abides by the selected model's provider", () => {
+    process.env.ANTHROPIC_API_KEY = 'anthropic-key';
+    const trajectory = new Trajectory();
+    const examples = [
+      { id: 'gpt-4o', provider: 'openai', expected: OpenAICompletionService },
+      { id: 'claude-2', provider: 'anthropic', expected: AnthropicCompletionService },
+      { id: 'deepseek-r1:8b', provider: 'ollama', expected: OllamaCompletionService },
+      { id: 'gemini-1.5-turbo', provider: 'vertex-ai', expected: GoogleVertexAICompletionService },
+    ] as const;
+    examples.forEach(({ id, provider, expected }) => {
+      const service = createCompletionService({
+        modelName: 'overridden',
+        temperature: 1,
+        trajectory,
+        selectedModel: { id, provider },
+      });
+      expect(service).toBeInstanceOf(expected);
+    });
   });
 });

--- a/packages/rpc/src/navie.ts
+++ b/packages/rpc/src/navie.ts
@@ -40,6 +40,55 @@ export namespace NavieRpc {
         thread: ConversationThread;
       };
     }
+
+    export namespace Models {
+      export type Model = {
+        id: string;
+        name: string;
+        provider: string;
+        createdAt: string;
+        maxInputTokens?: number;
+      };
+
+      export type CustomEndpoint = {
+        baseUrl?: string;
+        apiKey?: string;
+      };
+
+      export type ClientModel = Model & CustomEndpoint;
+      export type ListModel = Model & { tags?: string[] };
+
+      export type Config = {
+        provider: string;
+        apiKey?: string;
+        endpoint?: string;
+        [key: string]: string | undefined;
+      };
+
+      export namespace Add {
+        export const Method = 'v1.navie.models.add';
+        export type Params = ClientModel[];
+        export type Response = void;
+      }
+
+      export namespace List {
+        export const Method = 'v1.navie.models.list';
+        export type Params = void;
+        export type Response = Model[];
+      }
+
+      export namespace Select {
+        export const Method = 'v1.navie.models.select';
+        export type Params = { id: string | undefined };
+        export type Response = void;
+      }
+
+      export namespace GetConfig {
+        export const Method: string = 'v1.navie.models.getConfig';
+        export type Params = void;
+        export type Response = Config[];
+      }
+    }
   }
 
   export namespace V2 {


### PR DESCRIPTION
This PR implements a new model selector UI and supporting backend services, allowing users to choose between different AI models for Navie.

### @appland/rpc
- Added new RPC method definitions for model management (`v1.navie.models`)
- Includes methods for adding, listing, selecting, and getting model configurations

### @appland/navie
- Added support for per-message model overrides
- Implemented Ollama completion service
- Enhanced completion service factory to handle different model providers
- Added configuration for model-specific token limits
- Added support for custom API endpoints and keys

### @appland/components
- Added new ModelSelector.vue component with dropdown and configuration UI
- Integrated model selector with Chat.vue
- Updated ChatSearch.vue to handle model selection
- Added styling for model badges and configuration UI
- Added unit tests for ModelSelector component

### @appland/cli
- Implemented ModelRegistry to manage available AI models
- Added handlers for model-related RPC methods
- Added model refresh functionality to fetch available models from providers
- Added support for OpenAI, Anthropic, and Ollama model discovery
- Added unit tests for ModelRegistry

The changes allow users to select and configure different AI models through the UI, with support for standard providers (OpenAI, Anthropic) and local models (Ollama). The implementation includes proper configuration management, model discovery, and a user-friendly interface for model selection.

This should **not affect** existing code editor extensions. Code editor extensions must be upgraded to provide external models and, export `APPMAP_NAVIE_MODEL_SELECTOR`, set and persist the selected model.

https://github.com/user-attachments/assets/58abdd13-a7e6-4165-8e27-a5fe7b52769f

