### PR TITLE
fix: Improve worst case performance of file indexing

### DIFF
--- a/packages/cli/src/rpc/explain/collect-location-context.ts
+++ b/packages/cli/src/rpc/explain/collect-location-context.ts
@@ -91,7 +91,7 @@ export default async function collectLocationContext(
       continue;
     }
 
-    if (isBinaryFile(path)) {
+    if (await isBinaryFile(path)) {
       if (verbose()) warn(`[location-context] Skipping binary file: ${path}`);
       continue;
     }

--- a/packages/cli/src/rpc/explain/fileFilter.ts
+++ b/packages/cli/src/rpc/explain/fileFilter.ts
@@ -10,7 +10,7 @@ export default function fileFilter(
 ): FilterFn {
   return async (path: string) => {
     debug('Filtering: %s', path);
-    if (isBinaryFile(path)) {
+    if (await isBinaryFile(path)) {
       debug('Skipping binary file: %s', path);
       return false;
     }

--- a/packages/cli/src/rpc/explain/index/project-file-index.ts
+++ b/packages/cli/src/rpc/explain/index/project-file-index.ts
@@ -25,7 +25,7 @@ function fileFilter(
 ): FilterFn {
   return async (path: string) => {
     debug('Filtering: %s', path);
-    if (isBinaryFile(path)) {
+    if (await isBinaryFile(path)) {
       debug('Skipping binary file: %s', path);
       return false;
     }

--- a/packages/cli/tests/unit/rpc/explain/collect-location-context.spec.ts
+++ b/packages/cli/tests/unit/rpc/explain/collect-location-context.spec.ts
@@ -74,7 +74,7 @@ describe('collectLocationContext', () => {
     });
 
     it('includes explicitly named files even if outside source directories', async () => {
-      jest.mocked(isBinaryFile).mockReturnValue(false);
+      jest.mocked(isBinaryFile).mockResolvedValue(false);
 
       expect(await collect()).toMatchInlineSnapshot(`
         [
@@ -152,7 +152,7 @@ describe('collectLocationContext', () => {
       const collectNonExplicit = async () =>
         collectLocationContext(sourceDirectories, nonExplicitLocations, explicitFiles);
 
-      jest.mocked(isBinaryFile).mockReturnValue(false);
+      jest.mocked(isBinaryFile).mockResolvedValue(false);
 
       expect(await collectNonExplicit()).toMatchInlineSnapshot(`
         [
@@ -202,7 +202,7 @@ describe('collectLocationContext', () => {
     });
 
     it('skips binary files', async () => {
-      jest.mocked(isBinaryFile).mockReturnValue(true);
+      jest.mocked(isBinaryFile).mockResolvedValue(true);
 
       const result = await collect();
       expect(result).toEqual([]);

--- a/packages/search/src/cli.ts
+++ b/packages/search/src/cli.ts
@@ -53,7 +53,7 @@ const cli = yargs(hideBin(process.argv))
 
       const fileFilter = async (path: string) => {
         debug('Filtering: %s', path);
-        if (isBinaryFile(path)) {
+        if (await isBinaryFile(path)) {
           debug('Skipping binary file: %s', path);
           return false;
         }

--- a/packages/search/src/file-index.ts
+++ b/packages/search/src/file-index.ts
@@ -88,13 +88,10 @@ export default class FileIndex {
   get schemaVersion(): string | undefined {
     try {
       const version = this.database
-        .prepare<
-          [],
-          { version?: string }
-        >("SELECT value FROM metadata WHERE key = 'schema_version'")
+        .prepare<[], { value?: string }>("SELECT value FROM metadata WHERE key = 'schema_version'")
         .get();
-      if (!version?.version) return undefined;
-      return String(version.version);
+      if (!version?.value) return undefined;
+      return String(version.value);
     } catch (error) {
       debug('Error retrieving schema version: %s', error);
       return;

--- a/packages/search/src/file-type.ts
+++ b/packages/search/src/file-type.ts
@@ -2,70 +2,115 @@ import { stat } from 'fs/promises';
 import makeDebug from 'debug';
 
 import { isBinaryFile as checkBinaryFile } from 'isbinaryfile';
+import { basename } from 'path';
 
 const debug = makeDebug('appmap:search:file-type');
 
-const BINARY_FILE_EXTENSIONS: string[] = [
-  '7z',
-  'aac',
-  'avi',
-  'bmp',
-  'bz2',
-  'class',
-  'dll',
-  'doc',
-  'docx',
-  'dylib',
-  'ear',
-  'exe',
-  'eot',
-  'flac',
-  'flv',
-  'gif',
-  'gz',
-  'ico',
-  'jar',
-  'jpeg',
-  'jpg',
-  'js.map',
-  'min.js',
-  'min.css',
-  'mkv',
-  'mo',
-  'mov',
-  'mp3',
-  'mp4',
-  'mpg',
-  'odt',
-  'odp',
-  'ods',
-  'ogg',
-  'otf',
-  'pdf',
-  'po',
-  'png',
-  'ppt',
-  'pptx',
-  'pyc',
-  'rar',
-  'rtf',
-  'so',
-  'svg',
-  'tar',
-  'tiff',
-  'ttf',
-  'wav',
-  'webm',
-  'webp',
-  'woff',
-  'woff2',
-  'wmv',
-  'xls',
-  'xlsx',
-  'xz',
-  'yarn.lock',
-  'zip',
-].map((ext) => '.' + ext);
+const BINARY_FILE_MEMO = new Map<string, boolean>([
+  // Binary files
+  ['.7z', true],
+  ['.aac', true],
+  ['.avi', true],
+  ['.bin', true],
+  ['.bmp', true],
+  ['.bz2', true],
+  ['.class', true],
+  ['.data', true],
+  ['.dat', true],
+  ['.dll', true],
+  ['.doc', true],
+  ['.docx', true],
+  ['.dylib', true],
+  ['.ear', true],
+  ['.exe', true],
+  ['.eot', true],
+  ['.flac', true],
+  ['.flv', true],
+  ['.gif', true],
+  ['.gz', true],
+  ['.ico', true],
+  ['.jar', true],
+  ['.jpeg', true],
+  ['.jpg', true],
+  ['.js.map', true],
+  ['.min.js', true],
+  ['.min.css', true],
+  ['.mkv', true],
+  ['.mo', true],
+  ['.mov', true],
+  ['.mp3', true],
+  ['.mp4', true],
+  ['.mpg', true],
+  ['.odt', true],
+  ['.odp', true],
+  ['.ods', true],
+  ['.ogg', true],
+  ['.otf', true],
+  ['.pdf', true],
+  ['.po', true],
+  ['.png', true],
+  ['.ppt', true],
+  ['.pptx', true],
+  ['.pyc', true],
+  ['.rar', true],
+  ['.rtf', true],
+  ['.so', true],
+  ['.svg', true],
+  ['.tar', true],
+  ['.tiff', true],
+  ['.ttf', true],
+  ['.wav', true],
+  ['.webm', true],
+  ['.webp', true],
+  ['.woff', true],
+  ['.woff2', true],
+  ['.wmv', true],
+  ['.xls', true],
+  ['.xlsx', true],
+  ['.xz', true],
+  ['.yarn.lock', true],
+  ['.zip', true],
+
+  // Source code files
+  ['.cjs', false],
+  ['.mjs', false],
+  ['.coffee', false],
+  ['.dart', false],
+  ['.el', false],
+  ['.elm', false],
+  ['.js', false],
+  ['.ts', false],
+  ['.jsx', false],
+  ['.tsx', false],
+  ['.py', false],
+  ['.java', false],
+  ['.rb', false],
+  ['.php', false],
+  ['.go', false],
+  ['.rs', false],
+  ['.cpp', false],
+  ['.cc', false],
+  ['.cxx', false],
+  ['.h', false],
+  ['.hpp', false],
+  ['.cs', false],
+  ['.swift', false],
+  ['.kt', false],
+  ['.kts', false],
+  ['.scala', false],
+  ['.lua', false],
+  ['.sh', false],
+  ['.bat', false],
+  ['.pl', false],
+  ['.sql', false],
+  ['.html', false],
+  ['.htm', false],
+  ['.css', false],
+  ['.scss', false],
+  ['.sass', false],
+  ['.less', false],
+  ['.vue', false],
+]);
 
 const DATA_FILE_EXTENSIONS: string[] = [
   'cjs',
@@ -73,6 +118,7 @@ const DATA_FILE_EXTENSIONS: string[] = [
   'dat',
   'log',
   'json',
+  'toml',
   'tsv',
   'yaml',
   'yml',
@@ -108,10 +154,36 @@ export const isLargeFile = async (fileName: string): Promise<boolean> => {
   return fileSize > largeFileThreshold();
 };
 
+/* Returns unique file extensions for the given file path.
+ * E.g., for 'example.tar.gz', it returns [ '.tar.gz', '.gz'].
+ */
+export const getFileExtensions = (filePath: string): string[] => {
+  const fileName = basename(filePath).toLowerCase();
+  const parts = fileName.split('.');
+  if (parts.length <= 1) return [];
+
+  const extensions: string[] = [];
+  for (let i = 1; i < parts.length; i++) {
+    const ext = '.' + parts.slice(i).join('.');
+    extensions.push(ext);
+  }
+  return extensions;
+};
+
 export const isBinaryFile = async (filePath: string): Promise<boolean> => {
-  if (BINARY_FILE_EXTENSIONS.some((ext) => filePath.endsWith(ext))) return true;
+  const fileExtensions = getFileExtensions(filePath);
+  for (const ext of fileExtensions) {
+    if (BINARY_FILE_MEMO.has(ext)) {
+      return BINARY_FILE_MEMO.get(ext) === true;
+    }
+  }
+
   try {
-    return await checkBinaryFile(filePath);
+    const isBinary = await checkBinaryFile(filePath);
+    fileExtensions.forEach((ext) => {
+      BINARY_FILE_MEMO.set(ext, isBinary);
+    });
+    return isBinary;
   } catch (error) {
     debug(`Error reading file: %s`, filePath);
     debug(error);

--- a/packages/search/src/file-type.ts
+++ b/packages/search/src/file-type.ts
@@ -1,7 +1,7 @@
 import { stat } from 'fs/promises';
 import makeDebug from 'debug';
 
-import { isBinaryFileSync } from 'isbinaryfile';
+import { isBinaryFile as checkBinaryFile } from 'isbinaryfile';
 
 const debug = makeDebug('appmap:search:file-type');
 
@@ -108,10 +108,10 @@ export const isLargeFile = async (fileName: string): Promise<boolean> => {
   return fileSize > largeFileThreshold();
 };
 
-export const isBinaryFile = (filePath: string): boolean => {
+export const isBinaryFile = async (filePath: string): Promise<boolean> => {
   if (BINARY_FILE_EXTENSIONS.some((ext) => filePath.endsWith(ext))) return true;
   try {
-    return isBinaryFileSync(filePath);
+    return await checkBinaryFile(filePath);
   } catch (error) {
     debug(`Error reading file: %s`, filePath);
     debug(error);

--- a/packages/search/test/file-index.spec.ts
+++ b/packages/search/test/file-index.spec.ts
@@ -153,4 +153,23 @@ describe('FileIndex', () => {
       newIndex.close();
     });
   });
+
+  describe('schemaVersion', () => {
+    it('returns the schema version when set', () => {
+      const db = new sqlite3(':memory:');
+      db.exec(`
+        CREATE TABLE metadata (key TEXT PRIMARY KEY, value TEXT);
+        INSERT INTO metadata (key, value) VALUES ('schema_version', '1');
+      `);
+      const index = new FileIndex(db);
+      expect(index.schemaVersion).toBe('1');
+    });
+
+    it('returns undefined when schema version is not set', () => {
+      const db = new sqlite3(':memory:');
+      const index = new FileIndex(db);
+      db.exec('DELETE FROM metadata');
+      expect(index.schemaVersion).toBeUndefined();
+    });
+  });
 });

--- a/packages/search/test/file-type.spec.ts
+++ b/packages/search/test/file-type.spec.ts
@@ -1,0 +1,108 @@
+import { isBinaryFile as checkBinaryFile } from 'isbinaryfile';
+import { getFileExtensions, isBinaryFile } from '../src/file-type';
+
+jest.mock('isbinaryfile');
+const mockedCheckBinaryFile = jest.mocked(checkBinaryFile);
+
+describe('getFileExtensions', () => {
+  it('returns empty array for files without extensions', () => {
+    expect(getFileExtensions('filename')).toEqual([]);
+    expect(getFileExtensions('/path/to/filename')).toEqual([]);
+  });
+
+  it('returns single extension for simple files', () => {
+    expect(getFileExtensions('file.txt')).toEqual(['.txt']);
+    expect(getFileExtensions('/path/to/file.js')).toEqual(['.js']);
+  });
+
+  it('returns multiple extensions for compound extensions', () => {
+    expect(getFileExtensions('file.tar.gz')).toEqual(['.tar.gz', '.gz']);
+    expect(getFileExtensions('/path/to/file.min.js')).toEqual(['.min.js', '.js']);
+  });
+
+  it('handles paths with dots correctly', () => {
+    expect(getFileExtensions('/path.to/file.txt')).toEqual(['.txt']);
+    expect(getFileExtensions('/path.with.dots/file.tar.gz')).toEqual(['.tar.gz', '.gz']);
+  });
+
+  it('converts extensions to lowercase', () => {
+    expect(getFileExtensions('file.TXT')).toEqual(['.txt']);
+    expect(getFileExtensions('file.TAR.GZ')).toEqual(['.tar.gz', '.gz']);
+  });
+});
+
+describe('isBinaryFile', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns true for known binary extensions', async () => {
+    const binaryFiles = [
+      'image.jpg',
+      'archive.tar.gz',
+      'document.pdf',
+      'program.exe',
+      'library.dll',
+    ];
+
+    for (const file of binaryFiles) {
+      const result = await isBinaryFile(file);
+      expect(result).toBe(true);
+      // Ensure checkBinaryFile wasn't called for known extensions
+      expect(mockedCheckBinaryFile).not.toHaveBeenCalled();
+    }
+  });
+
+  it('returns false when checkBinaryFile throws an error', async () => {
+    mockedCheckBinaryFile.mockRejectedValue(new Error('File read error'));
+
+    const result = await isBinaryFile('unknown.xyz');
+    expect(result).toBe(false);
+    expect(mockedCheckBinaryFile).toHaveBeenCalledWith('unknown.xyz');
+  });
+
+  it('caches results of checkBinaryFile', async () => {
+    mockedCheckBinaryFile.mockResolvedValueOnce(true);
+
+    // First call should check the file
+    const result1 = await isBinaryFile('test.xyz');
+    expect(result1).toBe(true);
+    expect(mockedCheckBinaryFile).toHaveBeenCalledTimes(1);
+
+    // Second call should use cached result
+    const result2 = await isBinaryFile('another.xyz');
+    expect(result2).toBe(true);
+    expect(mockedCheckBinaryFile).toHaveBeenCalledTimes(1);
+  });
+
+  it('checks unknown extensions using checkBinaryFile', async () => {
+    mockedCheckBinaryFile.mockResolvedValueOnce(false);
+
+    const result = await isBinaryFile('text.unknown');
+    expect(result).toBe(false);
+    expect(mockedCheckBinaryFile).toHaveBeenCalledWith('text.unknown');
+  });
+
+  it('handles compound extensions correctly', async () => {
+    mockedCheckBinaryFile.mockResolvedValueOnce(true);
+
+    const result = await isBinaryFile('file.custom.format');
+    expect(result).toBe(true);
+    expect(mockedCheckBinaryFile).toHaveBeenCalledWith('file.custom.format');
+  });
+
+  it('handles files with no extension correctly', async () => {
+    const filePath = 'file_without_extension';
+    mockedCheckBinaryFile.mockResolvedValueOnce(true);
+
+    const result = await isBinaryFile(filePath);
+    expect(result).toBe(true);
+    expect(mockedCheckBinaryFile).toHaveBeenCalledWith(filePath);
+    expect(mockedCheckBinaryFile).toHaveBeenCalledTimes(1);
+
+    // Edge case: because there's no extension, no result is cached. The method
+    // will be called again.
+    await isBinaryFile(filePath);
+    expect(mockedCheckBinaryFile).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
This pull request introduces several optimizations and a critical bug fix to the file indexing process, significantly reducing the time required to index a project and ensuring the index is correctly maintained between sessions.

#### Summary of Changes

This PR addresses performance bottlenecks and a correctness issue within the file search indexer:

*   **Optimized Binary File Detection with Caching:** To minimize disk I/O during indexing, the binary file detection logic now uses a cache. This cache is pre-populated with a list of common binary and source-code file extensions to avoid hitting the disk for most files. For unknown file types, the result of the check is cached for subsequent lookups.

*   **Improved I/O Concurrency for Faster Indexing:** The file-type checking process has been made asynchronous. This allows multiple file-read operations to be performed concurrently, which enables the OS and drive to optimize the I/O queue. In testing, this change cut the end-to-end indexing time in half for large projects on fast storage. In my testing, this alone cut index times in half.

*   **Prevented Unnecessary Index Re-creation:** A bug was fixed where the file index schema version was being read incorrectly from the metadata table. This caused the version check to fail on every run, leading to the entire index being dropped and rebuilt unnecessarily. This fix ensures the index is correctly preserved.