### PR TITLE
Support `APPMAP_CUSTOMER_ID` (managed entitlement)

### DIFF
--- a/packages/cli/src/lib/checkLicense.ts
+++ b/packages/cli/src/lib/checkLicense.ts
@@ -1,29 +1,59 @@
-import { warn } from 'node:console';
+/* eslint-disable no-console */
+// These warnings are the command's user-facing licensing output, not print debugging.
+//
+// Most of this package marks such output by importing `warn` from 'console' instead, which
+// sidesteps no-console because the rule only matches the global. That import also bypasses jest's
+// console, so the messages escape test buffering — hence the global here. A shared output helper
+// owning this suppression would be better than either, but that is a package-wide change.
 
 import { loadConfiguration, LicenseKey } from '@appland/client';
 import { Telemetry } from '@appland/telemetry';
 
+import customerId from './customerId';
+
 export default async function checkLicense(required = false): Promise<void> {
   const config = loadConfiguration(false);
+  const customer = customerId();
+
+  // Reported whatever the key turns out to be: an entitled installation that says nothing about it
+  // is indistinguishable from one where the customer ID was never configured.
+  if (customer)
+    console.warn(
+      `Entitled to AppMap as customer ${customer} at machine id ${Telemetry.machineId}.`
+    );
+
+  // A customer ID entitles the installation on its own, so a key that is missing, rejected or
+  // unverifiable is reported but not fatal. Throw when nothing covers the problem and leave the
+  // caller to surface it; otherwise this is the only report of it.
+  const licenseProblem = (message: string, error?: unknown): void => {
+    if (required && !customer) throw error ?? new Error(message);
+    console.warn(`Warning: ${message}`);
+  };
 
   if (!config.apiKey) {
-    warn(
-      'Warning: No license key provided. Please set the APPMAP_API_KEY environment variable.'
-    );
-    if (required) throw new Error('License key is required');
+    // Entitlement is reported above, and the missing key is expected in that case.
+    if (customer) return;
+
+    licenseProblem('No license key provided. Please set the APPMAP_API_KEY environment variable.');
     return;
   }
 
+  // The key is still checked when a customer ID is also set: it is what authenticates, and the
+  // check is a server-visible event that usage tracking depends on. Entitlement only decides
+  // whether a bad outcome is fatal.
   try {
     if (await LicenseKey.check(config.apiKey)) {
-      warn(`Valid license for ${config.username ?? 'unknown user'} at machine id ${Telemetry.machineId}.`);
-    } else {
-      warn('Warning: The provided license key is not valid.');
-      if (required) throw new Error('The provided license key is not valid');
+      console.warn(
+        `Valid license for ${config.username ?? 'unknown user'} at machine id ${Telemetry.machineId}.`
+      );
+      return;
     }
   } catch (e) {
-    warn('Warning: Failed to check license key:');
-    warn(e);
-    if (required) throw e;
+    // Rethrow the original error rather than one built from the message, so a caller that does
+    // escalate keeps the stack.
+    licenseProblem(`Failed to check license key: ${e instanceof Error ? e.message : String(e)}`, e);
+    return;
   }
+
+  licenseProblem('The provided license key is not valid.');
 }

--- a/packages/cli/src/lib/customerId.ts
+++ b/packages/cli/src/lib/customerId.ts
@@ -1,0 +1,13 @@
+/**
+ * The customer ID identifies the customer in a managed deployment, where entitlement is settled by
+ * a B2B agreement rather than by authenticating against getappmap.com. It is set by administrators
+ * through the IDE extension's organization configuration, which passes it down to this process as
+ * APPMAP_CUSTOMER_ID.
+ *
+ * It is *not* a credential and never stands in for an API key: when both are present the API key
+ * wins for authentication and the customer ID is attribution-only. Blank values read as unset.
+ */
+export default function customerId(): string | undefined {
+  const value = process.env.APPMAP_CUSTOMER_ID?.trim();
+  return value ? value : undefined;
+}

