### PR TITLE
Thread Initialization and Message Handling Improvements

### DIFF
--- a/packages/cli/src/rpc/explain/navie/navie-local.ts
+++ b/packages/cli/src/rpc/explain/navie/navie-local.ts
@@ -131,7 +131,6 @@ export default class LocalNavie extends EventEmitter implements INavie {
 
     this.#reportConfigTelemetry();
     log(`[local-navie] Processing question ${userMessageId} in thread ${threadId}`);
-    this.emit('ack', userMessageId, threadId);
 
     try {
       const clientRequest: Navie.ClientRequest = {
@@ -164,6 +163,8 @@ export default class LocalNavie extends EventEmitter implements INavie {
         }
         history?.question(threadId, userMessageId, question, codeSelection, prompt);
       }
+
+      this.emit('ack', userMessageId, threadId);
 
       const startTime = Date.now();
       this.activeNavie = navie(

--- a/packages/cli/src/rpc/navie/register.ts
+++ b/packages/cli/src/rpc/navie/register.ts
@@ -65,7 +65,7 @@ export async function register(
     };
   }
 
-  threadService.registerThread(thread);
+  await threadService.registerThread(thread);
 
   return { thread };
 }

--- a/packages/cli/src/rpc/navie/services/threadService.ts
+++ b/packages/cli/src/rpc/navie/services/threadService.ts
@@ -78,13 +78,13 @@ export default class ThreadService {
    *
    * @param conversationThread The thread to register
    */
-  registerThread(conversationThread: ConversationThread) {
+  async registerThread(conversationThread: ConversationThread) {
     if (this.memoryThreads.has(conversationThread.id)) {
       throw new Error(`Thread ${conversationThread.id} is already registered`);
     }
 
     const thread = new Thread(conversationThread, this.navieService);
-    thread.initialize();
+    await thread.initialize();
 
     this.memoryThreads.set(conversationThread.id, thread);
   }

--- a/packages/cli/src/rpc/navie/thread/index.ts
+++ b/packages/cli/src/rpc/navie/thread/index.ts
@@ -71,8 +71,9 @@ export class Thread {
     }
   }
 
-  initialize() {
+  async initialize() {
     this.logEvent({ type: 'thread-init', conversationThread: this.conversationThread });
+    await this.flush();
   }
 
   private logEvent(event: NavieEvent) {

--- a/packages/cli/src/rpc/navie/thread/index.ts
+++ b/packages/cli/src/rpc/navie/thread/index.ts
@@ -32,10 +32,22 @@ export type EventListener = (...args: any[]) => void;
 function convertContext(context?: NavieRpc.V1.Thread.ContextItem[]): UserContext.ContextItem[] {
   if (!context) return [];
   return context.map((item) => {
-    if (item.content) {
-      return { type: 'code-snippet', content: item.content, location: item.uri };
+    let location = item.uri;
+    try {
+      const uri = URI.parse(item.uri);
+      if (uri.scheme === 'file') {
+        location = uri.fsPath;
+        if (uri.range) {
+          location += [uri.range.start, uri.range.end].filter(Boolean).join('-');
+        }
+      }
+    } catch (e) {
+      console.warn('[convertContext]', e);
     }
-    return { type: 'file', location: item.uri };
+    if (item.content) {
+      return { type: 'code-snippet', content: item.content, location };
+    }
+    return { type: 'file', location };
   });
 }
 

--- a/packages/cli/tests/unit/rpc/navie/services/threadService.spec.ts
+++ b/packages/cli/tests/unit/rpc/navie/services/threadService.spec.ts
@@ -15,7 +15,6 @@ describe('ThreadService', () => {
 
   beforeEach(() => {
     container.reset();
-    container;
 
     threadIndexService = {
       delete: jest.fn(),
@@ -32,7 +31,7 @@ describe('ThreadService', () => {
 
   describe('getThread', () => {
     it('retrieves a thread from memory', async () => {
-      threadService.registerThread({ id: threadId } as unknown as ConversationThread);
+      await threadService.registerThread({ id: threadId } as unknown as ConversationThread);
       await expect(threadService.getThread(threadId)).resolves.toBeInstanceOf(Thread);
     });
 
@@ -65,10 +64,10 @@ describe('ThreadService', () => {
   });
 
   describe('registerThread', () => {
-    it('fails if the thread is already registered', () => {
+    it('fails if the thread is already registered', async () => {
       const conversationThread = { id: threadId } as unknown as ConversationThread;
-      threadService.registerThread(conversationThread);
-      expect(() => threadService.registerThread(conversationThread)).toThrow(
+      await threadService.registerThread(conversationThread);
+      await expect(() => threadService.registerThread(conversationThread)).rejects.toThrow(
         `Thread ${conversationThread.id} is already registered`
       );
     });

--- a/packages/cli/tests/unit/rpc/navie/thread/index.spec.ts
+++ b/packages/cli/tests/unit/rpc/navie/thread/index.spec.ts
@@ -255,7 +255,7 @@ describe('Thread', () => {
     });
 
     it('does not raise an error if the thread index fails to update', async () => {
-      thread.initialize();
+      await thread.initialize();
       threadIndexService.index = jest.fn().mockImplementation(() => {
         throw new Error('test error');
       });
@@ -263,16 +263,15 @@ describe('Thread', () => {
     });
 
     it('does not raise an error if the history file fails to write', async () => {
-      thread.initialize();
       await writeFile(expectedPath, '');
       await chmod(expectedPath, 0o400);
+      await thread.initialize();
       await expect(thread.flush()).resolves.toBeUndefined();
       await expect(readFile(expectedPath, { encoding: 'utf-8' })).resolves.toBe('');
     });
 
     it('appends to an existing history file as expected', async () => {
-      thread.initialize();
-      await thread.flush();
+      await thread.initialize();
 
       thread.logEvent({ type: 'message', role: 'assistant', content: 'test', messageId: '1' });
       await thread.flush();


### PR DESCRIPTION
This PR addresses several issues related to thread handling and message processing in the Navie chat system:

1. Fixed file path handling when pinning items by converting URIs to filesystem paths
2. Improved thread initialization to ensure threads are properly persisted to disk
3. Enhanced message acknowledgment timing to prevent duplicate messages in chat history

## Changes

- Thread initialization now flushes conversation state to disk immediately
- Message acknowledgment occurs after chat history is read, preventing duplicate messages
- URI paths are converted to filesystem paths for better context lookup
- Added error handling for URI parsing during context conversion
- Updated unit tests to handle async thread registration

## Impact
These changes improve the reliability of chat thread persistence and message handling, particularly in cases where Navie restarts with open chat views or when working with pinned items in conversations.