### PR TITLE
fix: Update database name

### DIFF
--- a/packages/cli/src/rpc/navie/services/threadIndexService.ts
+++ b/packages/cli/src/rpc/navie/services/threadIndexService.ts
@@ -72,7 +72,7 @@ export interface ThreadIndexItem {
 @injectable()
 export class ThreadIndexService {
   static readonly MIGRATION_RETRIES = 5;
-  static readonly DEFAULT_DATABASE_PATH = join(homedir(), '.appmap', 'navie', 'thread-index.db');
+  static readonly DEFAULT_DATABASE_PATH = join(homedir(), '.appmap', 'navie', 'chat-history.db');
   static readonly DATABASE = 'ThreadIndexDatabase';
 
   constructor(@inject(ThreadIndexService.DATABASE) private readonly db: sqlite3.Database) {

--- a/packages/cli/src/rpc/navie/services/threadIndexService.ts
+++ b/packages/cli/src/rpc/navie/services/threadIndexService.ts
@@ -89,7 +89,11 @@ export class ThreadIndexService {
    * initialization to ensure that the database is up to date.
    */
   public async migrate(databaseFilePath = ThreadIndexService.DEFAULT_DATABASE_PATH) {
-    if (!this.shouldMigrate()) return;
+    try {
+      if (!this.shouldMigrate()) return;
+    } catch (e) {
+      console.error('Failed to check migration status, migration will be attempted:', e);
+    }
 
     let lockRelease: (() => Promise<void>) | undefined;
     try {


### PR DESCRIPTION
This PR addresses two issues related to the Navie chat history database managed by `ThreadIndexService`:

*   **Database Rename:** The underlying SQLite database file has been renamed from `~/.appmap/navie/thread-index.db` to `~/.appmap/navie/chat-history.db`. This provides a more accurate name for its purpose. (See commit `3670f77f`)

*   **Migration Robustness:** The `migrate` function now attempts to run migrations even if the initial check for the database version (`shouldMigrate()`, which queries `user_version`) throws an error. Previously, such an error would prevent migrations from running. This change improves robustness, allowing the system to potentially recover or initialize the database correctly in cases where it might be corrupted or inaccessible for the version check. An error is logged if the check fails. (See commit `a3baa611`)

These changes improve the clarity and resilience of the chat history feature.