### PR TITLE
fix: Make sure application insights telemetry quits gracefully

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -104,7 +104,6 @@
     "@sidvind/better-ajv-errors": "^0.9.1",
     "JSONStream": "^1.3.5",
     "ajv": "^8.6.3",
-    "applicationinsights": "^2.1.4",
     "async": "^3.2.4",
     "axios": "^0.27.2",
     "better-sqlite3": "^11.5.0",

--- a/packages/scanner/package.json
+++ b/packages/scanner/package.json
@@ -68,7 +68,6 @@
     "@appland/telemetry": "workspace:^",
     "@types/cli-progress": "^3.9.2",
     "ajv": "^8.8.2",
-    "applicationinsights": "^2.1.4",
     "async": "^3.2.4",
     "boxen": "^5.0.1",
     "chalk": "^4.1.2",

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -22,7 +22,6 @@
     "**/*": "prettier --write --ignore-unknown"
   },
   "dependencies": {
-    "applicationinsights": "^2.1.4",
     "conf": "<11",
     "read-pkg-up": "^7.0.1"
   },
@@ -35,6 +34,7 @@
     "eslint-config-prettier": "^10.1.8",
     "jest": "^29.5.0",
     "lint-staged": "^10.5.4",
+    "nock": "^13.2.2",
     "prettier": "^2.7.1",
     "sinon": "^13.0.1",
     "ts-jest": "^29.0.5",

--- a/packages/telemetry/tests/backends/application-insights.spec.ts
+++ b/packages/telemetry/tests/backends/application-insights.spec.ts
@@ -1,71 +1,60 @@
-import { TelemetryClient, setup } from 'applicationinsights';
+import nock from 'nock';
+
+import type { TelemetryData } from '../../src';
 import { ApplicationInsightsBackend } from '../../src/backends/application-insights';
-import { TelemetryData } from '../../src';
 
-jest.mock('applicationinsights', () => {
-  const mockClient = {
-    trackEvent: jest.fn(),
-    flush: jest.fn(),
-    context: {
-      tags: {},
-      keys: {},
-    },
-    setAutoPopulateAzureProperties: jest.fn(),
-  };
-  return {
-    TelemetryClient: jest.fn(() => mockClient),
-    setup: jest.fn().mockReturnValue({
-      setAutoCollectRequests: jest.fn().mockReturnThis(),
-      setAutoCollectPerformance: jest.fn().mockReturnThis(),
-      setAutoCollectExceptions: jest.fn().mockReturnThis(),
-      setAutoCollectDependencies: jest.fn().mockReturnThis(),
-      setAutoCollectHeartbeat: jest.fn().mockReturnThis(),
-      setAutoDependencyCorrelation: jest.fn().mockReturnThis(),
-      setAutoCollectConsole: jest.fn().mockReturnThis(),
-      setInternalLogging: jest.fn().mockReturnThis(),
-      setSendLiveMetrics: jest.fn().mockReturnThis(),
-      setUseDiskRetryCaching: jest.fn().mockReturnThis(),
-    }),
-  };
-});
+const AI_ENDPOINT = 'https://dc.services.visualstudio.com';
+const AI_PATH = '/v2/track';
 
