### PR TITLE
fix: Don't crash on licence check errors

### DIFF
--- a/packages/cli/src/lib/checkLicense.ts
+++ b/packages/cli/src/lib/checkLicense.ts
@@ -14,10 +14,16 @@ export default async function checkLicense(required = false): Promise<void> {
     return;
   }
 
-  if (await LicenseKey.check(config.apiKey)) {
-    warn(`Valid license for ${config.username ?? 'unknown user'} at machine id ${Telemetry.machineId}.`);
-  } else {
-    warn('Warning: The provided license key is not valid.');
-    if (required) throw new Error('The provided license key is not valid');
+  try {
+    if (await LicenseKey.check(config.apiKey)) {
+      warn(`Valid license for ${config.username ?? 'unknown user'} at machine id ${Telemetry.machineId}.`);
+    } else {
+      warn('Warning: The provided license key is not valid.');
+      if (required) throw new Error('The provided license key is not valid');
+    }
+  } catch (e) {
+    warn('Warning: Failed to check license key:');
+    warn(e);
+    if (required) throw e;
   }
 }

--- a/packages/client/src/licenseKey.ts
+++ b/packages/client/src/licenseKey.ts
@@ -9,11 +9,12 @@ import verbose from './verbose';
 export default {
   async check(licenseKey: string, retryOptions: RetryOptions = {}): Promise<boolean> {
     const commandDescription = `Checking if API key is valid`;
+    const requestPath = ['api', 'api_keys', 'check'].join('/');
+    const request = buildRequest(requestPath, { requireApiKey: false });
+    request.headers.authorization = `Bearer ${licenseKey}`;
+
     const makeRequest = async (): Promise<IncomingMessage> => {
       const retrier = retry(commandDescription, retryOptions, makeRequest);
-      const requestPath = ['api', 'api_keys', 'check'].join('/');
-      const request = buildRequest(requestPath, { requireApiKey: false });
-      request.headers.authorization = `Bearer ${licenseKey}`;
       return new Promise<IncomingMessage>((resolve, reject) => {
         const interaction = request.requestFunction(
           request.url,
@@ -37,7 +38,9 @@ export default {
       response.on('end', () => {});
 
       if (!response.statusCode) {
-        throw new Error('No status code was provided by the server');
+        throw new Error(
+          `License key check failed for ${request.url.toString()}: No status code was provided by the server`
+        );
       }
       if (response.statusCode === 404) {
         return false;
@@ -45,7 +48,9 @@ export default {
       if (response.statusCode < 300) {
         return true;
       }
-      throw new Error(`Unexpected status code: ${response.statusCode}`);
+      throw new Error(
+        `License key check failed: Unexpected status code ${response.statusCode} from ${request.url.toString()}`
+      );
     });
   },
 };


### PR DESCRIPTION
When checking licence, if the licence check is non-mandatory, don't throw error (and crash) when there's a problem contacting the server.