### PR TITLE
ci: install prebuilt rcodesign instead of building from source

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -212,12 +212,6 @@ jobs:
       - name: Setup Node
         uses: ./.github/actions/setup-node
 
-      - name: Restore cargo cache
-        uses: actions/cache@v5
-        with:
-          path: ~/.cargo
-          key: ${{ runner.os }}-${{ runner.arch }}-cargo
-
       - name: Build binary
         run: |
           yarn build
@@ -262,12 +256,6 @@ jobs:
       - name: Setup Node
         uses: ./.github/actions/setup-node
 
-      - name: Restore cargo cache
-        uses: actions/cache@v5
-        with:
-          path: ~/.cargo
-          key: ${{ runner.os }}-${{ runner.arch }}-cargo
-
       - name: Build binary
         run: |
           yarn build
@@ -300,12 +288,6 @@ jobs:
 
       - name: Setup Node
         uses: ./.github/actions/setup-node
-
-      - name: Restore cargo cache
-        uses: actions/cache@v5
-        with:
-          path: ~/.cargo
-          key: ${{ runner.os }}-${{ runner.arch }}-cargo
 
       - name: Build
         shell: bash

--- a/bin/presign
+++ b/bin/presign
@@ -19,12 +19,37 @@ done
 
 [ "${EXIT_CODE}" -ne 0 ] && exit "${EXIT_CODE}"
 
+# Pinned release of rcodesign. A prebuilt binary is used on purpose: building apple-codesign
+# from source costs several minutes on every macOS CI job, and pinning a released version keeps
+# the tool that signs our releases reproducible.
+RCODESIGN_VERSION="0.29.0"
+RCODESIGN_SHA256="d98372d5524226ccf9dc0eda03d4e4f5826182dabb2fc3f2bd303ed9113a748d"
+INSTALL_DIR="/usr/local/bin"
+
 # If rcodesign is not installed, install it.
 if ! command -v rcodesign &>/dev/null; then
+  if [ "$(uname -s)" != "Darwin" ]; then
+    echo "No pinned rcodesign build is configured for $(uname -s)." >&2
+    echo "Add the matching release asset and its checksum, or install rcodesign manually." >&2
+    exit 1
+  fi
+
   echo "Installing codesigning dependencies..."
-  cargo install \
-    --git https://github.com/indygreg/apple-platform-rs \
-    --branch main \
-    --bin rcodesign \
-    apple-codesign
+
+  DIST_NAME="apple-codesign-${RCODESIGN_VERSION}-macos-universal"
+  TMP_DIR="$(mktemp -d)"
+  TARBALL_PATH="${TMP_DIR}/${DIST_NAME}.tar.gz"
+
+  curl -sSfL -o "${TARBALL_PATH}" \
+    "https://github.com/indygreg/apple-platform-rs/releases/download/apple-codesign%2F${RCODESIGN_VERSION}/${DIST_NAME}.tar.gz"
+  echo "${RCODESIGN_SHA256}  ${TARBALL_PATH}" | shasum -a 256 --check
+  tar xzf "${TARBALL_PATH}" -C "${TMP_DIR}"
+
+  if [ -w "${INSTALL_DIR}" ]; then
+    install -m 755 "${TMP_DIR}/${DIST_NAME}/rcodesign" "${INSTALL_DIR}/rcodesign"
+  else
+    sudo install -m 755 "${TMP_DIR}/${DIST_NAME}/rcodesign" "${INSTALL_DIR}/rcodesign"
+  fi
 fi
+
+rcodesign --version


### PR DESCRIPTION
*bin/presign* built *apple-codesign* from git via `cargo install`, compiling the whole Rust dependency tree on every macOS job. This cost several minutes on each of macos-x64 and macos-arm64.

The `~/.cargo` cache could not help: `cargo install` compiles in a throwaway target directory, so caching ~/.cargo only avoids crate downloads, never the compile. It skipped the install entirely only when ~/.cargo/bin/rcodesign itself was restored, and that rarely happened for releases -- a run can restore caches only from its own ref or the default branch, so every release tag started cold.

Download the pinned upstream 0.29.0 prebuilt binary instead and verify its sha256. Pinning a release also makes the tool that signs our releases reproducible, which `--branch main` did not.

All flags used by bin/sign and bin/notarize work on 0.29.0; --entitlements-xml-path and --api-key-path are accepted aliases of the newer --entitlements-xml-file and --api-key-file.

Drop the now-unused cargo caches from both macOS jobs and from the windows job, which never used Rust at all — it signs via *azure/trusted-signing-action*, so that step restored and re-saved an empty *~/.cargo* for nothing.