### PR TITLE
feat: Customize Navie's User Agent

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -39,8 +39,16 @@ import * as RpcClientCommand from './cmds/rpcClient';
 import * as NavieCommand from './cmds/navie';
 import * as ApplyCommand from './cmds/apply';
 import { default as sqlErrorLog } from './lib/sqlErrorLog';
+import { RequestHeaders } from '@appland/navie';
+import { PACKAGE_VERSION } from './lib/packageVersion';
+import detectCodeEditor from './lib/detectCodeEditor';
 
 setSQLErrorHandler(sqlErrorLog);
+
+RequestHeaders.instance.update({
+  version: PACKAGE_VERSION,
+  codeEditor: detectCodeEditor(),
+});
 
 // eslint-disable-next-line no-unused-expressions
 yargs(process.argv.slice(2))

--- a/packages/cli/src/lib/packageVersion.ts
+++ b/packages/cli/src/lib/packageVersion.ts
@@ -1,0 +1,13 @@
+import { sync as readPackageUpSync } from 'read-pkg-up';
+
+/**
+ * Returns the version from package.json, or undefined if it cannot be found.
+ *
+ * This is a cached value, so it will only be calculated once.
+ */
+function getPackageVersion(): string | undefined {
+  const result = readPackageUpSync({ cwd: __dirname });
+  return result?.packageJson?.version;
+}
+
+export const PACKAGE_VERSION = getPackageVersion();

--- a/packages/navie/src/index.ts
+++ b/packages/navie/src/index.ts
@@ -1,4 +1,3 @@
-/* eslint-disable import/prefer-default-export */
 export { default as applyContext } from './lib/apply-context';
 export { default as extractFileChanges } from './lib/extract-file-changes';
 export { default as Message } from './message';
@@ -16,3 +15,4 @@ export * as InteractionHistory from './interaction-history';
 export { SELECTED_BACKEND } from './services/completion-service-factory';
 export { UserOptions, default as parseOptions } from './lib/parse-options';
 export { REVIEW_DIFF_LOCATION } from './commands/review-command';
+export { default as RequestHeaders } from './lib/request-headers';

--- a/packages/navie/src/lib/request-headers.ts
+++ b/packages/navie/src/lib/request-headers.ts
@@ -1,0 +1,29 @@
+interface UpdateOptions {
+  version?: string;
+  codeEditor?: string;
+}
+
+export default class RequestHeaders {
+  private version?: string;
+  private codeEditor?: string;
+  private platform: string = `${process.platform}-${process.arch}`;
+  private nodeVersion: string = `${process.release.name} ${process.versions.node}`;
+
+  static instance = new RequestHeaders();
+  private constructor() {
+    // nothing to do
+  }
+
+  update(opts: UpdateOptions) {
+    if (opts.version) this.version = opts.version;
+    if (opts.codeEditor) this.codeEditor = opts.codeEditor;
+  }
+
+  buildHeaders(): Record<string, string> {
+    const product = ['AppMap Navie', this.version].filter(Boolean).join('/');
+    const info = [this.platform, this.nodeVersion, this.codeEditor].filter(Boolean).join('; ');
+    return {
+      'User-Agent': `${product} (${info})`,
+    };
+  }
+}

--- a/packages/navie/src/services/anthropic-completion-service.ts
+++ b/packages/navie/src/services/anthropic-completion-service.ts
@@ -16,6 +16,7 @@ import CompletionService, {
 } from './completion-service';
 import Trajectory from '../lib/trajectory';
 import MessageTokenReducerService from './message-token-reducer-service';
+import RequestHeaders from '../lib/request-headers';
 
 /*
   Generated on https://docs.anthropic.com/en/docs/about-claude/models with
@@ -127,6 +128,9 @@ export default class AnthropicCompletionService implements CompletionService {
       modelName: options?.model ?? this.modelName,
       temperature: options?.temperature ?? this.temperature,
       streaming: options?.streaming ?? true,
+      clientOptions: {
+        defaultHeaders: RequestHeaders.instance.buildHeaders(),
+      },
     });
   }
 

--- a/packages/navie/test/services/openai-completion-service.spec.ts
+++ b/packages/navie/test/services/openai-completion-service.spec.ts
@@ -146,7 +146,14 @@ describe('OpenAICompletionService', () => {
       it('completes the question', async () => {
         await complete({ temperature: 0.5 });
         expect(completionWithRetry).toHaveBeenCalledWith(
-          expect.objectContaining({ temperature: 0.5 })
+          expect.objectContaining({ temperature: 0.5 }),
+          {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            headers: expect.objectContaining({
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+              'User-Agent': expect.stringContaining('AppMap Navie'),
+            }),
+          }
         );
       });
     });
@@ -194,7 +201,14 @@ describe('OpenAICompletionService', () => {
           ],
           temperature: options.temperature,
           model: service.miniModelName,
-        })
+        }),
+        {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          headers: expect.objectContaining({
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            'User-Agent': expect.stringContaining('AppMap Navie'),
+          }),
+        }
       );
     });
 
@@ -277,7 +291,14 @@ describe('OpenAICompletionService', () => {
                 ),
               },
             ],
-          })
+          }),
+          {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            headers: expect.objectContaining({
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+              'User-Agent': expect.stringContaining('AppMap Navie'),
+            }),
+          }
         );
       });
 


### PR DESCRIPTION
This pull request introduces a feature to customize the User Agent for Navie by implementing a `RequestHeaders` class. The changes include:

- **User Agent Customization:** A new `RequestHeaders` class is introduced to construct and manage request headers, allowing the Navie client to send customized User Agent strings for outgoing requests. The User Agent includes information about the AppMap, code editor, platform, and Node.js version.
  
- **Version Detection:** Integration of a utility to read the package version from `package.json`. This is used in forming the User Agent string.
  
- **Header Integration:** The headers configured by the `RequestHeaders` instance are used in both the `AnthropicCompletionService` and `OpenAICompletionService` to ensure all HTTP requests from these services include the customized User Agent.

- **Testing Updates:** Enhancements to tests for the OpenAICompletionService to validate the inclusion of the User Agent in HTTP requests.

This update improves the identification of Navie clients by external services, aiding better analytics and debugging capabilities. It also broadens customization by dynamically pulling the editor version and other runtime details.