### PR TITLE
feat: @diff command

### DIFF
--- a/packages/navie/src/command.ts
+++ b/packages/navie/src/command.ts
@@ -12,6 +12,7 @@ export enum CommandMode {
   Suggest = 'suggest',
   Observe = 'observe',
   Review = 'review',
+  Diff = 'diff',
   Welcome = 'welcome',
 }
 

--- a/packages/navie/src/commands/diff-command.ts
+++ b/packages/navie/src/commands/diff-command.ts
@@ -1,0 +1,47 @@
+import Command, { CommandRequest } from '../command';
+import { ProjectInfo } from '../project-info';
+import ProjectInfoService from '../services/project-info-service';
+
+// Define output formats: text, json, jsonl
+export type DiffOutputFormat = 'text' | 'json' | 'jsonl';
+
+export interface ProjectDiffInfo {
+  directory: string;
+  diff?: string;
+}
+
+// Transform ProjectInfo to ProjectDiffInfo
+export function projectInfoToProjectDiffInfo(projectInfo: ProjectInfo): ProjectDiffInfo {
+  return {
+    directory: projectInfo.directory,
+    diff: projectInfo.diff,
+  };
+}
+
+export default class DiffCommand implements Command {
+  constructor(private readonly projectInfoService: ProjectInfoService) {}
+
+  async *execute(request: CommandRequest): AsyncIterable<string> {
+    const outputFormat = request.userOptions.stringValue('format') || 'text';
+    const baseBranch = request.userOptions.stringValue('base');
+
+    const projectInfoResponse = await this.projectInfoService.lookupProjectInfo(true, baseBranch);
+    const projectInfo = Array.isArray(projectInfoResponse)
+      ? projectInfoResponse
+      : [projectInfoResponse];
+
+    if (outputFormat === 'text') {
+      for (const info of projectInfo) {
+        yield `Changes in ${info.directory}:\n`;
+        yield info.diff || 'No changes detected.';
+        yield '\n';
+      }
+    } else if (outputFormat === 'json') {
+      yield JSON.stringify(projectInfo.map(projectInfoToProjectDiffInfo), null, 2);
+    } else if (outputFormat === 'jsonl') {
+      for (const info of projectInfo) {
+        yield JSON.stringify(projectInfoToProjectDiffInfo(info)) + '\n';
+      }
+    }
+  }
+}

--- a/packages/navie/src/navie.ts
+++ b/packages/navie/src/navie.ts
@@ -195,11 +195,8 @@ export default function navie(
       interactionHistory,
       projectInfoService
     );
-  
-  const buildDiffCommand = () =>
-    new DiffCommand(
-      projectInfoService
-    )
+
+  const buildDiffCommand = () => new DiffCommand(projectInfoService);
 
   const buildReviewCommand = () =>
     new ReviewCommand(

--- a/packages/navie/src/navie.ts
+++ b/packages/navie/src/navie.ts
@@ -41,6 +41,7 @@ import ReviewCommand from './commands/review-command';
 import WelcomeCommand from './commands/welcome-command';
 import InvokeTestsService from './services/invoke-tests-service';
 import { TestInvocationProvider } from './test-invocation';
+import DiffCommand from './commands/diff-command';
 
 export type ChatHistory = Message[];
 
@@ -194,6 +195,11 @@ export default function navie(
       interactionHistory,
       projectInfoService
     );
+  
+  const buildDiffCommand = () =>
+    new DiffCommand(
+      projectInfoService
+    )
 
   const buildReviewCommand = () =>
     new ReviewCommand(
@@ -217,6 +223,7 @@ export default function navie(
     [CommandMode.Suggest]: buildSuggestCommand,
     [CommandMode.Observe]: buildObserveCommand,
     [CommandMode.Review]: buildReviewCommand,
+    [CommandMode.Diff]: buildDiffCommand,
     [CommandMode.Welcome]: buildWelcomeCommand,
   };
 


### PR DESCRIPTION
Other Navie capabilities such as `@context` are accessible via @ command string. 

Because Navie performs special processing of the code diff, such as removal of binary files, having `@diff` available as a standalone command can be useful when building workflows using Navie.

## Example

```bash
$ ./built/cli.js navie -d ~/source/appland/spring-petclinic \
  "@diff /base=main /format=jsonl" > ~/source/appland/spring-petclinic/diff.jsonl
```

```bash
$ llm -f diff.json "List URL routes impacted by the change"                    
```

Based on the changes in the code, here are the URL routes that were impacted:

Primary Authentication Routes:
- `/login` - New login endpoint for form-based authentication
- `/logout` - New logout endpoint

Routes with Added Security Requirements:
1. `/owners/**` - Now requires ROLE_ADMIN
2. `/owners/new` - Now requires CSRF token and ROLE_ADMIN
3. `/owners/{ownerId}/edit` - Now requires CSRF token and ROLE_ADMIN
4. `/owners/{ownerId}/pets/new` - Now requires CSRF token and ROLE_ADMIN
5. `/owners/{ownerId}/pets/{petId}/edit` - Now requires CSRF token and ROLE_ADMIN
6. `/owners/{ownerId}/pets/{petId}/visits/new` - Now requires CSRF token and ROLE_ADMIN

Public Routes (Explicitly Permitted):
- `/` - Home page
- `/oups` - Error trigger page 
- `/error` - Error page
- `/webjars/**`
- `/css/**`
- `/js/**`
- `/images/**`
- `/resources/**`

The changes implement Spring Security with form-based authentication and require:

1. Authentication for most routes
2. ROLE_ADMIN specifically for owner-related operations
3. CSRF tokens for all POST requests
4. Public access maintained for static resources and error pages

The security configuration allows anonymous access to the home page and static resources while protecting sensitive operations behind authentication and proper authorization.

