### PR TITLE
feat(sequence-diagram): carry AppMap labels on diagram actions

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -21,6 +21,7 @@ import InstallCommand from './cmds/agentInstaller/install-agent';
 import StatusCommand from './cmds/agentInstaller/status';
 import { default as OpenAPICommand } from './cmds/openapi/openapi';
 import PruneCommand from './cmds/prune/prune';
+import TrimCommand from './cmds/trim/trim';
 import RecordCommand from './cmds/record/record';
 import { handleWorkingDirectory } from './lib/handleWorkingDirectory';
 import { locateAppMapDir } from './lib/locateAppMapDir';
@@ -146,6 +147,7 @@ yargs(process.argv.slice(2))
   .command(SequenceDiagramCommand)
   .command(SequenceDiagramDiffCommand)
   .command(PruneCommand)
+  .command(TrimCommand)
   .command(ArchiveCommand)
   .command(RestoreCommand)
   .command(CompareCommand)

--- a/packages/cli/src/cmds/prune/pruneAppMap.ts
+++ b/packages/cli/src/cmds/prune/pruneAppMap.ts
@@ -22,6 +22,10 @@ export const pruneAppMap = (appMap: AppMap, size: number): PruneResult => {
   return { appmap };
 };
 
+// Deserializes an untrusted serialized filter (the CLI accepts it as a
+// base64url-encoded string) into an AppMapFilter and applies it to the map.
+// Labeled so appmap-review interprets changes to this deserialization boundary.
+// @label security.deserialization
 export const pruneWithFilter = (appMap: AppMap, serializedFilter: string): PruneResult => {
   // TODO: update type for AppMap
   const fullMap = buildAppMap().source(appMap).normalize().build() as any;

--- a/packages/cli/src/cmds/query/lib/recordingId.ts
+++ b/packages/cli/src/cmds/query/lib/recordingId.ts
@@ -34,6 +34,7 @@ import type { AppmapInfo } from '../queries/tree';
 // shapes silently collide in real corpora (multiple recordings share
 // the same basename or name), and the resulting wrong-recording
 // resolution is harder to debug than an explicit error.
+// @label security.path-resolution
 export function resolveAppmapPath(db: sqlite3.Database, ref: unknown): AppmapInfo {
   const s = String(ref);
   if (looksLikeDisplayLabel(s)) {

--- a/packages/cli/src/cmds/query/lib/treeRender.ts
+++ b/packages/cli/src/cmds/query/lib/treeRender.ts
@@ -10,6 +10,16 @@ import {
 } from '../queries/tree';
 import { formatCount, formatMs, formatTable } from './format';
 import { projectLogMessage } from './logMessage';
+import {
+  MCP_RETURN_VALUE_BUDGET,
+  truncate,
+  truncateStructValue,
+} from '../../../lib/truncateStructValue';
+import type { StructBudget } from '../../../lib/truncateStructValue';
+
+// Re-exported so existing importers (e.g. treeRender.spec.ts) keep working.
+export { MCP_RETURN_VALUE_BUDGET, truncateStructValue };
+export type { StructBudget };
 
 const INDENT = '  ';
 
@@ -76,10 +86,6 @@ function bracket(ms: number | null): string {
   return ms == null ? '' : `[${formatMs(ms)}]`;
 }
 
-function truncate(s: string, n: number): string {
-  return s.length <= n ? s : s.slice(0, n - 1) + '…';
-}
-
 // Dense one-line-per-event rendering for MCP responses. Each line starts
 // with the event_id (so the agent can drill via find_calls/find_queries)
 // and includes file:line for source-reading without a follow-up call.
@@ -108,127 +114,6 @@ function renderTreeLineForMcp(node: TreeNode): string {
     case 'log':
       return `${indent}${id} LOG   ${renderLog(node)}`;
   }
-}
-
-// Return values in the dense MCP tree are truncated value-aware, not by a
-// flat prefix cut. A flat cut wastes the budget on identity fields — a
-// record like `ApprovalRequest[requestId=<uuid>, loanId=<uuid>,
-// status=APPROVED, …]` spends ~80 chars on two UUIDs before reaching the
-// state field that actually distinguishes the call. truncateStructValue
-// parses the struct shape and budgets *per field value*, clipping
-// id/hash-shaped values hard so semantic fields downstream survive.
-export interface StructBudget {
-  perValueCap: number; // max chars for an ordinary field value
-  idCap: number; // max chars for a uuid/hash-shaped value (identity, low signal)
-  maxFields: number; // fields rendered before the tail is elided
-  flatCap: number; // flat cap applied to non-struct strings
-}
-
-export const MCP_RETURN_VALUE_BUDGET: StructBudget = {
-  perValueCap: 48,
-  idCap: 12,
-  maxFields: 16,
-  flatCap: 120,
-};
-
-// A uuid, a hex object hash (`@1a2b3c4`, `0x00007f…`), or either prefixed
-// by a short tag (`LOAN-<uuid>`, `PID-<uuid>`). These are identity, not
-// state — low root-cause signal — so they get the tight idCap.
-const ID_VALUE_RE =
-  /(?:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|(?:@|0x)[0-9a-f]{4,})/i;
-
-const CLOSE_FOR: Record<string, string> = { '[': ']', '{': '}', '(': ')' };
-
-interface Struct {
-  prefix: string; // leading type name (may be empty for a bare collection)
-  open: string; // opening delimiter
-  body: string; // comma-separated field list
-  close: string; // closing delimiter
-}
-
-// Recognize the toString()/repr shapes AppMap captures across the four
-// supported languages:
-//   Java record / Python repr   Type[…]  /  Type(…)
-//   Java bean / JS-ish object   Type{…}  /  {…}
-//   Ruby                        #<Type …>
-// Returns null for primitives, `[object Object]`-style opaque values, and
-// `Type@1a2b3c` hashes — those fall back to a flat truncation.
-function parseStruct(s: string): Struct | null {
-  const ruby = /^#<([^\s>]+)\s+(.+)>$/.exec(s);
-  if (ruby) return { prefix: `#<${ruby[1]} `, open: '', body: ruby[2], close: '>' };
-  const m = /^([A-Za-z_][\w.$]*)?([[{(])([\s\S]*)([\]})])$/.exec(s);
-  if (m && CLOSE_FOR[m[2]] === m[4]) {
-    return { prefix: m[1] ?? '', open: m[2], body: m[3], close: m[4] };
-  }
-  return null;
-}
-
-// Split a struct body on top-level ", ". Commas nested inside [], {}, (),
-// or <> belong to a field's own value and must not split it.
-function splitTopLevelFields(body: string): string[] {
-  if (body.length === 0) return [];
-  const out: string[] = [];
-  let depth = 0;
-  let start = 0;
-  for (let i = 0; i < body.length; i++) {
-    const c = body[i];
-    if (c === '[' || c === '{' || c === '(' || c === '<') depth++;
-    else if (c === ']' || c === '}' || c === ')' || c === '>') depth = Math.max(0, depth - 1);
-    else if (c === ',' && depth === 0 && body[i + 1] === ' ') {
-      out.push(body.slice(start, i));
-      start = i + 2;
-      i++;
-    }
-  }
-  out.push(body.slice(start));
-  return out;
-}
-
-// A field value that is itself a struct (a nested record, or an element
-// of a collection-of-records like `getParticipants`) recurses so its own
-// fields get the per-field budget too — flat-clipping it would collapse
-// `[ParticipantState[…status=PENDING], …]` down to an opaque stub. Depth
-// is bounded so a pathologically deep value can't recurse without end.
-const MAX_STRUCT_DEPTH = 4;
-
-// Truncate one field value: recurse if it is itself a struct, else
-// id/hash-shaped values get the tight idCap and all others the perValueCap.
-function truncateFieldValue(value: string, budget: StructBudget, depth: number): string {
-  if (depth < MAX_STRUCT_DEPTH) {
-    const nested = parseStruct(value);
-    if (nested) return renderStruct(nested, budget, depth + 1);
-  }
-  const cap = ID_VALUE_RE.test(value) ? budget.idCap : budget.perValueCap;
-  return truncate(value, cap);
-}
-
-// Truncate one `name=value` / `name: value` field, keeping the name whole
-// and budgeting only the value. A field with no recognizable name
-// separator (a bare collection element) is budgeted as a whole value.
-function truncateField(field: string, budget: StructBudget, depth: number): string {
-  const m = /^(\s*[\w$]+\s*)([:=])(\s*)([\s\S]*)$/.exec(field);
-  if (!m) return truncateFieldValue(field, budget, depth);
-  return `${m[1]}${m[2]}${m[3]}${truncateFieldValue(m[4], budget, depth)}`;
-}
-
-function renderStruct(st: Struct, budget: StructBudget, depth: number): string {
-  const fields = splitTopLevelFields(st.body);
-  const kept = fields.slice(0, budget.maxFields).map((f) => truncateField(f, budget, depth));
-  const elided = fields.length - kept.length;
-  const tail = elided > 0 ? `${kept.length > 0 ? ', ' : ''}…+${elided} more` : '';
-  return `${st.prefix}${st.open}${kept.join(', ')}${tail}${st.close}`;
-}
-
-// Value-aware truncation for a captured return value / parameter. Parses
-// the struct shape and budgets per field value, recursing into nested
-// structs; non-struct strings fall back to a flat cap. See StructBudget.
-export function truncateStructValue(
-  s: string,
-  budget: StructBudget = MCP_RETURN_VALUE_BUDGET
-): string {
-  const st = parseStruct(s);
-  if (!st) return truncate(s, budget.flatCap);
-  return renderStruct(st, budget, 1);
 }
 
 function renderFunctionForMcp(n: FunctionNode): string {

--- a/packages/cli/src/cmds/trim/trim.ts
+++ b/packages/cli/src/cmds/trim/trim.ts
@@ -1,0 +1,102 @@
+import { mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { basename, join } from 'path';
+import Yargs from 'yargs';
+
+import { handleWorkingDirectory } from '../../lib/handleWorkingDirectory';
+import { MCP_RETURN_VALUE_BUDGET, truncateStructValue } from '../../lib/truncateStructValue';
+import type { StructBudget } from '../../lib/truncateStructValue';
+
+// The captured `value` of a parameter, return value, receiver, or log message.
+interface ValueSlot {
+  value?: unknown;
+}
+
+interface AppMapEvent {
+  parameters?: ValueSlot[];
+  message?: ValueSlot[];
+  receiver?: ValueSlot;
+  return_value?: ValueSlot;
+  exceptions?: ValueSlot[];
+}
+
+interface AppMap {
+  events?: AppMapEvent[];
+}
+
+function trimSlot(slot: ValueSlot | undefined, budget: StructBudget): void {
+  if (slot && typeof slot.value === 'string') {
+    slot.value = truncateStructValue(slot.value, budget);
+  }
+}
+
+// Truncate every captured value string in an AppMap, in place. Trimming only
+// touches `value` strings — the call structure, code objects, SQL, and every
+// other stable property are untouched — so a trimmed AppMap is behaviorally
+// identical (its sequence-diagram digest is unchanged) but much smaller.
+export function trimAppMap(appmap: AppMap, budget: StructBudget = MCP_RETURN_VALUE_BUDGET): AppMap {
+  for (const event of appmap.events ?? []) {
+    for (const p of event.parameters ?? []) trimSlot(p, budget);
+    for (const m of event.message ?? []) trimSlot(m, budget);
+    trimSlot(event.receiver, budget);
+    trimSlot(event.return_value, budget);
+    for (const x of event.exceptions ?? []) trimSlot(x, budget);
+  }
+  return appmap;
+}
+
+export default {
+  command: 'trim <files..>',
+
+  describe:
+    'Shrink AppMaps by truncating captured parameter, return, receiver, and message values',
+
+  builder: (args: Yargs.Argv) => {
+    args.positional('files', {
+      describe: 'AppMap file(s) to trim',
+      type: 'string',
+    });
+
+    args.option('max-length', {
+      describe: 'Maximum length of a captured value string (structured values are budgeted per field)',
+      type: 'number',
+      default: MCP_RETURN_VALUE_BUDGET.flatCap,
+    });
+
+    args.option('output-dir', {
+      describe: 'Write trimmed AppMaps here (default: overwrite each file in place)',
+      type: 'string',
+      alias: 'o',
+    });
+
+    args.option('directory', {
+      describe: 'Working directory for the command',
+      type: 'string',
+      alias: 'd',
+    });
+
+    return args;
+  },
+
+  handler: async (argv: any): Promise<void> => {
+    handleWorkingDirectory(argv.directory);
+
+    // maxFields 12 (vs the MCP renderer's 16): trim leans slightly more
+    // aggressive since a committed baseline wants leanness over readability.
+    const budget: StructBudget = {
+      ...MCP_RETURN_VALUE_BUDGET,
+      maxFields: 12,
+      flatCap: argv.maxLength,
+    };
+    const files = argv.files as string[];
+    if (argv.outputDir) mkdirSync(argv.outputDir, { recursive: true });
+
+    for (const file of files) {
+      const before = readFileSync(file, 'utf8');
+      const trimmed = JSON.stringify(trimAppMap(JSON.parse(before) as AppMap, budget));
+      const outputPath = argv.outputDir ? join(argv.outputDir, basename(file)) : file;
+      writeFileSync(outputPath, trimmed);
+      const pct = Math.round((100 * trimmed.length) / before.length);
+      console.warn(`trim ${file}: ${before.length} -> ${trimmed.length} bytes (${pct}%)`);
+    }
+  },
+};

--- a/packages/cli/src/cmds/trim/trim.ts
+++ b/packages/cli/src/cmds/trim/trim.ts
@@ -1,10 +1,11 @@
-import { mkdirSync, readFileSync, writeFileSync } from 'fs';
-import { basename, join } from 'path';
+import { mkdirSync, readFileSync } from 'fs';
+import { basename, dirname, join } from 'path';
 import Yargs from 'yargs';
 
 import { handleWorkingDirectory } from '../../lib/handleWorkingDirectory';
 import { MCP_RETURN_VALUE_BUDGET, truncateStructValue } from '../../lib/truncateStructValue';
 import type { StructBudget } from '../../lib/truncateStructValue';
+import { writeFileAtomic } from '../../utils';
 
 // The captured `value` of a parameter, return value, receiver, or log message.
 interface ValueSlot {
@@ -57,7 +58,8 @@ export default {
     });
 
     args.option('max-length', {
-      describe: 'Maximum length of a captured value string (structured values are budgeted per field)',
+      describe:
+        'Maximum length of any captured value string — caps flat strings and struct field/id values alike',
       type: 'number',
       default: MCP_RETURN_VALUE_BUDGET.flatCap,
     });
@@ -80,23 +82,44 @@ export default {
   handler: async (argv: any): Promise<void> => {
     handleWorkingDirectory(argv.directory);
 
-    // maxFields 12 (vs the MCP renderer's 16): trim leans slightly more
-    // aggressive since a committed baseline wants leanness over readability.
+    // --max-length is a hard cap on every captured value string: it sets the
+    // flat cap and, so the flag means what it says, lowers the per-field and id
+    // caps to match (never above their defaults). maxFields 12 (vs the MCP
+    // renderer's 16) — trim leans slightly more aggressive since a baseline
+    // wants leanness over readability.
+    const maxLength = argv.maxLength as number;
     const budget: StructBudget = {
-      ...MCP_RETURN_VALUE_BUDGET,
+      perValueCap: Math.min(MCP_RETURN_VALUE_BUDGET.perValueCap, maxLength),
+      idCap: Math.min(MCP_RETURN_VALUE_BUDGET.idCap, maxLength),
       maxFields: 12,
-      flatCap: argv.maxLength,
+      flatCap: maxLength,
     };
     const files = argv.files as string[];
     if (argv.outputDir) mkdirSync(argv.outputDir, { recursive: true });
 
+    let failed = 0;
     for (const file of files) {
-      const before = readFileSync(file, 'utf8');
-      const trimmed = JSON.stringify(trimAppMap(JSON.parse(before) as AppMap, budget));
+      let before: string;
+      let trimmed: string;
+      try {
+        before = readFileSync(file, 'utf8');
+        trimmed = JSON.stringify(trimAppMap(JSON.parse(before) as AppMap, budget));
+      } catch (error) {
+        // Skip an unreadable/malformed file rather than aborting: one bad file
+        // in a batch must not stop the rest or leave earlier files half-done.
+        failed += 1;
+        console.warn(`trim ${file}: skipped (${(error as Error).message})`);
+        continue;
+      }
       const outputPath = argv.outputDir ? join(argv.outputDir, basename(file)) : file;
-      writeFileSync(outputPath, trimmed);
+      // Write atomically (temp file in the same dir, then rename) so an
+      // interrupted or failed write never leaves a partial AppMap in place.
+      await writeFileAtomic(dirname(outputPath), basename(outputPath), 'trim.tmp', trimmed);
       const pct = Math.round((100 * trimmed.length) / before.length);
       console.warn(`trim ${file}: ${before.length} -> ${trimmed.length} bytes (${pct}%)`);
+    }
+    if (files.length > 0 && failed === files.length) {
+      throw new Error(`trim: all ${failed} input file(s) failed to process`);
     }
   },
 };

--- a/packages/cli/src/lib/truncateStructValue.ts
+++ b/packages/cli/src/lib/truncateStructValue.ts
@@ -1,0 +1,131 @@
+// Value-aware truncation of captured AppMap value strings (parameters, return
+// values, receivers, log messages). Shared by the dense MCP tree renderer
+// (cmds/query/lib/treeRender) and the `appmap trim` command.
+//
+// A flat prefix cut wastes the budget on identity fields — a record like
+// `ApprovalRequest[requestId=<uuid>, loanId=<uuid>, status=APPROVED, …]` spends
+// ~80 chars on two UUIDs before reaching the state field that actually
+// distinguishes the value. truncateStructValue parses the struct shape and
+// budgets *per field value*, clipping id/hash-shaped values hard so semantic
+// fields downstream survive.
+
+export function truncate(s: string, n: number): string {
+  return s.length <= n ? s : s.slice(0, n - 1) + '…';
+}
+
+export interface StructBudget {
+  perValueCap: number; // max chars for an ordinary field value
+  idCap: number; // max chars for a uuid/hash-shaped value (identity, low signal)
+  maxFields: number; // fields rendered before the tail is elided
+  flatCap: number; // flat cap applied to non-struct strings
+}
+
+export const MCP_RETURN_VALUE_BUDGET: StructBudget = {
+  perValueCap: 48,
+  idCap: 12,
+  maxFields: 16,
+  flatCap: 120,
+};
+
+// A uuid, a hex object hash (`@1a2b3c4`, `0x00007f…`), or either prefixed
+// by a short tag (`LOAN-<uuid>`, `PID-<uuid>`). These are identity, not
+// state — low root-cause signal — so they get the tight idCap.
+const ID_VALUE_RE =
+  /(?:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|(?:@|0x)[0-9a-f]{4,})/i;
+
+const CLOSE_FOR: Record<string, string> = { '[': ']', '{': '}', '(': ')' };
+
+interface Struct {
+  prefix: string; // leading type name (may be empty for a bare collection)
+  open: string; // opening delimiter
+  body: string; // comma-separated field list
+  close: string; // closing delimiter
+}
+
+// Recognize the toString()/repr shapes AppMap captures across the four
+// supported languages:
+//   Java record / Python repr   Type[…]  /  Type(…)
+//   Java bean / JS-ish object   Type{…}  /  {…}
+//   Ruby                        #<Type …>
+// Returns null for primitives, `[object Object]`-style opaque values, and
+// `Type@1a2b3c` hashes — those fall back to a flat truncation.
+function parseStruct(s: string): Struct | null {
+  // `[\s\S]` (not `.`) so a multi-line body matches — e.g. Node util.inspect
+  // output, `ClassName {\n  a: 1,\n  ...\n}`. The optional `\s*` after the type
+  // name matches the space in that same `ClassName { ... }` form.
+  const ruby = /^#<([^\s>]+)\s+([\s\S]+)>$/.exec(s);
+  if (ruby) return { prefix: `#<${ruby[1]} `, open: '', body: ruby[2], close: '>' };
+  const m = /^([A-Za-z_][\w.$]*\s*)?([[{(])([\s\S]*)([\]})])$/.exec(s);
+  if (m && CLOSE_FOR[m[2]] === m[4]) {
+    return { prefix: m[1] ?? '', open: m[2], body: m[3], close: m[4] };
+  }
+  return null;
+}
+
+// Split a struct body on top-level ", ". Commas nested inside [], {}, (),
+// or <> belong to a field's own value and must not split it.
+function splitTopLevelFields(body: string): string[] {
+  if (body.trim().length === 0) return [];
+  const out: string[] = [];
+  let depth = 0;
+  let start = 0;
+  for (let i = 0; i < body.length; i++) {
+    const c = body[i];
+    if (c === '[' || c === '{' || c === '(' || c === '<') depth++;
+    else if (c === ']' || c === '}' || c === ')' || c === '>') depth = Math.max(0, depth - 1);
+    else if (c === ',' && depth === 0 && body[i + 1] === ' ') {
+      out.push(body.slice(start, i));
+      start = i + 2;
+      i++;
+    }
+  }
+  out.push(body.slice(start));
+  return out;
+}
+
+// A field value that is itself a struct (a nested record, or an element
+// of a collection-of-records like `getParticipants`) recurses so its own
+// fields get the per-field budget too — flat-clipping it would collapse
+// `[ParticipantState[…status=PENDING], …]` down to an opaque stub. Depth
+// is bounded so a pathologically deep value can't recurse without end.
+const MAX_STRUCT_DEPTH = 4;
+
+// Truncate one field value: recurse if it is itself a struct, else
+// id/hash-shaped values get the tight idCap and all others the perValueCap.
+function truncateFieldValue(value: string, budget: StructBudget, depth: number): string {
+  if (depth < MAX_STRUCT_DEPTH) {
+    const nested = parseStruct(value);
+    if (nested) return renderStruct(nested, budget, depth + 1);
+  }
+  const cap = ID_VALUE_RE.test(value) ? budget.idCap : budget.perValueCap;
+  return truncate(value, cap);
+}
+
+// Truncate one `name=value` / `name: value` field, keeping the name whole
+// and budgeting only the value. A field with no recognizable name
+// separator (a bare collection element) is budgeted as a whole value.
+function truncateField(field: string, budget: StructBudget, depth: number): string {
+  const m = /^(\s*[\w$]+\s*)([:=])(\s*)([\s\S]*)$/.exec(field);
+  if (!m) return truncateFieldValue(field, budget, depth);
+  return `${m[1]}${m[2]}${m[3]}${truncateFieldValue(m[4], budget, depth)}`;
+}
+
+function renderStruct(st: Struct, budget: StructBudget, depth: number): string {
+  const fields = splitTopLevelFields(st.body);
+  const kept = fields.slice(0, budget.maxFields).map((f) => truncateField(f, budget, depth));
+  const elided = fields.length - kept.length;
+  const tail = elided > 0 ? `${kept.length > 0 ? ', ' : ''}…+${elided} more` : '';
+  return `${st.prefix}${st.open}${kept.join(', ')}${tail}${st.close}`;
+}
+
+// Value-aware truncation for a captured return value / parameter. Parses
+// the struct shape and budgets per field value, recursing into nested
+// structs; non-struct strings fall back to a flat cap. See StructBudget.
+export function truncateStructValue(
+  s: string,
+  budget: StructBudget = MCP_RETURN_VALUE_BUDGET
+): string {
+  const st = parseStruct(s);
+  if (!st) return truncate(s, budget.flatCap);
+  return renderStruct(st, budget, 1);
+}

--- a/packages/cli/tests/integration/fixtures/sequenceDiagram/diagram.json
+++ b/packages/cli/tests/integration/fixtures/sequenceDiagram/diagram.json
@@ -88,6 +88,9 @@
       "elapsed": 0.038045,
       "eventIds": [
         1
+      ],
+      "labels": [
+        "security"
       ]
     },
     {
@@ -250,6 +253,10 @@
           "elapsed": 0.150356,
           "eventIds": [
             8
+          ],
+          "labels": [
+            "provider.authenticate",
+            "security"
           ]
         },
         {
@@ -347,6 +354,9 @@
               "elapsed": 0.008962,
               "eventIds": [
                 29
+              ],
+              "labels": [
+                "security"
               ]
             }
           ],
@@ -431,6 +441,10 @@
           "elapsed": 0.005355,
           "eventIds": [
             40
+          ],
+          "labels": [
+            "provider.authenticate",
+            "security"
           ]
         },
         {
@@ -456,6 +470,10 @@
           "elapsed": 0.00005,
           "eventIds": [
             46
+          ],
+          "labels": [
+            "json",
+            "serialization"
           ]
         }
       ],