-interface ApplicationInsightsBackendPrivate {
-  client: TelemetryClient;
-  flush: jest.Mock;
-  sendEvent: jest.Mock;
+interface Envelope {
+  name: string;
+  time: string;
+  iKey: string;
+  tags: Record<string, string>;
+  data: {
+    baseType: string;
+    baseData: TelemetryData;
+  };
 }
 
 describe('ApplicationInsightsBackend', () => {
+  let requestBody: Envelope[];
+  let scope: nock.Scope;
+
+  beforeEach(() => {
+    nock.disableNetConnect();
+    scope = nock(AI_ENDPOINT)
+      .post(AI_PATH, (body: Envelope[]) => {
+        requestBody = body;
+        return true;
+      })
+      .reply(200);
+  });
+
   afterEach(() => {
-    jest.clearAllMocks();
+    nock.cleanAll();
+    nock.enableNetConnect();
   });
 
-  it('initializes with default configuration', () => {
+  const waitForRequest = async (scope: nock.Scope) => {
+    return new Promise<void>((resolve, reject) => {
+      const interval = setInterval(() => {
+        if (scope.isDone()) {
+          clearInterval(interval);
+          resolve();
+        }
+      }, 10);
+      setTimeout(() => {
+        clearInterval(interval);
+        reject(new Error('waitForRequest timed out'));
+      }, 1000);
+    });
+  };
+
+  it('initializes with default configuration', async () => {
     const backend = new ApplicationInsightsBackend('user-id', 'session-id', 'product-name', {
       type: 'application-insights',
-    }) as unknown as ApplicationInsightsBackendPrivate;
-    expect(backend.client).toBeDefined();
-
-    const [[instrumentationKey]] = (setup as jest.Mock).mock.calls;
-    expect(instrumentationKey).toMatch(/^[a-z0-9-]+$/);
-  });
-
-  it('uses provided instrumentation key', () => {
-    const mockInstrumentationKey = 'test-instrumentation-key';
-    const backend = new ApplicationInsightsBackend('user-id', 'session-id', 'product-name', {
-      type: 'application-insights',
-      instrumentationKey: mockInstrumentationKey,
-    }) as unknown as ApplicationInsightsBackendPrivate;
-    expect(backend.client).toBeDefined();
-
-    const [[instrumentationKey]] = (setup as jest.Mock).mock.calls;
-    expect(instrumentationKey).toStrictEqual(mockInstrumentationKey);
-  });
-
-  it('sends events correctly', () => {
-    const backend = new ApplicationInsightsBackend('user-id', 'session-id', 'product-name', {
-      type: 'application-insights',
-    }) as unknown as ApplicationInsightsBackendPrivate;
+    });
 
     const event: TelemetryData = {
       name: 'test-event',
@@ -74,7 +63,98 @@ describe('ApplicationInsightsBackend', () => {
     };
 
     backend.sendEvent(event);
-    expect(backend.client.trackEvent).toHaveBeenCalledWith(event);
-    expect(backend.client.flush).toHaveBeenCalled();
+
+    await waitForRequest(scope);
+
+    const envelope = requestBody[0];
+    expect(envelope.iKey).toMatch(/^[a-z0-9-]+$/);
+  });
+
+  it('uses provided instrumentation key', async () => {
+    const mockInstrumentationKey = 'test-instrumentation-key';
+    const backend = new ApplicationInsightsBackend('user-id', 'session-id', 'product-name', {
+      type: 'application-insights',
+      instrumentationKey: mockInstrumentationKey,
+    });
+
+    const event: TelemetryData = {
+      name: 'test-event',
+    };
+
+    backend.sendEvent(event);
+
+    await waitForRequest(scope);
+
+    const envelope = requestBody[0];
+    expect(envelope.iKey).toBe(mockInstrumentationKey);
+  });
+
+  it('sends events correctly', async () => {
+    const backend = new ApplicationInsightsBackend('user-id', 'session-id', 'product-name', {
+      type: 'application-insights',
+    });
+
+    const event: TelemetryData = {
+      name: 'test-event',
+      properties: { key: 'value' },
+      metrics: { metric1: 100 },
+    };
+
+    backend.sendEvent(event);
+
+    await waitForRequest(scope);
+
+    const envelope = requestBody[0];
+    expect(envelope.name).toBe('Microsoft.ApplicationInsights.Event');
+    expect(envelope.data.baseType).toBe('EventData');
+    expect(envelope.data.baseData).toEqual(event);
+    expect(envelope.tags).toMatchObject({
+      'ai.user.id': 'user-id',
+      'ai.session.id': 'session-id',
+      'ai.cloud.role': 'product-name',
+    });
+  });
+
+  it('handles https errors', async () => {
+    nock.cleanAll(); // Don't use the default scope
+    const errorScope = nock(AI_ENDPOINT).post(AI_PATH).replyWithError('test error');
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    const backend = new ApplicationInsightsBackend('user-id', 'session-id', 'product-name', {
+      type: 'application-insights',
+    });
+
+    const event: TelemetryData = {
+      name: 'test-event',
+    };
+
+    backend.sendEvent(event);
+
+    await waitForRequest(errorScope);
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Error sending telemetry data to Application Insights',
+      expect.any(Error)
+    );
+  });
+
+  it('logs a warning for non-2xx HTTP responses', async () => {
+    nock.cleanAll();
+    const errorScope = nock(AI_ENDPOINT).post(AI_PATH).reply(500, { message: 'Internal Server Error' });
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    const backend = new ApplicationInsightsBackend('user-id', 'session-id', 'product-name', {
+      type: 'application-insights',
+    });
+
+    const event: TelemetryData = {
+      name: 'test-event',
+    };
+
+    backend.sendEvent(event);
+
+    await waitForRequest(errorScope);
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      'ApplicationInsightsBackend: Failed to send telemetry event. Status: 500'
+    );
   });
 });

--- a/packages/telemetry/tests/client.spec.ts
+++ b/packages/telemetry/tests/client.spec.ts
@@ -1,7 +1,6 @@
 
 import Conf from 'conf';
 import { name as appName, version } from '../package.json';
-import { Contracts } from 'applicationinsights';
 import assert from 'node:assert';
 import { TelemetryClient } from '../src';
 import { createMockServer } from './helpers/mockServer';
@@ -17,7 +16,7 @@ describe('TelemetryClient', () => {
   });
 
   describe('Telemetry', () => {
-    let sendEvent: jest.MockedFunction<(data: Contracts.EventTelemetry) => void>;
+    let sendEvent: jest.MockedFunction<(data: EventTelemetry) => void>;
     let flush: jest.MockedFunction<() => void>;
     let client: TelemetryClient;
     const sessionId = 'the-session-id';
@@ -102,7 +101,7 @@ describe('TelemetryClient', () => {
       const [[{ properties }]] = sendEvent.mock.calls;
       assert(properties);
 
-      const envVars: string = properties['common.environmentVariables'];
+      const envVars: string = properties['common.environmentVariables'] || '';
       expect(envVars.split(',')).toBeInstanceOf(Array);
       expect(envVars).toMatch(/\bNODE_ENV\b/);
     });
@@ -149,3 +148,10 @@ describe('TelemetryClient', () => {
     });
   });
 });
