### PR TITLE
fix(cli): package built/html in binary instead of stale per-file asset paths

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -183,8 +183,7 @@
     "assets": [
       "package.json",
       "resources",
-      "built/appmap.html",
-      "built/sequenceDiagram.html",
+      "built/html",
       "built/docs",
       "../../node_modules/better-sqlite3/build/Release/better_sqlite3.node",
       "node_modules/better-sqlite3/build/Release/better_sqlite3.node"


### PR DESCRIPTION
The pkg assets listed built/*.html paths that never existed (esbuild outputs to built/html/). The query-ui directory was also missing entirely, causing "query-ui bundle not found" at runtime. Replace all entries with built/html to cover HTML, JS, and CSS in one shot.