### PR TITLE
feat(cli): emit self-contained before/after sequence comparison bundles

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -30,6 +30,7 @@ const OpenCommand = require('./cmds/open/open');
 const InspectCommand = require('./cmds/inspect/inspect');
 const SequenceDiagramCommand = require('./cmds/sequenceDiagram');
 const SequenceDiagramDiffCommand = require('./cmds/sequenceDiagramDiff');
+const SequenceDiagramCompareCommand = require('./cmds/sequenceDiagramCompare');
 const StatsCommand = require('./cmds/stats/stats');
 const ArchiveCommand = require('./cmds/archive/archive');
 const RestoreCommand = require('./cmds/archive/restore');
@@ -147,6 +148,7 @@ yargs(process.argv.slice(2))
   .command(InspectCommand)
   .command(SequenceDiagramCommand)
   .command(SequenceDiagramDiffCommand)
+  .command(SequenceDiagramCompareCommand)
   .command(PruneCommand)
   .command(TrimCommand)
   .command(SanitizeCommand)

--- a/packages/cli/src/cmds/sequenceDiagramCompare.ts
+++ b/packages/cli/src/cmds/sequenceDiagramCompare.ts
@@ -2,19 +2,33 @@ import { mkdir, readFile, writeFile } from 'fs/promises';
 import { basename, dirname, join } from 'path';
 import yargs from 'yargs';
 
