### PR TITLE
[DO NOT MERGE] feat(components): organization configuration prompt on the sign-in screen

### DIFF
--- a/packages/components/src/components/SignIn.vue
+++ b/packages/components/src/components/SignIn.vue
@@ -194,7 +194,7 @@ export default {
       return this.enableOrgConfig && !this.orgConfigApplied && !this.orgConfigJustApplied;
     },
     showOrgConfigConfirmation() {
-      return this.enableOrgConfig && this.orgConfigJustApplied;
+      return this.enableOrgConfig && (this.orgConfigJustApplied || this.orgConfigApplied);
     },
   },
 

--- a/packages/components/src/components/SignIn.vue
+++ b/packages/components/src/components/SignIn.vue
@@ -58,6 +58,26 @@
             </a>
           </p>
         </div>
+
+        <div v-if="showOrgConfigPrompt" class="org-config" data-cy="org-config-prompt">
+          <p>
+            Using AppMap through your organization?<br />
+            <a class="link" href="/" data-cy="org-config-link" @click.prevent="applyOrgConfig">
+              Apply your organization&rsquo;s configuration first
+            </a>
+          </p>
+        </div>
+        <div
+          v-else-if="showOrgConfigConfirmation"
+          class="org-config-applied"
+          data-cy="org-config-applied"
+        >
+          <CheckIcon class="check-icon" />
+          <p>
+            <strong>Organization configuration applied.</strong><br />
+            Now activate with your work email above.
+          </p>
+        </div>
       </div>
 
       <div class="your-data">
@@ -123,6 +143,7 @@ import GitHubLogo from '@/assets/github-logo.svg';
 import GitLabLogo from '@/assets/gitlab-logo.svg';
 import EmailIcon from '@/assets/email.svg';
 import ExternalLinkIcon from '@/assets/external-link.svg';
+import CheckIcon from '@/assets/check.svg';
 
 const GENERIC_ERROR_MSG = 'Something went wrong, please try again later.';
 
@@ -136,12 +157,24 @@ export default {
     GitLabLogo,
     ExternalLinkIcon,
     EmailIcon,
+    CheckIcon,
   },
 
   props: {
     appmapServerUrl: {
       type: String,
       default: 'https://getappmap.com',
+    },
+    // Host opt-in: only hosts that handle the 'apply-org-config' event should enable this.
+    enableOrgConfig: {
+      type: Boolean,
+      default: false,
+    },
+    // Set by the host when an organization configuration is already in effect
+    // (e.g. applied earlier, or delivered via a managed environment).
+    orgConfigApplied: {
+      type: Boolean,
+      default: false,
     },
   },
 
@@ -152,7 +185,17 @@ export default {
       verificationCode: '',
       error: '',
       pendingRequest: undefined,
+      orgConfigJustApplied: false,
     };
