### PR TITLE
feat: Ignore some files in the diff and remove diff size limit

### DIFF
--- a/packages/cli/src/lib/processPatchset.ts
+++ b/packages/cli/src/lib/processPatchset.ts
@@ -3,12 +3,22 @@
  * message indicating that there is a change and its size.
  * @param patchset - The patchset to process.
  * @param maxDiffLength - The maximum length of a diff to include in the patchset.
+ * @param ignoreList - A list of paths to ignore when processing the patchset.
+ *                    This is useful for ignoring files that are not relevant to the
+ *                    changes being made, such as dependencies or generated files.
+ *                    The default ignore list includes common directories and files
+ *                    that are typically not relevant to code changes.
  * @returns The processed patchset.
  */
-
-export default function processPatchset(patchset: string, maxDiffLength = 5000): string {
+export default function processPatchset(
+  patchset: string,
+  maxDiffLength = Infinity,
+  ignoreList = DEFAULT_IGNORE_LIST
+): string {
   const parts = patchset.split(/^(?=diff|commit)/m);
+  const ignoreRegex = buildIgnoreRegex(ignoreList);
   return parts
+    .filter((part) => !part.match(ignoreRegex))
     .map((part) => {
       if (part.startsWith('diff')) {
         const lines = part.split('\n');
@@ -22,3 +32,27 @@ export default function processPatchset(patchset: string, maxDiffLength = 5000):
     })
     .join('');
 }
+
+function buildIgnoreRegex(ignoreList: readonly string[]): RegExp {
+  if (ignoreList.length === 0) return /(?!)/; // Matches nothing
+  const escapedIgnoreList = ignoreList.map((path) => path.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&'));
+  return new RegExp(`^diff --git a/(?:${escapedIgnoreList.join('|')})(/| )`, 's');
+}
+
+const DEFAULT_IGNORE_LIST: readonly string[] = [
+  'node_modules',
+  'vendor',
+  'venv',
+  'dist',
+  'build',
+  'target',
+  'coverage',
+  'tmp',
+  'log',
+  '.venv',
+  'yarn.lock',
+  'package-lock.json',
+  'Gemfile.lock',
+  'go.sum',
+  'composer.lock',
+];

--- a/packages/cli/tests/unit/lib/processPatchset.spec.ts
+++ b/packages/cli/tests/unit/lib/processPatchset.spec.ts
@@ -1,6 +1,97 @@
 import processPatchset from '../../../src/lib/processPatchset';
 
 describe('processPatchset', () => {
+  describe('ignore list filtering', () => {
+    it('should filter out diffs for ignored paths', () => {
+      const patchset = `diff --git a/node_modules/pkg/file.js b/node_modules/pkg/file.js
+index 83db48f..f735c4e 100644
+--- a/node_modules/pkg/file.js
++++ b/node_modules/pkg/file.js
+@@ -1,3 +1,3 @@
+-old content
++new content
+diff --git a/yarn.lock b/yarn.lock
+index 83db48f..f735c4e 100644
+--- a/yarn.lock
++++ b/yarn.lock
+@@ -1,3 +1,3 @@
+-old content
++new content`;
+
+      const result = processPatchset(patchset);
+      expect(result).toBe('');
+    });
+
+    it('should keep diffs for non-ignored paths', () => {
+      const patchset = `diff --git a/src/file1.js b/src/file1.js
+index 83db48f..f735c4e 100644
+--- a/src/file1.js
++++ b/src/file1.js
+@@ -1,3 +1,3 @@
+-old content
++new content`;
+
+      const result = processPatchset(patchset);
+      expect(result).toBe(patchset);
+    });
+
+    it('should respect custom ignore list', () => {
+      const patchset = `diff --git a/src/file1.js b/src/file1.js
+index 83db48f..f735c4e 100644
+--- a/src/file1.js
++++ b/src/file1.js
+@@ -1,3 +1,3 @@
+-old content
++new content`;
+
+      const result = processPatchset(patchset, undefined, ['src']);
+      expect(result).toBe('');
+    });
+
+    it('should keep diffs for paths that only start with ignored paths', () => {
+      const patchset = `diff --git a/srcfile1.js b/srcfile1.js
+index 83db48f..f735c4e 100644
+--- a/srcfile1.js
++++ b/srcfile1.js
+@@ -1,3 +1,3 @@
+-old content
++new content`;
+
+      const result = processPatchset(patchset, undefined, ['src']);
+      expect(result).toBe(patchset);
+    });
+
+    it('should filter out only ignored paths when patchset contains both ignored and non-ignored files', () => {
+      const patchset = `diff --git a/node_modules/pkg/file.js b/node_modules/pkg/file.js
+index 83db48f..f735c4e 100644
+--- a/node_modules/pkg/file.js
++++ b/node_modules/pkg/file.js
+@@ -1,3 +1,3 @@
+-old content
++new content
+diff --git a/src/file1.js b/src/file1.js
+index 83db48f..f735c4e 100644
+--- a/src/file1.js
++++ b/src/file1.js
+@@ -1,3 +1,3 @@
+-old content
++new content`;
+
+      const result = processPatchset(patchset);
+
+      // Should keep only the non-ignored file diff
+      const expected = `diff --git a/src/file1.js b/src/file1.js
+index 83db48f..f735c4e 100644
+--- a/src/file1.js
++++ b/src/file1.js
+@@ -1,3 +1,3 @@
+-old content
++new content`;
+
+      expect(result).toBe(expected);
+    });
+  });
+  
   it('should handle patchset with small diffs correctly', () => {
     const patchset = `diff --git a/file1.txt b/file1.txt
 index 83db48f..f735c4e 100644


### PR DESCRIPTION
This pull request enhances the `processPatchset` function in the `packages/cli` module by introducing an ignore list feature to filter out irrelevant file changes, such as dependencies or generated files. It also includes unit tests to ensure the functionality works as expected. The most important changes are detailed below.

### Enhancements to `processPatchset` functionality:

* **Added support for an ignore list:** The `processPatchset` function now accepts an `ignoreList` parameter, which specifies paths to exclude when processing patchsets. A default ignore list (`DEFAULT_IGNORE_LIST`) is provided, covering common directories and files like `node_modules`, `dist`, and lock files.
* **Implemented `buildIgnoreRegex` helper function:** This function generates a regular expression from the ignore list to efficiently filter out unwanted paths from the patchset.

### Unit tests for ignore list functionality:

* **Comprehensive test coverage:** Added multiple test cases in `processPatchset.spec.ts` to validate the ignore list behavior, including scenarios for default and custom ignore lists, partial path matches, and mixed ignored/non-ignored paths.