### PR TITLE
fix: Update parseLocation to handle negative line numbers correctly

### DIFF
--- a/packages/cli/src/rpc/explain/parseLocation.ts
+++ b/packages/cli/src/rpc/explain/parseLocation.ts
@@ -4,13 +4,14 @@ import { warn } from 'console';
 export default function parseLocation(location: string): [string, number | undefined] | undefined {
   if (!location.includes(':')) return [location, undefined];
 
-  const locationTest = /([^:]+):(\d+)$/.exec(location);
+  const locationTest = /([^:]+):(-?\d+)$/.exec(location);
   if (!locationTest) {
     warn(chalk.gray(`Invalid location format: ${location}. Skipping file lookup.`));
     return;
   }
 
   const [requestedFileName, lineNoStr] = locationTest.slice(1);
-  const lineNoReturned = lineNoStr ? parseInt(lineNoStr, 10) : undefined;
+  const lineNoReturned =
+    lineNoStr && !lineNoStr.startsWith('-') ? parseInt(lineNoStr, 10) : undefined;
   return [requestedFileName, lineNoReturned];
 }

--- a/packages/cli/tests/unit/rpc/explain/parseLocation.spec.ts
+++ b/packages/cli/tests/unit/rpc/explain/parseLocation.spec.ts
@@ -13,4 +13,8 @@ describe('parseLocation', () => {
     expect(parseLocation('OpenSSL::random')).toBeUndefined();
     expect(parseLocation('file.js:')).toBeUndefined();
   });
+
+  it('ignores line number if negative', () => {
+    expect(parseLocation('file.js:-123')).toEqual(['file.js', undefined]);
+  });
 });


### PR DESCRIPTION
It seems that sometimes appmaps contain -1 as a placeholder for unknown line number. Handle this case gracefully.

Fixes #2304