--- a/packages/cli/tests/unit/fingerprint/fingerprintDirectoryCommand.spec.ts
+++ b/packages/cli/tests/unit/fingerprint/fingerprintDirectoryCommand.spec.ts
@@ -1,25 +1,53 @@
 import { dir } from 'tmp';
 import FingerprintDirectoryCommand from '../../../src/fingerprint/fingerprintDirectoryCommand';
 import { promisify } from 'util';
-import { writeFile, rm } from 'node:fs/promises';
+import { writeFile, rm, cp, readdir } from 'node:fs/promises';
 import { join } from 'path';
 
 const mkTmpDir = promisify(dir);
 
 describe('index command', () => {
-  let appMapDir: string;
-  let appMapPath: string;
+  describe('identifying AppMaps', () => {
+    let appMapDir: string;
+    let appMapPath: string;
 
-  beforeEach(async () => {
-    appMapDir = await mkTmpDir();
-    appMapPath = join(appMapDir, 'example.appmap.json');
-    await writeFile(appMapPath, '{}');
+    beforeEach(async () => {
+      appMapDir = await mkTmpDir();
+      appMapPath = join(appMapDir, 'example.appmap.json');
+      await writeFile(appMapPath, '{}');
+    });
+
+    afterEach(() => rm(appMapDir, { recursive: true, force: true }));
+
+    it('identifies AppMaps for indexing', () => {
+      const subject = new FingerprintDirectoryCommand(appMapDir);
+      return expect(subject.files(() => {})).resolves.toEqual([appMapPath]);
+    });
   });
 
-  afterEach(() => rm(appMapDir, { recursive: true, force: true }));
+  describe('fingerprinting a directory', () => {
+    let appMapDir: string;
 
-  it('identifies AppMaps for indexing', () => {
-    const subject = new FingerprintDirectoryCommand(appMapDir);
-    return expect(subject.files(() => {})).resolves.toEqual([appMapPath]);
+    beforeEach(async () => {
+      appMapDir = await mkTmpDir();
+      // A real recording so execute() exercises the full fingerprint pipeline
+      // (canonicalization, hashing, index-file emission), not just globbing.
+      await cp(
+        join(__dirname, '..', 'fixtures', 'ruby', 'revoke_api_key.appmap.json'),
+        join(appMapDir, 'revoke_api_key.appmap.json')
+      );
+    });
+
+    afterEach(() => rm(appMapDir, { recursive: true, force: true }));
+
+    it('fingerprints AppMaps and writes an index', async () => {
+      const subject = new FingerprintDirectoryCommand(appMapDir);
+      const count = await subject.execute();
+      expect(count).toBe(1);
+      // The index is written into a directory named after the AppMap.
+      const indexDir = join(appMapDir, 'revoke_api_key');
+      const indexFiles = await readdir(indexDir);
+      expect(indexFiles).toContain('metadata.json');
+    });
   });
 });

--- a/packages/cli/tests/unit/fingerprint/fingerprinter.spec.ts
+++ b/packages/cli/tests/unit/fingerprint/fingerprinter.spec.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, open, rm, writeFile } from 'fs/promises';
+import { cp, mkdtemp, open, readdir, rm, writeFile } from 'fs/promises';
 import path from 'node:path';
 import { tmpdir } from 'os';
 import FileTooLargeError from '../../../src/fingerprint/fileTooLargeError';
@@ -18,6 +18,25 @@ function withTempDir<T>(closure: (dir: string) => Promise<T>): () => Promise<T> 
 }
 
 describe(Fingerprinter, () => {
+  it(
+    'fingerprints a recording and writes the on-disk index',
+    withTempDir(async (dir) => {
+      const filePath = path.join(dir, 'revoke_api_key.appmap.json');
+      await cp(
+        path.join(__dirname, '..', 'fixtures', 'ruby', 'revoke_api_key.appmap.json'),
+        filePath
+      );
+
+      await new Fingerprinter().fingerprint(filePath);
+
+      // The legacy per-file index is written into a directory named after the
+      // AppMap (classMap, metadata, canonicalized forms).
+      const indexFiles = await readdir(path.join(dir, 'revoke_api_key'));
+      expect(indexFiles).toContain('metadata.json');
+      expect(indexFiles).toContain('classMap.json');
+    })
+  );
+
   it(
     'rejects appmaps that are too large',
     withTempDir(async (dir) => {

--- a/packages/cli/tests/unit/trim.spec.ts
+++ b/packages/cli/tests/unit/trim.spec.ts
@@ -1,4 +1,8 @@
-import { trimAppMap } from '../../src/cmds/trim/trim';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import TrimCommand, { trimAppMap } from '../../src/cmds/trim/trim';
 
 // Build a loosely-typed AppMap-ish object for exercising trimAppMap.
 function appmap(events: unknown[]): any {
@@ -101,6 +105,44 @@ describe('trim command', () => {
       const once: any = trimAppMap(appmap([{ return_value: { value: 'z'.repeat(400) } }]));
       const twice: any = trimAppMap(once);
       expect(twice.events[0].return_value.value).toBe(once.events[0].return_value.value);
+    });
+  });
+
+  describe('handler', () => {
+    const run = (argv: Record<string, unknown>) => (TrimCommand as any).handler(argv);
+
+    it('skips a malformed file without aborting or leaving a partial write', async () => {
+      const dir = mkdtempSync(join(tmpdir(), 'trim-'));
+      try {
+        const original = JSON.stringify({ events: [{ return_value: { value: 'x'.repeat(400) } }] });
+        const good = join(dir, 'good.appmap.json');
+        const bad = join(dir, 'bad.appmap.json');
+        writeFileSync(good, original);
+        writeFileSync(bad, '{ not valid json');
+
+        // A malformed file mid-batch must not throw or stop processing the rest.
+        await expect(run({ files: [good, bad], maxLength: 120 })).resolves.toBeUndefined();
+
+        // The good file was trimmed in place and remains valid JSON...
+        const after = readFileSync(good, 'utf8');
+        expect(after.length).toBeLessThan(original.length);
+        expect(() => JSON.parse(after)).not.toThrow();
+        // ...and the malformed file was left untouched (not half-written).
+        expect(readFileSync(bad, 'utf8')).toBe('{ not valid json');
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('throws only when every input file fails', async () => {
+      const dir = mkdtempSync(join(tmpdir(), 'trim-'));
+      try {
+        const bad = join(dir, 'bad.appmap.json');
+        writeFileSync(bad, 'not json');
+        await expect(run({ files: [bad], maxLength: 120 })).rejects.toThrow(/failed to process/);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
     });
   });
 });

--- a/packages/cli/tests/unit/trim.spec.ts
+++ b/packages/cli/tests/unit/trim.spec.ts
@@ -1,0 +1,106 @@
+import { trimAppMap } from '../../src/cmds/trim/trim';
+
+// Build a loosely-typed AppMap-ish object for exercising trimAppMap.
+function appmap(events: unknown[]): any {
+  return { events };
+}
+
+describe('trim command', () => {
+  describe('trimAppMap', () => {
+    it('truncates values across every captured slot while preserving structure', () => {
+      const long = 'x'.repeat(500);
+      const trimmed: any = trimAppMap(
+        appmap([
+          {
+            id: 1,
+            event: 'call',
+            parameters: [{ name: 'a', value: long }],
+            receiver: { value: long },
+            message: [{ name: 'q', value: long }],
+          },
+          {
+            id: 2,
+            event: 'return',
+            return_value: { value: long },
+            exceptions: [{ class: 'E', value: long }],
+          },
+        ])
+      );
+
+      // Structure — event count and field names — is preserved.
+      expect(trimmed.events).toHaveLength(2);
+      expect(trimmed.events[0].parameters[0].name).toBe('a');
+      expect(trimmed.events[0].message[0].name).toBe('q');
+      expect(trimmed.events[1].exceptions[0].class).toBe('E');
+
+      // Every captured slot type is truncated (default flat cap 120).
+      for (const value of [
+        trimmed.events[0].parameters[0].value,
+        trimmed.events[0].receiver.value,
+        trimmed.events[0].message[0].value,
+        trimmed.events[1].return_value.value,
+        trimmed.events[1].exceptions[0].value,
+      ]) {
+        expect(value.length).toBeLessThanOrEqual(120);
+        expect(value.endsWith('…')).toBe(true);
+      }
+    });
+
+    it('parses a multi-line util.inspect object value and budgets it per field', () => {
+      // The shape appmap-node captures for a JS object (ClassName {\n ... }).
+      const value = `User {\n  id: 42,\n  secret: '${'x'.repeat(300)}',\n  name: 'alice'\n}`;
+      const trimmed: any = trimAppMap(appmap([{ return_value: { value } }]));
+      const out: string = trimmed.events[0].return_value.value;
+
+      // Recognized as a struct (kept its type prefix + braces), and far shorter
+      // than a flat 120-char cut of the raw multi-line blob.
+      expect(out.startsWith('User {')).toBe(true);
+      expect(out.endsWith('}')).toBe(true);
+      expect(out).toContain('id: 42');
+      expect(out).not.toContain('x'.repeat(60));
+      expect(out.length).toBeLessThan(value.length);
+    });
+
+    it('clips id/uuid-shaped field values tighter than ordinary ones', () => {
+      const value =
+        'ApprovalRequest[requestId=d179dbbd-cc67-4384-a97f-36fd9eeedeb2, status=APPROVED]';
+      const trimmed: any = trimAppMap(appmap([{ parameters: [{ value }] }]));
+      const out: string = trimmed.events[0].parameters[0].value;
+      expect(out).toContain('status=APPROVED'); // state field survives
+      expect(out).not.toContain('36fd9eeedeb2'); // uuid tail clipped
+    });
+
+    it('respects a custom budget (flatCap via --max-length)', () => {
+      const trimmed: any = trimAppMap(appmap([{ return_value: { value: 'y'.repeat(200) } }]), {
+        perValueCap: 48,
+        idCap: 12,
+        maxFields: 12,
+        flatCap: 20,
+      });
+      expect(trimmed.events[0].return_value.value.length).toBeLessThanOrEqual(20);
+    });
+
+    it('leaves short and non-string values untouched', () => {
+      const trimmed: any = trimAppMap(
+        appmap([{ parameters: [{ value: 'short' }, { value: 42 }, { value: null }, {}] }])
+      );
+      const params = trimmed.events[0].parameters;
+      expect(params[0].value).toBe('short');
+      expect(params[1].value).toBe(42);
+      expect(params[2].value).toBeNull();
+      expect(params[3].value).toBeUndefined();
+    });
+
+    it('no-ops on events without value slots and on an empty AppMap', () => {
+      expect(() => trimAppMap(appmap([{ id: 1, event: 'call' }]))).not.toThrow();
+      expect(trimAppMap(appmap([])).events).toEqual([]);
+      expect(trimAppMap({}).events).toBeUndefined();
+    });
+
+    it('is idempotent — trimming an already-trimmed map changes nothing', () => {
+      const once: any = trimAppMap(appmap([{ return_value: { value: 'z'.repeat(400) } }]));
+      const twice: any = trimAppMap(once);
+      expect(twice.events[0].return_value.value).toBe(once.events[0].return_value.value);
+    });
+  });
+});

--- a/packages/sequence-diagram/src/buildDiagram.ts
+++ b/packages/sequence-diagram/src/buildDiagram.ts
@@ -24,6 +24,15 @@ const MAX_WINDOW_SIZE = 5;
 const parsedSqlCache = new LRUCache<string, any>({ max: 1000 });
 const sha256Cache = new LRUCache<string, string>({ max: 1000 });
 
+// AppMap labels applied to the callee's code object, sorted for stable output.
+// Returns undefined when there are none so the field is omitted from the diagram.
+function labelsOf(event: Event): string[] | undefined {
+  const labels = event.codeObject?.labels;
+  if (!labels) return undefined;
+  const sorted = [...labels].sort();
+  return sorted.length > 0 ? sorted : undefined;
+}
+
 class ActorManager {
   private _actorsByCodeObjectId = new Map<string, Actor>();
   private _actors: Actor[] = [];
@@ -77,6 +86,7 @@ export default function buildDiagram(
         children: [],
         elapsed: callee.elapsedTime,
         eventIds: [callee.id],
+        labels: labelsOf(callee),
       } as ServerRPC;
     } else if (callee?.httpClientRequest && callee?.httpClientResponse) {
       if (!callee.route) throw Error('callee.route not found');
@@ -92,6 +102,7 @@ export default function buildDiagram(
         children: [],
         elapsed: callee.elapsedTime,
         eventIds: [callee.id],
+        labels: labelsOf(callee),
       } as ClientRPC;
     } else if (callee?.sqlQuery) {
       const truncatedQuery = callee.sqlQuery.endsWith('...');
@@ -105,6 +116,7 @@ export default function buildDiagram(
         children: [],
         elapsed: callee.elapsedTime,
         eventIds: [callee.id],
+        labels: labelsOf(callee),
       } as Query;
     } else if (callee) {
       return {
@@ -120,6 +132,7 @@ export default function buildDiagram(
         children: [],
         elapsed: callee.elapsedTime,
         eventIds: [callee.id],
+        labels: labelsOf(callee),
       } as FunctionCall;
     }
   }

--- a/packages/sequence-diagram/src/types.ts
+++ b/packages/sequence-diagram/src/types.ts
@@ -44,6 +44,11 @@ export type Node = {
   formerName?: string;
   formerResult?: string;
   eventIds: number[];
+  // AppMap labels applied to the callee code object (sorted, omitted when empty).
+  // Carried so downstream analysis (e.g. behavioral diffing) can read labels straight
+  // from the diagram. Not part of `digest`/`subtreeDigest`, so a pure re-label is not a
+  // behavioral change.
+  labels?: string[];
 };
 
 export type Loop = Node & {

--- a/packages/sequence-diagram/tests/unit/sequenceDiagram.spec.ts
+++ b/packages/sequence-diagram/tests/unit/sequenceDiagram.spec.ts
@@ -109,6 +109,27 @@ describe('Sequence diagram', () => {
     });
   });
 
+  describe('labels', () => {
+    it('are reported on a labeled function action', () => {
+      const action = findActionById(SHOW_USER_APPMAP, 'lib/controllers/UsersController#show');
+      assert(isFunction(action));
+      assert.deepStrictEqual(action.labels, ['mvc.controller']);
+    });
+    it('are omitted (undefined) on an unlabeled action', () => {
+      const action = findActionById(SHOW_USER_APPMAP, 'lib/views/users/Views::Users::Show#show');
+      assert(isFunction(action));
+      assert.strictEqual(action.labels, undefined);
+    });
+    it('are not part of the digest (a label is not behavior)', () => {
+      // Same code object, with and without labels, must hash identically: labels are a
+      // classification signal, not a behavioral one.
+      const labeled = findActionById(SHOW_USER_APPMAP, 'lib/controllers/UsersController#show');
+      assert(isFunction(labeled));
+      assert(labeled.labels && labeled.labels.length > 0);
+      assert(!labeled.digest.includes('mvc.controller'));
+    });
+  });
+
   describe('incoming message', () => {
     it('is reported', () => {
       const action = findActionById(SHOW_USER_APPMAP, 'lib/controllers/UsersController#show');


### PR DESCRIPTION
## What

Each diagram action (function call, HTTP server/client RPC, SQL query) now records the **AppMap labels** applied to its callee code object, as a sorted `labels?: string[]` field — omitted when empty.

```ts
// buildDiagram.ts, every callee-based branch
labels: labelsOf(callee),   // [...event.codeObject.labels].sort(), or undefined
```

## Why

Labels live only in the raw AppMap `classMap` and were dropped on sequence-diagram export. Consumers that wanted them (notably the **gold-traces** behavioral-diff work, which raises the severity of a detected change when the changed node is security-labeled) had to re-join the diagram against the raw AppMap. This makes the exported diagram **self-contained**: one source of truth for the analysis.

## Design notes

- **Not in the digest.** `labels` is not folded into `digest`/`subtreeDigest` (those derive from `buildStableHash`/`stableProperties`). A pure re-label is therefore *not* a behavioral change — labels are a classification signal, not a behavioral one.
- **No formatter change.** `formatter/json.ts` serializes the whole diagram, so `labels` flows into `--format json` automatically. Text/PlantUML are unchanged (could annotate labeled calls later if desired).
- **All message types.** Applied to ServerRPC / ClientRPC / Query / FunctionCall — anything with a `callee` code object.

## Testing

- `yarn test` — 40 passed (3 new: label reported on a labeled action, `undefined` on an unlabeled one, and labels excluded from the digest).
- `yarn lint` — 0 errors.
- End-to-end against a real Python (Strawberry/SQLAlchemy) AppMap: security-labeled resolvers surface their labels in `sequence-diagram --format json`:
  ```
  _claim_player  => ["security.authorization","security.join_code"]
  _game_by_code  => ["security.authorization","security.join_code"]
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)