### PR TITLE
fix(cli): skip empty sequence diagram diff snippets in change report

### DIFF
--- a/packages/cli/src/cmds/compare/ReportFieldCalculator.ts
+++ b/packages/cli/src/cmds/compare/ReportFieldCalculator.ts
@@ -74,7 +74,7 @@ export default class ReportFieldCalculator {
             const action = diagramDiff.rootActions[actionIndex];
             diagramDiff.rootActions = [action];
             const snippet = format(FormatType.Text, diagramDiff, 'diff');
-            // TODO: nop if this is the empty string
+            if (snippet.diagram === '') continue;
             if (!sequenceDiagramDiff.has(snippet.diagram))
               sequenceDiagramDiff.set(snippet.diagram, []);
             sequenceDiagramDiff.get(snippet.diagram)?.push(appmap);

--- a/packages/cli/tests/unit/fixtures/compare/.appmap/change-report/all-succeeded/change-report.json
+++ b/packages/cli/tests/unit/fixtures/compare/.appmap/change-report/all-succeeded/change-report.json
@@ -21,11 +21,6 @@
   ],
   "removedAppMaps": ["minitest/Relationship_should_be_valid"],
   "sequenceDiagramDiff": {
-    "": [
-      "minitest/Microposts_interface_micropost_interface",
-      "minitest/Users_login_login_with_valid_information_followed_by_logout",
-      "minitest/Users_signup_valid_signup_information_with_account_activation"
-    ],
     "changed HTTP server request `GET /users/{id}` to return 302 instead of 200\n  changed function call `app/helpers#show` to function call `app/helpers#logged_in_user` and changed to return string instead of ActiveRecord::AssociationRelation\n    removed SQL `SELECT \"users\".* FROM \"users\" WHERE \"users\".\"id\" = ? LIMIT ?`\n    removed function call `controllers#page_number`\n    changed function call `app/helpers#render` to function call `app/helpers#store_location` and changed to return string instead of void\n  removed function call `views.render`\n    removed function call `helpers#gravatar_for`\n4 times:     removed function call `views.render`\n      removed SQL `SELECT COUNT(*) FROM \"users\" INNER JOIN \"relationships\" ON \"users\".\"id\" = \"relationships\".\"followed_id\" WHERE \"relationships\".\"follower_id\" = ?`\n      removed SQL `SELECT COUNT(*) FROM \"users\" INNER JOIN \"relationships\" ON \"users\".\"id\" = \"relationships\".\"follower_id\" WHERE \"relationships\".\"followed_id\" = ?`\n    removed SQL `SELECT 1 AS one FROM \"microposts\" WHERE \"microposts\".\"user_id\" = ? LIMIT ?`\n2 times:     removed SQL `SELECT COUNT(*) FROM \"microposts\" WHERE \"microposts\".\"user_id\" = ?`\n      removed SQL `SELECT \"microposts\".* FROM \"microposts\" WHERE \"microposts\".\"user_id\" = ? ORDER BY \"microposts\".\"created_at\" DESC LIMIT ? OFFSET ?`\n      removed loop\n    removed function call `helpers#full_title`\n      removed function call `helpers#logged_in?`": [
       "minitest/Users_profile_profile_display_while_anonyomus"
     ]

--- a/packages/cli/tests/unit/fixtures/compare/.appmap/change-report/invalid-openapi/change-report.json
+++ b/packages/cli/tests/unit/fixtures/compare/.appmap/change-report/invalid-openapi/change-report.json
@@ -8,9 +8,7 @@
       "sequenceDiagramDiff": "minitest/Microposts_interface_micropost_interface.diff.sequence.json"
     }
   ],
-  "sequenceDiagramDiff": {
-    "": ["minitest/Microposts_interface_micropost_interface"]
-  },
+  "sequenceDiagramDiff": {},
   "appMapMetadata": {
     "base": {
       "minitest/Microposts_interface_micropost_interface": {

--- a/packages/cli/tests/unit/fixtures/compare/.appmap/change-report/some-failed/change-report.json
+++ b/packages/cli/tests/unit/fixtures/compare/.appmap/change-report/some-failed/change-report.json
@@ -38,10 +38,6 @@
   "sequenceDiagramDiff": {
     "removed SQL `PRAGMA foreign_keys = ON`": [
       "minitest/Microposts_controller_should_redirect_destroy_for_wrong_micropost"
-    ],
-    "": [
-      "minitest/Microposts_interface_micropost_interface",
-      "minitest/User_associated_microposts_should_be_destroyed"
     ]
   },
   "appMapMetadata": {


### PR DESCRIPTION
## Summary

Implements a `TODO` in `ReportFieldCalculator.sequenceDiagramDiff` (`packages/cli/src/cmds/compare/ReportFieldCalculator.ts`):

```ts
// TODO: nop if this is the empty string
```

When building the sequence-diagram-diff section of a change report, each root action of a diagram diff is formatted as a text snippet and used as a map key grouping the AppMaps that share that diff. If formatting a root action produced an empty string, the AppMap was recorded under an empty-string key, which surfaced as a meaningless empty entry in the report. The loop now skips such snippets.

## Testing

- `yarn verify` (ESLint + `tsc --noEmit` on `packages/cli`) passes.
- `npx jest tests/unit/compare/ReportFieldCalculator.spec.ts` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0193Qq2wn6i53jaFiZkcewg4

---
_Generated by [Claude Code](https://claude.ai/code/session_0193Qq2wn6i53jaFiZkcewg4)_