--- a/packages/cli/tests/unit/lib/checkLicense.spec.ts
+++ b/packages/cli/tests/unit/lib/checkLicense.spec.ts
@@ -1,0 +1,150 @@
+import { LicenseKey, loadConfiguration } from '@appland/client';
+import { Telemetry } from '@appland/telemetry';
+
+import checkLicense from '../../../src/lib/checkLicense';
+
+jest.mock('@appland/client');
+
+const loadConfigurationMock = jest.mocked(loadConfiguration);
+const checkMock = jest.mocked(LicenseKey.check);
+
+const ENTITLED = `Entitled to AppMap as customer acme-corp at machine id ${Telemetry.machineId}.`;
+
+describe('checkLicense', () => {
+  let warn: jest.SpyInstance<void, unknown[]>;
+
+  beforeEach(() => {
+    // Not stubbed: jest's console is silent by default (`silent` in jest.config.js), and letting
+    // the messages through means TEST_SILENT=false shows what the command actually prints.
+    warn = jest.spyOn(console, 'warn');
+    loadConfigurationMock.mockReturnValue({
+      baseURL: 'https://getappmap.com',
+      apiURL: 'https://api.getappmap.com',
+    });
+  });
+
+  // Spies are restored by the suite's `restoreMocks` setting; this resets the automocked module.
+  afterEach(() => {
+    jest.resetAllMocks();
+    delete process.env.APPMAP_CUSTOMER_ID;
+  });
+
+  const messages = () => warn.mock.calls.map(([message]) => String(message));
+
+  describe('with no API key', () => {
+    it('warns that no license key was provided', async () => {
+      await checkLicense();
+
+      expect(messages()).toEqual([
+        'Warning: No license key provided. Please set the APPMAP_API_KEY environment variable.',
+      ]);
+    });
+
+    it('throws, and does not also warn, when a license is required', async () => {
+      await expect(checkLicense(true)).rejects.toThrow('No license key provided');
+      expect(messages()).toEqual([]);
+    });
+
+    describe('and a customer ID', () => {
+      beforeEach(() => (process.env.APPMAP_CUSTOMER_ID = 'acme-corp'));
+
+      it('reports entitlement instead of warning', async () => {
+        await checkLicense();
+
+        expect(messages()).toEqual([ENTITLED]);
+      });
+
+      it('satisfies a required license', async () => {
+        await expect(checkLicense(true)).resolves.toBeUndefined();
+      });
+
+      it('treats a blank customer ID as unset', async () => {
+        process.env.APPMAP_CUSTOMER_ID = '  ';
+
+        await checkLicense();
+
+        expect(messages()).toEqual([
+          'Warning: No license key provided. Please set the APPMAP_API_KEY environment variable.',
+        ]);
+      });
+    });
+  });
+
+  describe('with an API key', () => {
+    beforeEach(() => {
+      loadConfigurationMock.mockReturnValue({
+        baseURL: 'https://getappmap.com',
+        apiURL: 'https://api.getappmap.com',
+        apiKey: 'the-api-key',
+        username: 'alice',
+      });
+      checkMock.mockResolvedValue(true);
+    });
+
+    it('checks the key', async () => {
+      await checkLicense();
+
+      expect(checkMock).toHaveBeenCalledWith('the-api-key');
+      expect(messages()).toEqual([expect.stringContaining('Valid license for alice')]);
+    });
+
+    it('still checks the key, and reports entitlement too, when a customer ID is also set', async () => {
+      process.env.APPMAP_CUSTOMER_ID = 'acme-corp';
+
+      await checkLicense();
+
+      expect(checkMock).toHaveBeenCalledWith('the-api-key');
+      expect(messages()).toEqual([ENTITLED, expect.stringContaining('Valid license for alice')]);
+    });
+
+    describe('that is rejected', () => {
+      beforeEach(() => checkMock.mockResolvedValue(false));
+
+      it('warns when a license is not required', async () => {
+        await checkLicense();
+        expect(messages()).toEqual(['Warning: The provided license key is not valid.']);
+      });
+
+      it('throws, and does not also warn, when a license is required', async () => {
+        await expect(checkLicense(true)).rejects.toThrow('The provided license key is not valid');
+        expect(messages()).toEqual([]);
+      });
+
+      it('is not fatal when a customer ID is set', async () => {
+        process.env.APPMAP_CUSTOMER_ID = 'acme-corp';
+
+        await expect(checkLicense(true)).resolves.toBeUndefined();
+
+        expect(checkMock).toHaveBeenCalledWith('the-api-key');
+        expect(messages()).toEqual([ENTITLED, 'Warning: The provided license key is not valid.']);
+      });
+    });
+
+    describe('that cannot be checked', () => {
+      const failure = new Error('ECONNREFUSED');
+
+      beforeEach(() => checkMock.mockRejectedValue(failure));
+
+      it('warns when a license is not required', async () => {
+        await checkLicense();
+        expect(messages()).toEqual(['Warning: Failed to check license key: ECONNREFUSED']);
+      });
+
+      it('rethrows the original error when a license is required', async () => {
+        await expect(checkLicense(true)).rejects.toBe(failure);
+        expect(messages()).toEqual([]);
+      });
+
+      it('is not fatal when a customer ID is set', async () => {
+        process.env.APPMAP_CUSTOMER_ID = 'acme-corp';
+
+        await expect(checkLicense(true)).resolves.toBeUndefined();
+
+        expect(messages()).toEqual([
+          ENTITLED,
+          'Warning: Failed to check license key: ECONNREFUSED',
+        ]);
+      });
+    });
+  });
+});

