### PR TITLE
fix: Restore frontend rendering of diff blocks

### DIFF
--- a/packages/components/src/components/chat-search/StreamingMessageContent.ts
+++ b/packages/components/src/components/chat-search/StreamingMessageContent.ts
@@ -2,6 +2,7 @@ import Vue from 'vue';
 import VCodeFencedContent from '@/components/chat/CodeFencedContent.vue';
 import VNextPromptButton from '@/components/chat/NextPromptButton.vue';
 import VInlineRecommendation from '@/components/chat/InlineRecommendation.vue';
+import VMarkdownCodeSnippet from '@/components/chat/MarkdownCodeSnippet.vue';
 
 function getAttributeRecord(attrs: NamedNodeMap): Record<string, string> {
   return Array.from(attrs).reduce((memo, attr) => {
@@ -76,6 +77,7 @@ export default Vue.extend({
     VCodeFencedContent,
     VNextPromptButton,
     VInlineRecommendation,
+    VMarkdownCodeSnippet,
   },
   data() {
     return {

--- a/packages/components/src/components/chat/ContextContainer.vue
+++ b/packages/components/src/components/chat/ContextContainer.vue
@@ -89,7 +89,7 @@
             @click.stop="onPin"
             data-cy="pin"
             :data-pinned="pinned"
-            v-if="isPinnable"
+            v-if="isPinnable && valueUri"
           >
             <v-pin-icon />
           </span>

--- a/packages/components/src/components/chat/UserMessage.vue
+++ b/packages/components/src/components/chat/UserMessage.vue
@@ -236,11 +236,21 @@ export default {
           'v-next-prompt-button',
           'v-code-fenced-content',
           'v-inline-recommendation',
+          'v-markdown-code-snippet',
           'change',
           'modified',
           'original',
         ],
-        ADD_ATTR: ['uri', 'command', 'prompt', 'target', 'emit-event', 'reasoning'],
+        ADD_ATTR: [
+          'uri',
+          'command',
+          'prompt',
+          'target',
+          'emit-event',
+          'reasoning',
+          'language',
+          'location',
+        ],
         ALLOWED_URI_REGEXP:
           /^(?:(?:(?:f|ht)tps?|mailto|event|file|urn):|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i,
       });

--- a/packages/components/tests/unit/chat/ContextContainer.spec.js
+++ b/packages/components/tests/unit/chat/ContextContainer.spec.js
@@ -15,7 +15,7 @@ describe('components/chat/ContextContainer.vue', () => {
   });
 
   it('emits pin event', async () => {
-    const wrapper = mount(VContextContainer);
+    const wrapper = mount(VContextContainer, { propsData: { uri: 'urn:uuid:0' } });
     await wrapper.find('[data-cy="pin"]').trigger('click');
 
     const events = wrapper.emitted().pin;

--- a/packages/components/tests/unit/chat/UserMessage.spec.ts
+++ b/packages/components/tests/unit/chat/UserMessage.spec.ts
@@ -102,6 +102,44 @@ describe('components/UserMessage.vue', () => {
       });
       expect(wrapper.get('[data-cy="message-text"]').text()).toBe(snippets.xss);
     });
+
+    it('renders change blocks', () => {
+      const wrapper = mount(VUserMessage, {
+        propsData: {
+          tokens: [
+            `<change>
+<file change-number-for-this-file="1">/home/db/dev/applandinc/vscode-appland/package.json</file>
+<original line-count="7" no-ellipsis="true">
+<![CDATA[
+  "dependencies": {
+    "@appland/appmap": "^3.129.0",
+    "@appland/client": "^1.23.0",
+    "@appland/components": "^4.46.1",
+    "@appland/diagrams": "^1.8.0",
+    "@appland/models": "^2.10.2",
+    "@appland/rpc": "^1.19.0",]]></original>
+<modified line-count="8" no-ellipsis="true">
+<![CDATA[
+  "dependencies": {
+    "@appland/appmap": "^3.129.0",
+    "@appland/client": "^1.23.0",
+    "@appland/components": "^4.46.1",
+    "@appland/diagrams": "^1.8.0",
+    "@appland/models": "^2.10.2",
+    "@appland/rpc": "^1.19.0",
+    "new-dependency": "^0.1.0",]]></modified>
+</change>
+`,
+          ],
+        },
+      });
+      expect(wrapper.get('[data-cy="context-header"]').text()).toContain('package.json');
+      expect(wrapper.get('.hljs-addition').text()).toContain('new-dependency');
+      expect(wrapper.get('[data-cy="apply"]').exists()).toBe(true);
+
+      // Pinned diffs are not supported as they're not identified by the thread backend.
+      expect(() => wrapper.get('[data-cy="pin"]')).toThrow();
+    });
   });
 
   describe('Save Button', () => {


### PR DESCRIPTION
Note that this isn't currently supported by the thread backend, so these blocks do not have identifiers and cannot be pinned.

![image](https://github.com/user-attachments/assets/3592a700-4e58-4adc-978c-48ffc5049410)

Resolves #2273