### PR TITLE
fix: Navie now properly renders indented code blocks

### DIFF
--- a/packages/components/src/lib/stripCodeFences.ts
+++ b/packages/components/src/lib/stripCodeFences.ts
@@ -1,11 +1,102 @@
+/**
+ * Checks for and removes the first and/or last lines if they match
+ * the code fence pattern (```).
+ * It also returns the indentation found on the opening fence line, if any.
+ *
+ * @param lines - An array of strings representing the lines of text.
+ * @returns An object containing the lines potentially stripped of fences (`contentLines`)
+ *          and the indentation string found preceding the opening fence (`openingIndent`),
+ *          which will be null if no opening fence was found.
+ */
+export function removeFenceLines(lines: string[]): {
+  contentLines: string[];
+  openingIndent: string | null;
+} {
+  if (lines.length === 0) {
+    return { contentLines: [], openingIndent: null };
+  }
+
+  const fenceRegex = /^(\s*)`{3,}/;
+  const openingMatch = lines[0].match(fenceRegex);
+
+  // Only check the last line if there's more than one line,
+  // or if there's only one line and it didn't match the opening fence.
+  // prettier-ignore
+  const closingMatch = (lines.length > 1 || !openingMatch)
+    ? lines[lines.length - 1].match(fenceRegex)
+    : null;
+
+  let start = 0;
+  let end = lines.length;
+  let openingIndent: string | null = null;
+
+  if (openingMatch) {
+    start = 1;
+    openingIndent = openingMatch[1]; // Capture the indentation (whitespace)
+  }
+
+  if (closingMatch) {
+    // Avoid reducing 'end' if the closing fence is the same line as a potential opening fence
+    if (lines.length > 1 || !openingMatch) {
+      end = lines.length - 1;
+    }
+  }
+
+  // Ensure 'end' isn't less than 'start', which can happen if input is e.g., ["```", "```"]
+  const finalEnd = Math.max(start, end);
+  const contentLines = lines.slice(start, finalEnd);
+
+  return { contentLines, openingIndent };
+}
+
+/**
+ * Removes a specific leading indentation string from each line in an array.
+ * If a line doesn't start with the exact indentation string, it's left unchanged.
+ *
+ * @param lines - The array of lines to dedent.
+ * @param indentToRemove - The exact whitespace string to remove from the start of each line.
+ * @returns A new array with lines dedented.
+ */
+export function dedentLines(lines: string[], indentToRemove: string): string[] {
+  // If indent is empty string, null, or undefined, no dedentation needed.
+  if (!indentToRemove) {
+    return lines;
+  }
+
+  return lines.map((line) => {
+    if (line.startsWith(indentToRemove)) {
+      return line.slice(indentToRemove.length);
+    }
+    return line; // Leave line as-is if it doesn't start with the indent
+  });
+}
+
+/**
+ * Removes optional code fences (```) from the start and end of a string
+ * and removes the leading indentation from the content lines, based *only*
+ * on the indentation level of the opening fence line.
+ *
+ * @param text - The input string potentially containing code fences.
+ * @returns The processed string with fences removed and content dedented.
+ */
 export default function stripCodeFences(text: string): string {
-  let sliceStart: number | undefined = undefined;
-  let sliceEnd: number | undefined = undefined;
-  if (text.match(/^`{3,}(.*)\n/)) {
-    sliceStart = 1;
+  const processedText = text.endsWith('\n') ? text.slice(0, -1) : text;
+
+  // Handle empty string edge case after potential trimming
+  if (processedText === '') {
+    return '';
   }
-  if (text.match(/\n`{3,}\s*?$/)) {
-    sliceEnd = -1;
-  }
-  return text.split('\n').slice(sliceStart, sliceEnd).join('\n');
+
+  const lines = processedText.split('\n');
+
+  // Step 1: Remove fence lines and detect opening indentation
+  const { contentLines, openingIndent } = removeFenceLines(lines);
+
+  // Step 2: Dedent the content lines based on the opening fence's indent
+  //         (Only run dedent if an opening fence was actually found)
+  const processedLines =
+    openingIndent !== null ? dedentLines(contentLines, openingIndent) : contentLines;
+
+  // Step 3: Join lines back together
+  return processedLines.join('\n');
 }

