### PR TITLE
fix: Update pkg dependency to use patched version

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,6 @@
   "resolutions": {
     "web-auth-library": "getappmap/web-auth-library#v1.0.3-cjs",
     "whatwg-url": "14.0.0",
-    "pkg@5.8.1": "patch:pkg@npm:5.8.1#.yarn/patches/pkg-npm-5.8.1-db9700609f.patch"
+    "pkg@5.8.1-patched": "patch:pkg@npm:5.8.1#.yarn/patches/pkg-npm-5.8.1-db9700609f.patch"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -140,7 +140,7 @@
     "openapi-types": "^12.1.3",
     "ora": "^5.4.1",
     "parse-diff": "^0.11.1",
-    "pkg": "^5.8.1",
+    "pkg": "5.8.1-patched",
     "port-pid": "^0.0.7",
     "pretty-bytes": "^5.6.0",
     "proper-lockfile": "^4.1.2",
@@ -184,4 +184,4 @@
   "optionalDependencies": {
     "puppeteer": "^19.7.5"
   }
-} 
+}

--- a/packages/scanner/package.json
+++ b/packages/scanner/package.json
@@ -51,7 +51,7 @@
     "jest": "^29.5.0",
     "nock": "^13.2.2",
     "openapi-types": "^9.3.0",
-    "pkg": "^5.8.0",
+    "pkg": "5.8.1-patched",
     "prettier": "^2.7.1",
     "semantic-release": "^19.0.2",
     "sinon": "^13.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -230,7 +230,7 @@ __metadata:
     openapi-types: ^12.1.3
     ora: ^5.4.1
     parse-diff: ^0.11.1
-    pkg: ^5.8.1
+    pkg: 5.8.1-patched
     port-pid: ^0.0.7
     prettier: ^2.7.1
     pretty-bytes: ^5.6.0
@@ -578,7 +578,7 @@ __metadata:
     openapi-diff: ^0.23.6
     openapi-types: ^9.3.0
     ora: ~5
-    pkg: ^5.8.0
+    pkg: 5.8.1-patched
     prettier: ^2.7.1
     pretty-format: ^27.4.6
     read-pkg-up: ^7.0.1
@@ -34790,7 +34790,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pkg@npm:^5.8.0, pkg@npm:^5.8.1":
+"pkg@npm:5.8.1":
   version: 5.8.1
   resolution: "pkg@npm:5.8.1"
   dependencies:
@@ -34816,6 +34816,35 @@ __metadata:
   bin:
     pkg: lib-es5/bin.js
   checksum: 5e750e716c3426706ea1fbd26832faf6a3ab8376b99f20aeb9c40fd48ad48e7b51375cd077b77669f3bfbefee69cc8111f49e0ca39e353fd0fc2dff95a57f822
+  languageName: node
+  linkType: hard
+
+"pkg@patch:pkg@npm:5.8.1#.yarn/patches/pkg-npm-5.8.1-db9700609f.patch::locator=root%40workspace%3A.":
+  version: 5.8.1
+  resolution: "pkg@patch:pkg@npm%3A5.8.1#.yarn/patches/pkg-npm-5.8.1-db9700609f.patch::version=5.8.1&hash=7dca8e&locator=root%40workspace%3A."
+  dependencies:
+    "@babel/generator": 7.18.2
+    "@babel/parser": 7.18.4
+    "@babel/types": 7.19.0
+    chalk: ^4.1.2
+    fs-extra: ^9.1.0
+    globby: ^11.1.0
+    into-stream: ^6.0.0
+    is-core-module: 2.9.0
+    minimist: ^1.2.6
+    multistream: ^4.1.0
+    pkg-fetch: 3.4.2
+    prebuild-install: 7.1.1
+    resolve: ^1.22.0
+    stream-meter: ^1.0.4
+  peerDependencies:
+    node-notifier: ">=9.0.1"
+  peerDependenciesMeta:
+    node-notifier:
+      optional: true
+  bin:
+    pkg: lib-es5/bin.js
+  checksum: 9864832ed7169d618b6e69f4e6cd48fd2e9b5c6cd3803bfb2f883a27b063097cd353c3db8d4bb37174832c306e82b60863e7e507b9ffbee9258363e4ea60ce0e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This pull request updates the `pkg` dependency across multiple files to use a patched version (`5.8.1-patched`) instead of the standard version. This makes sure we actually use the patch that resolves the mkdir race issue.

Dependency updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L50-R50): Updated the resolution for `pkg` to reference `5.8.1-patched` instead of `5.8.1`.
* [`packages/cli/package.json`](diffhunk://#diff-6e2e2a1851648938b325ba84de634407a4e69a644ea61102df15ca4a8a7a9758L143-R143): Changed the `pkg` dependency version from `^5.8.1` to `5.8.1-patched`.
* [`packages/scanner/package.json`](diffhunk://#diff-dd0786762cd9763aa4b1f750f4eb1daaebeb3f50ad413a5a98e1eeaf635c0d5aL54-R54): Updated the `pkg` dependency version from `^5.8.0` to `5.8.1-patched`.