### PR TITLE
fix: Migrate from node-sqlite3-wasm to better-sqlite3

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -38,6 +38,7 @@
     "@eslint/js": "~8.57.0",
     "@octokit/types": "^11.1.0",
     "@swc/core": "^1.3.76",
+    "@types/better-sqlite3": "^7.6.11",
     "@types/cors": "^2.8.17",
     "@types/express": "^5.0.1",
     "@types/fs-extra": "^9.0.13",
@@ -105,6 +106,7 @@
     "applicationinsights": "^2.1.4",
     "async": "^3.2.4",
     "axios": "^0.27.2",
+    "better-sqlite3": "^11.5.0",
     "body-parser": "^1.20.2",
     "boxen": "^5.0.1",
     "chalk": "^4.1.2",
@@ -133,7 +135,6 @@
     "lunr": "^2.3.9",
     "minimatch": "^5.1.2",
     "moo": "^0.5.1",
-    "node-sqlite3-wasm": "^0.8.34",
     "open": "^8.2.1",
     "openapi-diff": "^0.23.6",
     "openapi-types": "^12.1.3",
@@ -174,7 +175,9 @@
       "resources",
       "built/appmap.html",
       "built/sequenceDiagram.html",
-      "built/docs"
+      "built/docs",
+      "../../node_modules/better-sqlite3/build/Release/better_sqlite3.node",
+      "node_modules/better-sqlite3/build/Release/better_sqlite3.node"
     ],
     "outputPath": "dist"
   },

--- a/packages/cli/src/cmds/search/search.ts
+++ b/packages/cli/src/cmds/search/search.ts
@@ -1,5 +1,5 @@
-import sqlite3 from 'node-sqlite3-wasm';
 import yargs from 'yargs';
+import sqlite3 from 'better-sqlite3';
 import assert from 'assert';
 import { readFileSync } from 'fs';
 import { writeFile } from 'fs/promises';
