### PR TITLE
feat: Add PerformanceObserver import

### DIFF
--- a/packages/cli/src/cmds/index/rpc.ts
+++ b/packages/cli/src/cmds/index/rpc.ts
@@ -1,4 +1,5 @@
 import { warn } from 'node:console';
+import { PerformanceObserver } from 'node:perf_hooks';
 
 import yargs from 'yargs';
 

--- a/packages/cli/src/cmds/navie.ts
+++ b/packages/cli/src/cmds/navie.ts
@@ -1,6 +1,7 @@
 import { warn } from 'node:console';
 import { createWriteStream } from 'node:fs';
 import { readFile } from 'node:fs/promises';
+import { PerformanceObserver } from 'node:perf_hooks';
 import type { Writable } from 'node:stream';
 import { text } from 'node:stream/consumers';
 

--- a/packages/search/src/cli.ts
+++ b/packages/search/src/cli.ts
@@ -1,3 +1,5 @@
+import { PerformanceObserver } from 'node:perf_hooks';
+
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 import makeDebug from 'debug';


### PR DESCRIPTION
PerformanceObserver wasn't globally available in node 18, leading to crashes