### PR TITLE
@observe command can now make test cases

### DIFF
--- a/packages/navie/src/commands/explain-command.ts
+++ b/packages/navie/src/commands/explain-command.ts
@@ -34,8 +34,11 @@ export default class ExplainCommand implements Command {
     private readonly options: ExplainOptions,
     public readonly interactionHistory: InteractionHistory,
     private readonly completionService: CompletionService,
-    private readonly classifierService: ClassificationService,
-    private readonly agentSelectionService: AgentSelectionService,
+    private readonly classifierService: ClassificationService | undefined,
+    private readonly agentSelectionService: Pick<
+      AgentSelectionService,
+      'selectAgent' | 'contextService'
+    >,
     private readonly codeSelectionService: CodeSelectionService,
     private readonly projectInfoService: ProjectInfoService,
     private readonly memoryService: MemoryService
@@ -52,7 +55,7 @@ export default class ExplainCommand implements Command {
     let contextLabelsFn: Promise<ContextV2.ContextLabel[]> | undefined;
 
     performance.mark('classifyStart');
-    if (classifyEnabled)
+    if (classifyEnabled && this.classifierService)
       contextLabelsFn = this.classifierService
         .classifyQuestion(baseQuestion, chatHistory)
         .catch((err) => {

--- a/packages/navie/src/commands/observe-command.ts
+++ b/packages/navie/src/commands/observe-command.ts
@@ -38,10 +38,15 @@ const RelevantTest = z.object({
     .describe('An ordered list of terminal command(s) necessary to execute to install AppMap'),
   testCommands: z
     .array(
-      z.object({
-        command: z.string().describe('The command to execute'),
-        description: z.string().optional().describe('A description of the command'),
-      })
+      z
+        .union([
+          z.object({
+            command: z.string().describe('The command to execute'),
+            description: z.string().optional().describe('A description of the command'),
+          }),
+          z.string().describe('A command to execute'),
+        ])
+        .describe('The command to execute')
     )
     .optional()
     .describe('The ordered list of terminal command(s) that can be executed to run the test'),
@@ -205,7 +210,7 @@ ${
   testCommands?.length
     ? `I've identified the following commands that you may need to run to execute the test:
 <commands>
-${testCommands?.map((command) => `- \`${command.command}\`: ${command.description}`).join('\n')}
+${testCommands?.map((command) => `- ${commandDescription(command)}`).join('\n')}
 </commands>
 `
     : ''
@@ -249,4 +254,11 @@ Do not include:
       yield token;
     }
   }
+}
+
+function commandDescription(command: string | { command: string; description?: string }): string {
+  if (typeof command === 'string') {
+    return `\`${command}\``;
+  }
+  return `\`${command.command}\`: ${command.description ?? ''}`;
 }

--- a/packages/navie/src/interaction-history.ts
+++ b/packages/navie/src/interaction-history.ts
@@ -316,6 +316,21 @@ class InteractionHistory extends EventEmitter {
     this.events.push(event);
   }
 
+  /**
+   * Clone the interaction history.
+   * This is useful for creating a copy of the interaction history
+   * that can be modified without affecting the original.
+   * @note this is a shallow copy, so the events are not cloned.
+   * This means that modifying the events in the clone will also modify the events in the original.
+   * @returns a shallow copy of the interaction history
+   */
+  clone(): InteractionHistory {
+    const clone = new InteractionHistory();
+    clone.events.push(...this.events);
+    clone.acceptPinnedFileContext = this.acceptPinnedFileContext;
+    return clone;
+  }
+
   stopAcceptingPinnedFileContext() {
     this.acceptPinnedFileContext = false;
   }

--- a/packages/navie/src/lib/closing-tags.ts
+++ b/packages/navie/src/lib/closing-tags.ts
@@ -1,0 +1,33 @@
+/** Scan the text for any unclosed XML tags and returns the closing tags to be appended. */
+export default function closingTags(text: string): string {
+  // Stack to keep track of open tags
+  const openTags: string[] = [];
+
+  // Match opening and self-closing tags
+  const tagRegex = /<(\/)?([a-zA-Z]+)([^>]*?)(\/)?>/g;
+
+  for (const match of text.matchAll(tagRegex)) {
+    const [, close, tagName, attributes, selfClosing] = match;
+
+    // Skip self-closing tags
+    if (selfClosing) continue;
+
+    // Check if this is a closing tag
+    if (close || attributes.trim().startsWith('/')) {
+      // Found a closing tag, remove the matching opening tag if it exists
+      const lastOpenTag = openTags[openTags.length - 1];
+      if (lastOpenTag === tagName) {
+        openTags.pop();
+      }
+    } else {
+      // Found an opening tag, push it onto the stack
+      openTags.push(tagName);
+    }
+  }
+
+  // Generate closing tags for any remaining open tags in reverse order
+  return openTags
+    .reverse()
+    .map((tag) => `</${tag}>`)
+    .join('');
+}

--- a/packages/navie/src/lib/parse-options.ts
+++ b/packages/navie/src/lib/parse-options.ts
@@ -1,7 +1,21 @@
 import { ContextV2 } from '../context';
 
 export class UserOptions {
-  constructor(private options: Map<string, string | boolean>) {}
+  private options: Map<string, string | boolean>;
+  constructor(options: Map<string, string | boolean> | Record<string, string | boolean>) {
+    this.options = new Map<string, string | boolean>();
+    if (options instanceof Map) {
+      this.options = options;
+    } else {
+      Object.entries(options).forEach(([key, value]) => {
+        this.options.set(key.toLowerCase(), value);
+      });
+    }
+  }
+
+  [Symbol.iterator](): IterableIterator<[string, string | boolean]> {
+    return this.options.entries();
+  }
 
   has(key: string): boolean {
     return this.options.has(key);

--- a/packages/navie/src/lib/replace-stream.ts
+++ b/packages/navie/src/lib/replace-stream.ts
@@ -1,0 +1,35 @@
+import splitOn from './split-on';
+
+/**
+ * Replace a needle in a stream with a replacement function.
+ * The replacement function is called with the found string and returns an async iterable of strings.
+ * The replacement function can be async, and will be awaited.
+ * The replacement function can yield multiple strings.
+ * The replacement function can be called multiple times if the needle is found multiple times.
+ * @param source the source stream
+ * @param needle the string or regex to search
+ * @param replacement the replacement function
+ */
+export default async function* replaceStream(
+  source: AsyncIterable<string>,
+  needle: string | RegExp,
+  replacement: (found: string) => AsyncIterable<string>
+): AsyncIterable<string> {
+  let buffer = '';
+  for await (const chunk of source) {
+    buffer += chunk;
+    while (buffer) {
+      const [before, found, after] = splitOn(buffer, needle);
+      yield before;
+      if (found) {
+        if (after) {
+          yield* replacement(found);
+        } else {
+          buffer = found;
+          break;
+        }
+      }
+      buffer = after;
+    }
+  }
+}

--- a/packages/navie/test/lib/closing-tags.spec.ts
+++ b/packages/navie/test/lib/closing-tags.spec.ts
@@ -1,0 +1,35 @@
+import closingTags from '../../src/lib/closing-tags';
+
+describe('closingTags', () => {
+  it('returns empty string for no unclosed tags', () => {
+    expect(closingTags('<tag></tag>')).toBe('');
+  });
+
+  it('returns closing tag for single unclosed tag', () => {
+    expect(closingTags('<tag>')).toBe('</tag>');
+  });
+
+  it('handles multiple unclosed tags', () => {
+    expect(closingTags('<outer><inner>')).toBe('</inner></outer>');
+  });
+
+  it('handles self-closing tags', () => {
+    expect(closingTags('<outer><self/><inner>')).toBe('</inner></outer>');
+  });
+
+  it('handles properly closed inner tags', () => {
+    expect(closingTags('<outer><inner></inner>')).toBe('</outer>');
+  });
+
+  it('handles mixed closed and unclosed tags', () => {
+    expect(closingTags('<a><b></b><c>')).toBe('</c></a>');
+  });
+
+  it('handles tags with attributes', () => {
+    expect(closingTags('<div class="test"><span id="inner">')).toBe('</span></div>');
+  });
+
+  it('returns empty string for text without tags', () => {
+    expect(closingTags('plain text')).toBe('');
+  });
+});


### PR DESCRIPTION
This pull request introduces enhancements to the `observe-command` and `explain-command` functionality, focusing on improved test case suggestions, handling of unclosed XML tags, and better flexibility in user options. It also includes utility additions and test coverage for new functionality.

### Enhancements to `observe-command`:

* Added logic to suggest a test case when no relevant test is found, with detailed descriptions and placeholders for test case generation. (`[[1]](diffhunk://#diff-453f47dc0b3f8349e806c45215de8b8589cdab994445a033872a11f6dae2d98cR160-R162)`, `[[2]](diffhunk://#diff-453f47dc0b3f8349e806c45215de8b8589cdab994445a033872a11f6dae2d98cR193-R270)`, `[[3]](diffhunk://#diff-453f47dc0b3f8349e806c45215de8b8589cdab994445a033872a11f6dae2d98cL189-R296)`, `[[4]](diffhunk://#diff-453f47dc0b3f8349e806c45215de8b8589cdab994445a033872a11f6dae2d98cL225-R332)`)
* Introduced a new private method `suggestTestCase` to handle the generation of test case suggestions using `ExplainCommand`. (`[packages/navie/src/commands/observe-command.tsR193-R270](diffhunk://#diff-453f47dc0b3f8349e806c45215de8b8589cdab994445a033872a11f6dae2d98cR193-R270)`)
* Updated the `RelevantTest` schema to support nullable and transformed fields, and added a `suggestedTest` field for test case suggestions. (`[[1]](diffhunk://#diff-453f47dc0b3f8349e806c45215de8b8589cdab994445a033872a11f6dae2d98cR3-R60)`, `[[2]](diffhunk://#diff-453f47dc0b3f8349e806c45215de8b8589cdab994445a033872a11f6dae2d98cR72-R80)`)

### Enhancements to `explain-command`:

* Made `classifierService` optional and restricted `agentSelectionService` to specific properties, improving flexibility and type safety. (`[[1]](diffhunk://#diff-8fc64b3b138b643930110c42f044e061bdc178fb607f1fbcf34bd30b7b13e95cL37-R41)`, `[[2]](diffhunk://#diff-8fc64b3b138b643930110c42f044e061bdc178fb607f1fbcf34bd30b7b13e95cL55-R58)`)

### Utility additions:

* Added a `closingTags` function to detect and append missing XML closing tags, ensuring well-formed output. (`[packages/navie/src/lib/closing-tags.tsR1-R33](diffhunk://#diff-192232aef104a6ceddd59ee60925fa896ff165740e45f82e81195e1232e91412R1-R33)`)
* Introduced a `replaceStream` utility to replace specific patterns in a stream with asynchronous replacements. (`[packages/navie/src/lib/replace-stream.tsR1-R35](diffhunk://#diff-103e6121f36f41a08a0e12704ff43d2930a244b4b4e63d77f5a84bb23dbf5e01R1-R35)`)

### Improvements to `InteractionHistory`:

* Added a `clone` method to create shallow copies of interaction history for isolated modifications. (`[packages/navie/src/interaction-history.tsR319-R333](diffhunk://#diff-ed85c6d6714ad90002f856d93a39906e6cbd3135d24e1b4bb445c8360a9df27cR319-R333)`)

### Test coverage:

* Added unit tests for the `closingTags` utility to validate its behavior with various tag scenarios. (`[packages/navie/test/lib/closing-tags.spec.tsR1-R35](diffhunk://#diff-6e1aad13709c90f0f865d6437be1b34d8931838f059ea792158b095afc9e2c26R1-R35)`)