--- a/packages/telemetry/README.md
+++ b/packages/telemetry/README.md
@@ -36,6 +36,7 @@ The telemetry client can be configured using environment variables.
 *   `APPMAP_TELEMETRY_DISABLED`: Set to `1`, `true`, or `yes` to disable telemetry.
 *   `APPMAP_TELEMETRY_DEBUG`: Set to `1`, `true`, or `yes` to enable debug logging, which will print telemetry events to the console.
 *   `APPMAP_TELEMETRY_BACKEND`: Specifies the telemetry backend to use. Supported values are `application-insights` (default) and `splunk`.
+*   `APPMAP_CUSTOMER_ID`: Identifies the customer in a managed deployment. When set to a non-blank value it is reported on every event as `common.customerid`. It is not a credential and grants nothing on its own.
 
 ### Splunk Backend
 

--- a/packages/telemetry/src/client.ts
+++ b/packages/telemetry/src/client.ts
@@ -89,12 +89,16 @@ function buildDefaultConfiguration(
   // By default, the prop prefix will be the product name with non-word characters replaced by dots.
   const propPrefix = base.propPrefix || product.name.replace(/\W/g, '.').replace(/^\./, '') + '.';
   const backend = base.backend || defaultBackend();
+  // Set by managed deployments to attribute usage to a customer. Not a credential.
+  const customerId = process.env.APPMAP_CUSTOMER_ID?.trim();
+
   const properties: Record<string, string> = {
     'common.source': product.name,
     'common.os': os.platform(),
     'common.platformversion': os.release(),
     'common.arch': os.arch(),
     'common.hostname': os.hostname(),
+    ...(customerId ? { 'common.customerid': customerId } : {}),
     ...base.properties,
   };
 

--- a/packages/telemetry/tests/client.spec.ts
+++ b/packages/telemetry/tests/client.spec.ts
@@ -144,6 +144,47 @@ describe('TelemetryClient', () => {
       }
     });
 