+
+
+interface EventTelemetry {
+  name: string;
+  properties?: { [key: string]: string | undefined };
+  measurements?: { [key: string]: number | undefined };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -148,7 +148,6 @@ __metadata:
     "@types/yargs": ^17.0.2
     JSONStream: ^1.3.5
     ajv: ^8.6.3
-    applicationinsights: ^2.1.4
     async: ^3.2.4
     axios: ^0.27.2
     better-sqlite3: ^11.5.0
@@ -524,7 +523,6 @@ __metadata:
     "@typescript-eslint/eslint-plugin": ^4.30.0
     "@typescript-eslint/parser": ^4.30.0
     ajv: ^8.8.2
-    applicationinsights: ^2.1.4
     async: ^3.2.4
     boxen: ^5.0.1
     chalk: ^4.1.2
@@ -638,12 +636,12 @@ __metadata:
     "@types/node": ^22
     "@typescript-eslint/eslint-plugin": ^8.38.0
     "@typescript-eslint/parser": ^8.38.0
-    applicationinsights: ^2.1.4
     conf: <11
     eslint: ^9.32.0
     eslint-config-prettier: ^10.1.8
     jest: ^29.5.0
     lint-staged: ^10.5.4
+    nock: ^13.2.2
     prettier: ^2.7.1
     read-pkg-up: ^7.0.1
     sinon: ^13.0.1
@@ -660,74 +658,6 @@ __metadata:
   bin:
     x-default-browser: bin/x-default-browser.js
   checksum: f63b68a0ff41c8fe478b1b4822e169cac0d26c61b123c0400d5e16a8a5987732b85795aff16d6b21936f9c955f0d32bffbfc166890d3446f74a72a7a2c9633ea
-  languageName: node
-  linkType: hard
-
-"@azure/abort-controller@npm:^1.0.0":
-  version: 1.0.4
-  resolution: "@azure/abort-controller@npm:1.0.4"
-  dependencies:
-    tslib: ^2.0.0
-  checksum: 3bdb4d13505e91813729f053b5e50573aabcbb88cd7b187e8fd09aaf7a3ea8e2907ab6d6ee9bbe016060d312aecf189b2e1273e9fcc15bd93699632dcebafc06
-  languageName: node
-  linkType: hard
-
-"@azure/core-asynciterator-polyfill@npm:^1.0.0":
-  version: 1.0.2
-  resolution: "@azure/core-asynciterator-polyfill@npm:1.0.2"
-  checksum: ccdad3bcf3f670e0b4f52e421cd1566368dce36ea4b3cb18a9b554c14ea0c1436868cb55e774b2377307dcb222e4eb3777b48e97249157c612e9c24654a56d16
-  languageName: node
-  linkType: hard
-
-"@azure/core-auth@npm:^1.3.0":
-  version: 1.3.2
-  resolution: "@azure/core-auth@npm:1.3.2"
-  dependencies:
-    "@azure/abort-controller": ^1.0.0
-    tslib: ^2.2.0
-  checksum: 8b27de6f8a82a63643524757ef774b1637b0d5c7769b387c73bebeb918717e7193ad1d2413638fb02b28de8199f261c1a902e3d04f75d1ef684af33529d9e98d
-  languageName: node
-  linkType: hard
-
-"@azure/core-http@npm:^2.2.3":
-  version: 2.2.4
-  resolution: "@azure/core-http@npm:2.2.4"
-  dependencies:
-    "@azure/abort-controller": ^1.0.0
-    "@azure/core-asynciterator-polyfill": ^1.0.0
-    "@azure/core-auth": ^1.3.0
-    "@azure/core-tracing": 1.0.0-preview.13
-    "@azure/logger": ^1.0.0
-    "@types/node-fetch": ^2.5.0
-    "@types/tunnel": ^0.0.3
-    form-data: ^4.0.0
-    node-fetch: ^2.6.7
-    process: ^0.11.10
-    tough-cookie: ^4.0.0
-    tslib: ^2.2.0
-    tunnel: ^0.0.6
-    uuid: ^8.3.0
-    xml2js: ^0.4.19
-  checksum: abda8c34c6d54f61b77080b1d4c01b3828cf9a344eb100346ebcc5ef9903d8f57651fbc73c0230afad5fe497c5c6da576a77cf43827f87417cecac7d7e612967
-  languageName: node
-  linkType: hard
-
-"@azure/core-tracing@npm:1.0.0-preview.13":
-  version: 1.0.0-preview.13
-  resolution: "@azure/core-tracing@npm:1.0.0-preview.13"
-  dependencies:
-    "@opentelemetry/api": ^1.0.1
-    tslib: ^2.2.0
-  checksum: bc3ea8dce1fc6bb6e4cb2e82ec0c361b3e6f6e18e162f352eb347e6991c6461ebc249f5d1b36402cc0d295e2a6bcbaa68014445d7f4293c0792a698c430f145e
-  languageName: node
-  linkType: hard
-
-"@azure/logger@npm:^1.0.0":
-  version: 1.0.3
-  resolution: "@azure/logger@npm:1.0.3"
-  dependencies:
-    tslib: ^2.2.0
-  checksum: f3443c70c678a7449a5f3be09488a0a15711c506c9da6a81fa9e43178128ddf5db3abc02c99359d188e4ef47d703c5e5f206df71b0e01884245de3220ab1205b
   languageName: node
   linkType: hard
 
@@ -7962,63 +7892,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/api@npm:^1.0.1, @opentelemetry/api@npm:^1.0.4":
-  version: 1.1.0
-  resolution: "@opentelemetry/api@npm:1.1.0"
-  checksum: 8be8e8dd20a473639a9bb9b4185b8984f537f86e49829ba1d4c4e909f4480309cb22696b7eb7122882878dac0b5f4ce799d66ed72248568bafed085d6269e1bc
-  languageName: node
-  linkType: hard
-
-"@opentelemetry/core@npm:1.9.1, @opentelemetry/core@npm:^1.0.1":
-  version: 1.9.1
-  resolution: "@opentelemetry/core@npm:1.9.1"
-  dependencies:
-    "@opentelemetry/semantic-conventions": 1.9.1
-  peerDependencies:
-    "@opentelemetry/api": ">=1.0.0 <1.5.0"
-  checksum: 5581a809e2caff142136734634f45255ce9f1ed701cf38629b9e17d91a8d15449b467fb3a7f3d0d8b076f653090e50cc31d3b1db4cfefeda9b6b901c60581024
-  languageName: node
-  linkType: hard
-
-"@opentelemetry/resources@npm:1.9.1":
-  version: 1.9.1
-  resolution: "@opentelemetry/resources@npm:1.9.1"
-  dependencies:
-    "@opentelemetry/core": 1.9.1
-    "@opentelemetry/semantic-conventions": 1.9.1
-  peerDependencies:
-    "@opentelemetry/api": ">=1.0.0 <1.5.0"
-  checksum: cf15e5faa698df3f0abcee35f7b4271c019b6cb81cb521b07793fe622c716d9c6873216219879afd57a28202f748a839ecaf28e04268e490004f14bbb850c96e
-  languageName: node
-  linkType: hard
-
-"@opentelemetry/sdk-trace-base@npm:^1.0.1":
-  version: 1.9.1
-  resolution: "@opentelemetry/sdk-trace-base@npm:1.9.1"
-  dependencies:
-    "@opentelemetry/core": 1.9.1
-    "@opentelemetry/resources": 1.9.1
-    "@opentelemetry/semantic-conventions": 1.9.1
-  peerDependencies:
-    "@opentelemetry/api": ">=1.0.0 <1.5.0"
-  checksum: f9448132686b1a8c1fde7539845a2b31bcb315c3bbabccb20a18142db80eeed433b3713e2761151348c1b626ad00183f4b7e9b9868d1a8ab8c541dce1d082f38
-  languageName: node
-  linkType: hard
-
-"@opentelemetry/semantic-conventions@npm:1.9.1":
-  version: 1.9.1
-  resolution: "@opentelemetry/semantic-conventions@npm:1.9.1"
-  checksum: 6217ba14b8f0068a3400f054c1f9d918b2e22d1cf8d31112baa712b8d196e207aed7421c6df37ed1403f7109f51c7834c230cbe180313eee07db6f7e0a7797bc
-  languageName: node
-  linkType: hard
-
-"@opentelemetry/semantic-conventions@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "@opentelemetry/semantic-conventions@npm:1.0.1"
-  checksum: c17dd6494185587b92eb2147114e280c29ecdc1cec081adc4cf02919c04ed63ed0d96a6a1247b8147536b985ec376804327be5b7aca868aa3890d428ac2c6cc7
-  languageName: node
-  linkType: hard
-
 "@pkgjs/parseargs@npm:^0.11.0":
   version: 0.11.0
   resolution: "@pkgjs/parseargs@npm:0.11.0"
@@ -11358,16 +11231,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node-fetch@npm:^2.5.0":
-  version: 2.5.12
-  resolution: "@types/node-fetch@npm:2.5.12"
-  dependencies:
-    "@types/node": "*"
-    form-data: ^3.0.0
-  checksum: ad63c85ba6a9477b8e057ec8682257738130d98e8ece4e31141789bd99df9d9147985cc8bc0cb5c8983ed5aa6bb95d46df23d1e055f4ad5cf8b82fc69cf626c7
-  languageName: node
-  linkType: hard
-
 "@types/node-fetch@npm:^2.6.4":
   version: 2.6.9
   resolution: "@types/node-fetch@npm:2.6.9"
@@ -11772,15 +11635,6 @@ __metadata:
   version: 2.0.6
   resolution: "@types/trusted-types@npm:2.0.6"
   checksum: 04250c7175e565b4d32cc2fd9ac1824ab9f0b2cfa82a7978581ffa1c96d7ed4166dc2415b4670cfcb734b389c49c3e9fc028b06ff325d77cc9e6f06bb05e273e
-  languageName: node
-  linkType: hard
-
-"@types/tunnel@npm:^0.0.3":
-  version: 0.0.3
-  resolution: "@types/tunnel@npm:0.0.3"
-  dependencies:
-    "@types/node": "*"
-  checksum: 53e23a1f9fb14a491c00425b2a4fc443817564d77be5e1b95fcbeb6d009551b62ea82ffc3e5ca0c6b9f6b186824ca6ec46e7450c1bcd6674a46d1325f0116e24
   languageName: node
   linkType: hard
 
@@ -14767,28 +14621,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"applicationinsights@npm:^2.1.4":
-  version: 2.2.1
-  resolution: "applicationinsights@npm:2.2.1"
-  dependencies:
-    "@azure/core-http": ^2.2.3
-    "@opentelemetry/api": ^1.0.4
-    "@opentelemetry/core": ^1.0.1
-    "@opentelemetry/sdk-trace-base": ^1.0.1
-    "@opentelemetry/semantic-conventions": ^1.0.1
-    cls-hooked: ^4.2.2
-    continuation-local-storage: ^3.2.1
-    diagnostic-channel: 1.1.0
-    diagnostic-channel-publishers: 1.0.4
-  peerDependencies:
-    applicationinsights-native-metrics: "*"
-  peerDependenciesMeta:
-    applicationinsights-native-metrics:
-      optional: true
-  checksum: af0a8286b812aaf994966b4ae7b42b0925c24bf0cb9b0f87640d4fff760b4e91ef4bb89ced5d1a04fd4d88a925592212b751d5d0ce21f5ed405eff46864c96b8
-  languageName: node
-  linkType: hard
-
 "appmap-node@npm:^2.23.0":
   version: 2.23.0
   resolution: "appmap-node@npm:2.23.0"
@@ -15334,29 +15166,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"async-hook-jl@npm:^1.7.6":
-  version: 1.7.6
-  resolution: "async-hook-jl@npm:1.7.6"
-  dependencies:
-    stack-chain: ^1.3.7
-  checksum: f84421c83ad5bc4e54a3a6ad7be4fb911840a17c01e5ee3f8e4e9cd077a42c7bc206dbc6b36d52eaca5fa37f16a15f83d63135976cf3e17d5bdc2824f6002705
-  languageName: node
-  linkType: hard
-
 "async-limiter@npm:~1.0.0":
   version: 1.0.1
   resolution: "async-limiter@npm:1.0.1"
   checksum: 2b849695b465d93ad44c116220dee29a5aeb63adac16c1088983c339b0de57d76e82533e8e364a93a9f997f28bbfc6a92948cefc120652bd07f3b59f8d75cf2b
-  languageName: node
-  linkType: hard
-
-"async-listener@npm:^0.6.0":
-  version: 0.6.10
-  resolution: "async-listener@npm:0.6.10"
-  dependencies:
-    semver: ^5.3.0
-    shimmer: ^1.1.0
-  checksum: f64cb835ad1a07d4ee800df6c1532f2a4f99e1c2a11da8e83c1bd4452bc01729a85552377bc120f144abc17be6c0bd0f740ebedfdf4b79ebd18844a51e307326
   languageName: node
   linkType: hard
 
@@ -17729,17 +17542,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cls-hooked@npm:^4.2.2":
-  version: 4.2.2
-  resolution: "cls-hooked@npm:4.2.2"
-  dependencies:
-    async-hook-jl: ^1.7.6
-    emitter-listener: ^1.0.1
-    semver: ^5.4.1
-  checksum: 3a8a4e30b03a81ec275eb9c079c49d4497013e7fa36259e86c9b6aff7990e85eebbc97552ed8a035c19403f0b825000df9bada5c1c0ac7cf1b2506c3a903df60
-  languageName: node
-  linkType: hard
-
 "cmd-shim@npm:^5.0.0":
   version: 5.0.0
   resolution: "cmd-shim@npm:5.0.0"
@@ -18207,16 +18009,6 @@ __metadata:
   version: 1.0.4
   resolution: "content-type@npm:1.0.4"
   checksum: 3d93585fda985d1554eca5ebd251994327608d2e200978fdbfba21c0c679914d5faf266d17027de44b34a72c7b0745b18584ecccaa7e1fdfb6a68ac7114f12e0
-  languageName: node
-  linkType: hard
-
-"continuation-local-storage@npm:^3.2.1":
-  version: 3.2.1
-  resolution: "continuation-local-storage@npm:3.2.1"
-  dependencies:
-    async-listener: ^0.6.0
-    emitter-listener: ^1.1.1
-  checksum: 5ac1dcf354563a7121fc1653676ed8dda93565c469698dd7454c3485d9e2c3ca61347d754d02179d13d9e51665d23fffe6bf9e53e89a1865a0c5530384258c2f
   languageName: node
   linkType: hard
 
@@ -20256,24 +20048,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"diagnostic-channel-publishers@npm:1.0.4":
-  version: 1.0.4
-  resolution: "diagnostic-channel-publishers@npm:1.0.4"
-  peerDependencies:
-    diagnostic-channel: "*"
-  checksum: ec79a5868328c273d0de383f7e519a2822a023a85618f4ff5f51c402d7cf187f15849cdac40b9ff7bd986fb1accf4ca630845d56d05331ef9c294e4b5ced596e
-  languageName: node
-  linkType: hard
-
-"diagnostic-channel@npm:1.1.0":
-  version: 1.1.0
-  resolution: "diagnostic-channel@npm:1.1.0"
-  dependencies:
-    semver: ^5.3.0
-  checksum: 4298b83d556d45fd411279ca6fb8b05bf73552a8a46ae8d72b2624e3ce3131ce40aedddd8f37633485944776299e4b7dec4e9e267246ff0f97654a36f4272656
-  languageName: node
-  linkType: hard
-
 "diff-sequences@npm:^24.9.0":
   version: 24.9.0
   resolution: "diff-sequences@npm:24.9.0"
@@ -20794,15 +20568,6 @@ __metadata:
     minimalistic-assert: ^1.0.1
     minimalistic-crypto-utils: ^1.0.1
   checksum: 27b14a52f68bbbc0720da259f712cb73e953f6d2047958cd02fb0d0ade2e83849dc39fb4af630889c67df8817e24237428cf59c4f4c07700f755b401149a7375
-  languageName: node
-  linkType: hard
-
-"emitter-listener@npm:^1.0.1, emitter-listener@npm:^1.1.1":
-  version: 1.1.2
-  resolution: "emitter-listener@npm:1.1.2"
-  dependencies:
-    shimmer: ^1.2.0
-  checksum: 05166bad42a27e51a765ebac3b7d26ac111564fc2d36443cd819f95ef88ea1b9ba6f2895becbcea36f8009890a2a8cb7c36eb9e776d4978e370bd33cb0a181e8
   languageName: node
   linkType: hard
 
@@ -38281,7 +38046,7 @@ resolve@1.1.7:
   languageName: node
   linkType: hard
 
-"sax@npm:>=0.6.0, sax@npm:^1.2.4, sax@npm:~1.2.4":
+"sax@npm:^1.2.4, sax@npm:~1.2.4":
   version: 1.2.4
   resolution: "sax@npm:1.2.4"
   checksum: d3df7d32b897a2c2f28e941f732c71ba90e27c24f62ee918bd4d9a8cfb3553f2f81e5493c7f0be94a11c1911b643a9108f231dd6f60df3fa9586b5d2e3e9e1fe
@@ -38519,7 +38284,7 @@ resolve@1.1.7:
   languageName: node
   linkType: hard
 
-"semver@npm:2 || 3 || 4 || 5, semver@npm:^5.3.0, semver@npm:^5.4.1, semver@npm:^5.5, semver@npm:^5.5.0, semver@npm:^5.6.0, semver@npm:^5.7.0":
+"semver@npm:2 || 3 || 4 || 5, semver@npm:^5.5, semver@npm:^5.5.0, semver@npm:^5.6.0, semver@npm:^5.7.0":
   version: 5.7.1
   resolution: "semver@npm:5.7.1"
   bin:
@@ -38922,13 +38687,6 @@ resolve@1.1.7:
   version: 0.1.1
   resolution: "shellwords@npm:0.1.1"
   checksum: 8d73a5e9861f5e5f1068e2cfc39bc0002400fe58558ab5e5fa75630d2c3adf44ca1fac81957609c8320d5533e093802fcafc72904bf1a32b95de3c19a0b1c0d4
-  languageName: node
-  linkType: hard
-
-"shimmer@npm:^1.1.0, shimmer@npm:^1.2.0":
-  version: 1.2.1
-  resolution: "shimmer@npm:1.2.1"
-  checksum: aa0d6252ad1c682a4fdfda69e541be987f7a265ac7b00b1208e5e48cc68dc55f293955346ea4c71a169b7324b82c70f8400b3d3d2d60b2a7519f0a3522423250
   languageName: node
   linkType: hard
 
@@ -39654,13 +39412,6 @@ resolve@1.1.7:
   version: 0.1.8
   resolution: "stable@npm:0.1.8"
   checksum: 2ff482bb100285d16dd75cd8f7c60ab652570e8952c0bfa91828a2b5f646a0ff533f14596ea4eabd48bb7f4aeea408dce8f8515812b975d958a4cc4fa6b9dfeb
-  languageName: node
-  linkType: hard
-
-"stack-chain@npm:^1.3.7":
-  version: 1.3.7
-  resolution: "stack-chain@npm:1.3.7"
-  checksum: c2428e794a60e1f8e3b66898657d10b81ea18eefd0842d65f18bad6f53fbca597075079bbda8df5b409aebb82d2055bf9c4a8d439df18c554756ead197fc2260
   languageName: node
   linkType: hard
 
@@ -41392,7 +41143,7 @@ resolve@1.1.7:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.0.0, tslib@npm:^2.0.1, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.2.0":
+"tslib@npm:^2.0.0, tslib@npm:^2.0.1, tslib@npm:^2.0.3, tslib@npm:^2.1.0":
   version: 2.3.1
   resolution: "tslib@npm:2.3.1"
   checksum: de17a98d4614481f7fcb5cd53ffc1aaf8654313be0291e1bfaee4b4bb31a20494b7d218ff2e15017883e8ea9626599b3b0e0229c18383ba9dce89da2adf15cb9
@@ -41482,13 +41233,6 @@ resolve@1.1.7:
   dependencies:
     safe-buffer: ^5.0.1
   checksum: 05f6510358f8afc62a057b8b692f05d70c1782b70db86d6a1e0d5e28a32389e52fa6e7707b6c5ecccacc031462e4bc35af85ecfe4bbc341767917b7cf6965711
-  languageName: node
-  linkType: hard
-
-"tunnel@npm:^0.0.6":
-  version: 0.0.6
-  resolution: "tunnel@npm:0.0.6"
-  checksum: c362948df9ad34b649b5585e54ce2838fa583aa3037091aaed66793c65b423a264e5229f0d7e9a95513a795ac2bd4cb72cda7e89a74313f182c1e9ae0b0994fa
   languageName: node
   linkType: hard
 
@@ -42503,7 +42247,7 @@ typescript@~4.4.3:
   languageName: node
   linkType: hard
 
-"uuid@npm:^8.3.0, uuid@npm:^8.3.2":
+"uuid@npm:^8.3.2":
   version: 8.3.2
   resolution: "uuid@npm:8.3.2"
   bin:
@@ -43805,23 +43549,6 @@ typescript@~4.4.3:
   version: 4.0.0
   resolution: "xml-name-validator@npm:4.0.0"
   checksum: af100b79c29804f05fa35aa3683e29a321db9b9685d5e5febda3fa1e40f13f85abc40f45a6b2bf7bee33f68a1dc5e8eaef4cec100a304a9db565e6061d4cb5ad
-  languageName: node
-  linkType: hard
-
-"xml2js@npm:^0.4.19":
-  version: 0.4.23
-  resolution: "xml2js@npm:0.4.23"
-  dependencies:
-    sax: ">=0.6.0"
-    xmlbuilder: ~11.0.0
-  checksum: ca0cf2dfbf6deeaae878a891c8fbc0db6fd04398087084edf143cdc83d0509ad0fe199b890f62f39c4415cf60268a27a6aed0d343f0658f8779bd7add690fa98
-  languageName: node
-  linkType: hard
-
-"xmlbuilder@npm:~11.0.0":
-  version: 11.0.1
-  resolution: "xmlbuilder@npm:11.0.1"
-  checksum: 7152695e16f1a9976658215abab27e55d08b1b97bca901d58b048d2b6e106b5af31efccbdecf9b07af37c8377d8e7e821b494af10b3a68b0ff4ae60331b415b0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
It turns out that the applicationinsights package we've been using for telemetry does many requests behind the scenes, sometimes causing hangs (or at least long delays) on exit and generating unnecessary traffic.

Since we're just sending simple custom telemetry events, this change removes that library and reimplements the appinsights backend with plain https. This avoids hidden requests, cuts down complexity and removes a bunch of dependencies.