@@ -186,7 +186,7 @@ export const handler = async (argv: ArgumentTypes) => {
     };
 
     const index = await buildIndexInTempDir('appmaps', async (indexFile) => {
-      const db = new sqlite3.Database(indexFile);
+      const db = new sqlite3(indexFile);
       const fileIndex = new FileIndex(db);
       await buildAppMapIndex(fileIndex, [process.cwd()]);
       return fileIndex;

--- a/packages/cli/src/rpc/explain/index-snippets.ts
+++ b/packages/cli/src/rpc/explain/index-snippets.ts
@@ -1,5 +1,3 @@
-import sqlite3 from 'node-sqlite3-wasm';
-
 import {
   buildSnippetIndex,
   FileSearchResult,
@@ -8,6 +6,7 @@ import {
   readFileSafe,
   SnippetIndex,
 } from '@appland/search';
+import sqlite3 from 'better-sqlite3';
 
 export default async function indexSnippets(
   db: sqlite3.Database,

--- a/packages/cli/src/rpc/explain/index/appmap-file-index.ts
+++ b/packages/cli/src/rpc/explain/index/appmap-file-index.ts
@@ -1,4 +1,4 @@
-import sqlite3 from 'node-sqlite3-wasm';
+import sqlite3 from 'better-sqlite3';
 
 import { FileIndex, SessionId } from '@appland/search';
 
@@ -10,7 +10,7 @@ export async function buildAppMapFileIndex(
   appmapDirectories: string[]
 ): Promise<CloseableIndex<FileIndex>> {
   return await buildIndexInTempDir<FileIndex>('appmaps', async (indexFile) => {
-    const db = new sqlite3.Database(indexFile);
+    const db = new sqlite3(indexFile);
     const fileIndex = new FileIndex(db);
     await buildAppMapIndex(fileIndex, appmapDirectories);
     return fileIndex;

--- a/packages/cli/src/rpc/explain/index/project-file-index.ts
+++ b/packages/cli/src/rpc/explain/index/project-file-index.ts
@@ -1,5 +1,4 @@
 import makeDebug from 'debug';
-import sqlite3 from 'node-sqlite3-wasm';
 
 import {
   buildFileIndex,

--- a/packages/cli/src/rpc/explain/index/project-file-snippet-index.ts
+++ b/packages/cli/src/rpc/explain/index/project-file-snippet-index.ts
@@ -1,5 +1,4 @@
-import sqlite3 from 'node-sqlite3-wasm';
-
+import sqlite3 from 'better-sqlite3';
 import { FileSearchResult, SessionId, SnippetIndex } from '@appland/search';
 
 import buildIndexInTempDir, { CloseableIndex } from './build-index-in-temp-dir';
@@ -77,7 +76,7 @@ export async function buildProjectFileSnippetIndex(
   fileSearchResults: FileSearchResult[]
 ): Promise<ProjectFileSnippetIndex> {
   const snippetIndex = await buildIndexInTempDir('snippets', async (indexFile) => {
-    const db = new sqlite3.Database(indexFile);
+    const db = new sqlite3(indexFile);
     return await indexSnippets(db, fileSearchResults);
   });
 

--- a/packages/cli/src/rpc/search/search.ts
+++ b/packages/cli/src/rpc/search/search.ts
@@ -1,7 +1,5 @@
 import { isAbsolute, join } from 'path';
-
-import sqlite3 from 'node-sqlite3-wasm';
-
+import sqlite3 from 'better-sqlite3';
 import { FileIndex, generateSessionId } from '@appland/search';
 import { SearchRpc } from '@appland/rpc';
 
@@ -64,7 +62,7 @@ export async function handler(
     // Search across all AppMaps, creating a map from AppMap id to AppMapSearchResult
     const maxResults = options.maxDiagrams || options.maxResults || DEFAULT_MAX_DIAGRAMS;
     const index = await buildIndexInTempDir('appmaps', async (indexFile) => {
-      const db = new sqlite3.Database(indexFile);
+      const db = new sqlite3(indexFile);
       const fileIndex = new FileIndex(db);
       await buildAppMapIndex(
         fileIndex,

--- a/packages/cli/tests/setup.js
+++ b/packages/cli/tests/setup.js
@@ -2,8 +2,8 @@ require('reflect-metadata');
 
 const { container } = require('tsyringe');
 const { ThreadIndexService } = require('../src/rpc/navie/services/threadIndexService');
-const sqlite3 = require('node-sqlite3-wasm');
-const db = new sqlite3.Database(':memory:');
+const sqlite3 = require('better-sqlite3');
+const db = new sqlite3(':memory:');
 
 container.registerInstance(ThreadIndexService.DATABASE, db);
 container.registerInstance('INavieProvider', () => ({}));

--- a/packages/cli/tests/unit/rpc/navie/services/threadIndexService.spec.ts
+++ b/packages/cli/tests/unit/rpc/navie/services/threadIndexService.spec.ts
@@ -4,12 +4,12 @@
                   @typescript-eslint/no-unsafe-member-access
 */
 
+import sqlite3 from 'better-sqlite3';
 import { container } from 'tsyringe';
 import {
   ThreadIndexItem,
   ThreadIndexService,
 } from '../../../../../src/rpc/navie/services/threadIndexService';
-import sqlite3 from 'node-sqlite3-wasm';
 import configuration from '../../../../../src/rpc/configuration';
 import { mkdtemp, rm, writeFile } from 'fs/promises';
 import { join } from 'path';
@@ -22,7 +22,7 @@ describe('ThreadIndexService', () => {
 
   beforeEach(async () => {
     container.reset();
-    db = new sqlite3.Database(':memory:');
+    db = new sqlite3(':memory:');
     container.registerInstance(ThreadIndexService.DATABASE, db);
     threadIndexService = container.resolve(ThreadIndexService);
 

--- a/packages/navie/package.json
+++ b/packages/navie/package.json
@@ -43,7 +43,7 @@
     "@langchain/core": "^0.2.27",
     "@langchain/google-vertexai-web": "^0.1.0",
     "@langchain/openai": "^0.2.7",
-    "fast-xml-parser": "^4.4.0",
+    "fast-xml-parser": "^4.4.1",
     "js-yaml": "^4.1.0",
     "jsdom": "^16.6.0",
     "langchain": "^0.2.16",

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -21,6 +21,7 @@
   "author": "AppLand, Inc",
   "license": "Commons Clause + MIT",
   "devDependencies": {
+    "@types/better-sqlite3": "^7.6.13",
     "@types/jest": "^29.5.4",
     "@types/node": "^16",
     "eslint": "^9",
@@ -38,9 +39,9 @@
     "typescript-eslint": "^8.11.0"
   },
   "dependencies": {
+    "better-sqlite3": "^11.9.1",
     "cachedir": "^2.4.0",
     "isbinaryfile": "^5.0.4",
-    "node-sqlite3-wasm": "^0.8.34",
     "yargs": "^17.7.2"
   }
 }

--- a/packages/search/src/cli.ts
+++ b/packages/search/src/cli.ts
@@ -1,9 +1,9 @@
 import { PerformanceObserver } from 'node:perf_hooks';
 
+import sqlite3 from 'better-sqlite3';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 import makeDebug from 'debug';
-import sqlite3 from 'node-sqlite3-wasm';
 
 import { fileTokens } from './tokenize';
 import FileIndex from './file-index';
@@ -103,7 +103,7 @@ const cli = yargs(hideBin(process.argv))
 
       const splitter = langchainSplitter;
 
-      const snippetIndex = new SnippetIndex(new sqlite3.Database());
+      const snippetIndex = new SnippetIndex(new sqlite3());
       await buildSnippetIndex(snippetIndex, fileSearchResults, readFileSafe, splitter, fileTokens);
 
       console.log('');

--- a/packages/search/src/file-index.ts
+++ b/packages/search/src/file-index.ts
@@ -3,13 +3,16 @@ import { warn } from 'node:console';
 import { mkdir, stat } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 
+import sqlite3 from 'better-sqlite3';
 import cachedir from 'cachedir';
 import makeDebug from 'debug';
-import sqlite3 from 'node-sqlite3-wasm';
 
 const debug = makeDebug('appmap:search:file-index');
 
+const SCHEMA_VERSION = '1';
+
 const SCHEMA = `
+  BEGIN;
   CREATE VIRTUAL TABLE IF NOT EXISTS file_content USING fts5(
     directory UNINDEXED,
     file_path,
@@ -27,7 +30,10 @@ const SCHEMA = `
   CREATE TABLE IF NOT EXISTS metadata (
     key TEXT PRIMARY KEY,
     value TEXT
-  );`;
+  );
+  INSERT OR REPLACE INTO metadata (key, value) VALUES ('schema_version', ${SCHEMA_VERSION});
+  COMMIT;
+`;
 
 const SEARCH_SQL = `SELECT
     file_content.directory,
@@ -57,8 +63,6 @@ export type FileSearchResult = {
   score: number;
 };
 
-const SCHEMA_VERSION = '1';
-
 /**
  * The FileIndex class provides an interface to interact with the SQLite search index.
  *
@@ -72,33 +76,33 @@ const SCHEMA_VERSION = '1';
  * - `file_content`: A virtual table that holds the file content and allows for full-text search using BM25 ranking.
  */
 export default class FileIndex {
-  #search: sqlite3.Statement;
-
   constructor(public database: sqlite3.Database) {
-    if (this.schemaVersion !== SCHEMA_VERSION) {
-      debug('Schema version mismatch, recreating schema');
+    const version = this.schemaVersion;
+    if (version !== SCHEMA_VERSION) {
+      debug(`Schema version mismatch (${version}), recreating schema`);
       this.dropAllTables();
       this.createSchema();
     }
-    this.#search = this.database.prepare(SEARCH_SQL);
   }
 
   get schemaVersion(): string | undefined {
     try {
-      const version = this.database.get("SELECT value FROM metadata WHERE key = 'schema_version'");
-      if (!version?.value) return undefined;
-      return String(version.value);
-    } catch {
+      const version = this.database
+        .prepare<
+          [],
+          { version?: string }
+        >("SELECT value FROM metadata WHERE key = 'schema_version'")
+        .get();
+      if (!version?.version) return undefined;
+      return String(version.version);
+    } catch (error) {
+      debug('Error retrieving schema version: %s', error);
       return;
     }
   }
 
   private createSchema() {
     this.database.exec(SCHEMA);
-    this.database.run(
-      "INSERT OR REPLACE INTO metadata (key, value) VALUES ('schema_version', ?)",
-      SCHEMA_VERSION
-    );
   }
 
   private dropAllTables() {
@@ -115,19 +119,21 @@ export default class FileIndex {
     const cacheDir = cachedir('appmap');
     await mkdir(cacheDir, { recursive: true });
     const dbPath = join(cacheDir, name);
-    const db = new sqlite3.Database(dbPath);
+    const db = sqlite3(dbPath);
     debug('Using cached database: %s', dbPath);
     return new FileIndex(db);
   }
 
   get length(): number {
-    const row = this.database.get('SELECT COUNT(*) AS count FROM file_content');
+    const row = this.database
+      .prepare<[], { count?: number }>('SELECT COUNT(*) AS count FROM file_content')
+      .get();
     assert(typeof row?.count === 'number');
     return row.count;
   }
 
   get path(): string {
-    const file = this.database.get('PRAGMA database_list')?.file;
+    const file = this.database.prepare<[], { file?: string }>('PRAGMA database_list').get()?.file;
     assert(typeof file === 'string');
     return file || ':memory:';
   }
@@ -143,17 +149,19 @@ export default class FileIndex {
     files: AsyncIterable<{ directory: string; filePath: string }>,
     reader: (filePath: string) => Promise<{ symbols: string[]; words: string[] } | undefined>
   ): Promise<void> {
-    const insert = this.database.prepare(
+    const insert = this.database.prepare<[string, string, string, string]>(
       `INSERT INTO file_content (directory, file_path, file_symbols, file_words) VALUES (?, ?, ?, ?)`
     );
-    const update = this.database.prepare(
+    const update = this.database.prepare<[string, string, string, string]>(
       `UPDATE file_content SET file_symbols = ?, file_words = ? WHERE directory = ? AND file_path = ?`
     );
-    const setMetadata = this.database.prepare(`
+    const setMetadata = this.database.prepare<[string, string, number, number | null]>(`
       INSERT OR REPLACE INTO file_metadata (file_path, directory, generation, modified)
       VALUES (?, ?, ?, ?)
     `);
-    const getMetadata = this.database.prepare(`SELECT * FROM file_metadata WHERE file_path = ?`);
+    const getMetadata = this.database.prepare<[string], { modified: number }>(
+      `SELECT * FROM file_metadata WHERE file_path = ?`
+    );
     this.database.exec('BEGIN TRANSACTION');
     const generation = Date.now();
     try {
@@ -161,7 +169,7 @@ export default class FileIndex {
         const { directory, filePath } = file;
         const stats = await stat(filePath).catch(() => undefined);
         const metadata = getMetadata.get(filePath);
-        setMetadata.run([filePath, directory, generation, stats?.mtimeMs || null]);
+        setMetadata.run(filePath, directory, generation, stats?.mtimeMs || null);
         if (metadata) {
           if (stats && metadata.modified === stats.mtimeMs) {
             debug('Skipping unchanged file: %s', filePath);
@@ -175,9 +183,9 @@ export default class FileIndex {
           if (!content) continue;
           debug('Indexing file: %s', filePath);
           if (metadata) {
-            update.run([content.symbols.join(' '), content.words.join(' '), directory, filePath]);
+            update.run(content.symbols.join(' '), content.words.join(' '), directory, filePath);
           } else {
-            insert.run([directory, filePath, content.symbols.join(' '), content.words.join(' ')]);
+            insert.run(directory, filePath, content.symbols.join(' '), content.words.join(' '));
           }
         } catch (error) {
           warn('Error indexing file: %s', filePath);
@@ -190,12 +198,8 @@ export default class FileIndex {
       `);
       this.database.exec('COMMIT');
     } catch (error) {
-      this.database.exec('ROLLBACK');
+      if (this.database.open) this.database.exec('ROLLBACK');
       throw error;
-    } finally {
-      insert.finalize();
-      update.finalize();
-      getMetadata.finalize();
     }
   }
 
@@ -206,7 +210,9 @@ export default class FileIndex {
    * @returns An array of search results with directory, file path, and score.
    */
   search(query: string, limit = 10): FileSearchResult[] {
-    const rows = this.#search.all([query, limit]) as FileIndexRow[];
+    const rows = this.database
+      .prepare<[string, number], FileIndexRow>(SEARCH_SQL)
+      .all(query, limit);
     return rows.map((row) => ({
       directory: row.directory,
       filePath: row.file_path,
@@ -215,7 +221,6 @@ export default class FileIndex {
   }
 
   close() {
-    this.#search.finalize();
-    this.database.close();
+    if (this.database.open) this.database.close();
   }
 }

--- a/packages/search/test/file-index.spec.ts
+++ b/packages/search/test/file-index.spec.ts
@@ -1,21 +1,31 @@
-import { strict as assert } from 'assert';
+import { strict as assert } from 'node:assert';
+import { rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
-import sqlite3 from 'node-sqlite3-wasm';
+import sqlite3 from 'better-sqlite3';
 
 import FileIndex, { FileSearchResult } from '../src/file-index';
 
 describe('FileIndex', () => {
   let db: sqlite3.Database;
   let index: FileIndex;
+  let dbPath: string;
   const directory = 'src';
 
   beforeEach(() => {
-    db = new sqlite3.Database(':memory:');
+    dbPath = join(tmpdir(), `test-file-index-${Date.now()}.sqlite`);
+    db = new sqlite3(dbPath);
     index = new FileIndex(db);
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     if (index) index.close();
+    try {
+      await rm(dbPath);
+    } catch (e) {
+      console.warn(`Could not remove test database: ${e}`);
+    }
   });
 
   it('should insert and search a file', async () => {
@@ -51,5 +61,96 @@ describe('FileIndex', () => {
 
     results = index.search('symbol2');
     expect(results.map((r: FileSearchResult) => r.filePath)).toEqual(['test4.txt']);
+  });
+
+  describe('process interruption', () => {
+    it('should release database lock when process is killed during indexing', async () => {
+      // Set up a file stream that will take some time
+      const slowFiles = (async function* () {
+        for (let i = 0; i < 1000; i++) {
+          yield { directory, filePath: `test${i}.txt` };
+          await new Promise((resolve) => setTimeout(resolve, 1)); // Slow down indexing
+        }
+      })();
+
+      // Start indexing in the background
+      const indexingPromise = index.index(slowFiles, async () => ({
+        symbols: ['symbol1'],
+        words: ['word1'],
+      }));
+
+      // Wait a bit for indexing to start
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // Force close without proper cleanup
+      index.database.close();
+
+      // Original indexing should have failed
+      await expect(indexingPromise).rejects.toThrow();
+
+      // Try to open the database again
+      const newDb = sqlite3(dbPath);
+      const newIndex = new FileIndex(newDb);
+
+      // Should be able to perform operations
+      await newIndex.index(
+        (async function* () {
+          yield { directory, filePath: 'test.txt' };
+        })(),
+        async () => ({ symbols: ['symbol1'], words: ['word1'] })
+      );
+
+      const results = newIndex.search('symbol1');
+      expect(results.length).toBe(1);
+
+      newIndex.close();
+    });
+
+    it('should handle concurrent access attempts', async () => {
+      // First index some data
+      await index.index(
+        (async function* () {
+          yield { directory, filePath: 'test.txt' };
+        })(),
+        async () => ({ symbols: ['symbol1'], words: ['word1'] })
+      );
+
+      // Try to open another connection while the first is still active
+      expect(() => {
+        const concurrentDb = new sqlite3(dbPath);
+        concurrentDb.exec('SELECT * FROM file_content');
+        concurrentDb.close();
+      }).not.toThrow();
+    });
+
+    it('should recover from an interrupted transaction', async () => {
+      // Start a transaction but don't commit
+      index.database.exec('BEGIN TRANSACTION');
+      index.database.exec(`
+        INSERT INTO file_content (directory, file_path, file_symbols, file_words)
+        VALUES ('src', 'test.txt', 'symbol1', 'word1')
+      `);
+
+      // Force close without commit
+      index.database.close();
+
+      // Open new connection
+      const newDb = new sqlite3(dbPath);
+      const newIndex = new FileIndex(newDb);
+
+      // Database should be usable
+      await newIndex.index(
+        (async function* () {
+          yield { directory, filePath: 'test2.txt' };
+        })(),
+        async () => ({ symbols: ['symbol2'], words: ['word2'] })
+      );
+
+      const results = newIndex.search('symbol2');
+      expect(results.length).toBe(1);
+      expect(results[0].filePath).toBe('test2.txt');
+
+      newIndex.close();
+    });
   });
 });

--- a/packages/search/test/snippet-index.spec.ts
+++ b/packages/search/test/snippet-index.spec.ts
@@ -1,6 +1,5 @@
 import { strict as assert } from 'assert';
-
-import sqlite3 from 'node-sqlite3-wasm';
+import sqlite3 from 'better-sqlite3';
 
 import SnippetIndex, {
   fileChunkSnippetId,
@@ -27,7 +26,7 @@ describe('SnippetIndex', () => {
   const snippet4: SnippetId = { type: 'code-snippet', id: 'test4.txt:31' };
 
   beforeEach(() => {
-    db = new sqlite3.Database(':memory:');
+    db = new sqlite3(':memory:');
     index = new SnippetIndex(db);
     sessionId = generateSessionId();
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -481,7 +481,7 @@ __metadata:
     eslint-plugin-jest: ^28.8.3
     eslint-plugin-promise: ^6.0.1
     eslint-plugin-unicorn: ^39.0.0
-    fast-xml-parser: ^4.4.0
+    fast-xml-parser: ^4.4.1
     jest: ^29.7.0
     js-yaml: ^4.1.0
     jsdom: ^16.6.0
@@ -23271,17 +23271,6 @@ __metadata:
   version: 2.0.6
   resolution: "fast-levenshtein@npm:2.0.6"
   checksum: 92cfec0a8dfafd9c7a15fba8f2cc29cd0b62b85f056d99ce448bbcd9f708e18ab2764bda4dd5158364f4145a7c72788538994f0d1787b956ef0d1062b0f7c24c
-  languageName: node
-  linkType: hard
-
-"fast-xml-parser@npm:^4.4.0":
-  version: 4.4.0
-  resolution: "fast-xml-parser@npm:4.4.0"
-  dependencies:
-    strnum: ^1.0.5
-  bin:
-    fxparser: src/cli/cli.js
-  checksum: ad33a4b5165a0ffcb6e17ae78825bd4619a8298844a8a8408f2ea141a0d2d9439d18865dc5254162f09fe54d510ff18e5d5c0a190869cab21fc745ee66be816b
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -160,6 +160,7 @@ __metadata:
     "@octokit/types": ^11.1.0
     "@sidvind/better-ajv-errors": ^0.9.1
     "@swc/core": ^1.3.76
+    "@types/better-sqlite3": ^7.6.11
     "@types/cors": ^2.8.17
     "@types/express": ^5.0.1
     "@types/fs-extra": ^9.0.13
@@ -184,6 +185,7 @@ __metadata:
     applicationinsights: ^2.1.4
     async: ^3.2.4
     axios: ^0.27.2
+    better-sqlite3: ^11.5.0
     body-parser: ^1.20.2
     boxen: ^5.0.1
     chalk: ^4.1.2
@@ -223,7 +225,6 @@ __metadata:
     minimatch: ^5.1.2
     moo: ^0.5.1
     node-fetch: 2.6.7
-    node-sqlite3-wasm: ^0.8.34
     open: ^8.2.1
     openapi-diff: ^0.23.6
     openapi-types: ^12.1.3
@@ -600,8 +601,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@appland/search@workspace:packages/search"
   dependencies:
+    "@types/better-sqlite3": ^7.6.13
     "@types/jest": ^29.5.4
     "@types/node": ^16
+    better-sqlite3: ^11.9.1
     cachedir: ^2.4.0
     eslint: ^9
     eslint-config-prettier: ^9
@@ -612,7 +615,6 @@ __metadata:
     eslint-plugin-promise: ^7.1.0
     isbinaryfile: ^5.0.4
     jest: ^29.7.0
-    node-sqlite3-wasm: ^0.8.34
     prettier: ^3.3.3
     ts-jest: ^29.2.5
     tsc: ^2.0.4
@@ -10678,6 +10680,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/better-sqlite3@npm:^7.6.11, @types/better-sqlite3@npm:^7.6.13":
+  version: 7.6.13
+  resolution: "@types/better-sqlite3@npm:7.6.13"
+  dependencies:
+    "@types/node": "*"
+  checksum: 0b5bcca8d5441e0b234b2a120f6b6c8b8136fbe2a777a287ba72cf3c3c260abf5108e8b5cc3daae3fedd7f9f2f5a0abbb4cb72e45a4b82ebd6e1dd98fada3f7c
+  languageName: node
+  linkType: hard
+
 "@types/body-parser@npm:*":
   version: 1.19.2
   resolution: "@types/body-parser@npm:1.19.2"
@@ -15955,6 +15966,17 @@ __metadata:
   dependencies:
     open: ^8.0.4
   checksum: 1471552fa7f733561e7f49e812be074b421153006ca744de985fb6d38939807959fc5fe9cb819cf09f864782e294704fd3b31711ea14c115baf3330a2f1135de
+  languageName: node
+  linkType: hard
+
+"better-sqlite3@npm:^11.5.0, better-sqlite3@npm:^11.9.1":
+  version: 11.9.1
+  resolution: "better-sqlite3@npm:11.9.1"
+  dependencies:
+    bindings: ^1.5.0
+    node-gyp: latest
+    prebuild-install: ^7.1.1
+  checksum: 7a96555ba42aa9143d3f9b5218f4736f425a9f96b24cb9f6de0d52444b9d8c1c710b14ad859981101850cb9562fabf8fcc0dd72c3b04e23aa5620c8cd4ae597a
   languageName: node
   linkType: hard
 
@@ -32534,6 +32556,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"napi-build-utils@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "napi-build-utils@npm:2.0.0"
+  checksum: 532121efd2dd2272595580bca48859e404bdd4ed455a72a28432ba44868c38d0e64fac3026a8f82bf8563d2a18b32eb9a1d59e601a9da4e84ba4d45b922297f5
+  languageName: node
+  linkType: hard
+
 "native-request@npm:^1.0.5":
   version: 1.1.0
   resolution: "native-request@npm:1.1.0"
@@ -32969,13 +32998,6 @@ __metadata:
   version: 2.0.10
   resolution: "node-releases@npm:2.0.10"
   checksum: d784ecde25696a15d449c4433077f5cce620ed30a1656c4abf31282bfc691a70d9618bae6868d247a67914d1be5cc4fde22f65a05f4398cdfb92e0fc83cadfbc
-  languageName: node
-  linkType: hard
-
-"node-sqlite3-wasm@npm:^0.8.34":
-  version: 0.8.34
-  resolution: "node-sqlite3-wasm@npm:0.8.34"
-  checksum: c6c9b2c75d714badaa41ac66a9ed6a30a718252d9259268bb96d899308aa9024c8766a0995c10e5225e7c57cc8c1483ef9279c3b6e97ddd45b6dba3af3e6e551
   languageName: node
   linkType: hard
 
@@ -35702,6 +35724,28 @@ __metadata:
   bin:
     prebuild-install: bin.js
   checksum: dbf96d0146b6b5827fc8f67f72074d2e19c69628b9a7a0a17d0fad1bf37e9f06922896972e074197fc00a52eae912993e6ef5a0d471652f561df5cb516f3f467
+  languageName: node
+  linkType: hard
+
+"prebuild-install@npm:^7.1.1":
+  version: 7.1.3
+  resolution: "prebuild-install@npm:7.1.3"
+  dependencies:
+    detect-libc: ^2.0.0
+    expand-template: ^2.0.3
+    github-from-package: 0.0.0
+    minimist: ^1.2.3
+    mkdirp-classic: ^0.5.3
+    napi-build-utils: ^2.0.0
+    node-abi: ^3.3.0
+    pump: ^3.0.0
+    rc: ^1.2.7
+    simple-get: ^4.0.0
+    tar-fs: ^2.0.0
+    tunnel-agent: ^0.6.0
+  bin:
+    prebuild-install: bin.js
+  checksum: 300740ca415e9ddbf2bd363f1a6d2673cc11dd0665c5ec431bbb5bf024c2f13c56791fb939ce2b2a2c12f2d2a09c91316169e8063a80eb4482a44b8fe5b265e1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
While node-sqlite3-wasm was a good idea, it turned out to cause problems due to its simplistic locking strategy. File-based lock in conjunction with limited cleanup caused users to encounter "database is locked" errors with no recourse. It's possible to work on node-sqlite3-wasm to improve locking (and statement cleanup), but it's probably safer to move back to better-sqlite3 at least for now. Unfortunately this means shipping the compiled blob, with possible issues with some windows antivirus software and making it harder to use a different distribution strategy in the future :/

This reverts commit 86e0fe5386286816473c0b16a91f7fa80f8706af.