-import { AppMap, buildAppMap } from '@appland/models';
+import {
+  AppMap,
+  AppMapComparison,
+  BehavioralChange,
+  BehavioralChangeKind,
+  ComparisonReference,
+  ComparisonValueChange,
+  ComparisonView,
+  APPMAP_COMPARISON_KIND,
+  APPMAP_COMPARISON_SCHEMA_VERSION,
+  assertAppMapComparison,
+  buildAppMap,
+  makeComparisonChangeId,
+} from '@appland/models';
 import {
   Action,
   Actor,
+  actionActors,
   buildDiagram,
   buildDiffDiagram,
   Diagram,
   diff,
-  DiffMode,
   FormatType,
   format as formatDiagram,
   Move,
   MoveType,
+  NodeType,
   nodeName,
   nodeResult,
   SequenceDiagramOptions,
@@ -24,37 +38,20 @@ import {
 import { handleWorkingDirectory } from '../lib/handleWorkingDirectory';
 import { verbose } from '../utils';
 
+const packageVersion = require('../../package.json').version as string;
+
 export const command = 'sequence-diagram-compare <base-appmap> <head-appmap>';
 export const describe =
-  'Create a self-contained, interactive before/after sequence comparison bundle';
+  'Create a self-contained, interactive before/after AppMap comparison bundle';
 
-export type SequenceComparisonChange = {
-  id: string;
-  kind: 'added' | 'removed' | 'changed';
-  diffMode: DiffMode;
-  baseEventIds: number[];
-  headEventIds: number[];
-  diffEventIds: number[];
-  name: string;
-  formerName?: string;
-  result?: string;
-  formerResult?: string;
-  labels?: string[];
+type SequenceAlignment = {
+  actorOrder: string[];
 };
 
-export type SequenceComparisonBundle = {
-  kind: 'appmap.sequence-comparison';
-  schemaVersion: 1;
-  scenario?: string;
-  baseRevision?: string;
-  headRevision?: string;
-  baseAppMap: string;
-  headAppMap: string;
-  base: Diagram;
-  head: Diagram;
-  diff: Diagram;
-  changes: SequenceComparisonChange[];
-};
+export type SequenceComparisonView = ComparisonView<Diagram, SequenceAlignment>;
+export type SequenceComparisonBundle = AppMapComparison<{
+  sequence: SequenceComparisonView;
+}>;
 
 export const builder = (args: yargs.Argv) => {
   args.positional('base-appmap', {
@@ -81,7 +78,7 @@ export const builder = (args: yargs.Argv) => {
     type: 'string',
   });
   args.option('scenario', {
-    describe: 'stable scenario name shown by comparison viewers',
+    describe: 'stable scenario id shown by comparison viewers',
     type: 'string',
   });
   args.option('base-revision', {
@@ -110,12 +107,12 @@ function serializeDiagram(diagram: Diagram, description: string): Diagram {
   return JSON.parse(formatted.diagram) as Diagram;
 }
 
-function alignActors(diagrams: Diagram[]): void {
+function alignActors(diagrams: Diagram[]): string[] {
   const actorIds: string[] = [];
   const seen = new Set<string>();
 
-  // The merged diagram already contains the most useful union ordering. Add any
-  // actor which is only present as otherwise-unused context afterwards.
+  // The merged diagram provides the useful union ordering. Add otherwise-unused
+  // actors from the individual diagrams afterwards.
   for (const diagram of [...diagrams].reverse()) {
     for (const actor of [...diagram.actors].sort((a, b) => a.order - b.order)) {
       if (seen.has(actor.id)) continue;
@@ -131,6 +128,8 @@ function alignActors(diagrams: Diagram[]): void {
     });
     diagram.actors.sort((a, b) => a.order - b.order);
   }
+
+  return actorIds;
 }
 
 function actionAt(actions: Action[], index: number): Action | undefined {
@@ -138,12 +137,67 @@ function actionAt(actions: Action[], index: number): Action | undefined {
   return actions[index];
 }
 
+function actionFamily(action: Action): 'call' | 'query' | 'rpc' | 'control-flow' {
+  switch (action.nodeType) {
+    case NodeType.Function:
+      return 'call';
+    case NodeType.Query:
+      return 'query';
+    case NodeType.ServerRPC:
+    case NodeType.ClientRPC:
+      return 'rpc';
+    case NodeType.Loop:
+      return 'control-flow';
+  }
+}
+
+function actionIdentity(action: Action | undefined): unknown {
+  if (!action) return null;
+
+  const ancestors: unknown[] = [];
+  let parent = action.parent;
+  while (parent) {
+    ancestors.unshift({
+      nodeType: parent.nodeType,
+      digest: parent.digest,
+      actors: actionActors(parent).map((actor) => actor?.id || null),
+      name: nodeName(parent),
+    });
+    parent = parent.parent;
+  }
+
+  return {
+    nodeType: action.nodeType,
+    digest: action.digest,
+    actors: actionActors(action).map((actor) => actor?.id || null),
+    name: nodeName(action),
+    ancestors,
+  };
+}
+
+function referenceFor(action: Action | undefined): ComparisonReference | undefined {
+  if (!action || action.eventIds.length === 0) return undefined;
+  return { eventIds: [...action.eventIds] };
+}
+
+function valueChange(
+  before: string | number | undefined,
+  after: string | number | undefined
+): ComparisonValueChange | undefined {
+  if (before === undefined && after === undefined) return undefined;
+
+  const change: ComparisonValueChange = {};
+  if (before !== undefined) change.before = before;
+  if (after !== undefined) change.after = after;
+  return change;
+}
+
 function comparisonChange(
   move: Move,
-  index: number,
   baseActions: Action[],
-  headActions: Action[]
-): SequenceComparisonChange | undefined {
+  headActions: Action[],
+  occurrences: Map<string, number>
+): BehavioralChange | undefined {
   // Insert and delete moves retain the other cursor's previous position. It is
   // context, not the corresponding action, so never expose it as an alignment.
   const baseAction =
@@ -151,20 +205,16 @@ function comparisonChange(
   const headAction =
     move.moveType === MoveType.DeleteLeft ? undefined : actionAt(headActions, move.rNode);
 
-  let kind: SequenceComparisonChange['kind'];
-  let diffMode: DiffMode;
+  let status: 'added' | 'removed' | 'changed';
   switch (move.moveType) {
     case MoveType.InsertRight:
-      kind = 'added';
-      diffMode = DiffMode.Insert;
+      status = 'added';
       break;
     case MoveType.DeleteLeft:
-      kind = 'removed';
-      diffMode = DiffMode.Delete;
+      status = 'removed';
       break;
     case MoveType.Change:
-      kind = 'changed';
-      diffMode = DiffMode.Change;
+      status = 'changed';
       break;
     case MoveType.AdvanceBoth:
       return undefined;
@@ -173,22 +223,44 @@ function comparisonChange(
   const primaryAction = headAction || baseAction;
   if (!primaryAction) return undefined;
 
-  const baseEventIds = baseAction?.eventIds || [];
-  const headEventIds = headAction?.eventIds || [];
-  const diffEventIds = kind === 'removed' ? baseEventIds : headEventIds;
+  const kind = `${actionFamily(primaryAction)}-${status}` as BehavioralChangeKind;
+  const identity = {
+    version: 1,
+    kind,
+    base: actionIdentity(baseAction),
+    head: actionIdentity(headAction),
+  };
+  const baseId = makeComparisonChangeId(identity);
+  const occurrence = occurrences.get(baseId) || 0;
+  occurrences.set(baseId, occurrence + 1);
+
+  const base = referenceFor(baseAction);
+  const head = referenceFor(headAction);
+  const diff = status === 'removed' ? base : head;
+  const details = {
+    name: valueChange(baseAction ? nodeName(baseAction) : undefined, headAction ? nodeName(headAction) : undefined),
+    result: valueChange(nodeResult(baseAction), nodeResult(headAction)),
+  };
+  const filteredDetails = Object.fromEntries(
+    Object.entries(details).filter(([, value]) => value !== undefined)
+  ) as Record<string, ComparisonValueChange>;
+  const labels = Array.from(new Set(headAction?.labels || baseAction?.labels || [])).sort();
 
   return {
-    id: `change-${String(index + 1).padStart(4, '0')}`,
+    id: makeComparisonChangeId(identity, occurrence),
     kind,
-    diffMode,
-    baseEventIds,
-    headEventIds,
-    diffEventIds,
-    name: nodeName(primaryAction),
-    formerName: baseAction ? nodeName(baseAction) : undefined,
-    result: headAction ? nodeResult(headAction) : undefined,
-    formerResult: baseAction ? nodeResult(baseAction) : undefined,
-    labels: headAction?.labels || baseAction?.labels,
+    summary: `${status[0].toUpperCase()}${status.slice(1)} ${nodeName(primaryAction)}`,
+    base,
+    head,
+    views: {
+      sequence: {
+        base,
+        head,
+        diff,
+      },
+    },
+    details: Object.keys(filteredDetails).length > 0 ? filteredDetails : undefined,
+    labels: labels.length > 0 ? labels : undefined,
   };
 }
 
@@ -223,28 +295,60 @@ export async function buildComparisonBundle(
   const headDiagram = buildDiagramFor(headAppMapFile, headAppMap, diagramOptions);
   const computedDiff = diff(baseDiagram, headDiagram);
   const mergedDiagram = buildDiffDiagram(computedDiff);
+  const actorOrder = alignActors([baseDiagram, headDiagram, mergedDiagram]);
 
-  alignActors([baseDiagram, headDiagram, mergedDiagram]);
-
+  const occurrences = new Map<string, number>();
   const changes = computedDiff.moves
-    .map((move, index) =>
-      comparisonChange(move, index, computedDiff.baseActions, computedDiff.headActions)
+    .map((move) =>
+      comparisonChange(move, computedDiff.baseActions, computedDiff.headActions, occurrences)
     )
-    .filter(Boolean) as SequenceComparisonChange[];
+    .filter(Boolean) as BehavioralChange[];
 
-  return {
-    kind: 'appmap.sequence-comparison',
-    schemaVersion: 1,
-    scenario: options.scenario,
-    baseRevision: options.baseRevision,
-    headRevision: options.headRevision,
-    baseAppMap: basename(baseAppMapFile),
-    headAppMap: basename(headAppMapFile),
-    base: serializeDiagram(baseDiagram, 'base'),
-    head: serializeDiagram(headDiagram, 'head'),
-    diff: serializeDiagram(mergedDiagram, 'diff'),
+  const revisions: SequenceComparisonBundle['revisions'] = {};
+  if (options.baseRevision) revisions.base = options.baseRevision;
+  if (options.headRevision) revisions.head = options.headRevision;
+
+  const scenarioId = options.scenario || basename(headAppMapFile, '.appmap.json');
+  const bundle: SequenceComparisonBundle = {
+    kind: APPMAP_COMPARISON_KIND,
+    schemaVersion: APPMAP_COMPARISON_SCHEMA_VERSION,
+    producer: {
+      name: '@appland/appmap',
+      version: packageVersion,
+    },
+    scenario: {
+      id: scenarioId,
+    },
+    revisions: Object.keys(revisions).length > 0 ? revisions : undefined,
+    recordings: {
+      base: basename(baseAppMapFile),
+      head: basename(headAppMapFile),
+    },
+    capabilities: {
+      views: {
+        sequence: 1,
+      },
+      navigation: {
+        changes: 1,
+        eventAlignment: 1,
+      },
+    },
     changes,
+    views: {
+      sequence: {
+        schemaVersion: 1,
+        base: serializeDiagram(baseDiagram, 'base'),
+        head: serializeDiagram(headDiagram, 'head'),
+        diff: serializeDiagram(mergedDiagram, 'diff'),
+        alignment: {
+          actorOrder,
+        },
+      },
+    },
   };
+
+  assertAppMapComparison(bundle);
+  return bundle;
 }
 
 export const handler = async (argv: any) => {

--- a/packages/cli/src/cmds/sequenceDiagramCompare.ts
+++ b/packages/cli/src/cmds/sequenceDiagramCompare.ts
@@ -175,9 +175,20 @@ function actionIdentity(action: Action | undefined): unknown {
   };
 }
 
-function referenceFor(action: Action | undefined): ComparisonReference | undefined {
-  if (!action || action.eventIds.length === 0) return undefined;
-  return { eventIds: [...action.eventIds] };
+function referenceFor(
+  action: Action | undefined,
+  elementId: string
+): ComparisonReference | undefined {
+  if (!action) return undefined;
+
+  // Loops and other structural actions may not own an AppMap event. Preserve
+  // them with a comparison-local element id so every semantic change remains
+  // navigable even when event-based highlighting is unavailable.
+  const reference: ComparisonReference = {
+    elementIds: [elementId],
+  };
+  if (action.eventIds.length > 0) reference.eventIds = [...action.eventIds];
+  return reference;
 }
 
 function valueChange(
@@ -233,12 +244,17 @@ function comparisonChange(
   const baseId = makeComparisonChangeId(identity);
   const occurrence = occurrences.get(baseId) || 0;
   occurrences.set(baseId, occurrence + 1);
+  const changeId = makeComparisonChangeId(identity, occurrence);
 
-  const base = referenceFor(baseAction);
-  const head = referenceFor(headAction);
-  const diff = status === 'removed' ? base : head;
+  const base = referenceFor(baseAction, `${changeId}:sequence:base`);
+  const head = referenceFor(headAction, `${changeId}:sequence:head`);
+  const diffAction = status === 'removed' ? baseAction : headAction;
+  const diff = referenceFor(diffAction, `${changeId}:sequence:diff`);
   const details = {
-    name: valueChange(baseAction ? nodeName(baseAction) : undefined, headAction ? nodeName(headAction) : undefined),
+    name: valueChange(
+      baseAction ? nodeName(baseAction) : undefined,
+      headAction ? nodeName(headAction) : undefined
+    ),
     result: valueChange(nodeResult(baseAction), nodeResult(headAction)),
   };
   const filteredDetails = Object.fromEntries(
@@ -247,7 +263,7 @@ function comparisonChange(
   const labels = Array.from(new Set(headAction?.labels || baseAction?.labels || [])).sort();
 
   return {
-    id: makeComparisonChangeId(identity, occurrence),
+    id: changeId,
     kind,
     summary: `${status[0].toUpperCase()}${status.slice(1)} ${nodeName(primaryAction)}`,
     base,

--- a/packages/cli/src/cmds/sequenceDiagramCompare.ts
+++ b/packages/cli/src/cmds/sequenceDiagramCompare.ts
@@ -144,8 +144,12 @@ function comparisonChange(
   baseActions: Action[],
   headActions: Action[]
 ): SequenceComparisonChange | undefined {
-  const baseAction = actionAt(baseActions, move.lNode);
-  const headAction = actionAt(headActions, move.rNode);
+  // Insert and delete moves retain the other cursor's previous position. It is
+  // context, not the corresponding action, so never expose it as an alignment.
+  const baseAction =
+    move.moveType === MoveType.InsertRight ? undefined : actionAt(baseActions, move.lNode);
+  const headAction =
+    move.moveType === MoveType.DeleteLeft ? undefined : actionAt(headActions, move.rNode);
 
   let kind: SequenceComparisonChange['kind'];
   let diffMode: DiffMode;

--- a/packages/cli/src/cmds/sequenceDiagramCompare.ts
+++ b/packages/cli/src/cmds/sequenceDiagramCompare.ts
@@ -1,0 +1,271 @@
+import { mkdir, readFile, writeFile } from 'fs/promises';
+import { basename, dirname, join } from 'path';
+import yargs from 'yargs';
+
+import { AppMap, buildAppMap } from '@appland/models';
+import {
+  Action,
+  Actor,
+  buildDiagram,
+  buildDiffDiagram,
+  Diagram,
+  diff,
+  DiffMode,
+  FormatType,
+  format as formatDiagram,
+  Move,
+  MoveType,
+  nodeName,
+  nodeResult,
+  SequenceDiagramOptions,
+  Specification,
+} from '@appland/sequence-diagram';
+
+import { handleWorkingDirectory } from '../lib/handleWorkingDirectory';
+import { verbose } from '../utils';
+
+export const command = 'sequence-diagram-compare <base-appmap> <head-appmap>';
+export const describe =
+  'Create a self-contained, interactive before/after sequence comparison bundle';
+
+export type SequenceComparisonChange = {
+  id: string;
+  kind: 'added' | 'removed' | 'changed';
+  diffMode: DiffMode;
+  baseEventIds: number[];
+  headEventIds: number[];
+  diffEventIds: number[];
+  name: string;
+  formerName?: string;
+  result?: string;
+  formerResult?: string;
+  labels?: string[];
+};
+
+export type SequenceComparisonBundle = {
+  kind: 'appmap.sequence-comparison';
+  schemaVersion: 1;
+  scenario?: string;
+  baseRevision?: string;
+  headRevision?: string;
+  baseAppMap: string;
+  headAppMap: string;
+  base: Diagram;
+  head: Diagram;
+  diff: Diagram;
+  changes: SequenceComparisonChange[];
+};
+
+export const builder = (args: yargs.Argv) => {
+  args.positional('base-appmap', {
+    describe: 'AppMap recorded before the change',
+    type: 'string',
+    demandOption: true,
+  });
+  args.positional('head-appmap', {
+    describe: 'AppMap recorded after the change',
+    type: 'string',
+    demandOption: true,
+  });
+  args.option('directory', {
+    describe: 'program working directory',
+    type: 'string',
+    alias: 'd',
+  });
+  args.option('output-file', {
+    describe: 'comparison bundle file to write',
+    type: 'string',
+  });
+  args.option('output-dir', {
+    describe: 'directory in which to write the comparison bundle',
+    type: 'string',
+  });
+  args.option('scenario', {
+    describe: 'stable scenario name shown by comparison viewers',
+    type: 'string',
+  });
+  args.option('base-revision', {
+    describe: 'base Git revision recorded in the bundle',
+    type: 'string',
+  });
+  args.option('head-revision', {
+    describe: 'head Git revision recorded in the bundle',
+    type: 'string',
+  });
+  args.option('loops', {
+    describe: 'identify loops and collect them under Loop objects',
+    type: 'boolean',
+    default: true,
+  });
+  args.option('expand', {
+    describe: 'code objects to expand in all three diagrams',
+    type: 'string',
+  });
+
+  return args.strict();
+};
+
+function serializeDiagram(diagram: Diagram, description: string): Diagram {
+  const formatted = formatDiagram(FormatType.JSON, diagram, description);
+  return JSON.parse(formatted.diagram) as Diagram;
+}
+
+function alignActors(diagrams: Diagram[]): void {
+  const actorIds: string[] = [];
+  const seen = new Set<string>();
+
+  // The merged diagram already contains the most useful union ordering. Add any
+  // actor which is only present as otherwise-unused context afterwards.
+  for (const diagram of [...diagrams].reverse()) {
+    for (const actor of [...diagram.actors].sort((a, b) => a.order - b.order)) {
+      if (seen.has(actor.id)) continue;
+      seen.add(actor.id);
+      actorIds.push(actor.id);
+    }
+  }
+
+  const order = new Map(actorIds.map((id, index) => [id, index]));
+  for (const diagram of diagrams) {
+    diagram.actors.forEach((actor: Actor) => {
+      actor.order = order.get(actor.id) ?? actor.order;
+    });
+    diagram.actors.sort((a, b) => a.order - b.order);
+  }
+}
+
+function actionAt(actions: Action[], index: number): Action | undefined {
+  if (index < 0 || index >= actions.length) return undefined;
+  return actions[index];
+}
+
+function comparisonChange(
+  move: Move,
+  index: number,
+  baseActions: Action[],
+  headActions: Action[]
+): SequenceComparisonChange | undefined {
+  const baseAction = actionAt(baseActions, move.lNode);
+  const headAction = actionAt(headActions, move.rNode);
+
+  let kind: SequenceComparisonChange['kind'];
+  let diffMode: DiffMode;
+  switch (move.moveType) {
+    case MoveType.InsertRight:
+      kind = 'added';
+      diffMode = DiffMode.Insert;
+      break;
+    case MoveType.DeleteLeft:
+      kind = 'removed';
+      diffMode = DiffMode.Delete;
+      break;
+    case MoveType.Change:
+      kind = 'changed';
+      diffMode = DiffMode.Change;
+      break;
+    case MoveType.AdvanceBoth:
+      return undefined;
+  }
+
+  const primaryAction = headAction || baseAction;
+  if (!primaryAction) return undefined;
+
+  const baseEventIds = baseAction?.eventIds || [];
+  const headEventIds = headAction?.eventIds || [];
+  const diffEventIds = kind === 'removed' ? baseEventIds : headEventIds;
+
+  return {
+    id: `change-${String(index + 1).padStart(4, '0')}`,
+    kind,
+    diffMode,
+    baseEventIds,
+    headEventIds,
+    diffEventIds,
+    name: nodeName(primaryAction),
+    formerName: baseAction ? nodeName(baseAction) : undefined,
+    result: headAction ? nodeResult(headAction) : undefined,
+    formerResult: baseAction ? nodeResult(baseAction) : undefined,
+    labels: headAction?.labels || baseAction?.labels,
+  };
+}
+
+function buildDiagramFor(appmapFile: string, appmap: AppMap, options: SequenceDiagramOptions) {
+  const specification = Specification.build(appmap, options);
+  return buildDiagram(appmapFile, appmap, specification);
+}
+
+export async function buildComparisonBundle(
+  baseAppMapFile: string,
+  headAppMapFile: string,
+  options: {
+    loops?: boolean;
+    expand?: string | string[];
+    scenario?: string;
+    baseRevision?: string;
+    headRevision?: string;
+  } = {}
+): Promise<SequenceComparisonBundle> {
+  const baseData = JSON.parse(await readFile(baseAppMapFile, 'utf-8'));
+  const headData = JSON.parse(await readFile(headAppMapFile, 'utf-8'));
+  const baseAppMap = buildAppMap().source(baseData).build();
+  const headAppMap = buildAppMap().source(headData).build();
+
+  const diagramOptions: SequenceDiagramOptions = {
+    loops: options.loops !== false,
+  };
+  if (options.expand)
+    diagramOptions.expand = Array.isArray(options.expand) ? options.expand : [options.expand];
+
+  const baseDiagram = buildDiagramFor(baseAppMapFile, baseAppMap, diagramOptions);
+  const headDiagram = buildDiagramFor(headAppMapFile, headAppMap, diagramOptions);
+  const computedDiff = diff(baseDiagram, headDiagram);
+  const mergedDiagram = buildDiffDiagram(computedDiff);
+
+  alignActors([baseDiagram, headDiagram, mergedDiagram]);
+
+  const changes = computedDiff.moves
+    .map((move, index) =>
+      comparisonChange(move, index, computedDiff.baseActions, computedDiff.headActions)
+    )
+    .filter(Boolean) as SequenceComparisonChange[];
+
+  return {
+    kind: 'appmap.sequence-comparison',
+    schemaVersion: 1,
+    scenario: options.scenario,
+    baseRevision: options.baseRevision,
+    headRevision: options.headRevision,
+    baseAppMap: basename(baseAppMapFile),
+    headAppMap: basename(headAppMapFile),
+    base: serializeDiagram(baseDiagram, 'base'),
+    head: serializeDiagram(headDiagram, 'head'),
+    diff: serializeDiagram(mergedDiagram, 'diff'),
+    changes,
+  };
+}
+
+export const handler = async (argv: any) => {
+  verbose(argv.verbose);
+  handleWorkingDirectory(argv.directory);
+
+  const baseAppMapFile = argv.baseAppmap as string;
+  const headAppMapFile = argv.headAppmap as string;
+  const bundle = await buildComparisonBundle(baseAppMapFile, headAppMapFile, {
+    loops: argv.loops,
+    expand: argv.expand,
+    scenario: argv.scenario,
+    baseRevision: argv.baseRevision,
+    headRevision: argv.headRevision,
+  });
+
+  const defaultFileName = `${basename(
+    headAppMapFile,
+    '.appmap.json'
+  )}.compare.diff.sequence.json`;
+  const outputFile = argv.outputFile
+    ? (argv.outputFile as string)
+    : join((argv.outputDir as string) || dirname(headAppMapFile), defaultFileName);
+
+  await mkdir(dirname(outputFile), { recursive: true });
+  await writeFile(outputFile, JSON.stringify(bundle, null, 2));
+  console.log(`Printed comparison bundle ${outputFile}`);
+};

--- a/packages/cli/tests/unit/sequenceDiagramCompare.spec.ts
+++ b/packages/cli/tests/unit/sequenceDiagramCompare.spec.ts
@@ -1,11 +1,17 @@
-import { Diagram, DiffMode, unparseDiagram } from '@appland/sequence-diagram';
+import {
+  APPMAP_COMPARISON_KIND,
+  AppMapComparison,
+  assertAppMapComparison,
+} from '@appland/models';
+import { Diagram, unparseDiagram } from '@appland/sequence-diagram';
 import { existsSync, mkdirSync } from 'fs';
 import { readFile } from 'fs/promises';
 import path from 'path';
 
 import {
+  buildComparisonBundle,
   handler as compareSequenceDiagrams,
-  SequenceComparisonBundle,
+  SequenceComparisonView,
 } from '../../src/cmds/sequenceDiagramCompare';
 
 const fixtureDir = path.join(
@@ -22,8 +28,10 @@ const outputFile = path.join(outputDir, 'users.compare.diff.sequence.json');
 const baseAppMap = path.join(fixtureDir, 'user_not_found.appmap.json');
 const headAppMap = path.join(fixtureDir, 'show_user.appmap.json');
 
+type Bundle = AppMapComparison<{ sequence: SequenceComparisonView }>;
+
 describe('sequence diagram compare command', () => {
-  it('writes a self-contained before, after, and merged diff bundle', async () => {
+  it('writes a view-neutral contract with a versioned sequence view', async () => {
     await compareSequenceDiagrams({
       baseAppmap: baseAppMap,
       headAppmap: headAppMap,
@@ -35,39 +43,53 @@ describe('sequence diagram compare command', () => {
     });
 
     expect(existsSync(outputFile)).toBe(true);
-    const bundle = JSON.parse(
-      await readFile(outputFile, 'utf8')
-    ) as SequenceComparisonBundle;
+    const bundle = JSON.parse(await readFile(outputFile, 'utf8')) as Bundle;
+    expect(() => assertAppMapComparison(bundle)).not.toThrow();
 
-    expect(bundle.kind).toBe('appmap.sequence-comparison');
+    expect(bundle.kind).toBe(APPMAP_COMPARISON_KIND);
     expect(bundle.schemaVersion).toBe(1);
-    expect(bundle.scenario).toBe('show-user');
-    expect(bundle.baseRevision).toBe('base-sha');
-    expect(bundle.headRevision).toBe('head-sha');
+    expect(bundle.scenario.id).toBe('show-user');
+    expect(bundle.revisions).toEqual({ base: 'base-sha', head: 'head-sha' });
+    expect(bundle.recordings).toEqual({
+      base: 'user_not_found.appmap.json',
+      head: 'show_user.appmap.json',
+    });
+    expect(bundle.capabilities.views).toEqual({ sequence: 1 });
     expect(bundle.changes.length).toBeGreaterThan(0);
 
+    const sequence = bundle.views.sequence;
     const actorOrder = (diagram: Diagram) => diagram.actors.map((actor) => actor.id);
-    const diffActors = actorOrder(bundle.diff);
-    const baseActors = actorOrder(bundle.base);
-    const headActors = actorOrder(bundle.head);
+    const diffActors = actorOrder(sequence.diff);
+    const baseActors = actorOrder(sequence.base);
+    const headActors = actorOrder(sequence.head);
+    expect(sequence.alignment.actorOrder).toEqual(diffActors);
     expect(baseActors).toEqual(diffActors.filter((actorId) => baseActors.includes(actorId)));
     expect(headActors).toEqual(diffActors.filter((actorId) => headActors.includes(actorId)));
 
-    expect(() => unparseDiagram(bundle.base)).not.toThrow();
-    expect(() => unparseDiagram(bundle.head)).not.toThrow();
-    expect(() => unparseDiagram(bundle.diff)).not.toThrow();
+    expect(() => unparseDiagram(sequence.base)).not.toThrow();
+    expect(() => unparseDiagram(sequence.head)).not.toThrow();
+    expect(() => unparseDiagram(sequence.diff)).not.toThrow();
 
-    const changed = bundle.changes.find((change) => change.diffMode === DiffMode.Change);
-    const addedOrRemoved = bundle.changes.find(
-      (change) => change.diffMode === DiffMode.Insert || change.diffMode === DiffMode.Delete
-    );
-    expect(changed || addedOrRemoved).toBeDefined();
     bundle.changes.forEach((change) => {
-      expect(change.id).toMatch(/^change-\d{4}$/);
-      expect(Array.isArray(change.baseEventIds)).toBe(true);
-      expect(Array.isArray(change.headEventIds)).toBe(true);
-      expect(Array.isArray(change.diffEventIds)).toBe(true);
+      expect(change.id).toMatch(/^chg_[0-9a-f]{20}(?:_[1-9][0-9]*)?$/);
+      expect(change.kind).toMatch(/-(added|removed|changed)$/);
+      expect(change.views.sequence).toBeDefined();
     });
+  });
+
+  it('assigns deterministic ids which do not depend on positional numbering', async () => {
+    const options = {
+      scenario: 'show-user',
+      baseRevision: 'base-sha',
+      headRevision: 'head-sha',
+    };
+    const first = await buildComparisonBundle(baseAppMap, headAppMap, options);
+    const second = await buildComparisonBundle(baseAppMap, headAppMap, options);
+
+    expect(first.changes.map((change) => change.id)).toEqual(
+      second.changes.map((change) => change.id)
+    );
+    expect(first.changes.every((change) => !change.id.startsWith('change-'))).toBe(true);
   });
 });
 

--- a/packages/cli/tests/unit/sequenceDiagramCompare.spec.ts
+++ b/packages/cli/tests/unit/sequenceDiagramCompare.spec.ts
@@ -1,4 +1,5 @@
 import {
+  APPMAP_COMPARISON_CHANGE_ID_PATTERN,
   APPMAP_COMPARISON_KIND,
   AppMapComparison,
   assertAppMapComparison,
@@ -27,7 +28,7 @@ const outputDir = path.join('tests', 'output', 'sequence-comparison');
 const outputFile = path.join(outputDir, 'users.compare.diff.sequence.json');
 const baseAppMap = path.join(fixtureDir, 'user_not_found.appmap.json');
 const headAppMap = path.join(fixtureDir, 'show_user.appmap.json');
-const changeIdPattern = /^chg_[0-9a-f]{20}(?:_[2-9][0-9]*|_[1-9][0-9]+)?$/;
+const changeIdPattern = new RegExp(APPMAP_COMPARISON_CHANGE_ID_PATTERN);
 
 type Bundle = AppMapComparison<{ sequence: SequenceComparisonView }>;
 
@@ -75,6 +76,11 @@ describe('sequence diagram compare command', () => {
       expect(change.id).toMatch(changeIdPattern);
       expect(change.kind).toMatch(/-(added|removed|changed)$/);
       expect(change.views.sequence).toBeDefined();
+      Object.values(change.views.sequence || {})
+        .filter(Boolean)
+        .forEach((reference) => {
+          expect((reference?.eventIds?.length || 0) + (reference?.elementIds?.length || 0)).toBeGreaterThan(0);
+        });
     });
   });
 

--- a/packages/cli/tests/unit/sequenceDiagramCompare.spec.ts
+++ b/packages/cli/tests/unit/sequenceDiagramCompare.spec.ts
@@ -27,6 +27,7 @@ const outputDir = path.join('tests', 'output', 'sequence-comparison');
 const outputFile = path.join(outputDir, 'users.compare.diff.sequence.json');
 const baseAppMap = path.join(fixtureDir, 'user_not_found.appmap.json');
 const headAppMap = path.join(fixtureDir, 'show_user.appmap.json');
+const changeIdPattern = /^chg_[0-9a-f]{20}(?:_[2-9][0-9]*|_[1-9][0-9]+)?$/;
 
 type Bundle = AppMapComparison<{ sequence: SequenceComparisonView }>;
 
@@ -71,7 +72,7 @@ describe('sequence diagram compare command', () => {
     expect(() => unparseDiagram(sequence.diff)).not.toThrow();
 
     bundle.changes.forEach((change) => {
-      expect(change.id).toMatch(/^chg_[0-9a-f]{20}(?:_[1-9][0-9]*)?$/);
+      expect(change.id).toMatch(changeIdPattern);
       expect(change.kind).toMatch(/-(added|removed|changed)$/);
       expect(change.views.sequence).toBeDefined();
     });

--- a/packages/cli/tests/unit/sequenceDiagramCompare.spec.ts
+++ b/packages/cli/tests/unit/sequenceDiagramCompare.spec.ts
@@ -1,9 +1,12 @@
-import { DiffMode, unparseDiagram } from '@appland/sequence-diagram';
+import { Diagram, DiffMode, unparseDiagram } from '@appland/sequence-diagram';
 import { existsSync, mkdirSync } from 'fs';
 import { readFile } from 'fs/promises';
 import path from 'path';
 
-import { handler as compareSequenceDiagrams } from '../../src/cmds/sequenceDiagramCompare';
+import {
+  handler as compareSequenceDiagrams,
+  SequenceComparisonBundle,
+} from '../../src/cmds/sequenceDiagramCompare';
 
 const fixtureDir = path.join(
   '..',
@@ -32,7 +35,9 @@ describe('sequence diagram compare command', () => {
     });
 
     expect(existsSync(outputFile)).toBe(true);
-    const bundle = JSON.parse(await readFile(outputFile, 'utf8'));
+    const bundle = JSON.parse(
+      await readFile(outputFile, 'utf8')
+    ) as SequenceComparisonBundle;
 
     expect(bundle.kind).toBe('appmap.sequence-comparison');
     expect(bundle.schemaVersion).toBe(1);
@@ -41,13 +46,12 @@ describe('sequence diagram compare command', () => {
     expect(bundle.headRevision).toBe('head-sha');
     expect(bundle.changes.length).toBeGreaterThan(0);
 
-    const actorOrder = (diagram) => diagram.actors.map((actor) => actor.id);
-    expect(actorOrder(bundle.base)).toEqual(
-      actorOrder(bundle.diff).filter((actorId) => actorOrder(bundle.base).includes(actorId))
-    );
-    expect(actorOrder(bundle.head)).toEqual(
-      actorOrder(bundle.diff).filter((actorId) => actorOrder(bundle.head).includes(actorId))
-    );
+    const actorOrder = (diagram: Diagram) => diagram.actors.map((actor) => actor.id);
+    const diffActors = actorOrder(bundle.diff);
+    const baseActors = actorOrder(bundle.base);
+    const headActors = actorOrder(bundle.head);
+    expect(baseActors).toEqual(diffActors.filter((actorId) => baseActors.includes(actorId)));
+    expect(headActors).toEqual(diffActors.filter((actorId) => headActors.includes(actorId)));
 
     expect(() => unparseDiagram(bundle.base)).not.toThrow();
     expect(() => unparseDiagram(bundle.head)).not.toThrow();

--- a/packages/cli/tests/unit/sequenceDiagramCompare.spec.ts
+++ b/packages/cli/tests/unit/sequenceDiagramCompare.spec.ts
@@ -1,0 +1,70 @@
+import { DiffMode, unparseDiagram } from '@appland/sequence-diagram';
+import { existsSync, mkdirSync } from 'fs';
+import { readFile } from 'fs/promises';
+import path from 'path';
+
+import { handler as compareSequenceDiagrams } from '../../src/cmds/sequenceDiagramCompare';
+
+const fixtureDir = path.join(
+  '..',
+  'sequence-diagram',
+  'tests',
+  'fixtures',
+  'app',
+  'tmp',
+  'appmap'
+);
+const outputDir = path.join('tests', 'output', 'sequence-comparison');
+const outputFile = path.join(outputDir, 'users.compare.diff.sequence.json');
+const baseAppMap = path.join(fixtureDir, 'user_not_found.appmap.json');
+const headAppMap = path.join(fixtureDir, 'show_user.appmap.json');
+
+describe('sequence diagram compare command', () => {
+  it('writes a self-contained before, after, and merged diff bundle', async () => {
+    await compareSequenceDiagrams({
+      baseAppmap: baseAppMap,
+      headAppmap: headAppMap,
+      outputFile,
+      loops: true,
+      scenario: 'show-user',
+      baseRevision: 'base-sha',
+      headRevision: 'head-sha',
+    });
+
+    expect(existsSync(outputFile)).toBe(true);
+    const bundle = JSON.parse(await readFile(outputFile, 'utf8'));
+
+    expect(bundle.kind).toBe('appmap.sequence-comparison');
+    expect(bundle.schemaVersion).toBe(1);
+    expect(bundle.scenario).toBe('show-user');
+    expect(bundle.baseRevision).toBe('base-sha');
+    expect(bundle.headRevision).toBe('head-sha');
+    expect(bundle.changes.length).toBeGreaterThan(0);
+
+    const actorOrder = (diagram) => diagram.actors.map((actor) => actor.id);
+    expect(actorOrder(bundle.base)).toEqual(
+      actorOrder(bundle.diff).filter((actorId) => actorOrder(bundle.base).includes(actorId))
+    );
+    expect(actorOrder(bundle.head)).toEqual(
+      actorOrder(bundle.diff).filter((actorId) => actorOrder(bundle.head).includes(actorId))
+    );
+
+    expect(() => unparseDiagram(bundle.base)).not.toThrow();
+    expect(() => unparseDiagram(bundle.head)).not.toThrow();
+    expect(() => unparseDiagram(bundle.diff)).not.toThrow();
+
+    const changed = bundle.changes.find((change) => change.diffMode === DiffMode.Change);
+    const addedOrRemoved = bundle.changes.find(
+      (change) => change.diffMode === DiffMode.Insert || change.diffMode === DiffMode.Delete
+    );
+    expect(changed || addedOrRemoved).toBeDefined();
+    bundle.changes.forEach((change) => {
+      expect(change.id).toMatch(/^change-\d{4}$/);
+      expect(Array.isArray(change.baseEventIds)).toBe(true);
+      expect(Array.isArray(change.headEventIds)).toBe(true);
+      expect(Array.isArray(change.diffEventIds)).toBe(true);
+    });
+  });
+});
+
+beforeEach(() => mkdirSync(outputDir, { recursive: true }));

--- a/packages/models/package.json
+++ b/packages/models/package.json
@@ -26,7 +26,7 @@
     "types",
     "schema"
   ],
-  "types": "types/index.d.ts",
+  "types": "types/public.d.ts",
   "author": "",
   "license": "Commons Clause + MIT",
   "devDependencies": {

--- a/packages/models/package.json
+++ b/packages/models/package.json
@@ -23,7 +23,8 @@
   },
   "files": [
     "dist",
-    "types"
+    "types",
+    "schema"
   ],
   "types": "types/index.d.ts",
   "author": "",

--- a/packages/models/schema/CHANGELOG.md
+++ b/packages/models/schema/CHANGELOG.md
@@ -1,0 +1,19 @@
+# AppMap comparison schema changelog
+
+## Version 1 — 2026-08-19
+
+The first frozen comparison envelope establishes:
+
+- `kind: appmap.comparison`;
+- independent top-level and per-view schema versions;
+- the reserved `dependency`, `sequence`, `trace`, and `flame` view identifiers;
+- canonical `BehavioralChange` objects shared by every view;
+- deterministic, opaque `chg_<hash>` change IDs;
+- base/head recording and revision metadata;
+- capability negotiation for views and navigation;
+- Sequence Diagram view schema version 1;
+- conformance fixtures for clean, added, removed, changed, and reordered behavior.
+
+Additive fields remain backwards compatible. Any breaking envelope change requires
+`schemaVersion: 2`; a breaking payload change increments only the affected view's
+`schemaVersion`.

--- a/packages/models/schema/README.md
+++ b/packages/models/schema/README.md
@@ -1,0 +1,53 @@
+# AppMap comparison contract
+
+`comparison.schema.json` is the versioned, view-neutral envelope used to move a
+before/after behavioral comparison between CI, editors, web applications, and MCP
+hosts.
+
+## Compatibility rules
+
+- `kind` is always `appmap.comparison`.
+- `schemaVersion` changes only when an existing consumer can no longer safely read
+  the envelope.
+- Each view has its own `schemaVersion`; a breaking Sequence Diagram payload change
+  does not force a Dependency Map or Trace View payload change.
+- Additive fields are permitted. Consumers must ignore fields they do not understand.
+- Unsupported views may be ignored, but an unsupported top-level `schemaVersion`
+  must be rejected.
+- Behavioral change IDs are opaque and deterministic. Consumers must never infer
+  ordering or meaning from the hash itself.
+- A producer must validate the complete bundle before writing it.
+
+## Canonical change identity
+
+`makeComparisonChangeId` hashes canonical JSON with sorted object keys. A view
+producer supplies semantic identity, such as the action kind, stable action digest,
+actors, and ancestor path. Repeated indistinguishable changes use the occurrence
+suffix (`_2`, `_3`, and so on).
+
+This keeps IDs stable when an unrelated earlier change is inserted, unlike positional
+IDs such as `change-0004`.
+
+## Views
+
+Version 1 reserves four views:
+
+- `dependency`
+- `sequence`
+- `trace`
+- `flame`
+
+The first implementation supplies `views.sequence`. The envelope and shared
+`BehavioralChange` objects are deliberately ready for the other three views.
+
+## File names
+
+The JSON `kind` is authoritative, not the filename. The current CLI retains
+`*.compare.diff.sequence.json` while existing editor selectors are migrated. A future
+`.appmap.compare.json` name can use the same version-1 contract.
+
+## Examples
+
+`examples/` contains valid contract fixtures for clean, added, removed, changed, and
+reordered behavior. They are intended for consumers in other repositories and
+languages to use as conformance fixtures.

--- a/packages/models/schema/comparison.schema.json
+++ b/packages/models/schema/comparison.schema.json
@@ -1,0 +1,251 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://appmap.io/schemas/comparison/v1",
+  "title": "AppMap comparison bundle",
+  "description": "Portable, view-neutral before/after behavioral comparison data.",
+  "type": "object",
+  "required": [
+    "kind",
+    "schemaVersion",
+    "producer",
+    "scenario",
+    "recordings",
+    "capabilities",
+    "changes",
+    "views"
+  ],
+  "properties": {
+    "kind": { "const": "appmap.comparison" },
+    "schemaVersion": { "const": 1 },
+    "producer": { "$ref": "#/$defs/producer" },
+    "scenario": { "$ref": "#/$defs/scenario" },
+    "revisions": { "$ref": "#/$defs/revisions" },
+    "recordings": { "$ref": "#/$defs/recordings" },
+    "capabilities": { "$ref": "#/$defs/capabilities" },
+    "changes": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/change" }
+    },
+    "views": {
+      "type": "object",
+      "minProperties": 1,
+      "properties": {
+        "dependency": { "$ref": "#/$defs/genericView" },
+        "sequence": { "$ref": "#/$defs/sequenceView" },
+        "trace": { "$ref": "#/$defs/genericView" },
+        "flame": { "$ref": "#/$defs/genericView" }
+      },
+      "additionalProperties": false
+    },
+    "extensions": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true,
+  "$defs": {
+    "producer": {
+      "type": "object",
+      "required": ["name", "version"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "version": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": true
+    },
+    "scenario": {
+      "type": "object",
+      "required": ["id"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "name": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": true
+    },
+    "revisions": {
+      "type": "object",
+      "properties": {
+        "base": { "type": "string", "minLength": 1 },
+        "head": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": true
+    },
+    "recordings": {
+      "type": "object",
+      "required": ["base", "head"],
+      "properties": {
+        "base": { "type": "string", "minLength": 1 },
+        "head": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": true
+    },
+    "capabilities": {
+      "type": "object",
+      "required": ["views"],
+      "properties": {
+        "views": {
+          "type": "object",
+          "minProperties": 1,
+          "properties": {
+            "dependency": { "type": "integer", "minimum": 1 },
+            "sequence": { "type": "integer", "minimum": 1 },
+            "trace": { "type": "integer", "minimum": 1 },
+            "flame": { "type": "integer", "minimum": 1 }
+          },
+          "additionalProperties": false
+        },
+        "navigation": {
+          "type": "object",
+          "properties": {
+            "changes": { "type": "integer", "minimum": 1 },
+            "eventAlignment": { "type": "integer", "minimum": 1 }
+          },
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": true
+    },
+    "reference": {
+      "type": "object",
+      "properties": {
+        "eventIds": {
+          "type": "array",
+          "items": { "type": "integer", "minimum": 1 },
+          "uniqueItems": true
+        },
+        "elementIds": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        }
+      },
+      "anyOf": [
+        { "required": ["eventIds"] },
+        { "required": ["elementIds"] }
+      ],
+      "additionalProperties": true
+    },
+    "viewReference": {
+      "type": "object",
+      "properties": {
+        "base": { "$ref": "#/$defs/reference" },
+        "head": { "$ref": "#/$defs/reference" },
+        "diff": { "$ref": "#/$defs/reference" }
+      },
+      "minProperties": 1,
+      "additionalProperties": true
+    },
+    "valueChange": {
+      "type": "object",
+      "properties": {
+        "before": true,
+        "after": true
+      },
+      "minProperties": 1,
+      "additionalProperties": true
+    },
+    "change": {
+      "type": "object",
+      "required": ["id", "kind", "summary", "views"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^chg_[0-9a-f]{20}(?:_[2-9][0-9]*|_[1-9][0-9]+)?$"
+        },
+        "kind": {
+          "enum": [
+            "call-added",
+            "call-removed",
+            "call-changed",
+            "call-reordered",
+            "query-added",
+            "query-removed",
+            "query-changed",
+            "rpc-added",
+            "rpc-removed",
+            "rpc-changed",
+            "dependency-added",
+            "dependency-removed",
+            "dependency-changed",
+            "exception-added",
+            "exception-removed",
+            "exception-changed",
+            "control-flow-added",
+            "control-flow-removed",
+            "control-flow-changed",
+            "timing-changed",
+            "unknown"
+          ]
+        },
+        "summary": { "type": "string", "minLength": 1 },
+        "base": { "$ref": "#/$defs/reference" },
+        "head": { "$ref": "#/$defs/reference" },
+        "views": {
+          "type": "object",
+          "minProperties": 1,
+          "properties": {
+            "dependency": { "$ref": "#/$defs/viewReference" },
+            "sequence": { "$ref": "#/$defs/viewReference" },
+            "trace": { "$ref": "#/$defs/viewReference" },
+            "flame": { "$ref": "#/$defs/viewReference" }
+          },
+          "additionalProperties": false
+        },
+        "details": {
+          "type": "object",
+          "additionalProperties": { "$ref": "#/$defs/valueChange" }
+        },
+        "labels": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        }
+      },
+      "additionalProperties": true
+    },
+    "diagram": {
+      "type": "object",
+      "required": ["actors", "rootActions"],
+      "properties": {
+        "actors": { "type": "array" },
+        "rootActions": { "type": "array" }
+      },
+      "additionalProperties": true
+    },
+    "genericView": {
+      "type": "object",
+      "required": ["schemaVersion", "base", "head", "diff", "alignment"],
+      "properties": {
+        "schemaVersion": { "type": "integer", "minimum": 1 },
+        "base": { "type": "object" },
+        "head": { "type": "object" },
+        "diff": { "type": "object" },
+        "alignment": { "type": "object" }
+      },
+      "additionalProperties": true
+    },
+    "sequenceView": {
+      "type": "object",
+      "required": ["schemaVersion", "base", "head", "diff", "alignment"],
+      "properties": {
+        "schemaVersion": { "const": 1 },
+        "base": { "$ref": "#/$defs/diagram" },
+        "head": { "$ref": "#/$defs/diagram" },
+        "diff": { "$ref": "#/$defs/diagram" },
+        "alignment": {
+          "type": "object",
+          "required": ["actorOrder"],
+          "properties": {
+            "actorOrder": {
+              "type": "array",
+              "items": { "type": "string", "minLength": 1 },
+              "uniqueItems": true
+            }
+          },
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": true
+    }
+  }
+}

--- a/packages/models/schema/comparison.schema.json
+++ b/packages/models/schema/comparison.schema.json
@@ -110,11 +110,13 @@
       "properties": {
         "eventIds": {
           "type": "array",
+          "minItems": 1,
           "items": { "type": "integer", "minimum": 1 },
           "uniqueItems": true
         },
         "elementIds": {
           "type": "array",
+          "minItems": 1,
           "items": { "type": "string", "minLength": 1 },
           "uniqueItems": true
         }
@@ -132,7 +134,11 @@
         "head": { "$ref": "#/$defs/reference" },
         "diff": { "$ref": "#/$defs/reference" }
       },
-      "minProperties": 1,
+      "anyOf": [
+        { "required": ["base"] },
+        { "required": ["head"] },
+        { "required": ["diff"] }
+      ],
       "additionalProperties": true
     },
     "valueChange": {
@@ -141,7 +147,10 @@
         "before": true,
         "after": true
       },
-      "minProperties": 1,
+      "anyOf": [
+        { "required": ["before"] },
+        { "required": ["after"] }
+      ],
       "additionalProperties": true
     },
     "change": {
@@ -150,7 +159,7 @@
       "properties": {
         "id": {
           "type": "string",
-          "pattern": "^chg_[0-9a-f]{20}(?:_[2-9][0-9]*|_[1-9][0-9]+)?$"
+          "pattern": "^chg_[0-9a-f]{20}(?:_(?:[2-9]|[1-9][0-9]+))?$"
         },
         "kind": {
           "enum": [
@@ -197,10 +206,34 @@
         },
         "labels": {
           "type": "array",
+          "minItems": 1,
           "items": { "type": "string", "minLength": 1 },
           "uniqueItems": true
         }
       },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "kind": { "pattern": "-added$" } },
+            "required": ["kind"]
+          },
+          "then": { "required": ["head"] }
+        },
+        {
+          "if": {
+            "properties": { "kind": { "pattern": "-removed$" } },
+            "required": ["kind"]
+          },
+          "then": { "required": ["base"] }
+        },
+        {
+          "if": {
+            "properties": { "kind": { "pattern": "-(?:changed|reordered)$" } },
+            "required": ["kind"]
+          },
+          "then": { "required": ["base", "head"] }
+        }
+      ],
       "additionalProperties": true
     },
     "diagram": {

--- a/packages/models/schema/examples/added.json
+++ b/packages/models/schema/examples/added.json
@@ -1,0 +1,32 @@
+{
+  "kind": "appmap.comparison",
+  "schemaVersion": 1,
+  "producer": { "name": "contract-fixture", "version": "1" },
+  "scenario": { "id": "added-call" },
+  "recordings": { "base": "base.appmap.json", "head": "head.appmap.json" },
+  "capabilities": { "views": { "sequence": 1 } },
+  "changes": [
+    {
+      "id": "chg_11111111111111111111",
+      "kind": "call-added",
+      "summary": "Added authorize",
+      "head": { "eventIds": [3] },
+      "views": {
+        "sequence": {
+          "head": { "eventIds": [3] },
+          "diff": { "eventIds": [3] }
+        }
+      },
+      "details": { "name": { "after": "authorize" } }
+    }
+  ],
+  "views": {
+    "sequence": {
+      "schemaVersion": 1,
+      "base": { "actors": [], "rootActions": [] },
+      "head": { "actors": [], "rootActions": [] },
+      "diff": { "actors": [], "rootActions": [] },
+      "alignment": { "actorOrder": [] }
+    }
+  }
+}

--- a/packages/models/schema/examples/changed.json
+++ b/packages/models/schema/examples/changed.json
@@ -1,0 +1,34 @@
+{
+  "kind": "appmap.comparison",
+  "schemaVersion": 1,
+  "producer": { "name": "contract-fixture", "version": "1" },
+  "scenario": { "id": "changed-result" },
+  "recordings": { "base": "base.appmap.json", "head": "head.appmap.json" },
+  "capabilities": { "views": { "sequence": 1 } },
+  "changes": [
+    {
+      "id": "chg_33333333333333333333",
+      "kind": "call-changed",
+      "summary": "Changed loadUser result",
+      "base": { "eventIds": [5] },
+      "head": { "eventIds": [6] },
+      "views": {
+        "sequence": {
+          "base": { "eventIds": [5] },
+          "head": { "eventIds": [6] },
+          "diff": { "eventIds": [6] }
+        }
+      },
+      "details": { "result": { "before": "User", "after": "AuthorizationError" } }
+    }
+  ],
+  "views": {
+    "sequence": {
+      "schemaVersion": 1,
+      "base": { "actors": [], "rootActions": [] },
+      "head": { "actors": [], "rootActions": [] },
+      "diff": { "actors": [], "rootActions": [] },
+      "alignment": { "actorOrder": [] }
+    }
+  }
+}

--- a/packages/models/schema/examples/clean.json
+++ b/packages/models/schema/examples/clean.json
@@ -1,0 +1,22 @@
+{
+  "kind": "appmap.comparison",
+  "schemaVersion": 1,
+  "producer": { "name": "contract-fixture", "version": "1" },
+  "scenario": { "id": "clean" },
+  "revisions": { "base": "base", "head": "head" },
+  "recordings": { "base": "base.appmap.json", "head": "head.appmap.json" },
+  "capabilities": {
+    "views": { "sequence": 1 },
+    "navigation": { "changes": 1, "eventAlignment": 1 }
+  },
+  "changes": [],
+  "views": {
+    "sequence": {
+      "schemaVersion": 1,
+      "base": { "actors": [], "rootActions": [] },
+      "head": { "actors": [], "rootActions": [] },
+      "diff": { "actors": [], "rootActions": [] },
+      "alignment": { "actorOrder": [] }
+    }
+  }
+}

--- a/packages/models/schema/examples/removed.json
+++ b/packages/models/schema/examples/removed.json
@@ -1,0 +1,32 @@
+{
+  "kind": "appmap.comparison",
+  "schemaVersion": 1,
+  "producer": { "name": "contract-fixture", "version": "1" },
+  "scenario": { "id": "removed-query" },
+  "recordings": { "base": "base.appmap.json", "head": "head.appmap.json" },
+  "capabilities": { "views": { "sequence": 1 } },
+  "changes": [
+    {
+      "id": "chg_22222222222222222222",
+      "kind": "query-removed",
+      "summary": "Removed SELECT users query",
+      "base": { "eventIds": [4] },
+      "views": {
+        "sequence": {
+          "base": { "eventIds": [4] },
+          "diff": { "eventIds": [4] }
+        }
+      },
+      "details": { "query": { "before": "SELECT users" } }
+    }
+  ],
+  "views": {
+    "sequence": {
+      "schemaVersion": 1,
+      "base": { "actors": [], "rootActions": [] },
+      "head": { "actors": [], "rootActions": [] },
+      "diff": { "actors": [], "rootActions": [] },
+      "alignment": { "actorOrder": [] }
+    }
+  }
+}

--- a/packages/models/schema/examples/reordered.json
+++ b/packages/models/schema/examples/reordered.json
@@ -1,0 +1,34 @@
+{
+  "kind": "appmap.comparison",
+  "schemaVersion": 1,
+  "producer": { "name": "contract-fixture", "version": "1" },
+  "scenario": { "id": "reordered-call" },
+  "recordings": { "base": "base.appmap.json", "head": "head.appmap.json" },
+  "capabilities": { "views": { "sequence": 1 } },
+  "changes": [
+    {
+      "id": "chg_44444444444444444444",
+      "kind": "call-reordered",
+      "summary": "Moved authorize before loadUser",
+      "base": { "eventIds": [8] },
+      "head": { "eventIds": [7] },
+      "views": {
+        "sequence": {
+          "base": { "eventIds": [8] },
+          "head": { "eventIds": [7] },
+          "diff": { "eventIds": [7] }
+        }
+      },
+      "details": { "position": { "before": 3, "after": 2 } }
+    }
+  ],
+  "views": {
+    "sequence": {
+      "schemaVersion": 1,
+      "base": { "actors": [], "rootActions": [] },
+      "head": { "actors": [], "rootActions": [] },
+      "diff": { "actors": [], "rootActions": [] },
+      "alignment": { "actorOrder": [] }
+    }
+  }
+}

--- a/packages/models/src/comparison.ts
+++ b/packages/models/src/comparison.ts
@@ -1,0 +1,376 @@
+import sha256 from 'crypto-js/sha256.js';
+
+import comparisonSchema from '../schema/comparison.schema.json';
+
+export const APPMAP_COMPARISON_KIND = 'appmap.comparison' as const;
+export const APPMAP_COMPARISON_SCHEMA_VERSION = 1 as const;
+export const APPMAP_COMPARISON_CHANGE_ID_VERSION = 1 as const;
+
+export const comparisonViewIds = ['dependency', 'sequence', 'trace', 'flame'] as const;
+export type ComparisonViewId = (typeof comparisonViewIds)[number];
+
+export const behavioralChangeKinds = [
+  'call-added',
+  'call-removed',
+  'call-changed',
+  'call-reordered',
+  'query-added',
+  'query-removed',
+  'query-changed',
+  'rpc-added',
+  'rpc-removed',
+  'rpc-changed',
+  'dependency-added',
+  'dependency-removed',
+  'dependency-changed',
+  'exception-added',
+  'exception-removed',
+  'exception-changed',
+  'control-flow-added',
+  'control-flow-removed',
+  'control-flow-changed',
+  'timing-changed',
+  'unknown',
+] as const;
+export type BehavioralChangeKind = (typeof behavioralChangeKinds)[number];
+
+export type ComparisonValue =
+  | null
+  | boolean
+  | number
+  | string
+  | ComparisonValue[]
+  | { [key: string]: ComparisonValue };
+
+export type ComparisonValueChange = {
+  before?: ComparisonValue;
+  after?: ComparisonValue;
+};
+
+export type ComparisonReference = {
+  eventIds?: number[];
+  elementIds?: string[];
+};
+
+export type ComparisonViewReference = {
+  base?: ComparisonReference;
+  head?: ComparisonReference;
+  diff?: ComparisonReference;
+};
+
+export type BehavioralChange = {
+  id: string;
+  kind: BehavioralChangeKind;
+  summary: string;
+  base?: ComparisonReference;
+  head?: ComparisonReference;
+  views: Partial<Record<ComparisonViewId, ComparisonViewReference>>;
+  details?: Record<string, ComparisonValueChange>;
+  labels?: string[];
+};
+
+export type ComparisonView<TPayload = unknown, TAlignment = unknown> = {
+  schemaVersion: number;
+  base: TPayload;
+  head: TPayload;
+  diff: TPayload;
+  alignment: TAlignment;
+};
+
+export type ComparisonViewMap = Partial<Record<ComparisonViewId, ComparisonView>>;
+
+export type AppMapComparison<TViews extends ComparisonViewMap = ComparisonViewMap> = {
+  kind: typeof APPMAP_COMPARISON_KIND;
+  schemaVersion: typeof APPMAP_COMPARISON_SCHEMA_VERSION;
+  producer: {
+    name: string;
+    version: string;
+  };
+  scenario: {
+    id: string;
+    name?: string;
+  };
+  revisions?: {
+    base?: string;
+    head?: string;
+  };
+  recordings: {
+    base: string;
+    head: string;
+  };
+  capabilities: {
+    views: Partial<Record<ComparisonViewId, number>>;
+    navigation?: {
+      changes?: number;
+      eventAlignment?: number;
+    };
+  };
+  changes: BehavioralChange[];
+  views: TViews;
+  extensions?: Record<string, unknown>;
+};
+
+export const appMapComparisonSchema = comparisonSchema;
+
+const changeKinds = new Set<string>(behavioralChangeKinds);
+const viewIds = new Set<string>(comparisonViewIds);
+const changeIdPattern = /^chg_[0-9a-f]{20}(?:_[2-9][0-9]*|_[1-9][0-9]+)?$/;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function canonicalize(value: unknown): string {
+  if (value === null) return 'null';
+  if (Array.isArray(value)) return `[${value.map(canonicalize).join(',')}]`;
+
+  switch (typeof value) {
+    case 'boolean':
+    case 'number':
+    case 'string':
+      return JSON.stringify(value);
+    case 'object': {
+      const record = value as Record<string, unknown>;
+      return `{${Object.keys(record)
+        .filter((key) => record[key] !== undefined)
+        .sort()
+        .map((key) => `${JSON.stringify(key)}:${canonicalize(record[key])}`)
+        .join(',')}}`;
+    }
+    default:
+      throw new TypeError(`Comparison identities cannot contain ${typeof value}`);
+  }
+}
+
+/**
+ * Canonical JSON representation used by every comparison producer before hashing a
+ * behavioral change identity. Object key order never affects the result.
+ */
+export function canonicalComparisonIdentity(identity: unknown): string {
+  return canonicalize(identity);
+}
+
+/**
+ * Create an opaque, deterministic change id. `occurrence` disambiguates repeated,
+ * otherwise-identical changes while keeping unrelated earlier changes from renumbering it.
+ */
+export function makeComparisonChangeId(identity: unknown, occurrence = 0): string {
+  if (!Number.isInteger(occurrence) || occurrence < 0)
+    throw new RangeError('occurrence must be a non-negative integer');
+
+  const digest = sha256(canonicalComparisonIdentity(identity)).toString().slice(0, 20);
+  return `chg_${digest}${occurrence === 0 ? '' : `_${occurrence + 1}`}`;
+}
+
+function validateString(value: unknown, path: string, errors: string[]): value is string {
+  if (typeof value === 'string' && value.length > 0) return true;
+  errors.push(`${path} must be a non-empty string`);
+  return false;
+}
+
+function validatePositiveIntegerArray(value: unknown, path: string, errors: string[]): boolean {
+  if (!Array.isArray(value)) {
+    errors.push(`${path} must be an array`);
+    return false;
+  }
+
+  const valid = value.every((item) => Number.isInteger(item) && item > 0);
+  if (!valid) errors.push(`${path} must contain positive integers`);
+  if (new Set(value).size !== value.length) errors.push(`${path} must contain unique values`);
+  return valid;
+}
+
+function validateStringArray(value: unknown, path: string, errors: string[]): boolean {
+  if (!Array.isArray(value)) {
+    errors.push(`${path} must be an array`);
+    return false;
+  }
+
+  const valid = value.every((item) => typeof item === 'string' && item.length > 0);
+  if (!valid) errors.push(`${path} must contain non-empty strings`);
+  if (new Set(value).size !== value.length) errors.push(`${path} must contain unique values`);
+  return valid;
+}
+
+function validateReference(value: unknown, path: string, errors: string[]): boolean {
+  if (!isRecord(value)) {
+    errors.push(`${path} must be an object`);
+    return false;
+  }
+
+  let hasReference = false;
+  if (value.eventIds !== undefined) {
+    hasReference = true;
+    validatePositiveIntegerArray(value.eventIds, `${path}.eventIds`, errors);
+  }
+  if (value.elementIds !== undefined) {
+    hasReference = true;
+    validateStringArray(value.elementIds, `${path}.elementIds`, errors);
+  }
+  if (!hasReference) errors.push(`${path} must contain eventIds or elementIds`);
+  return hasReference;
+}
+
+function validateViewReference(value: unknown, path: string, errors: string[]): void {
+  if (!isRecord(value)) {
+    errors.push(`${path} must be an object`);
+    return;
+  }
+
+  const references = ['base', 'head', 'diff'].filter((side) => value[side] !== undefined);
+  if (references.length === 0) errors.push(`${path} must reference base, head, or diff`);
+  references.forEach((side) => validateReference(value[side], `${path}.${side}`, errors));
+}
+
+function validateChange(
+  value: unknown,
+  path: string,
+  availableViews: Set<string>,
+  ids: Set<string>,
+  errors: string[]
+): void {
+  if (!isRecord(value)) {
+    errors.push(`${path} must be an object`);
+    return;
+  }
+
+  if (!validateString(value.id, `${path}.id`, errors)) return;
+  if (!changeIdPattern.test(value.id)) errors.push(`${path}.id has an unsupported format`);
+  if (ids.has(value.id)) errors.push(`${path}.id must be unique`);
+  ids.add(value.id);
+
+  if (typeof value.kind !== 'string' || !changeKinds.has(value.kind))
+    errors.push(`${path}.kind is unsupported`);
+  validateString(value.summary, `${path}.summary`, errors);
+
+  if (value.base !== undefined) validateReference(value.base, `${path}.base`, errors);
+  if (value.head !== undefined) validateReference(value.head, `${path}.head`, errors);
+
+  if (typeof value.kind === 'string') {
+    if (value.kind.endsWith('-added') && value.head === undefined)
+      errors.push(`${path}.head is required for an added change`);
+    if (value.kind.endsWith('-removed') && value.base === undefined)
+      errors.push(`${path}.base is required for a removed change`);
+    if ((value.kind.endsWith('-changed') || value.kind.endsWith('-reordered')) &&
+        (value.base === undefined || value.head === undefined))
+      errors.push(`${path}.base and ${path}.head are required for changed/reordered changes`);
+  }
+
+  if (!isRecord(value.views) || Object.keys(value.views).length === 0) {
+    errors.push(`${path}.views must contain at least one view reference`);
+  } else {
+    Object.entries(value.views).forEach(([viewId, reference]) => {
+      if (!viewIds.has(viewId)) errors.push(`${path}.views.${viewId} is unsupported`);
+      if (!availableViews.has(viewId))
+        errors.push(`${path}.views.${viewId} does not have a corresponding bundle view`);
+      validateViewReference(reference, `${path}.views.${viewId}`, errors);
+    });
+  }
+
+  if (value.labels !== undefined) validateStringArray(value.labels, `${path}.labels`, errors);
+  if (value.details !== undefined && !isRecord(value.details))
+    errors.push(`${path}.details must be an object`);
+}
+
+function validateDiagram(value: unknown, path: string, errors: string[]): void {
+  if (!isRecord(value)) {
+    errors.push(`${path} must be an object`);
+    return;
+  }
+  if (!Array.isArray(value.actors)) errors.push(`${path}.actors must be an array`);
+  if (!Array.isArray(value.rootActions)) errors.push(`${path}.rootActions must be an array`);
+}
+
+/** Return all contract violations. An empty result means the bundle is valid. */
+export function validateAppMapComparison(value: unknown): string[] {
+  const errors: string[] = [];
+  if (!isRecord(value)) return ['$ must be an object'];
+
+  if (value.kind !== APPMAP_COMPARISON_KIND)
+    errors.push(`$.kind must be ${APPMAP_COMPARISON_KIND}`);
+  if (value.schemaVersion !== APPMAP_COMPARISON_SCHEMA_VERSION)
+    errors.push(`$.schemaVersion must be ${APPMAP_COMPARISON_SCHEMA_VERSION}`);
+
+  if (!isRecord(value.producer)) errors.push('$.producer must be an object');
+  else {
+    validateString(value.producer.name, '$.producer.name', errors);
+    validateString(value.producer.version, '$.producer.version', errors);
+  }
+
+  if (!isRecord(value.scenario)) errors.push('$.scenario must be an object');
+  else {
+    validateString(value.scenario.id, '$.scenario.id', errors);
+    if (value.scenario.name !== undefined)
+      validateString(value.scenario.name, '$.scenario.name', errors);
+  }
+
+  if (value.revisions !== undefined) {
+    if (!isRecord(value.revisions)) errors.push('$.revisions must be an object');
+    else {
+      if (value.revisions.base !== undefined)
+        validateString(value.revisions.base, '$.revisions.base', errors);
+      if (value.revisions.head !== undefined)
+        validateString(value.revisions.head, '$.revisions.head', errors);
+    }
+  }
+
+  if (!isRecord(value.recordings)) errors.push('$.recordings must be an object');
+  else {
+    validateString(value.recordings.base, '$.recordings.base', errors);
+    validateString(value.recordings.head, '$.recordings.head', errors);
+  }
+
+  const availableViews = new Set<string>();
+  if (!isRecord(value.views) || Object.keys(value.views).length === 0) {
+    errors.push('$.views must contain at least one view');
+  } else {
+    Object.entries(value.views).forEach(([viewId, view]) => {
+      if (!viewIds.has(viewId)) errors.push(`$.views.${viewId} is unsupported`);
+      availableViews.add(viewId);
+      if (!isRecord(view)) {
+        errors.push(`$.views.${viewId} must be an object`);
+        return;
+      }
+      if (!Number.isInteger(view.schemaVersion) || Number(view.schemaVersion) < 1)
+        errors.push(`$.views.${viewId}.schemaVersion must be a positive integer`);
+      if (viewId === 'sequence') {
+        validateDiagram(view.base, '$.views.sequence.base', errors);
+        validateDiagram(view.head, '$.views.sequence.head', errors);
+        validateDiagram(view.diff, '$.views.sequence.diff', errors);
+        if (!isRecord(view.alignment)) errors.push('$.views.sequence.alignment must be an object');
+        else validateStringArray(view.alignment.actorOrder, '$.views.sequence.alignment.actorOrder', errors);
+      }
+    });
+  }
+
+  if (!isRecord(value.capabilities)) errors.push('$.capabilities must be an object');
+  else if (!isRecord(value.capabilities.views) || Object.keys(value.capabilities.views).length === 0)
+    errors.push('$.capabilities.views must contain at least one view capability');
+  else {
+    Object.entries(value.capabilities.views).forEach(([viewId, version]) => {
+      if (!viewIds.has(viewId)) errors.push(`$.capabilities.views.${viewId} is unsupported`);
+      if (!Number.isInteger(version) || Number(version) < 1)
+        errors.push(`$.capabilities.views.${viewId} must be a positive integer`);
+      const view = isRecord(value.views) ? value.views[viewId] : undefined;
+      if (!isRecord(view)) errors.push(`$.capabilities.views.${viewId} has no corresponding view`);
+      else if (view.schemaVersion !== version)
+        errors.push(`$.capabilities.views.${viewId} must match the view schemaVersion`);
+    });
+  }
+
+  if (!Array.isArray(value.changes)) errors.push('$.changes must be an array');
+  else {
+    const ids = new Set<string>();
+    value.changes.forEach((change, index) =>
+      validateChange(change, `$.changes[${index}]`, availableViews, ids, errors)
+    );
+  }
+
+  return errors;
+}
+
+export function assertAppMapComparison(value: unknown): asserts value is AppMapComparison {
+  const errors = validateAppMapComparison(value);
+  if (errors.length > 0)
+    throw new TypeError(`Invalid AppMap comparison bundle:\n- ${errors.join('\n- ')}`);
+}

--- a/packages/models/src/comparison.ts
+++ b/packages/models/src/comparison.ts
@@ -5,6 +5,8 @@ import comparisonSchema from '../schema/comparison.schema.json';
 export const APPMAP_COMPARISON_KIND = 'appmap.comparison' as const;
 export const APPMAP_COMPARISON_SCHEMA_VERSION = 1 as const;
 export const APPMAP_COMPARISON_CHANGE_ID_VERSION = 1 as const;
+export const APPMAP_COMPARISON_CHANGE_ID_PATTERN =
+  '^chg_[0-9a-f]{20}(?:_(?:[2-9]|[1-9][0-9]+))?$' as const;
 
 export const comparisonViewIds = ['dependency', 'sequence', 'trace', 'flame'] as const;
 export type ComparisonViewId = (typeof comparisonViewIds)[number];
@@ -114,10 +116,18 @@ export const appMapComparisonSchema = comparisonSchema;
 
 const changeKinds = new Set<string>(behavioralChangeKinds);
 const viewIds = new Set<string>(comparisonViewIds);
-const changeIdPattern = /^chg_[0-9a-f]{20}(?:_[2-9][0-9]*|_[1-9][0-9]+)?$/;
+const changeIdPattern = new RegExp(APPMAP_COMPARISON_CHANGE_ID_PATTERN);
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isComparisonValue(value: unknown): value is ComparisonValue {
+  if (value === null || typeof value === 'string' || typeof value === 'boolean') return true;
+  if (typeof value === 'number') return Number.isFinite(value);
+  if (Array.isArray(value)) return value.every(isComparisonValue);
+  if (isRecord(value)) return Object.values(value).every(isComparisonValue);
+  return false;
 }
 
 function canonicalize(value: unknown): string {
@@ -174,22 +184,29 @@ function validatePositiveIntegerArray(value: unknown, path: string, errors: stri
     return false;
   }
 
+  if (value.length === 0) errors.push(`${path} must not be empty`);
   const valid = value.every((item) => Number.isInteger(item) && item > 0);
   if (!valid) errors.push(`${path} must contain positive integers`);
   if (new Set(value).size !== value.length) errors.push(`${path} must contain unique values`);
-  return valid;
+  return value.length > 0 && valid;
 }
 
-function validateStringArray(value: unknown, path: string, errors: string[]): boolean {
+function validateStringArray(
+  value: unknown,
+  path: string,
+  errors: string[],
+  allowEmpty = false
+): boolean {
   if (!Array.isArray(value)) {
     errors.push(`${path} must be an array`);
     return false;
   }
 
+  if (!allowEmpty && value.length === 0) errors.push(`${path} must not be empty`);
   const valid = value.every((item) => typeof item === 'string' && item.length > 0);
   if (!valid) errors.push(`${path} must contain non-empty strings`);
   if (new Set(value).size !== value.length) errors.push(`${path} must contain unique values`);
-  return valid;
+  return (allowEmpty || value.length > 0) && valid;
 }
 
 function validateReference(value: unknown, path: string, errors: string[]): boolean {
@@ -200,14 +217,14 @@ function validateReference(value: unknown, path: string, errors: string[]): bool
 
   let hasReference = false;
   if (value.eventIds !== undefined) {
-    hasReference = true;
-    validatePositiveIntegerArray(value.eventIds, `${path}.eventIds`, errors);
+    hasReference = validatePositiveIntegerArray(value.eventIds, `${path}.eventIds`, errors) ||
+      hasReference;
   }
   if (value.elementIds !== undefined) {
-    hasReference = true;
-    validateStringArray(value.elementIds, `${path}.elementIds`, errors);
+    hasReference = validateStringArray(value.elementIds, `${path}.elementIds`, errors) ||
+      hasReference;
   }
-  if (!hasReference) errors.push(`${path} must contain eventIds or elementIds`);
+  if (!hasReference) errors.push(`${path} must contain at least one eventId or elementId`);
   return hasReference;
 }
 
@@ -220,6 +237,19 @@ function validateViewReference(value: unknown, path: string, errors: string[]): 
   const references = ['base', 'head', 'diff'].filter((side) => value[side] !== undefined);
   if (references.length === 0) errors.push(`${path} must reference base, head, or diff`);
   references.forEach((side) => validateReference(value[side], `${path}.${side}`, errors));
+}
+
+function validateValueChange(value: unknown, path: string, errors: string[]): void {
+  if (!isRecord(value)) {
+    errors.push(`${path} must be an object`);
+    return;
+  }
+
+  const sides = ['before', 'after'].filter((side) => value[side] !== undefined);
+  if (sides.length === 0) errors.push(`${path} must contain before or after`);
+  sides.forEach((side) => {
+    if (!isComparisonValue(value[side])) errors.push(`${path}.${side} must be JSON-compatible`);
+  });
 }
 
 function validateChange(
@@ -251,8 +281,10 @@ function validateChange(
       errors.push(`${path}.head is required for an added change`);
     if (value.kind.endsWith('-removed') && value.base === undefined)
       errors.push(`${path}.base is required for a removed change`);
-    if ((value.kind.endsWith('-changed') || value.kind.endsWith('-reordered')) &&
-        (value.base === undefined || value.head === undefined))
+    if (
+      (value.kind.endsWith('-changed') || value.kind.endsWith('-reordered')) &&
+      (value.base === undefined || value.head === undefined)
+    )
       errors.push(`${path}.base and ${path}.head are required for changed/reordered changes`);
   }
 
@@ -268,8 +300,13 @@ function validateChange(
   }
 
   if (value.labels !== undefined) validateStringArray(value.labels, `${path}.labels`, errors);
-  if (value.details !== undefined && !isRecord(value.details))
-    errors.push(`${path}.details must be an object`);
+  if (value.details !== undefined) {
+    if (!isRecord(value.details)) errors.push(`${path}.details must be an object`);
+    else
+      Object.entries(value.details).forEach(([name, detail]) =>
+        validateValueChange(detail, `${path}.details.${name}`, errors)
+      );
+  }
 }
 
 function validateDiagram(value: unknown, path: string, errors: string[]): void {
@@ -279,6 +316,33 @@ function validateDiagram(value: unknown, path: string, errors: string[]): void {
   }
   if (!Array.isArray(value.actors)) errors.push(`${path}.actors must be an array`);
   if (!Array.isArray(value.rootActions)) errors.push(`${path}.rootActions must be an array`);
+}
+
+function validateView(value: unknown, viewId: string, path: string, errors: string[]): void {
+  if (!isRecord(value)) {
+    errors.push(`${path} must be an object`);
+    return;
+  }
+
+  if (!Number.isInteger(value.schemaVersion) || Number(value.schemaVersion) < 1)
+    errors.push(`${path}.schemaVersion must be a positive integer`);
+
+  for (const field of ['base', 'head', 'diff', 'alignment']) {
+    if (!isRecord(value[field])) errors.push(`${path}.${field} must be an object`);
+  }
+
+  if (viewId === 'sequence') {
+    validateDiagram(value.base, `${path}.base`, errors);
+    validateDiagram(value.head, `${path}.head`, errors);
+    validateDiagram(value.diff, `${path}.diff`, errors);
+    if (isRecord(value.alignment))
+      validateStringArray(value.alignment.actorOrder, `${path}.alignment.actorOrder`, errors, true);
+  }
+}
+
+function validatePositiveInteger(value: unknown, path: string, errors: string[]): void {
+  if (!Number.isInteger(value) || Number(value) < 1)
+    errors.push(`${path} must be a positive integer`);
 }
 
 /** Return all contract violations. An empty result means the bundle is valid. */
@@ -326,37 +390,52 @@ export function validateAppMapComparison(value: unknown): string[] {
   } else {
     Object.entries(value.views).forEach(([viewId, view]) => {
       if (!viewIds.has(viewId)) errors.push(`$.views.${viewId} is unsupported`);
-      availableViews.add(viewId);
-      if (!isRecord(view)) {
-        errors.push(`$.views.${viewId} must be an object`);
-        return;
-      }
-      if (!Number.isInteger(view.schemaVersion) || Number(view.schemaVersion) < 1)
-        errors.push(`$.views.${viewId}.schemaVersion must be a positive integer`);
-      if (viewId === 'sequence') {
-        validateDiagram(view.base, '$.views.sequence.base', errors);
-        validateDiagram(view.head, '$.views.sequence.head', errors);
-        validateDiagram(view.diff, '$.views.sequence.diff', errors);
-        if (!isRecord(view.alignment)) errors.push('$.views.sequence.alignment must be an object');
-        else validateStringArray(view.alignment.actorOrder, '$.views.sequence.alignment.actorOrder', errors);
-      }
+      else availableViews.add(viewId);
+      validateView(view, viewId, `$.views.${viewId}`, errors);
     });
   }
 
+  const capabilityViews = new Set<string>();
   if (!isRecord(value.capabilities)) errors.push('$.capabilities must be an object');
-  else if (!isRecord(value.capabilities.views) || Object.keys(value.capabilities.views).length === 0)
-    errors.push('$.capabilities.views must contain at least one view capability');
   else {
-    Object.entries(value.capabilities.views).forEach(([viewId, version]) => {
-      if (!viewIds.has(viewId)) errors.push(`$.capabilities.views.${viewId} is unsupported`);
-      if (!Number.isInteger(version) || Number(version) < 1)
-        errors.push(`$.capabilities.views.${viewId} must be a positive integer`);
-      const view = isRecord(value.views) ? value.views[viewId] : undefined;
-      if (!isRecord(view)) errors.push(`$.capabilities.views.${viewId} has no corresponding view`);
-      else if (view.schemaVersion !== version)
-        errors.push(`$.capabilities.views.${viewId} must match the view schemaVersion`);
-    });
+    if (!isRecord(value.capabilities.views) || Object.keys(value.capabilities.views).length === 0) {
+      errors.push('$.capabilities.views must contain at least one view capability');
+    } else {
+      Object.entries(value.capabilities.views).forEach(([viewId, version]) => {
+        if (!viewIds.has(viewId)) errors.push(`$.capabilities.views.${viewId} is unsupported`);
+        else capabilityViews.add(viewId);
+        validatePositiveInteger(version, `$.capabilities.views.${viewId}`, errors);
+        const view = isRecord(value.views) ? value.views[viewId] : undefined;
+        if (!isRecord(view)) errors.push(`$.capabilities.views.${viewId} has no corresponding view`);
+        else if (view.schemaVersion !== version)
+          errors.push(`$.capabilities.views.${viewId} must match the view schemaVersion`);
+      });
+    }
+
+    if (value.capabilities.navigation !== undefined) {
+      if (!isRecord(value.capabilities.navigation))
+        errors.push('$.capabilities.navigation must be an object');
+      else {
+        if (value.capabilities.navigation.changes !== undefined)
+          validatePositiveInteger(
+            value.capabilities.navigation.changes,
+            '$.capabilities.navigation.changes',
+            errors
+          );
+        if (value.capabilities.navigation.eventAlignment !== undefined)
+          validatePositiveInteger(
+            value.capabilities.navigation.eventAlignment,
+            '$.capabilities.navigation.eventAlignment',
+            errors
+          );
+      }
+    }
   }
+
+  availableViews.forEach((viewId) => {
+    if (!capabilityViews.has(viewId))
+      errors.push(`$.views.${viewId} has no corresponding capability`);
+  });
 
   if (!Array.isArray(value.changes)) errors.push('$.changes must be an array');
   else {
@@ -365,6 +444,9 @@ export function validateAppMapComparison(value: unknown): string[] {
       validateChange(change, `$.changes[${index}]`, availableViews, ids, errors)
     );
   }
+
+  if (value.extensions !== undefined && !isRecord(value.extensions))
+    errors.push('$.extensions must be an object');
 
   return errors;
 }

--- a/packages/models/src/index.js
+++ b/packages/models/src/index.js
@@ -20,4 +20,5 @@ export {
   filterStringToFilterState,
   mergeFilterState,
 } from './serialize';
+export * from './comparison';
 export * from './util';

--- a/packages/models/tests/unit/comparison.spec.ts
+++ b/packages/models/tests/unit/comparison.spec.ts
@@ -2,6 +2,7 @@ import { readFile } from 'fs/promises';
 import path from 'path';
 
 import {
+  APPMAP_COMPARISON_CHANGE_ID_PATTERN,
   APPMAP_COMPARISON_KIND,
   APPMAP_COMPARISON_SCHEMA_VERSION,
   appMapComparisonSchema,
@@ -33,15 +34,18 @@ describe('AppMap comparison contract', () => {
     expect(appMapComparisonSchema.properties.schemaVersion.const).toBe(
       APPMAP_COMPARISON_SCHEMA_VERSION
     );
+    expect(appMapComparisonSchema.$defs.change.properties.id.pattern).toBe(
+      APPMAP_COMPARISON_CHANGE_ID_PATTERN
+    );
     expect(appMapComparisonSchema.$defs.change.properties.kind.enum).toEqual(
       behavioralChangeKinds
     );
     expect(Object.keys(appMapComparisonSchema.properties.views.properties)).toEqual(
       comparisonViewIds
     );
-    expect(Object.keys(appMapComparisonSchema.$defs.capabilities.properties.views.properties)).toEqual(
-      comparisonViewIds
-    );
+    expect(
+      Object.keys(appMapComparisonSchema.$defs.capabilities.properties.views.properties)
+    ).toEqual(comparisonViewIds);
   });
 
   it('canonicalizes identities independently of object key order', () => {
@@ -55,7 +59,7 @@ describe('AppMap comparison contract', () => {
 
   it('uses an occurrence suffix only for indistinguishable repeated changes', () => {
     const identity = { kind: 'call-added', action: 'authorize' };
-    expect(makeComparisonChangeId(identity)).toMatch(/^chg_[0-9a-f]{20}$/);
+    expect(makeComparisonChangeId(identity)).toMatch(new RegExp(APPMAP_COMPARISON_CHANGE_ID_PATTERN));
     expect(makeComparisonChangeId(identity, 1)).toBe(`${makeComparisonChangeId(identity)}_2`);
   });
 
@@ -68,5 +72,45 @@ describe('AppMap comparison contract', () => {
     const errors = validateAppMapComparison(duplicate);
     expect(errors).toContain('$.changes[1].id must be unique');
     expect(errors).toContain('$.capabilities.views.sequence must match the view schemaVersion');
+  });
+
+  it('rejects empty references and details without a before or after value', async () => {
+    const example = JSON.parse(JSON.stringify(await loadExample('added')));
+    example.changes[0].head.eventIds = [];
+    example.changes[0].details = { name: {} };
+
+    const errors = validateAppMapComparison(example);
+    expect(errors).toContain('$.changes[0].head.eventIds must not be empty');
+    expect(errors).toContain('$.changes[0].details.name must contain before or after');
+  });
+
+  it('requires every supplied view to declare a matching capability', async () => {
+    const example = JSON.parse(JSON.stringify(await loadExample('clean')));
+    example.views.trace = {
+      schemaVersion: 1,
+      base: {},
+      head: {},
+      diff: {},
+      alignment: {},
+    };
+
+    expect(validateAppMapComparison(example)).toContain(
+      '$.views.trace has no corresponding capability'
+    );
+  });
+
+  it('requires the correct side for added, removed, changed, and reordered changes', async () => {
+    const added = JSON.parse(JSON.stringify(await loadExample('added')));
+    delete added.changes[0].head;
+
+    const changed = JSON.parse(JSON.stringify(await loadExample('changed')));
+    delete changed.changes[0].base;
+
+    expect(validateAppMapComparison(added)).toContain(
+      '$.changes[0].head is required for an added change'
+    );
+    expect(validateAppMapComparison(changed)).toContain(
+      '$.changes[0].base and $.changes[0].head are required for changed/reordered changes'
+    );
   });
 });

--- a/packages/models/tests/unit/comparison.spec.ts
+++ b/packages/models/tests/unit/comparison.spec.ts
@@ -1,0 +1,61 @@
+import { readFile } from 'fs/promises';
+import path from 'path';
+
+import {
+  APPMAP_COMPARISON_KIND,
+  APPMAP_COMPARISON_SCHEMA_VERSION,
+  appMapComparisonSchema,
+  assertAppMapComparison,
+  canonicalComparisonIdentity,
+  makeComparisonChangeId,
+  validateAppMapComparison,
+} from '../../src/comparison';
+
+const examples = ['clean', 'added', 'removed', 'changed', 'reordered'];
+const examplesDir = path.resolve(__dirname, '../../schema/examples');
+
+async function loadExample(name: string): Promise<Record<string, unknown>> {
+  return JSON.parse(await readFile(path.join(examplesDir, `${name}.json`), 'utf8'));
+}
+
+describe('AppMap comparison contract', () => {
+  it.each(examples)('accepts the %s conformance fixture', async (name) => {
+    const example = await loadExample(name);
+    expect(validateAppMapComparison(example)).toEqual([]);
+    expect(() => assertAppMapComparison(example)).not.toThrow();
+  });
+
+  it('exports a schema which matches the runtime constants', () => {
+    expect(appMapComparisonSchema.$id).toBe('https://appmap.io/schemas/comparison/v1');
+    expect(appMapComparisonSchema.properties.kind.const).toBe(APPMAP_COMPARISON_KIND);
+    expect(appMapComparisonSchema.properties.schemaVersion.const).toBe(
+      APPMAP_COMPARISON_SCHEMA_VERSION
+    );
+  });
+
+  it('canonicalizes identities independently of object key order', () => {
+    expect(canonicalComparisonIdentity({ head: 2, base: 1 })).toBe(
+      canonicalComparisonIdentity({ base: 1, head: 2 })
+    );
+    expect(makeComparisonChangeId({ head: 2, base: 1 })).toBe(
+      makeComparisonChangeId({ base: 1, head: 2 })
+    );
+  });
+
+  it('uses an occurrence suffix only for indistinguishable repeated changes', () => {
+    const identity = { kind: 'call-added', action: 'authorize' };
+    expect(makeComparisonChangeId(identity)).toMatch(/^chg_[0-9a-f]{20}$/);
+    expect(makeComparisonChangeId(identity, 1)).toBe(`${makeComparisonChangeId(identity)}_2`);
+  });
+
+  it('rejects duplicate change ids and mismatched view capabilities', async () => {
+    const example = await loadExample('added');
+    const duplicate = JSON.parse(JSON.stringify(example));
+    duplicate.changes.push(duplicate.changes[0]);
+    duplicate.capabilities.views.sequence = 2;
+
+    const errors = validateAppMapComparison(duplicate);
+    expect(errors).toContain('$.changes[1].id must be unique');
+    expect(errors).toContain('$.capabilities.views.sequence must match the view schemaVersion');
+  });
+});

--- a/packages/models/tests/unit/comparison.spec.ts
+++ b/packages/models/tests/unit/comparison.spec.ts
@@ -6,7 +6,9 @@ import {
   APPMAP_COMPARISON_SCHEMA_VERSION,
   appMapComparisonSchema,
   assertAppMapComparison,
+  behavioralChangeKinds,
   canonicalComparisonIdentity,
+  comparisonViewIds,
   makeComparisonChangeId,
   validateAppMapComparison,
 } from '../../src/comparison';
@@ -25,11 +27,20 @@ describe('AppMap comparison contract', () => {
     expect(() => assertAppMapComparison(example)).not.toThrow();
   });
 
-  it('exports a schema which matches the runtime constants', () => {
+  it('keeps the published JSON schema aligned with runtime constants', () => {
     expect(appMapComparisonSchema.$id).toBe('https://appmap.io/schemas/comparison/v1');
     expect(appMapComparisonSchema.properties.kind.const).toBe(APPMAP_COMPARISON_KIND);
     expect(appMapComparisonSchema.properties.schemaVersion.const).toBe(
       APPMAP_COMPARISON_SCHEMA_VERSION
+    );
+    expect(appMapComparisonSchema.$defs.change.properties.kind.enum).toEqual(
+      behavioralChangeKinds
+    );
+    expect(Object.keys(appMapComparisonSchema.properties.views.properties)).toEqual(
+      comparisonViewIds
+    );
+    expect(Object.keys(appMapComparisonSchema.$defs.capabilities.properties.views.properties)).toEqual(
+      comparisonViewIds
     );
   });
 

--- a/packages/models/types/comparison.d.ts
+++ b/packages/models/types/comparison.d.ts
@@ -1,0 +1,116 @@
+declare module '@appland/models' {
+  export const APPMAP_COMPARISON_KIND: 'appmap.comparison';
+  export const APPMAP_COMPARISON_SCHEMA_VERSION: 1;
+  export const APPMAP_COMPARISON_CHANGE_ID_VERSION: 1;
+
+  export const comparisonViewIds: readonly ['dependency', 'sequence', 'trace', 'flame'];
+  export type ComparisonViewId = (typeof comparisonViewIds)[number];
+
+  export const behavioralChangeKinds: readonly [
+    'call-added',
+    'call-removed',
+    'call-changed',
+    'call-reordered',
+    'query-added',
+    'query-removed',
+    'query-changed',
+    'rpc-added',
+    'rpc-removed',
+    'rpc-changed',
+    'dependency-added',
+    'dependency-removed',
+    'dependency-changed',
+    'exception-added',
+    'exception-removed',
+    'exception-changed',
+    'control-flow-added',
+    'control-flow-removed',
+    'control-flow-changed',
+    'timing-changed',
+    'unknown'
+  ];
+  export type BehavioralChangeKind = (typeof behavioralChangeKinds)[number];
+
+  export type ComparisonValue =
+    | null
+    | boolean
+    | number
+    | string
+    | ComparisonValue[]
+    | { [key: string]: ComparisonValue };
+
+  export type ComparisonValueChange = {
+    before?: ComparisonValue;
+    after?: ComparisonValue;
+  };
+
+  export type ComparisonReference = {
+    eventIds?: number[];
+    elementIds?: string[];
+  };
+
+  export type ComparisonViewReference = {
+    base?: ComparisonReference;
+    head?: ComparisonReference;
+    diff?: ComparisonReference;
+  };
+
+  export type BehavioralChange = {
+    id: string;
+    kind: BehavioralChangeKind;
+    summary: string;
+    base?: ComparisonReference;
+    head?: ComparisonReference;
+    views: Partial<Record<ComparisonViewId, ComparisonViewReference>>;
+    details?: Record<string, ComparisonValueChange>;
+    labels?: string[];
+  };
+
+  export type ComparisonView<TPayload = unknown, TAlignment = unknown> = {
+    schemaVersion: number;
+    base: TPayload;
+    head: TPayload;
+    diff: TPayload;
+    alignment: TAlignment;
+  };
+
+  export type ComparisonViewMap = Partial<Record<ComparisonViewId, ComparisonView>>;
+
+  export type AppMapComparison<TViews extends ComparisonViewMap = ComparisonViewMap> = {
+    kind: typeof APPMAP_COMPARISON_KIND;
+    schemaVersion: typeof APPMAP_COMPARISON_SCHEMA_VERSION;
+    producer: {
+      name: string;
+      version: string;
+    };
+    scenario: {
+      id: string;
+      name?: string;
+    };
+    revisions?: {
+      base?: string;
+      head?: string;
+    };
+    recordings: {
+      base: string;
+      head: string;
+    };
+    capabilities: {
+      views: Partial<Record<ComparisonViewId, number>>;
+      navigation?: {
+        changes?: number;
+        eventAlignment?: number;
+      };
+    };
+    changes: BehavioralChange[];
+    views: TViews;
+    extensions?: Record<string, unknown>;
+  };
+
+  export const appMapComparisonSchema: Record<string, any>;
+
+  export function canonicalComparisonIdentity(identity: unknown): string;
+  export function makeComparisonChangeId(identity: unknown, occurrence?: number): string;
+  export function validateAppMapComparison(value: unknown): string[];
+  export function assertAppMapComparison(value: unknown): asserts value is AppMapComparison;
+}

--- a/packages/models/types/comparison.d.ts
+++ b/packages/models/types/comparison.d.ts
@@ -2,6 +2,8 @@ declare module '@appland/models' {
   export const APPMAP_COMPARISON_KIND: 'appmap.comparison';
   export const APPMAP_COMPARISON_SCHEMA_VERSION: 1;
   export const APPMAP_COMPARISON_CHANGE_ID_VERSION: 1;
+  export const APPMAP_COMPARISON_CHANGE_ID_PATTERN:
+    '^chg_[0-9a-f]{20}(?:_(?:[2-9]|[1-9][0-9]+))?$';
 
   export const comparisonViewIds: readonly ['dependency', 'sequence', 'trace', 'flame'];
   export type ComparisonViewId = (typeof comparisonViewIds)[number];

--- a/packages/models/types/public.d.ts
+++ b/packages/models/types/public.d.ts
@@ -1,0 +1,2 @@
+/// <reference path="./index.d.ts" />
+/// <reference path="./comparison.d.ts" />


### PR DESCRIPTION
## Purpose

Introduce the first data-plane primitive for an interactive AppMap PR comparison workspace: one portable file containing the **before diagram**, **after diagram**, **merged semantic diff**, and event alignment for synchronized change navigation.

This is the Sequence Diagram vertical slice toward synchronized before/after/overlay views for Dependency Map, Sequence Diagram, Trace View, and Flame Graph.

## Changes

- Add `appmap sequence-diagram-compare <base-appmap> <head-appmap>`.
- Emit `*.compare.diff.sequence.json` containing:
  - serialized base and head sequence diagrams;
  - the existing merged semantic diff;
  - aligned actor ordering;
  - stable change IDs;
  - base/head/diff event IDs for added, removed, and changed actions;
  - optional scenario and revision metadata.
- Register the command in the CLI.
- Add a focused unit test using existing AppMap fixtures.

## Example

```sh
appmap sequence-diagram-compare \
  base.appmap.json \
  head.appmap.json \
  --scenario login-success \
  --base-revision "$BASE_SHA" \
  --head-revision "$HEAD_SHA" \
  --output-file login-success.compare.diff.sequence.json
```

## Companion work

- Viewer: `tryingET/vscode-appland#1`
- End-to-end producer/dogfood: `tryingET/appmap-node#1`
- Artifact publisher: `tryingET/review-action#1`
- Deterministic comparison skill: `tryingET/skills#1`

## Validation

Cross-repository dogfood is green in [`tryingET/appmap-node` run 32134789649](https://github.com/tryingET/appmap-node/actions/runs/32134789649):

- [x] CLI branch builds and runs the new command.
- [x] Exact base/head `appmap-node` revisions build.
- [x] Recordings are sanitized.
- [x] Control comparison contains 0 changes.
- [x] Visual comparison contains exactly 1 added `authorize` call.
- [x] Portable comparison artifact uploads.
- [x] The real generated bundle opens in the companion VS Code Electron test.
- [x] Dogfood VSIX packages and uploads.
- [x] Review-action publisher/skill harness passes.

Artifacts:

- `appmap-pr-comparison` — artifact `9323691826`, SHA-256 `0cd6a4fc0a11f38713e6739fbab585e2f553dd6cece002d33c4d53a66651e0e9`
- `appmap-comparison-vsix` — artifact `9323896071`, SHA-256 `7855a61259d588b0ee12807143f6dd63c15a33708f67722a474db07207b531f0`

The upstream CI and native-build runs currently show `action_required`, awaiting first-time-contributor workflow approval rather than reporting a code failure. The PR remains draft while the dependency chain is reviewed.