+  },
+
+  computed: {
+    showOrgConfigPrompt() {
+      return this.enableOrgConfig && !this.orgConfigApplied && !this.orgConfigJustApplied;
+    },
+    showOrgConfigConfirmation() {
+      return this.enableOrgConfig && this.orgConfigJustApplied;
+    },
   },
 
   methods: {
@@ -167,6 +210,13 @@ export default {
     },
     signIn(target) {
       this.$root.$emit('sign-in', target);
+    },
+    applyOrgConfig() {
+      this.$root.$emit('apply-org-config');
+    },
+    // Called by the host (via ref) once the organization configuration has been applied.
+    onOrgConfigApplied() {
+      this.orgConfigJustApplied = true;
     },
     reset() {
       this.email = '';
@@ -363,6 +413,38 @@ export default {
 
     .accept-tos {
       width: 90%;
+    }
+
+    .org-config {
+      width: 90%;
+      padding-top: 1rem;
+      border-top: 1px solid $gray3;
+      text-align: center;
+      color: $gray4;
+      line-height: 1.45;
+
+      a.link {
+        font-weight: 600;
+      }
+    }
+
+    .org-config-applied {
+      width: 90%;
+      display: flex;
+      align-items: flex-start;
+      gap: 0.6rem;
+      padding: 0.7rem 0.9rem;
+      border: 1px solid rgba($alert-success, 0.4);
+      border-radius: 0.5rem;
+      line-height: 1.45;
+
+      .check-icon {
+        flex-shrink: 0;
+        width: 14px;
+        height: 14px;
+        margin-top: 0.25rem;
+        fill: $alert-success;
+      }
     }
   }
 

--- a/packages/components/src/stories/SignIn.stories.js
+++ b/packages/components/src/stories/SignIn.stories.js
@@ -28,11 +28,27 @@ const OrgConfigTemplate = (args, { argTypes }) => ({
   components: { VSignIn },
   template: '<v-sign-in v-bind="$props" ref="vsCode" />',
   mounted() {
-    this.$root.$on('apply-org-config', () => this.$refs.vsCode.onOrgConfigApplied());
+    this.applyOrgConfigHandler = () => {
+      if (this.$refs.vsCode) {
+        this.$refs.vsCode.onOrgConfigApplied();
+      }
+    };
+    this.$root.$on('apply-org-config', this.applyOrgConfigHandler);
+  },
+  beforeDestroy() {
+    if (this.applyOrgConfigHandler) {
+      this.$root.$off('apply-org-config', this.applyOrgConfigHandler);
+    }
   },
 });
 
 export const SignInWithOrgConfig = OrgConfigTemplate.bind({});
 SignInWithOrgConfig.args = {
   enableOrgConfig: true,
+};
+
+export const SignInWithOrgConfigAlreadyApplied = OrgConfigTemplate.bind({});
+SignInWithOrgConfigAlreadyApplied.args = {
+  enableOrgConfig: true,
+  orgConfigApplied: true,
 };

--- a/packages/components/src/stories/SignIn.stories.js
+++ b/packages/components/src/stories/SignIn.stories.js
@@ -20,3 +20,8 @@ const Template = (args, { argTypes }) => ({
 });
 
 export const SignIn = Template.bind({});
+
+export const SignInWithOrgConfig = Template.bind({});
+SignInWithOrgConfig.args = {
+  enableOrgConfig: true,
+};

--- a/packages/components/src/stories/SignIn.stories.js
+++ b/packages/components/src/stories/SignIn.stories.js
@@ -21,7 +21,18 @@ const Template = (args, { argTypes }) => ({
 
 export const SignIn = Template.bind({});
 
-export const SignInWithOrgConfig = Template.bind({});
+// Simulates a host that handles the apply-org-config event, so e2e tests can
+// exercise the full click → event → confirmation round trip.
+const OrgConfigTemplate = (args, { argTypes }) => ({
+  props: Object.keys(argTypes),
+  components: { VSignIn },
+  template: '<v-sign-in v-bind="$props" ref="vsCode" />',
+  mounted() {
+    this.$root.$on('apply-org-config', () => this.$refs.vsCode.onOrgConfigApplied());
+  },
+});
+
+export const SignInWithOrgConfig = OrgConfigTemplate.bind({});
 SignInWithOrgConfig.args = {
   enableOrgConfig: true,
 };

--- a/packages/components/tests/e2e/specs/sidebarSignIn.spec.js
+++ b/packages/components/tests/e2e/specs/sidebarSignIn.spec.js
@@ -107,16 +107,9 @@ describe('Sidebar activation page with organization configuration enabled', () =
   });
 
   it('shows a confirmation once the configuration has been applied', () => {
-    cy.get('.signin-sidebar').then(($el) => {
-      // __vue__ resolves to the outermost story wrapper sharing the root
-      // element; walk down to the SignIn instance.
-      let vm = $el[0].__vue__;
-      while (vm && typeof vm.onOrgConfigApplied !== 'function') {
-        vm = vm.$children && vm.$children[0];
-      }
-      expect(vm, 'SignIn component instance').to.exist;
-      vm.onOrgConfigApplied();
-    });
+    // The story wrapper acts as the host: it answers apply-org-config by
+    // calling onOrgConfigApplied() on the component.
+    cy.get('[data-cy="org-config-link"]').click();
     cy.get('[data-cy="org-config-prompt"]').should('not.exist');
     cy.get('[data-cy="org-config-applied"]')
       .should('contain.text', 'Organization configuration applied.')

--- a/packages/components/tests/e2e/specs/sidebarSignIn.spec.js
+++ b/packages/components/tests/e2e/specs/sidebarSignIn.spec.js
@@ -108,7 +108,14 @@ describe('Sidebar activation page with organization configuration enabled', () =
 
   it('shows a confirmation once the configuration has been applied', () => {
     cy.get('.signin-sidebar').then(($el) => {
-      $el[0].__vue__.onOrgConfigApplied();
+      // __vue__ resolves to the outermost story wrapper sharing the root
+      // element; walk down to the SignIn instance.
+      let vm = $el[0].__vue__;
+      while (vm && typeof vm.onOrgConfigApplied !== 'function') {
+        vm = vm.$children && vm.$children[0];
+      }
+      expect(vm, 'SignIn component instance').to.exist;
+      vm.onOrgConfigApplied();
     });
     cy.get('[data-cy="org-config-prompt"]').should('not.exist');
     cy.get('[data-cy="org-config-applied"]')

--- a/packages/components/tests/e2e/specs/sidebarSignIn.spec.js
+++ b/packages/components/tests/e2e/specs/sidebarSignIn.spec.js
@@ -68,6 +68,11 @@ describe('Sidebar activation page', () => {
     cy.get('#email-input').should('have.value', '');
   });
 
+  it('does not show the organization configuration prompt by default', () => {
+    cy.get('[data-cy="org-config-prompt"]').should('not.exist');
+    cy.get('[data-cy="org-config-applied"]').should('not.exist');
+  });
+
   it('shows an error message with incorrect verification code', () => {
     cy.intercept('POST', 'https://getappmap.com/api/activations*', {
       statusCode: 201,
@@ -79,5 +84,35 @@ describe('Sidebar activation page', () => {
     });
     cy.get('#verification-code-input').type('1234').type('{enter}');
     cy.get('.error').should('contain.text', 'Invalid verification code, please try again.');
+  });
+});
+
+describe('Sidebar activation page with organization configuration enabled', () => {
+  beforeEach(() => {
+    cy.visit(
+      'http://localhost:6006/iframe.html?args=&id=pages-vs-code--sign-in-with-org-config&viewMode=story'
+    );
+  });
+
+  it('shows the organization configuration prompt', () => {
+    cy.get('[data-cy="org-config-prompt"]').should(
+      'contain.text',
+      'Using AppMap through your organization?'
+    );
+    cy.get('[data-cy="org-config-link"]').should(
+      'contain.text',
+      'Apply your organization’s configuration first'
+    );
+    cy.get('[data-cy="org-config-applied"]').should('not.exist');
+  });
+
+  it('shows a confirmation once the configuration has been applied', () => {
+    cy.get('.signin-sidebar').then(($el) => {
+      $el[0].__vue__.onOrgConfigApplied();
+    });
+    cy.get('[data-cy="org-config-prompt"]').should('not.exist');
+    cy.get('[data-cy="org-config-applied"]')
+      .should('contain.text', 'Organization configuration applied.')
+      .should('contain.text', 'Now activate with your work email above.');
   });
 });

--- a/packages/components/tests/e2e/specs/sidebarSignIn.spec.js
+++ b/packages/components/tests/e2e/specs/sidebarSignIn.spec.js
@@ -116,3 +116,18 @@ describe('Sidebar activation page with organization configuration enabled', () =
       .should('contain.text', 'Now activate with your work email above.');
   });
 });
+
+describe('Sidebar activation page with organization configuration already applied', () => {
+  beforeEach(() => {
+    cy.visit(
+      'http://localhost:6006/iframe.html?args=&id=pages-vs-code--sign-in-with-org-config-already-applied&viewMode=story'
+    );
+  });
+
+  it('shows the configuration confirmation directly and hides the prompt', () => {
+    cy.get('[data-cy="org-config-prompt"]').should('not.exist');
+    cy.get('[data-cy="org-config-applied"]')
+      .should('contain.text', 'Organization configuration applied.')
+      .should('contain.text', 'Now activate with your work email above.');
+  });
+});

--- a/packages/components/tests/unit/SignIn.spec.js
+++ b/packages/components/tests/unit/SignIn.spec.js
@@ -31,4 +31,42 @@ describe('SignIn.vue', () => {
 
     expect(fetchStub.mock.calls.length).toBe(1);
   });
+
+  describe('organization configuration', () => {
+    it('does not show the prompt unless enabled by the host', () => {
+      expect(wrapper.find('[data-cy="org-config-prompt"]').exists()).toBe(false);
+      expect(wrapper.find('[data-cy="org-config-applied"]').exists()).toBe(false);
+    });
+
+    it('shows the prompt when enabled', () => {
+      wrapper = shallowMount(SignIn, { propsData: { enableOrgConfig: true } });
+      expect(wrapper.find('[data-cy="org-config-prompt"]').exists()).toBe(true);
+      expect(wrapper.find('[data-cy="org-config-applied"]').exists()).toBe(false);
+    });
+
+    it('does not show the prompt when a configuration is already applied', () => {
+      wrapper = shallowMount(SignIn, {
+        propsData: { enableOrgConfig: true, orgConfigApplied: true },
+      });
+      expect(wrapper.find('[data-cy="org-config-prompt"]').exists()).toBe(false);
+      expect(wrapper.find('[data-cy="org-config-applied"]').exists()).toBe(false);
+    });
+
+    it('emits apply-org-config on the root when the link is clicked', () => {
+      wrapper = shallowMount(SignIn, { propsData: { enableOrgConfig: true } });
+      const rootEmit = jest.spyOn(wrapper.vm.$root, '$emit');
+      wrapper.find('[data-cy="org-config-link"]').trigger('click');
+      expect(rootEmit).toHaveBeenCalledWith('apply-org-config');
+    });
+
+    it('replaces the prompt with a confirmation once applied', async () => {
+      wrapper = shallowMount(SignIn, { propsData: { enableOrgConfig: true } });
+      wrapper.vm.onOrgConfigApplied();
+      await wrapper.vm.$nextTick();
+      expect(wrapper.find('[data-cy="org-config-prompt"]').exists()).toBe(false);
+      expect(wrapper.find('[data-cy="org-config-applied"]').text()).toContain(
+        'Organization configuration applied.'
+      );
+    });
+  });
 });

--- a/packages/components/tests/unit/SignIn.spec.js
+++ b/packages/components/tests/unit/SignIn.spec.js
@@ -44,12 +44,15 @@ describe('SignIn.vue', () => {
       expect(wrapper.find('[data-cy="org-config-applied"]').exists()).toBe(false);
     });
 
-    it('does not show the prompt when a configuration is already applied', () => {
+    it('shows the confirmation banner (and hides prompt) when a configuration is already applied', () => {
       wrapper = shallowMount(SignIn, {
         propsData: { enableOrgConfig: true, orgConfigApplied: true },
       });
       expect(wrapper.find('[data-cy="org-config-prompt"]').exists()).toBe(false);
-      expect(wrapper.find('[data-cy="org-config-applied"]').exists()).toBe(false);
+      expect(wrapper.find('[data-cy="org-config-applied"]').exists()).toBe(true);
+      expect(wrapper.find('[data-cy="org-config-applied"]').text()).toContain(
+        'Organization configuration applied.'
+      );
     });
 
     it('emits apply-org-config on the root when the link is clicked', () => {


### PR DESCRIPTION
## What

Adds an opt-in "enterprise configuration" prompt to `VSidebarSignIn`: a quiet text link below the Terms of Service — *"Using AppMap through your organization? Apply your organization's configuration first"* — that lets a user apply their organization's AppMap configuration before activating.

This is the shared-component half of the sign-in discoverability work for enterprise deployments (the host/extension half lives on vscode-appland's `feat/organization-config` branch).

## How it works

- **`enableOrgConfig` prop** (default `false`): host opt-in. Only hosts that handle the new event should set it, so existing hosts — including the IntelliJ plugin, which renders this same component — are unaffected until they wire up support.
- **`orgConfigApplied` prop** (default `false`): set by the host when an organization configuration is already in effect (applied earlier, or delivered via a managed environment / `APPMAP_CONFIG_URL`); hides the prompt.
- Clicking the link emits **`apply-org-config`** on the root, following the existing `sign-in`/`activate` event pattern. The host runs its configuration flow (e.g. `appmap.setConfigurationUrl`) and calls **`onOrgConfigApplied()`** on the component when it completes.
- On completion the prompt is replaced with a confirmation — *"✓ Organization configuration applied. Now activate with your work email above."* — so the user is directed to the remaining step instead of being left mid-flow.

## Host integration (vscode-appland side, not in this PR)

- Pass `enableOrgConfig` / `orgConfigApplied` through the existing `init-sign-in` message (`signInWebview.ts` → `web/src/signInView.js` props).
- Handle the `apply-org-config` event via the existing `MessagePublisher.rpc` request/response channel; call `onOrgConfigApplied()` on resolve.
- Requires a small applied-marker in the one-shot apply path of `remoteConfig.ts` so `orgConfigApplied` can be computed.

## Testing

- 5 new unit tests in `tests/unit/SignIn.spec.js` (default-hidden, shown when enabled, hidden when applied, event emission, confirmation state) — all passing alongside the existing 2.
- Cypress e2e cases and a new `SignInWithOrgConfig` story for Storybook/Chromatic coverage.
- ESLint clean on changed `src` files. Note: `yarn verify` flags a pre-existing invalid `tests/e2e/.eslintrc.js` (ESM `export default` in a legacy eslintrc); the package's `lint` script only covers `src/`, so CI lint is unaffected.

https://claude.ai/code/session_01QLMnc8L8e1JwkLPXzT3D57

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLMnc8L8e1JwkLPXzT3D57)_