### PR TITLE
fix(build-native): switch pkg compression from Zstd to Brotli

### DIFF
--- a/packages/cli/bin/build-native
+++ b/packages/cli/bin/build-native
@@ -7,7 +7,7 @@ set -e
 # Otherwise every target will be built.
 OS="${1}"
 ARCH="${2:-x64}"
-ARGS="--config package.json --compress Zstd"
+ARGS="--config package.json --compress Brotli"
 PKG_NAME=$(node -p "require('./package.json').name.split('/').pop()")
 
 # check if OS is set and OS/ARCH is the same as the current system.


### PR DESCRIPTION
## Summary

- Telemetry shows OOM errors on Windows machines, with the backtrace pointing at zstd decompression during pkg binary unpack.
- `packages/cli/bin/build-native` switched compression from `GZip` to `Zstd` in `a563769` ("Migrate to @yao-pkg/pkg 6.20.0 and node 24 for binary builds"), a plausible point where the Windows OOM reports started.
- `packages/scanner/bin/build-native` is a symlink to the cli script, so it picks up the same change.

## Benchmark

Built `packages/cli` for `node22-linux-x64` with each `@yao-pkg/pkg --compress` mode (`None`, `GZip`, `Brotli`, `Zstd`) and measured `--help` startup (10 trials each, after a warm-up run) and peak RSS via GNU `time -v`:

| Method | Size | Startup (mean) | Peak RSS (mean) |
|---|---|---|---|
| None (baseline) | 560 MiB | 1.48s | 282 MB |
| GZip | 222 MiB (−60%) | 1.95s | 283 MB |
| **Brotli** | **191 MiB (−66%)** | 2.26s | 284 MB |
| Zstd (current) | 221 MiB (−60%) | 2.62s (slowest) | **555 MB (~2×)** |

Zstd roughly doubles peak memory versus every other mode (including uncompressed) and is also the slowest to start — reproduced consistently across 15+ runs. Brotli produces the smallest binary of all four modes, keeps memory at baseline, and starts faster than Zstd (though ~300ms slower than GZip).

Caveats: measured on Linux x64, not the affected Windows machines (couldn't build/run Windows binaries in the sandbox this was benchmarked in), but the memory blowup lives in pkg's decompression path, which is shared across platforms — only the absolute numbers would be expected to differ.

## Change

One-line change: `--compress Zstd` → `--compress Brotli` in `packages/cli/bin/build-native`.

## Test plan

- [ ] CI native builds succeed for all platforms (linux/macos/windows, x64/arm64)
- [ ] Windows binary no longer OOMs on affected machines (telemetry follow-up post-release)
- [ ] `appmap --help` still works correctly on a built binary


---
_Generated by [Claude Code](https://claude.ai/code/session_01Bw3FNg2bRoYxGJBshgEf3Z)_