+    it('does not send common.customerid when no customer ID is set', () => {
+      client.sendEvent({ name: 'test' });
+
+      const [[{ properties }]] = sendEvent.mock.calls;
+      assert(properties);
+
+      expect(properties).not.toHaveProperty('common.customerid');
+    });
+
+    it('sends the customer ID from the environment', () => {
+      process.env.APPMAP_CUSTOMER_ID = ' acme-corp ';
+      try {
+        const client = new TelemetryClient({ backend });
+        client.enabled = true;
+        client.sendEvent({ name: 'test' });
+
+        const [[{ properties }]] = sendEvent.mock.calls;
+        assert(properties);
+
+        expect(properties['common.customerid']).toBe('acme-corp');
+      } finally {
+        delete process.env.APPMAP_CUSTOMER_ID;
+      }
+    });
+
+    it('treats a blank customer ID as unset', () => {
+      process.env.APPMAP_CUSTOMER_ID = '  ';
+      try {
+        const client = new TelemetryClient({ backend });
+        client.enabled = true;
+        client.sendEvent({ name: 'test' });
+
+        const [[{ properties }]] = sendEvent.mock.calls;
+        assert(properties);
+
+        expect(properties).not.toHaveProperty('common.customerid');
+      } finally {
+        delete process.env.APPMAP_CUSTOMER_ID;
+      }
+    });
+
     it('cannot be configured twice', () => {
       // It's already been configured once in the constructor
       expect(() => {


### PR DESCRIPTION
## Motivation

In enterprise deployments where licensing is already settled by a B2B agreement, requiring every user to authenticate against getappmap.com is pure friction: it fails outright under network restrictions and creates audit review burden for a flow that grants nothing the contract hasn't already granted. Administrators can now set a customer ID through the IDE's organization-configuration channels, which passes it down to CLI subprocesses as `APPMAP_CUSTOMER_ID`.

This is the appmap-js half of that feature, and it is deliberately small — until now the CLI simply ignored the variable. Two things change: telemetry reports it, and `checkLicense` treats it as entitlement.

It is **not** a cryptographic license key and must never be described as an enforcement mechanism. The code is open source, so any client-side check is a business-process boundary rather than a security boundary. The identifier is not a secret and grants nothing on its own.

Companion PRs, which share the naming and the semantics:

- VS Code extension: getappmap/vscode-appland#1119
- IntelliJ plugin: getappmap/appmap-intellij-plugin#959

## `common.customerid` telemetry

`buildDefaultConfiguration` reads `APPMAP_CUSTOMER_ID` and adds `common.customerid` alongside the other `common.*` defaults, so it lands on every event, on both backends, from every entry point. Blank and whitespace-only values read as unset rather than being reported as an empty string, and `base.properties` / `APPMAP_TELEMETRY_PROPERTIES` can still override it.

Note this lives in `@appland/telemetry`, so it applies to every consumer of the package rather than only to the CLI. The CLI picks it up for free — `packages/cli/src/cli.ts:51` configures the shared default client.

The property name is deliberately all lower-case with no separator, matching the existing `common.extname` / `common.ideversion` style. The other two implementations depend on that spelling.

## Entitlement in `checkLicense`

A customer ID entitles the installation on its own, so the licensing check reports that state instead of warning about a key the user was never expected to have.

Entitlement is not a credential and never substitutes for one. When an API key is present it is still checked — the real key wins for authentication, and the check stays visible to the server, which usage tracking depends on. Entitlement only decides whether a bad outcome is *fatal*: a key that is missing, rejected or unverifiable is still reported, but does not fail a `required` check for an installation a contract already entitles.

Entitlement is reported unconditionally whenever a customer ID is set, before anything is said about the key. An entitled installation that stayed silent about it would be indistinguishable from one where the customer ID was never configured — exactly the thing an administrator is trying to confirm.

What the command prints:

| State | Output |
| --- | --- |
| Entitled, no API key | `Entitled to AppMap as customer acme-corp at machine id <id>.` |
| Entitled, valid key | the same line, then `Valid license for alice at machine id <id>.` |
| Entitled, key rejected or unverifiable | the same line, then the warning |
| Not entitled | unchanged in every case |

The machine id is on the entitlement message for the same reason 1acab71e9 put it on the valid-key message — correlating telemetry with user logs for troubleshooting. That applies at least as strongly here, since attributing usage to a customer is the whole point of this deployment mode.

## Incidental fixes

Found while restructuring `checkLicense`; none are related to customer IDs.

- The invalid-key `throw` sat *inside* the `try` that catches check failures, so a required check against an invalid key reported `Failed to check license key` over its own error before rethrowing it.
- A failed check `warn()`ed the caught error object, printing a backtrace nobody needs. It now reports the underlying message on the one line.
- A fatal problem was both warned about and thrown, reporting it twice once the caller surfaced the error. `licenseProblem` now does one or the other.

## Notes for review

`checkLicense` switches from the imported `warn` to the global `console.warn` behind a file-level `eslint-disable no-console`. This is the one stylistic oddity in the diff and it is deliberate: most of this package imports `warn` from `'console'`, which sidesteps the lint rule because the rule only matches the global — but that import also resolves against Node's real console rather than the one jest installs, so the messages escape test buffering and land on raw stderr, uncaptured. Writing to the global lets the tests spy on it with a plain `jest.spyOn(console, 'warn')` and lets `TEST_SILENT=false` attribute each message to its source line. A shared output helper owning that suppression would be better than either, but that is a package-wide change (~53 files) and not one for this PR to make.

One contract change: the error thrown for a missing key is now the warning text rather than `'License key is required'`, so what you see is what gets thrown. All three call sites use `required = false`, so nothing observable changes today.

## Testing

`packages/cli/tests/unit/lib/checkLicense.spec.ts` is new — 13 cases covering entitled and unentitled across no key, valid key, rejected key and unreachable check, each split into the warns-when-not-required and throws-without-warning-when-required outcomes, plus blank-value handling and the both-present case that pins "the key is still checked".

Three cases added to `packages/telemetry/tests/client.spec.ts` for present, absent and blank customer IDs.

`yarn verify` is clean on both packages.