### PR TITLE
fix(cli): sanitize SQL in the class map, not just events

### DIFF
--- a/packages/cli/src/lib/sanitizeAppMap.ts
+++ b/packages/cli/src/lib/sanitizeAppMap.ts
@@ -23,7 +23,10 @@ export const CLI_VERSION: string = require('../../package.json').version;
 // Sanitization is positional, driven by the AppMap format: it touches only
 // the fields defined to hold captured runtime data. Code object names,
 // classes, paths, labels, and route templates are schema, not data, and are
-// never modified.
+// never modified — with one exception: a `query` code object's name IS a SQL
+// statement, literals included, so it is parameterized exactly like an event's
+// sql_query (otherwise a literal that was scrubbed from the events would still
+// survive in the class map).
 //
 // The per-file token namespace is deliberate: unlinkability across
 // files/revisions is the anti-correlation guarantee, and (routes aside) values
@@ -199,8 +202,18 @@ interface AppMapMetadata {
   [key: string]: unknown;
 }
 
+// A class-map code object. Only `type: 'query'` nodes carry captured data (the
+// SQL statement, in `name`); every other node is schema.
+interface ClassMapEntry {
+  type?: string;
+  name?: unknown;
+  sql?: unknown;
+  children?: ClassMapEntry[];
+}
+
 interface AppMap {
   metadata?: AppMapMetadata;
+  classMap?: ClassMapEntry[];
   events?: AppMapEvent[];
   // Late updates to events, keyed by event id — e.g. a promise's return value,
   // filled in after the call event was written. Same shape as an event.
@@ -286,11 +299,23 @@ export function sanitizeAppMap(
       masker.reserveThrough(Number(match[1]));
     }
   }
+  // A query code object in the classMap carries the SQL statement (in `name`)
+  // with its literals — the same secret/PII surface as an event's sql_query,
+  // but keyed without the adapter. Record each statement's adapter now, before
+  // the events pass rewrites their sql, so the classMap sanitizes identically.
+  const sqlAdapters = new Map<string, string | undefined>();
+  for (const event of appmap.events ?? []) {
+    const query = event.sql_query;
+    if (query && typeof query.sql === 'string' && !sqlAdapters.has(query.sql))
+      sqlAdapters.set(query.sql, query.database_type);
+  }
+
   for (const event of appmap.events ?? []) sanitizeEvent(event, masker);
   // eventUpdates carry the same captured-data fields as events; sanitize them
   // in place, in the same token namespace. They are deliberately not merged
   // into their events — sanitize changes values only, never structure.
   for (const update of Object.values(appmap.eventUpdates ?? {})) sanitizeEvent(update, masker);
+  sanitizeClassMap(appmap.classMap, masker, sqlAdapters);
   sanitizeMetadata(appmap.metadata, masker);
 
   // Provenance. Masking is one-way, so on a re-run the values still verbatim