--- a/packages/components/tests/unit/lib/stripCodeFences.spec.js
+++ b/packages/components/tests/unit/lib/stripCodeFences.spec.js
@@ -1,0 +1,235 @@
+import stripCodeFences, { removeFenceLines, dedentLines } from '@/lib/stripCodeFences';
+
+describe('removeFenceLines', () => {
+  it('should return empty array and null indent for empty input', () => {
+    expect(removeFenceLines([])).toEqual({ contentLines: [], openingIndent: null });
+  });
+
+  it('should return original lines and null indent if no fences are present', () => {
+    const lines = ['line 1', 'line 2'];
+    expect(removeFenceLines(lines)).toEqual({
+      contentLines: ['line 1', 'line 2'],
+      openingIndent: null,
+    });
+  });
+
+  it('removes opening fences with a language specifier', () => {
+    const lines = ['```javascript', 'content line 1', 'content line 2'];
+    expect(removeFenceLines(lines)).toEqual({
+      contentLines: ['content line 1', 'content line 2'],
+      openingIndent: '',
+    });
+  });
+
+  it('should remove only opening fence (no indent) and return empty indent', () => {
+    const lines = ['```', 'content'];
+    expect(removeFenceLines(lines)).toEqual({ contentLines: ['content'], openingIndent: '' });
+  });
+
+  it('should remove only opening fence (with indent) and return the indent', () => {
+    const lines = ['  ```', '  content'];
+    expect(removeFenceLines(lines)).toEqual({ contentLines: ['  content'], openingIndent: '  ' });
+  });
+
+  it('should remove only closing fence and return null indent', () => {
+    const lines = ['content', '```'];
+    expect(removeFenceLines(lines)).toEqual({ contentLines: ['content'], openingIndent: null });
+  });
+
+  it('should remove both fences (no indent) and return empty indent', () => {
+    const lines = ['```', 'content', '```'];
+    expect(removeFenceLines(lines)).toEqual({ contentLines: ['content'], openingIndent: '' });
+  });
+
+  it('should remove both fences (opening indent) and return the opening indent', () => {
+    const lines = ['  ```', '  content line 1', '  content line 2', '```'];
+    expect(removeFenceLines(lines)).toEqual({
+      contentLines: ['  content line 1', '  content line 2'],
+      openingIndent: '  ',
+    });
+  });
+
+  it('should remove both fences (different indents) and return the opening indent', () => {
+    const lines = ['  ```', '  content', '    ```']; // Closing indent is ignored for detection
+    expect(removeFenceLines(lines)).toEqual({ contentLines: ['  content'], openingIndent: '  ' });
+  });
+
+  it('should handle fences with more than 3 backticks', () => {
+    const lines = ['````markdown', 'content', '````'];
+    expect(removeFenceLines(lines)).toEqual({ contentLines: ['content'], openingIndent: '' });
+  });
+
+  it('should handle fences with indentation and more backticks', () => {
+    const lines = ['    ``````', '    content', '    ``````'];
+    expect(removeFenceLines(lines)).toEqual({
+      contentLines: ['    content'],
+      openingIndent: '    ',
+    });
+  });
+
+  it('should handle single line input (content)', () => {
+    const lines = ['just content'];
+    expect(removeFenceLines(lines)).toEqual({
+      contentLines: ['just content'],
+      openingIndent: null,
+    });
+  });
+
+  it('should handle single line input (fence)', () => {
+    const lines = ['```'];
+    expect(removeFenceLines(lines)).toEqual({ contentLines: [], openingIndent: '' });
+  });
+
+  it('should handle two lines input (both fences)', () => {
+    const lines = ['```', '```'];
+    expect(removeFenceLines(lines)).toEqual({ contentLines: [], openingIndent: '' });
+  });
+
+  it('should handle two lines input (both fences with indent)', () => {
+    const lines = ['  ```', '  ```'];
+    expect(removeFenceLines(lines)).toEqual({ contentLines: [], openingIndent: '  ' });
+  });
+
+  it('should not remove fence-like lines in the middle', () => {
+    const lines = ['```', 'line 1', '```', 'line 2', '```'];
+    expect(removeFenceLines(lines)).toEqual({
+      contentLines: ['line 1', '```', 'line 2'],
+      openingIndent: '',
+    });
+  });
+});
+
+describe('dedentLines', () => {
+  it('should return empty array for empty input', () => {
+    expect(dedentLines([], '  ')).toEqual([]);
+  });
+
+  it('should return original lines if indentToRemove is empty', () => {
+    const lines = ['  line 1', '  line 2'];
+    expect(dedentLines(lines, '')).toEqual(['  line 1', '  line 2']);
+  });
+
+  it('should remove the specified indent from lines that start with it', () => {
+    const lines = ['  line 1', '  line 2', 'no indent'];
+    const indent = '  ';
+    expect(dedentLines(lines, indent)).toEqual(['line 1', 'line 2', 'no indent']);
+  });
+
+  it('should remove tab indentation', () => {
+    const lines = ['\tline 1', '\tline 2', 'no indent'];
+    const indent = '\t';
+    expect(dedentLines(lines, indent)).toEqual(['line 1', 'line 2', 'no indent']);
+  });
+
+  it('should not change lines that do not start with the exact indent', () => {
+    const lines = [' line 1', '  line 2', '    line 3'];
+    const indent = '  '; // two spaces
+    expect(dedentLines(lines, indent)).toEqual([' line 1', 'line 2', '  line 3']);
+  });
+
+  it('should handle lines that are shorter than the indent', () => {
+    const lines = [' ', '  line 2'];
+    const indent = '  ';
+    expect(dedentLines(lines, indent)).toEqual([' ', 'line 2']);
+  });
+
+  it('should handle lines consisting only of the indent', () => {
+    const lines = ['  ', '  line 2'];
+    const indent = '  ';
+    expect(dedentLines(lines, indent)).toEqual(['', 'line 2']);
+  });
+
+  it('should handle empty lines within the content', () => {
+    const lines = ['  line 1', '', '  line 3'];
+    const indent = '  ';
+    expect(dedentLines(lines, indent)).toEqual(['line 1', '', 'line 3']);
+  });
+});
+
+describe('stripCodeFences', () => {
+  it('should handle text without fences', () => {
+    const text = 'line 1\nline 2';
+    expect(stripCodeFences(text)).toBe('line 1\nline 2');
+  });
+
+  it('should handle text with fences but no opening indent', () => {
+    const text = '```\ncontent line 1\ncontent line 2\n```';
+    expect(stripCodeFences(text)).toBe('content line 1\ncontent line 2');
+  });
+
+  it('should remove fences and dedent based on opening fence indent', () => {
+    const text = '  ```\n  content line 1\n    indented further\n  line 3\n  ```';
+    const expected = 'content line 1\n  indented further\nline 3';
+    expect(stripCodeFences(text)).toBe(expected);
+  });
+
+  it('should remove only opening fence and dedent', () => {
+    const text = '  ```\n  content line 1\n  content line 2';
+    const expected = 'content line 1\ncontent line 2';
+    expect(stripCodeFences(text)).toBe(expected);
+  });
+
+  it('should remove only closing fence and not dedent', () => {
+    const text = '  content line 1\n  content line 2\n```';
+    const expected = '  content line 1\n  content line 2'; // No dedent applied
+    expect(stripCodeFences(text)).toBe(expected);
+  });
+
+  it('should handle text with fences but no content', () => {
+    const text = '```\n```';
+    expect(stripCodeFences(text)).toBe('');
+  });
+
+  it('should handle text with indented fences but no content', () => {
+    const text = '  ```\n  ```';
+    expect(stripCodeFences(text)).toBe('');
+  });
+
+  it('should handle empty string input', () => {
+    expect(stripCodeFences('')).toBe('');
+  });
+
+  it('should handle single line fence', () => {
+    expect(stripCodeFences('```')).toBe('');
+  });
+
+  it('should handle single line indented fence', () => {
+    expect(stripCodeFences('  ```')).toBe('');
+  });
+
+  it('should handle single line content', () => {
+    expect(stripCodeFences('just content')).toBe('just content');
+  });
+
+  it('should preserve empty lines within the content after dedenting', () => {
+    const text = '  ```\n  line 1\n\n  line 3\n  ```';
+    const expected = 'line 1\n\nline 3';
+    expect(stripCodeFences(text)).toBe(expected);
+  });
+
+  it('should not dedent if content doesnt start with opening fence indent', () => {
+    const text = '  ```\nline 1\nanother line\n  ```';
+    const expected = 'line 1\nanother line'; // Fences removed, but no lines matched '  ' prefix
+    expect(stripCodeFences(text)).toBe(expected);
+  });
+
+  it('should handle fences with language specifiers', () => {
+    const text = '```javascript\nconst x = 1;\n```';
+    expect(stripCodeFences(text)).toBe('const x = 1;');
+  });
+
+  it('should handle indented fences with language specifiers', () => {
+    const text = '  ```typescript\n  const y: string = "hello";\n  ```';
+    expect(stripCodeFences(text)).toBe('const y: string = "hello";');
+  });
+
+  it('should handle trailing newline after closing fence', () => {
+    const text = '```\ncontent\n```\n';
+    expect(stripCodeFences(text)).toBe('content');
+  });
+
+  it('should handle leading newline before opening fence', () => {
+    const text = '\n```\ncontent\n```';
+    expect(stripCodeFences(text)).toBe('\n```\ncontent');
+  });
+});


### PR DESCRIPTION
This pull request addresses an issue where code blocks enclosed in triple backticks (```) were not rendered correctly if the entire block, including the opening and closing fences, was indented.

**Problem:**

The previous implementation of `stripCodeFences` did not account for leading whitespace before the code fences. This resulted in the indentation being incorrectly included as part of the code content, disrupting formatting.

**Solution:**

The `stripCodeFences` utility has been refactored to correctly handle indented code blocks:

1.  It now detects the specific amount of leading whitespace (indentation) present on the line with the opening code fence (` ``` `).
2.  It removes the opening and closing fence lines.
3.  It then removes the *exact* indentation detected in step 1 from the beginning of each line within the code block's content. This preserves relative indentation *within* the block while removing the block's overall indentation relative to its container.
4.  The logic has been broken down into smaller, testable helper functions for clarity and robustness.

**Testing:**

Comprehensive unit tests have been added for the updated utility and its helper functions, covering various scenarios including:
*   Blocks with and without fences.
*   Differing levels of indentation on opening/closing fences and content lines.
*   Empty blocks or blocks with only fences.
*   Edge cases like single-line inputs and empty strings.
*   Preservation of internal empty lines and relative indentation.