### PR TITLE
chore(ci): cache yarn packages per native build job

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -12,7 +12,7 @@ runs:
       shell: bash
       run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
     - name: Restore Yarn packages
-      uses: actions/cache/restore@v5
+      uses: actions/cache@v5
       with:
         path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
         key: ${{ github.job }}-yarn-${{ hashFiles('yarn.lock') }}


### PR DESCRIPTION
Swaps 'actions/cache/restore' to 'action/cache' inside actions/setup-node.yml

Supposedly, it should heal always-cold yarn cache in native builds without breaking anything.

(The reason for always cold yarn cache was the lack of corresponding save step anywhere in the flow).