@@ -310,6 +335,28 @@ export function sanitizeAppMap(
 // in the repository URL, and exception / test-failure messages. The command
 // pipeline's normalize step also strips repository credentials, but the walk
 // must not depend on it — the security guarantee lives here, alone.
+// A query code object's `name` (some formats also a `sql` field) is a SQL
+// statement with literals — the same secret surface sanitizeSql handles for an
+// event's sql_query. Parameterize it with the same adapter and masker so it
+// matches the event exactly. Everything else in the classMap (packages,
+// classes, functions, route templates) is schema and is left untouched.
+// @label security.sanitization
+function sanitizeClassMap(
+  entries: ClassMapEntry[] | undefined,
+  masker: ValueMasker,
+  sqlAdapters: Map<string, string | undefined>
+): void {
+  for (const entry of entries ?? []) {
+    if (entry.type === 'query') {
+      if (typeof entry.name === 'string')
+        entry.name = sanitizeSql(entry.name, sqlAdapters.get(entry.name), masker);
+      if (typeof entry.sql === 'string')
+        entry.sql = sanitizeSql(entry.sql, sqlAdapters.get(entry.sql), masker);
+    }
+    sanitizeClassMap(entry.children, masker, sqlAdapters);
+  }
+}
+
 function sanitizeMetadata(metadata: AppMapMetadata | undefined, masker: ValueMasker): void {
   if (!metadata) return;
   const git = metadata.git;

--- a/packages/cli/tests/unit/cmds/sanitize.spec.ts
+++ b/packages/cli/tests/unit/cmds/sanitize.spec.ts
@@ -213,6 +213,37 @@ describe('sanitizeAppMap', () => {
     expect(appmap.events[0].sql_query.sql).toMatch(/^<v\d+>$/);
   });
 
+  it('sanitizes SQL in the class map too, so no event literal survives anywhere', () => {
+    const secret = 'kevin@app.land';
+    const statement = `SELECT * FROM users WHERE email = '${secret}'`;
+    const appmap = {
+      classMap: [
+        {
+          type: 'database',
+          name: 'Database',
+          children: [{ type: 'query', name: statement }],
+        },
+      ],
+      events: [{ sql_query: { sql: statement, database_type: 'postgres' } }],
+    };
+    sanitizeAppMap(appmap);
+
+    // The class-map query node is parameterized, identical to the event's SQL.
+    expect(appmap.classMap[0].children[0].name).toContain('SELECT * FROM users WHERE email = ?');
+    expect(appmap.events[0].sql_query.sql).toContain('SELECT * FROM users WHERE email = ?');
+    // The literal survives nowhere in the document — class map included.
+    expect(JSON.stringify(appmap)).not.toContain(secret);
+  });
+
+  it('fails closed on a class-map query it cannot parameterize', () => {
+    const appmap = {
+      classMap: [{ type: 'query', name: "SELECT * FROM users WHERE name = 'unterminated" }],
+      events: [],
+    };
+    sanitizeAppMap(appmap);
+    expect(appmap.classMap[0].name).toMatch(/^<v\d+>$/);
+  });
+
   it('sanitizes exception messages and message parameters', () => {
     const appmap = {
       events: [


### PR DESCRIPTION
## Problem
`appmap sanitize` promises a committed AppMap that is "structurally incapable of
carrying a secret", but `sanitizeAppMap` only walked `events`, `eventUpdates`, and
`metadata` — **not the `classMap`**. A `query` code object's `name` is the raw SQL
statement, literals included, so a query's secret/PII literals survived there.

On a fixture, after `appmap sanitize`:

```
event sql_query.sql :  INSERT INTO "api_keys" (…) VALUES (?, ?)                      ← sanitized
classMap query node :  INSERT INTO "api_keys" (…) VALUES ('admin', 'example api key') …  ← RAW
literal 'admin' in classMap? true      ← leaks
metadata.sanitized present?  true      ← and stamped "sanitized"
```

The design comment even states "code object names … are schema … never modified" —
but a query node's name is a SQL statement, not schema, so the assumption breaks for
that one node type.

## Fix
Walk the `classMap` and run each `type: 'query'` node's SQL through the existing
`sanitizeSql` (parameterize via `normalizeSQL`, or fail closed to a `<vN>` token on
residue), sharing the same `ValueMasker`. The SQL→adapter map is captured from the
events **before** they're rewritten, so class-map SQL sanitizes identically to its
event. Everything else in the class map (packages, classes, functions, routes) is
schema and untouched.

## Verification
- New tests: no event literal survives **anywhere** in the sanitized output (class
  map included); a class-map query that can't be parameterized fails closed to a token.
- End-to-end on the fixture: class-map SQL becomes `VALUES (?, ?)`, and `'admin'` /
  `'example api key'` are gone from the class map.
- Full `sanitize.spec.ts` 25/25; `verify` (lint + tsc) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)