### PR TITLE
revive enriched scan:completed telemetry (watch mode)

### DIFF
--- a/packages/scanner/package.json
+++ b/packages/scanner/package.json
@@ -18,6 +18,7 @@
     "schema-up-to-date": "git diff --exit-code src/configuration/schema/options.json",
     "doc-up-to-date": "git diff --exit-code doc/",
     "lint": "eslint src --ext .ts",
+    "typecheck": "tsc --noEmit",
     "ci": "yarn lint && yarn build && yarn schema-up-to-date && yarn doc-up-to-date && yarn test",
     "test": "yarn jest",
     "jest": "jest --filter=./test/testFilter.js --detectOpenHandles",

--- a/packages/scanner/src/cli/scan/watchScan.ts
+++ b/packages/scanner/src/cli/scan/watchScan.ts
@@ -55,11 +55,11 @@ export class Watcher {
   appmapPoller?: chokidar.FSWatcher;
   configWatcher?: chokidar.FSWatcher;
   scanEventEmitter = new EventEmitter();
-  private cancelScanTelemetry: () => void;
+  private scanTelemetry: WatchScanTelemetry;
 
   constructor(private options: WatchScanOptions) {
     this.queue.error((error, task) => console.warn(`Problem processing ${task}:\n`, error));
-    this.cancelScanTelemetry = WatchScanTelemetry.watch(this.scanEventEmitter, options.appmapDir);
+    this.scanTelemetry = new WatchScanTelemetry(this.scanEventEmitter, options.appmapDir);
   }
 
   async watch(): Promise<void> {
@@ -141,7 +141,7 @@ export class Watcher {
   }
 
   async close(): Promise<void> {
-    this.cancelScanTelemetry();
+    await this.scanTelemetry.cancel();
     await Promise.all(
       (['appmapWatcher', 'appmapPoller', 'configWatcher'] as const).map((k) => {
         const closer = this[k]?.close();

--- a/packages/scanner/src/cli/scan/watchScan.ts
+++ b/packages/scanner/src/cli/scan/watchScan.ts
@@ -13,6 +13,7 @@ import {
 } from '../../configuration/configurationProvider';
 import { Telemetry } from '@appland/telemetry';
 import EventEmitter from 'events';
+import { WatchScanTelemetry } from './watchScanTelemetry';
 import isAncestorPath from '../../util/isAncestorPath';
 import { debuglog } from 'util';
 import { warn } from 'console';
@@ -54,9 +55,11 @@ export class Watcher {
   appmapPoller?: chokidar.FSWatcher;
   configWatcher?: chokidar.FSWatcher;
   scanEventEmitter = new EventEmitter();
+  private cancelScanTelemetry: () => void;
 
   constructor(private options: WatchScanOptions) {
     this.queue.error((error, task) => console.warn(`Problem processing ${task}:\n`, error));
+    this.cancelScanTelemetry = WatchScanTelemetry.watch(this.scanEventEmitter, options.appmapDir);
   }
 
   async watch(): Promise<void> {
@@ -138,6 +141,7 @@ export class Watcher {
   }
 
   async close(): Promise<void> {
+    this.cancelScanTelemetry();
     await Promise.all(
       (['appmapWatcher', 'appmapPoller', 'configWatcher'] as const).map((k) => {
         const closer = this[k]?.close();

--- a/packages/scanner/src/cli/scan/watchScanTelemetry.ts
+++ b/packages/scanner/src/cli/scan/watchScanTelemetry.ts
@@ -1,5 +1,5 @@
-import { EventEmitter } from 'stream';
-import EventAggregator, { CancelFn } from '../../util/eventAggregator';
+import type { EventEmitter } from 'stream';
+import EventAggregator from '../../util/eventAggregator';
 import { ScanResults, sendScanResultsTelemetry } from '../../report/scanResults';
 
 export type ScanEvent = {
@@ -16,16 +16,11 @@ export class WatchScanTelemetry {
     );
   }
 
-  cancel(): void {
-    this.aggregator.cancel();
+  cancel(): Promise<void> {
+    return this.aggregator.cancel();
   }
 
-  static watch(scanEvents: EventEmitter, appmapDir?: string): CancelFn {
-    const telemetry = new WatchScanTelemetry(scanEvents, appmapDir);
-    return () => telemetry.cancel();
-  }
-
-  private sendTelemetry(scanEvents: ScanEvent[]) {
+  private sendTelemetry(scanEvents: ScanEvent[]): Promise<void> {
     let elapsed = 0;
     const telemetryScanResults = new ScanResults();
     for (const scanEvent of scanEvents) {
@@ -33,7 +28,7 @@ export class WatchScanTelemetry {
       elapsed += scanEvent.elapsed;
     }
 
-    sendScanResultsTelemetry({
+    return sendScanResultsTelemetry({
       ruleIds: telemetryScanResults.summary.rules,
       numAppMaps: telemetryScanResults.summary.numAppMaps,
       numFindings: telemetryScanResults.summary.numFindings,

--- a/packages/scanner/src/cli/scan/watchScanTelemetry.ts
+++ b/packages/scanner/src/cli/scan/watchScanTelemetry.ts
@@ -1,0 +1,46 @@
+import { EventEmitter } from 'stream';
+import EventAggregator, { CancelFn } from '../../util/eventAggregator';
+import { ScanResults, sendScanResultsTelemetry } from '../../report/scanResults';
+
+export type ScanEvent = {
+  scanResults: ScanResults;
+  elapsed: number;
+};
+
+export class WatchScanTelemetry {
+  private readonly aggregator: EventAggregator<ScanEvent>;
+
+  constructor(scanEvents: EventEmitter, private readonly appmapDir?: string) {
+    this.aggregator = new EventAggregator<ScanEvent>(scanEvents, 'scan', (events) =>
+      this.sendTelemetry(events)
+    );
+  }
+
+  cancel(): void {
+    this.aggregator.cancel();
+  }
+
+  static watch(scanEvents: EventEmitter, appmapDir?: string): CancelFn {
+    const telemetry = new WatchScanTelemetry(scanEvents, appmapDir);
+    return () => telemetry.cancel();
+  }
+
+  private sendTelemetry(scanEvents: ScanEvent[]) {
+    let elapsed = 0;
+    const telemetryScanResults = new ScanResults();
+    for (const scanEvent of scanEvents) {
+      telemetryScanResults.aggregate(scanEvent.scanResults);
+      elapsed += scanEvent.elapsed;
+    }
+
+    sendScanResultsTelemetry({
+      ruleIds: telemetryScanResults.summary.rules,
+      numAppMaps: telemetryScanResults.summary.numAppMaps,
+      numFindings: telemetryScanResults.summary.numFindings,
+      findingCountsByRule: telemetryScanResults.summary.findingCountsByRule,
+      findingCountsByImpactDomain: telemetryScanResults.summary.findingCountsByImpactDomain,
+      elapsedMs: elapsed,
+      appmapDir: this.appmapDir,
+    });
+  }
+}

--- a/packages/scanner/src/report/scanResults.ts
+++ b/packages/scanner/src/report/scanResults.ts
@@ -1,8 +1,45 @@
 import { Metadata } from '@appland/models';
+import { Git, GitState, Telemetry, TelemetryData } from '@appland/telemetry';
 import Check from '../check';
 import Configuration from '../configuration/types/configuration';
 import { Finding } from '../index';
 import { AppMapMetadata, ScanSummary } from './scanSummary';
+
+/** Tally values in `source` into `target`, summing counts for repeated keys. */
+function mergeCounts(target: Record<string, number>, source: Record<string, number>): void {
+  for (const [key, count] of Object.entries(source)) {
+    target[key] = (target[key] ?? 0) + count;
+  }
+}
+
+/** Count findings by the value returned from `key`, skipping undefined keys. */
+function countFindings(
+  findings: Finding[],
+  key: (finding: Finding) => string | undefined
+): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const finding of findings) {
+    const value = key(finding);
+    if (value === undefined) continue;
+    counts[value] = (counts[value] ?? 0) + 1;
+  }
+  return counts;
+}
+
+/**
+ * Serialize a counts map to JSON with keys sorted, so the output is deterministic
+ * regardless of the order findings were discovered (stable to compare downstream).
+ *
+ * This relies on JSON.stringify emitting keys in own-property order, which the spec
+ * fixes as integer-index keys first, then other string keys in insertion order. Rule
+ * IDs and impact domains are never integer-like, so inserting them sorted (via
+ * fromEntries) yields sorted JSON. If keys could be integer-like strings, they'd be
+ * hoisted ahead of insertion order and this wouldn't hold.
+ */
+function sortedCountsJson(counts: Record<string, number>): string {
+  const sorted = Object.fromEntries(Object.entries(counts).sort(([a], [b]) => a.localeCompare(b)));
+  return JSON.stringify(sorted);
+}
 
 class DistinctItems<T> {
   private members: Record<string, T> = {};
@@ -72,6 +109,8 @@ export class ScanResults {
       rules: [...new Set(checks.map((check) => check.rule.id))].sort(),
       ruleLabels: [...new Set(checks.map((check) => check.rule.labels || []).flat())].sort(),
       numFindings: findings.length,
+      findingCountsByRule: countFindings(findings, (finding) => finding.ruleId),
+      findingCountsByImpactDomain: countFindings(findings, (finding) => finding.impactDomain),
       appMapMetadata: collectMetadata(Object.values(appMapMetadata)),
     };
   }
@@ -88,8 +127,56 @@ export class ScanResults {
       ...new Set(this.summary.ruleLabels.concat(sourceScanResults.summary.ruleLabels)),
     ];
     this.summary.numFindings += sourceScanResults.summary.numFindings;
+    mergeCounts(this.summary.findingCountsByRule, sourceScanResults.summary.findingCountsByRule);
+    mergeCounts(
+      this.summary.findingCountsByImpactDomain,
+      sourceScanResults.summary.findingCountsByImpactDomain
+    );
 
     // we don't need sourceScanResults.summary.appMetadata
     // appMapMetadata.Git may also contain secrets we don't want to transmit.
   }
+}
+
+export type ScanTelemetry = {
+  ruleIds: string[];
+  numAppMaps: number;
+  numFindings: number;
+  findingCountsByRule: Record<string, number>;
+  findingCountsByImpactDomain: Record<string, number>;
+  elapsedMs: number;
+  appmapDir?: string;
+};
+
+/**
+ * Build the `scan:completed` telemetry payload. Pure and synchronous: git state and
+ * contributor count are resolved by the caller and passed in.
+ */
+export function scanCompletedEvent(
+  telemetry: ScanTelemetry,
+  gitState: string,
+  contributors: number
+): TelemetryData {
+  return {
+    name: 'scan:completed',
+    properties: {
+      rules: [...telemetry.ruleIds].sort().join(', '),
+      git_state: gitState,
+      findingsByRule: sortedCountsJson(telemetry.findingCountsByRule),
+      findingsByImpactDomain: sortedCountsJson(telemetry.findingCountsByImpactDomain),
+    },
+    metrics: {
+      duration: telemetry.elapsedMs / 1000,
+      numRules: telemetry.ruleIds.length,
+      numAppMaps: telemetry.numAppMaps,
+      numFindings: telemetry.numFindings,
+      contributors,
+    },
+  };
+}
+
+export async function sendScanResultsTelemetry(telemetry: ScanTelemetry): Promise<void> {
+  const gitState = GitState[await Git.state(telemetry.appmapDir)];
+  const contributors = (await Git.contributors(60, telemetry.appmapDir)).length;
+  Telemetry.sendEvent(scanCompletedEvent(telemetry, gitState, contributors));
 }

--- a/packages/scanner/src/report/scanResults.ts
+++ b/packages/scanner/src/report/scanResults.ts
@@ -1,5 +1,5 @@
 import { Metadata } from '@appland/models';
-import { Git, GitState, Telemetry, TelemetryData } from '@appland/telemetry';
+import { Git, GitState, Telemetry, type TelemetryData } from '@appland/telemetry';
 import Check from '../check';
 import Configuration from '../configuration/types/configuration';
 import { Finding } from '../index';
@@ -176,7 +176,12 @@ export function scanCompletedEvent(
 }
 
 export async function sendScanResultsTelemetry(telemetry: ScanTelemetry): Promise<void> {
-  const gitState = GitState[await Git.state(telemetry.appmapDir)];
-  const contributors = (await Git.contributors(60, telemetry.appmapDir)).length;
-  Telemetry.sendEvent(scanCompletedEvent(telemetry, gitState, contributors));
+  // Never let telemetry (git lookups, sending) reject and break the caller's shutdown.
+  try {
+    const gitState = GitState[await Git.state(telemetry.appmapDir)];
+    const contributors = (await Git.contributors(60, telemetry.appmapDir)).length;
+    Telemetry.sendEvent(scanCompletedEvent(telemetry, gitState, contributors));
+  } catch {
+    // ignore
+  }
 }

--- a/packages/scanner/src/report/scanSummary.ts
+++ b/packages/scanner/src/report/scanSummary.ts
@@ -18,5 +18,9 @@ export interface ScanSummary {
   ruleLabels: string[];
   numChecks: number;
   numFindings: number;
+  // Number of findings keyed by the rule that produced them.
+  findingCountsByRule: Record<string, number>;
+  // Number of findings keyed by impact domain (findings without one are omitted).
+  findingCountsByImpactDomain: Record<string, number>;
   appMapMetadata: AppMapMetadata;
 }

--- a/packages/scanner/src/util/eventAggregator.ts
+++ b/packages/scanner/src/util/eventAggregator.ts
@@ -1,8 +1,6 @@
-import { EventEmitter } from 'events';
+import type { EventEmitter } from 'events';
 
 export const MaxMSBetween = 10 * 1000;
-
-export type CancelFn = () => void;
 
 /**
  * Batches the payloads emitted on a single emitter/event, invoking `callback` with the
@@ -19,33 +17,37 @@ export default class EventAggregator<E> {
   private readonly onEvent = (event: E): void => {
     this.pending.push(event);
     if (this.timeout) clearTimeout(this.timeout);
-    this.timeout = setTimeout(this.flush, this.maxMsBetween).unref();
+    // The periodic/exit flushes are fire-and-forget; only cancel() awaits.
+    this.timeout = setTimeout(() => void this.flush(), this.maxMsBetween).unref();
   };
 
-  // Emit the pending batch now. No-op when nothing is pending.
-  private readonly flush = (): void => {
+  private readonly onBeforeExit = (): void => void this.flush();
+
+  // Emit the pending batch now and await the callback. No-op when nothing is pending.
+  private async flush(): Promise<void> {
     if (!this.timeout) return;
     clearTimeout(this.timeout);
     this.timeout = undefined;
     const batch = this.pending;
     this.pending = [];
-    this.callback(batch);
-  };
+    await this.callback(batch);
+  }
 
   constructor(
     private readonly emitter: EventEmitter,
     private readonly event: string,
-    private readonly callback: (events: E[]) => void,
+    private readonly callback: (events: E[]) => void | Promise<void>,
     private readonly maxMsBetween = MaxMSBetween
   ) {
     emitter.addListener(event, this.onEvent);
-    process.on('beforeExit', this.flush);
+    process.on('beforeExit', this.onBeforeExit);
   }
 
-  // Detach the listeners and emit any final pending batch. Idempotent.
-  cancel(): void {
+  // Detach the listeners and emit any final pending batch. Idempotent; awaiting it
+  // ensures the final batch is delivered before the caller proceeds (e.g. shutdown).
+  async cancel(): Promise<void> {
     this.emitter.removeListener(this.event, this.onEvent);
-    process.removeListener('beforeExit', this.flush);
-    this.flush();
+    process.removeListener('beforeExit', this.onBeforeExit);
+    await this.flush();
   }
 }

--- a/packages/scanner/src/util/eventAggregator.ts
+++ b/packages/scanner/src/util/eventAggregator.ts
@@ -1,53 +1,51 @@
 import { EventEmitter } from 'events';
 
-export type PendingEvent<E> = {
-  emitter: EventEmitter;
-  event: string;
-  arg: E;
-};
-
 export const MaxMSBetween = 10 * 1000;
 
 export type CancelFn = () => void;
 
-// TODO: Unify with the code in packages/cli - find a way to make a common import.
+/**
+ * Batches the payloads emitted on a single emitter/event, invoking `callback` with the
+ * accumulated batch once `maxMsBetween` ms pass without a new event (or at process exit).
+ *
+ * The emitter is bound at construction and there is exactly one of everything (one event
+ * listener, one beforeExit listener), so `cancel()` can always tear down completely —
+ * there is no way to half-detach it.
+ */
 export default class EventAggregator<E> {
-  private pending: PendingEvent<E>[] = [];
+  private pending: E[] = [];
   private timeout?: NodeJS.Timeout;
 
-  constructor(
-    private callback: (events: PendingEvent<E>[]) => void,
-    private maxMsBetween = MaxMSBetween
-  ) {
-    process.on('beforeExit', () => {
-      if (this.timeout) {
-        clearTimeout(this.timeout);
-        this.emitPending();
-      }
-    });
-  }
-
-  private push(emitter: EventEmitter, event: string, arg: E) {
-    this.pending.push({ emitter, event, arg });
-    this.refresh();
-  }
-
-  private refresh() {
+  private readonly onEvent = (event: E): void => {
+    this.pending.push(event);
     if (this.timeout) clearTimeout(this.timeout);
-    this.timeout = setTimeout(this.emitPending.bind(this), this.maxMsBetween).unref();
-  }
+    this.timeout = setTimeout(this.flush, this.maxMsBetween).unref();
+  };
 
-  private emitPending() {
-    this.callback(this.pending);
+  // Emit the pending batch now. No-op when nothing is pending.
+  private readonly flush = (): void => {
+    if (!this.timeout) return;
+    clearTimeout(this.timeout);
     this.timeout = undefined;
+    const batch = this.pending;
     this.pending = [];
+    this.callback(batch);
+  };
+
+  constructor(
+    private readonly emitter: EventEmitter,
+    private readonly event: string,
+    private readonly callback: (events: E[]) => void,
+    private readonly maxMsBetween = MaxMSBetween
+  ) {
+    emitter.addListener(event, this.onEvent);
+    process.on('beforeExit', this.flush);
   }
 
-  attach(emitter: EventEmitter, event: string): CancelFn {
-    const listenerFn = (...args: any[]) => {
-      this.push(emitter, event, args[0]);
-    };
-    emitter.addListener(event, listenerFn);
-    return () => emitter.removeListener(event, listenerFn);
+  // Detach the listeners and emit any final pending batch. Idempotent.
+  cancel(): void {
+    this.emitter.removeListener(this.event, this.onEvent);
+    process.removeListener('beforeExit', this.flush);
+    this.flush();
   }
 }

--- a/packages/scanner/test/cli/scan.spec.ts
+++ b/packages/scanner/test/cli/scan.spec.ts
@@ -216,10 +216,10 @@ describe('scan', () => {
     }
 
     afterEach(async () => {
-      if (watcher) watcher.close();
+      if (watcher) await watcher.close();
       watcher = undefined;
 
-      fsextra.rm(tmpDir, { recursive: true });
+      await fsextra.rm(tmpDir, { recursive: true });
     });
 
     it('scans already indexed AppMaps on start', async () => {

--- a/packages/scanner/test/cli/scan/watchScanTelemetry.spec.ts
+++ b/packages/scanner/test/cli/scan/watchScanTelemetry.spec.ts
@@ -1,0 +1,77 @@
+import { EventEmitter } from 'events';
+import { Metadata } from '@appland/models';
+
+import { Finding } from '../../../src';
+import * as scanResultsModule from '../../../src/report/scanResults';
+import { WatchScanTelemetry } from '../../../src/cli/scan/watchScanTelemetry';
+
+const { ScanResults } = scanResultsModule;
+
+const finding = (ruleId: string, impactDomain?: string): Finding =>
+  ({ ruleId, impactDomain } as Finding);
+
+const scanResultsFor = (appmap: string, findings: Finding[]): InstanceType<typeof ScanResults> =>
+  new ScanResults({ checks: [] }, { [appmap]: {} as Metadata }, findings, []);
+
+describe('WatchScanTelemetry', () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  it('batches scan events and sends a single aggregated scan:completed', () => {
+    const send = jest
+      .spyOn(scanResultsModule, 'sendScanResultsTelemetry')
+      .mockResolvedValue(undefined);
+
+    const emitter = new EventEmitter();
+    const cancel = WatchScanTelemetry.watch(emitter, '/tmp/appmaps');
+
+    emitter.emit('scan', {
+      scanResults: scanResultsFor('a', [finding('rule-a', 'Security')]),
+      elapsed: 1000,
+    });
+    emitter.emit('scan', {
+      scanResults: scanResultsFor('b', [
+        finding('rule-a', 'Security'),
+        finding('rule-b', 'Performance'),
+      ]),
+      elapsed: 500,
+    });
+
+    jest.advanceTimersByTime(10_000);
+
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        numAppMaps: 2,
+        numFindings: 3,
+        findingCountsByRule: { 'rule-a': 2, 'rule-b': 1 },
+        findingCountsByImpactDomain: { Security: 2, Performance: 1 },
+        elapsedMs: 1500,
+        appmapDir: '/tmp/appmaps',
+      })
+    );
+
+    cancel();
+  });
+
+  it('stops listening for scan events once cancelled', () => {
+    const send = jest
+      .spyOn(scanResultsModule, 'sendScanResultsTelemetry')
+      .mockResolvedValue(undefined);
+
+    const emitter = new EventEmitter();
+    const cancel = WatchScanTelemetry.watch(emitter, '/tmp/appmaps');
+    cancel();
+
+    emitter.emit('scan', {
+      scanResults: scanResultsFor('a', [finding('rule-a', 'Security')]),
+      elapsed: 1000,
+    });
+    jest.advanceTimersByTime(10_000);
+
+    expect(send).not.toHaveBeenCalled();
+  });
+});

--- a/packages/scanner/test/cli/scan/watchScanTelemetry.spec.ts
+++ b/packages/scanner/test/cli/scan/watchScanTelemetry.spec.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'events';
-import { Metadata } from '@appland/models';
+import type { Metadata } from '@appland/models';
 
-import { Finding } from '../../../src';
+import type { Finding } from '../../../src';
 import * as scanResultsModule from '../../../src/report/scanResults';
 import { WatchScanTelemetry } from '../../../src/cli/scan/watchScanTelemetry';
 
@@ -20,13 +20,13 @@ describe('WatchScanTelemetry', () => {
     jest.restoreAllMocks();
   });
 
-  it('batches scan events and sends a single aggregated scan:completed', () => {
+  it('batches scan events and sends a single aggregated scan:completed', async () => {
     const send = jest
       .spyOn(scanResultsModule, 'sendScanResultsTelemetry')
       .mockResolvedValue(undefined);
 
     const emitter = new EventEmitter();
-    const cancel = WatchScanTelemetry.watch(emitter, '/tmp/appmaps');
+    const telemetry = new WatchScanTelemetry(emitter, '/tmp/appmaps');
 
     emitter.emit('scan', {
       scanResults: scanResultsFor('a', [finding('rule-a', 'Security')]),
@@ -54,17 +54,17 @@ describe('WatchScanTelemetry', () => {
       })
     );
 
-    cancel();
+    await telemetry.cancel();
   });
 
-  it('stops listening for scan events once cancelled', () => {
+  it('stops listening for scan events once cancelled', async () => {
     const send = jest
       .spyOn(scanResultsModule, 'sendScanResultsTelemetry')
       .mockResolvedValue(undefined);
 
     const emitter = new EventEmitter();
-    const cancel = WatchScanTelemetry.watch(emitter, '/tmp/appmaps');
-    cancel();
+    const telemetry = new WatchScanTelemetry(emitter, '/tmp/appmaps');
+    await telemetry.cancel();
 
     emitter.emit('scan', {
       scanResults: scanResultsFor('a', [finding('rule-a', 'Security')]),

--- a/packages/scanner/test/report/scanResults.spec.ts
+++ b/packages/scanner/test/report/scanResults.spec.ts
@@ -1,0 +1,76 @@
+import { Finding } from '../../src';
+import { ScanResults, scanCompletedEvent, ScanTelemetry } from '../../src/report/scanResults';
+
+const finding = (ruleId: string, impactDomain?: string): Finding =>
+  ({ ruleId, impactDomain } as Finding);
+
+describe('ScanResults finding breakdowns', () => {
+  it('counts findings by rule and by impact domain', () => {
+    const results = new ScanResults(
+      { checks: [] },
+      {},
+      [
+        finding('rule-a', 'Security'),
+        finding('rule-a', 'Security'),
+        finding('rule-b', 'Performance'),
+      ],
+      []
+    );
+
+    expect(results.summary.findingCountsByRule).toEqual({ 'rule-a': 2, 'rule-b': 1 });
+    expect(results.summary.findingCountsByImpactDomain).toEqual({ Security: 2, Performance: 1 });
+  });
+
+  it('ignores findings with no impact domain in the impact-domain breakdown', () => {
+    const results = new ScanResults({ checks: [] }, {}, [finding('rule-a')], []);
+
+    expect(results.summary.findingCountsByRule).toEqual({ 'rule-a': 1 });
+    expect(results.summary.findingCountsByImpactDomain).toEqual({});
+  });
+
+  it('sums the breakdowns when aggregating scan results', () => {
+    const a = new ScanResults({ checks: [] }, {}, [finding('rule-a', 'Security')], []);
+    const b = new ScanResults(
+      { checks: [] },
+      {},
+      [finding('rule-a', 'Security'), finding('rule-c', 'Stability')],
+      []
+    );
+
+    a.aggregate(b);
+
+    expect(a.summary.numFindings).toBe(3);
+    expect(a.summary.findingCountsByRule).toEqual({ 'rule-a': 2, 'rule-c': 1 });
+    expect(a.summary.findingCountsByImpactDomain).toEqual({ Security: 2, Stability: 1 });
+  });
+});
+
+describe('scanCompletedEvent', () => {
+  const telemetry: ScanTelemetry = {
+    ruleIds: ['rule-b', 'rule-a'],
+    numAppMaps: 3,
+    numFindings: 5,
+    findingCountsByRule: { 'rule-b': 2, 'rule-a': 3 },
+    findingCountsByImpactDomain: { Security: 3, Performance: 2 },
+    elapsedMs: 2000,
+  };
+
+  it('builds a scan:completed event with per-rule and impact-domain breakdowns', () => {
+    const event = scanCompletedEvent(telemetry, 'Ok', 4);
+
+    expect(event.name).toBe('scan:completed');
+    expect(event.properties).toEqual({
+      rules: 'rule-a, rule-b',
+      git_state: 'Ok',
+      findingsByRule: JSON.stringify({ 'rule-a': 3, 'rule-b': 2 }),
+      findingsByImpactDomain: JSON.stringify({ Performance: 2, Security: 3 }),
+    });
+    expect(event.metrics).toEqual({
+      duration: 2,
+      numRules: 2,
+      numAppMaps: 3,
+      numFindings: 5,
+      contributors: 4,
+    });
+  });
+});

--- a/packages/scanner/test/util.ts
+++ b/packages/scanner/test/util.ts
@@ -1,4 +1,5 @@
 import { AppMap, buildAppMap } from '@appland/models';
+import { Telemetry } from '@appland/telemetry';
 import { readFile } from 'fs/promises';
 import { join } from 'path';
 import RuleChecker from '../src/ruleChecker';
@@ -51,24 +52,19 @@ const scan = async (
   return { appMap: appMapData, findings };
 };
 
-const stubTelemetry = (): void => {
-  jest.mock('@appland/telemetry', () => {
-    const originalModule = jest.requireActual('@appland/telemetry');
+// Stub telemetry by spying on the shared Telemetry singleton. This must mutate the
+// same instance the code under test imported, so spy on the object rather than
+// jest.mock()-ing the module in a beforeEach (which can't replace an already-imported
+// binding, letting the real client — and a real network/git call — run in tests).
+let telemetrySpy: jest.SpyInstance | undefined;
 
-    //Mock the default export and named export 'foo'
-    return {
-      __esModule: true,
-      ...originalModule,
-      Telemetry: {
-        configure: jest.fn(),
-        sendEvent: jest.fn(),
-      },
-    };
-  });
+const stubTelemetry = (): void => {
+  telemetrySpy = jest.spyOn(Telemetry, 'sendEvent').mockImplementation(() => undefined);
 };
 
 const unstubTelemetry = (): void => {
-  jest.unmock('@appland/telemetry');
+  telemetrySpy?.mockRestore();
+  telemetrySpy = undefined;
 };
 
 export { fixtureAppMap, fixtureAppMapFileName, scan, stubTelemetry, unstubTelemetry };

--- a/packages/scanner/test/util/eventAggregator.spec.ts
+++ b/packages/scanner/test/util/eventAggregator.spec.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from 'events';
 import EventAggregator from '../../src/util/eventAggregator';
 
 describe('EventAggregator', () => {
-  it('removes both the event listener and the beforeExit listener when cancelled', () => {
+  it('removes both the event listener and the beforeExit listener when cancelled', async () => {
     const baseline = process.listenerCount('beforeExit');
     const emitter = new EventEmitter();
 
@@ -10,12 +10,12 @@ describe('EventAggregator', () => {
     expect(process.listenerCount('beforeExit')).toBe(baseline + 1);
     expect(emitter.listenerCount('event')).toBe(1);
 
-    aggregator.cancel();
+    await aggregator.cancel();
     expect(process.listenerCount('beforeExit')).toBe(baseline);
     expect(emitter.listenerCount('event')).toBe(0);
   });
 
-  it('flushes the pending batch when cancelled', () => {
+  it('flushes the pending batch when cancelled', async () => {
     const callback = jest.fn();
     const emitter = new EventEmitter();
     const aggregator = new EventAggregator<string>(emitter, 'event', callback);
@@ -24,18 +24,18 @@ describe('EventAggregator', () => {
     emitter.emit('event', 'b');
     expect(callback).not.toHaveBeenCalled(); // still batched, timer not yet fired
 
-    aggregator.cancel();
+    await aggregator.cancel();
 
     expect(callback).toHaveBeenCalledTimes(1);
     expect(callback.mock.calls[0][0]).toEqual(['a', 'b']);
   });
 
-  it('does not invoke the callback when cancelled with nothing pending', () => {
+  it('does not invoke the callback when cancelled with nothing pending', async () => {
     const callback = jest.fn();
     const emitter = new EventEmitter();
     const aggregator = new EventAggregator<string>(emitter, 'event', callback);
 
-    aggregator.cancel();
+    await aggregator.cancel();
 
     expect(callback).not.toHaveBeenCalled();
   });

--- a/packages/scanner/test/util/eventAggregator.spec.ts
+++ b/packages/scanner/test/util/eventAggregator.spec.ts
@@ -1,0 +1,42 @@
+import { EventEmitter } from 'events';
+import EventAggregator from '../../src/util/eventAggregator';
+
+describe('EventAggregator', () => {
+  it('removes both the event listener and the beforeExit listener when cancelled', () => {
+    const baseline = process.listenerCount('beforeExit');
+    const emitter = new EventEmitter();
+
+    const aggregator = new EventAggregator(emitter, 'event', () => undefined);
+    expect(process.listenerCount('beforeExit')).toBe(baseline + 1);
+    expect(emitter.listenerCount('event')).toBe(1);
+
+    aggregator.cancel();
+    expect(process.listenerCount('beforeExit')).toBe(baseline);
+    expect(emitter.listenerCount('event')).toBe(0);
+  });
+
+  it('flushes the pending batch when cancelled', () => {
+    const callback = jest.fn();
+    const emitter = new EventEmitter();
+    const aggregator = new EventAggregator<string>(emitter, 'event', callback);
+
+    emitter.emit('event', 'a');
+    emitter.emit('event', 'b');
+    expect(callback).not.toHaveBeenCalled(); // still batched, timer not yet fired
+
+    aggregator.cancel();
+
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(callback.mock.calls[0][0]).toEqual(['a', 'b']);
+  });
+
+  it('does not invoke the callback when cancelled with nothing pending', () => {
+    const callback = jest.fn();
+    const emitter = new EventEmitter();
+    const aggregator = new EventAggregator<string>(emitter, 'event', callback);
+
+    aggregator.cancel();
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Re-emit the batched scan:completed event from the scan watcher, with per-rule and impact-domain finding counts as sorted JSON. Drop the removed scan:started event and the env-var-names attachment.

Bind EventAggregator to a single emitter at construction so cancel() fully detaches it (event + beforeExit listeners) and flushes any final pending batch -- it can no longer leak a process listener.

The scan:completed event was removed in https://github.com/getappmap/appmap-js/commit/c7d0a928661351bc10e51c0531689caa3ff98b1f ("feat: Clean up telemetry"); this reinstates it for corporate visibility.