### PR TITLE
chore(deps): Drop octokit from scanner in favor of plain fetch

### DIFF
--- a/packages/scanner/package.json
+++ b/packages/scanner/package.json
@@ -81,7 +81,6 @@
     "js-yaml": "^4.3.1",
     "lru-cache": "^10",
     "minimatch": "^5.1.9",
-    "octokit": "^2.0.19",
     "openapi-diff": "^0.23.6",
     "ora": "~5",
     "pretty-format": "^27.4.6",

--- a/packages/scanner/src/integration/github/commitStatus.ts
+++ b/packages/scanner/src/integration/github/commitStatus.ts
@@ -1,5 +1,3 @@
-import { Octokit } from 'octokit';
-
 import {
   owner,
   repo,
@@ -13,7 +11,9 @@ import {
 
 type CommitStatusState = 'pending' | 'success' | 'error' | 'failure';
 
-export default function postCommitStatus(
+const GITHUB_API_URL = 'https://api.github.com';
+
+export default async function postCommitStatus(
   state: CommitStatusState,
   description: string
 ): Promise<unknown> {
@@ -22,15 +22,32 @@ export default function postCommitStatus(
   validateOwner();
   validateSha();
 
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const octo = new Octokit({ auth: token() });
+  const url = `${GITHUB_API_URL}/repos/${encodeURIComponent(owner()!)}/${encodeURIComponent(
+    repo()!
+  )}/statuses/${encodeURIComponent(sha()!)}`;
 
-  return octo.rest.repos.createCommitStatus({
-    owner: owner()!,
-    repo: repo()!,
-    sha: sha()!,
-    state: state,
-    context: 'appland/scanner',
-    description: description,
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      accept: 'application/vnd.github+json',
+      authorization: `token ${token()!}`,
+      'content-type': 'application/json',
+      'user-agent': 'appland-scanner',
+      'x-github-api-version': '2022-11-28',
+    },
+    body: JSON.stringify({
+      state,
+      context: 'appland/scanner',
+      description,
+    }),
   });
+
+  if (!response.ok)
+    throw new Error(
+      `Failed to update commit status: ${response.status} ${
+        response.statusText
+      } ${await response.text()}`
+    );
+
+  return (await response.json()) as unknown;
 }

--- a/packages/scanner/test/integration/github/commitStatus.spec.ts
+++ b/packages/scanner/test/integration/github/commitStatus.spec.ts
@@ -1,0 +1,86 @@
+import postCommitStatus from '../../../src/integration/github/commitStatus';
+import { ValidationError } from '../../../src/errors';
+
+const ENV_VARS = [
+  'GH_STATUS_TOKEN',
+  'GH_TOKEN',
+  'CIRCLE_SHA1',
+  'TRAVIS_PULL_REQUEST_SHA',
+  'TRAVIS_COMMIT',
+  'CI_COMMIT_ID',
+  'GITHUB_SHA',
+  'CIRCLE_PROJECT_USERNAME',
+  'CIRCLE_PROJECT_REPONAME',
+  'TRAVIS_REPO_SLUG',
+  'CI_REPO_OWNER',
+  'CI_REPO_NAME',
+];
+
+describe('postCommitStatus', () => {
+  const originalEnv = process.env;
+  let fetchMock: jest.SpyInstance;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    for (const name of ENV_VARS) delete process.env[name];
+
+    process.env.GH_TOKEN = 'the-token';
+    process.env.GITHUB_SHA = 'deadbeef';
+    process.env.CIRCLE_PROJECT_USERNAME = 'getappmap';
+    process.env.CIRCLE_PROJECT_REPONAME = 'appmap-js';
+
+    fetchMock = jest.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ id: 1, state: 'success' }), {
+        status: 201,
+        headers: { 'content-type': 'application/json' },
+      })
+    );
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    jest.restoreAllMocks();
+  });
+
+  it('posts the status to the commit statuses endpoint', async () => {
+    const result = await postCommitStatus('success', '3 checks passed');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+
+    expect(url).toBe('https://api.github.com/repos/getappmap/appmap-js/statuses/deadbeef');
+    expect(init.method).toBe('POST');
+    expect(init.headers).toMatchObject({ authorization: 'token the-token' });
+    expect(JSON.parse(init.body as string)).toEqual({
+      state: 'success',
+      context: 'appland/scanner',
+      description: '3 checks passed',
+    });
+    expect(result).toEqual({ id: 1, state: 'success' });
+  });
+
+  it('URL-encodes owner, repo and sha', async () => {
+    process.env.CIRCLE_PROJECT_REPONAME = 'weird/repo name';
+
+    await postCommitStatus('pending', 'running');
+
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://api.github.com/repos/getappmap/weird%2Frepo%20name/statuses/deadbeef'
+    );
+  });
+
+  it('throws when GitHub rejects the request', async () => {
+    fetchMock.mockResolvedValue(new Response('Bad credentials', { status: 401 }));
+
+    await expect(postCommitStatus('failure', '1 finding')).rejects.toThrow(
+      /Failed to update commit status: 401 .*Bad credentials/
+    );
+  });
+
+  it('validates configuration before making a request', async () => {
+    delete process.env.GH_TOKEN;
+
+    await expect(postCommitStatus('success', 'ok')).rejects.toThrow(ValidationError);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -535,7 +535,6 @@ __metadata:
     lru-cache: "npm:^10"
     minimatch: "npm:^5.1.9"
     nock: "npm:^13.2.2"
-    octokit: "npm:^2.0.19"
     openapi-diff: "npm:^0.23.6"
     openapi-types: "npm:^9.3.0"
     ora: "npm:~5"
@@ -4287,79 +4286,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@octokit/app@npm:^13.1.5":
-  version: 13.1.5
-  resolution: "@octokit/app@npm:13.1.5"
-  dependencies:
-    "@octokit/auth-app": "npm:^4.0.13"
-    "@octokit/auth-unauthenticated": "npm:^3.0.0"
-    "@octokit/core": "npm:^4.0.0"
-    "@octokit/oauth-app": "npm:^4.0.7"
-    "@octokit/plugin-paginate-rest": "npm:^6.0.0"
-    "@octokit/types": "npm:^9.0.0"
-    "@octokit/webhooks": "npm:^10.0.0"
-  checksum: 10c0/deb79bbf29e1704e4981a8fe2344510a2e65a3f647331f03bd1d575803362dc33d78aee4b195c68bcee1787053de2a9b74b6cb75d69fc95eee5af9326fefbcbd
-  languageName: node
-  linkType: hard
-
-"@octokit/auth-app@npm:^4.0.13":
-  version: 4.0.13
-  resolution: "@octokit/auth-app@npm:4.0.13"
-  dependencies:
-    "@octokit/auth-oauth-app": "npm:^5.0.0"
-    "@octokit/auth-oauth-user": "npm:^2.0.0"
-    "@octokit/request": "npm:^6.0.0"
-    "@octokit/request-error": "npm:^3.0.0"
-    "@octokit/types": "npm:^9.0.0"
-    deprecation: "npm:^2.3.1"
-    lru-cache: "npm:^9.0.0"
-    universal-github-app-jwt: "npm:^1.1.1"
-    universal-user-agent: "npm:^6.0.0"
-  checksum: 10c0/71289c45180b564f80cf508e15a5438678c9a16d4e2911e33f949644b6d1ac91294ab3e1af4d9f43e96763a79ae0c12ec91a2fdebbeea95d3f9b4a280f8ea1b4
-  languageName: node
-  linkType: hard
-
-"@octokit/auth-oauth-app@npm:^5.0.0":
-  version: 5.0.6
-  resolution: "@octokit/auth-oauth-app@npm:5.0.6"
-  dependencies:
-    "@octokit/auth-oauth-device": "npm:^4.0.0"
-    "@octokit/auth-oauth-user": "npm:^2.0.0"
-    "@octokit/request": "npm:^6.0.0"
-    "@octokit/types": "npm:^9.0.0"
-    "@types/btoa-lite": "npm:^1.0.0"
-    btoa-lite: "npm:^1.0.0"
-    universal-user-agent: "npm:^6.0.0"
-  checksum: 10c0/94760dc9799c8a5b3f723892272b8852f8f15f5a1ff0d2eb4d145b984cb305622a625ffcc332f18f9359c6cc43ceb5fe07e31d4079e7b2a436ecbaed093ae986
-  languageName: node
-  linkType: hard
-
-"@octokit/auth-oauth-device@npm:^4.0.0":
-  version: 4.0.5
-  resolution: "@octokit/auth-oauth-device@npm:4.0.5"
-  dependencies:
-    "@octokit/oauth-methods": "npm:^2.0.0"
-    "@octokit/request": "npm:^6.0.0"
-    "@octokit/types": "npm:^9.0.0"
-    universal-user-agent: "npm:^6.0.0"
-  checksum: 10c0/e962835dcbb2138aa75077284968eb8e2d244859ed8c72dd0ecf2e55724c1bdedbe32e94bcd4f0a44c3e2fc382433ac10026ec0808b9b8bccece1741160227a1
-  languageName: node
-  linkType: hard
-
-"@octokit/auth-oauth-user@npm:^2.0.0":
-  version: 2.1.2
-  resolution: "@octokit/auth-oauth-user@npm:2.1.2"
-  dependencies:
-    "@octokit/auth-oauth-device": "npm:^4.0.0"
-    "@octokit/oauth-methods": "npm:^2.0.0"
-    "@octokit/request": "npm:^6.0.0"
-    "@octokit/types": "npm:^9.0.0"
-    btoa-lite: "npm:^1.0.0"
-    universal-user-agent: "npm:^6.0.0"
-  checksum: 10c0/3adc7aa7cf277d50572120be22832a4ef2f88103371d888be6ad3a9d58b4b40f3c2e3b3dca4df583dd4c48f45ed0c4825c426fc1ff8a4570e9cba2857004452e
-  languageName: node
-  linkType: hard
-
 "@octokit/auth-token@npm:^3.0.0":
   version: 3.0.3
   resolution: "@octokit/auth-token@npm:3.0.3"
@@ -4376,17 +4302,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@octokit/auth-unauthenticated@npm:^3.0.0":
-  version: 3.0.5
-  resolution: "@octokit/auth-unauthenticated@npm:3.0.5"
-  dependencies:
-    "@octokit/request-error": "npm:^3.0.0"
-    "@octokit/types": "npm:^9.0.0"
-  checksum: 10c0/d5c3e2f673762447207eff1fe0e09f2eba42c0cb9442f10b5660fa115a18fdb206f758b218d6d1ab048967d53f9da67c8baf4d2a6e46bb9dbe113ce24c009a0a
-  languageName: node
-  linkType: hard
-
-"@octokit/core@npm:^4.0.0, @octokit/core@npm:^4.2.1":
+"@octokit/core@npm:^4.2.1":
   version: 4.2.1
   resolution: "@octokit/core@npm:4.2.1"
   dependencies:
@@ -4401,18 +4317,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@octokit/core@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "@octokit/core@npm:5.0.0"
+"@octokit/core@npm:^5.0.2":
+  version: 5.2.2
+  resolution: "@octokit/core@npm:5.2.2"
   dependencies:
     "@octokit/auth-token": "npm:^4.0.0"
-    "@octokit/graphql": "npm:^7.0.0"
-    "@octokit/request": "npm:^8.0.2"
-    "@octokit/request-error": "npm:^5.0.0"
-    "@octokit/types": "npm:^11.0.0"
+    "@octokit/graphql": "npm:^7.1.0"
+    "@octokit/request": "npm:^8.4.1"
+    "@octokit/request-error": "npm:^5.1.1"
+    "@octokit/types": "npm:^13.0.0"
     before-after-hook: "npm:^2.2.0"
     universal-user-agent: "npm:^6.0.0"
-  checksum: 10c0/b963c197af88b2b461c564d94ddb330a8a0b7f88e09b1986ca46cb3d63c95d98b338e1b548ad547131c2ffa2af3525d69ab492a74cd23fc4abc357d529c1e1d4
+  checksum: 10c0/b4484d85552303b839613e2133dcd064fa06a7c10fe0ebd11ba8f67cb8e3384e48983c589f4d1dc0fa3754857784e3d90ff4eab9782e118baf13ddd1b834957c
   languageName: node
   linkType: hard
 
@@ -4427,14 +4343,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@octokit/endpoint@npm:^9.0.0":
-  version: 9.0.0
-  resolution: "@octokit/endpoint@npm:9.0.0"
+"@octokit/endpoint@npm:^9.0.6":
+  version: 9.0.6
+  resolution: "@octokit/endpoint@npm:9.0.6"
   dependencies:
-    "@octokit/types": "npm:^11.0.0"
-    is-plain-object: "npm:^5.0.0"
+    "@octokit/types": "npm:^13.1.0"
     universal-user-agent: "npm:^6.0.0"
-  checksum: 10c0/8291a4378320ea4c9fe6878fbf7281be4dd96c4d6b4317b5eeec119c430c3ede5b53f6983b1c7dc3e7056bb60748186dfa1d674e00fc65cea26f7a62f21dc7b2
+  checksum: 10c0/8e06197b21869aeb498e0315093ca6fbee12bd1bdcfc1667fcd7d79d827d84f2c5a30702ffd28bba7879780e367d14c30df5b20d47fcaed5de5fdc05f5d4e013
   languageName: node
   linkType: hard
 
@@ -4449,51 +4364,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@octokit/graphql@npm:^7.0.0":
-  version: 7.0.1
-  resolution: "@octokit/graphql@npm:7.0.1"
+"@octokit/graphql@npm:^7.1.0":
+  version: 7.1.1
+  resolution: "@octokit/graphql@npm:7.1.1"
   dependencies:
-    "@octokit/request": "npm:^8.0.1"
-    "@octokit/types": "npm:^11.0.0"
+    "@octokit/request": "npm:^8.4.1"
+    "@octokit/types": "npm:^13.0.0"
     universal-user-agent: "npm:^6.0.0"
-  checksum: 10c0/bfc79dff1a96210afcd27051a7b5fcacfc20d549f3d8bf1ac162ebe5a825d429d3b4f217a73169f8d5549fed535582e303a89b65f5a356557a91319326d80605
-  languageName: node
-  linkType: hard
-
-"@octokit/oauth-app@npm:^4.0.7, @octokit/oauth-app@npm:^4.2.1":
-  version: 4.2.2
-  resolution: "@octokit/oauth-app@npm:4.2.2"
-  dependencies:
-    "@octokit/auth-oauth-app": "npm:^5.0.0"
-    "@octokit/auth-oauth-user": "npm:^2.0.0"
-    "@octokit/auth-unauthenticated": "npm:^3.0.0"
-    "@octokit/core": "npm:^4.0.0"
-    "@octokit/oauth-authorization-url": "npm:^5.0.0"
-    "@octokit/oauth-methods": "npm:^2.0.0"
-    "@types/aws-lambda": "npm:^8.10.83"
-    fromentries: "npm:^1.3.1"
-    universal-user-agent: "npm:^6.0.0"
-  checksum: 10c0/d6caa25fc3188afdcf06aa883df88d89d9668ba3a4525162486113b7c98ab5a46e2640d05b4cefd929db7c4d62e967f737d287bb97be4f12632c152da68f9085
-  languageName: node
-  linkType: hard
-
-"@octokit/oauth-authorization-url@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "@octokit/oauth-authorization-url@npm:5.0.0"
-  checksum: 10c0/f9059cc070a06a276c43adfd106f995883c4ac846f00f0fef9218c2675355d7321cf9e8f83855574ba5104f37bc06a599a4c3e5edc3dc07714d9c9f4d34a47e2
-  languageName: node
-  linkType: hard
-
-"@octokit/oauth-methods@npm:^2.0.0":
-  version: 2.0.6
-  resolution: "@octokit/oauth-methods@npm:2.0.6"
-  dependencies:
-    "@octokit/oauth-authorization-url": "npm:^5.0.0"
-    "@octokit/request": "npm:^6.2.3"
-    "@octokit/request-error": "npm:^3.0.3"
-    "@octokit/types": "npm:^9.0.0"
-    btoa-lite: "npm:^1.0.0"
-  checksum: 10c0/eeaaa772de3dbce954b6fea7aeaa77e87aafcae831618321e128ab65e8009aec518a0417db1a856cf55522bd0f5ff9916cba3fe9ed2287ca4c18a589ee8df05a
+  checksum: 10c0/c27216200f3f4ce7ce2a694fb7ea43f8ea4a807fbee3a423c41ed137dd7948dfc0bbf6ea1656f029a7625c84b583acdef740a7032266d0eff55305c91c3a1ed6
   languageName: node
   linkType: hard
 
@@ -4504,7 +4382,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@octokit/plugin-paginate-rest@npm:^6.0.0, @octokit/plugin-paginate-rest@npm:^6.1.0, @octokit/plugin-paginate-rest@npm:^6.1.2":
+"@octokit/openapi-types@npm:^24.2.0":
+  version: 24.2.0
+  resolution: "@octokit/openapi-types@npm:24.2.0"
+  checksum: 10c0/8f47918b35e9b7f6109be6f7c8fc3a64ad13a48233112b29e92559e64a564b810eb3ebf81b4cd0af1bb2989d27b9b95cca96e841ec4e23a3f68703cefe62fd9e
+  languageName: node
+  linkType: hard
+
+"@octokit/plugin-paginate-rest@npm:11.4.4-cjs.2":
+  version: 11.4.4-cjs.2
+  resolution: "@octokit/plugin-paginate-rest@npm:11.4.4-cjs.2"
+  dependencies:
+    "@octokit/types": "npm:^13.7.0"
+  peerDependencies:
+    "@octokit/core": 5
+  checksum: 10c0/1d61a63c98a18c171bccdc6cf63ffe279fe852e8bdc9db6647ffcb27f4ea485fdab78fb71b552ed0f2186785cf5264f8ed3f9a8f33061e4697b5f73b097accb1
+  languageName: node
+  linkType: hard
+
+"@octokit/plugin-paginate-rest@npm:^6.1.2":
   version: 6.1.2
   resolution: "@octokit/plugin-paginate-rest@npm:6.1.2"
   dependencies:
@@ -4513,17 +4409,6 @@ __metadata:
   peerDependencies:
     "@octokit/core": ">=4"
   checksum: 10c0/def241c4f00b864822ab6414eaadd8679a6d332004c7e77467cfc1e6d5bdcc453c76bd185710ee942e4df201f9dd2170d960f46af5b14ef6f261a0068f656364
-  languageName: node
-  linkType: hard
-
-"@octokit/plugin-paginate-rest@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "@octokit/plugin-paginate-rest@npm:8.0.0"
-  dependencies:
-    "@octokit/types": "npm:^11.0.0"
-  peerDependencies:
-    "@octokit/core": ">=5"
-  checksum: 10c0/72eb881b5d6dc71f0619a41f0918a7c2d7a4aba50c83a72267e81b5528bb882e1f6e83fb7ba90a602c60dd434e76bdc34c1fc2a11526b51c58c8d9ead55bf17a
   languageName: node
   linkType: hard
 
@@ -4536,25 +4421,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@octokit/plugin-rest-endpoint-methods@npm:^7.1.1":
-  version: 7.2.1
-  resolution: "@octokit/plugin-rest-endpoint-methods@npm:7.2.1"
+"@octokit/plugin-rest-endpoint-methods@npm:13.3.2-cjs.1":
+  version: 13.3.2-cjs.1
+  resolution: "@octokit/plugin-rest-endpoint-methods@npm:13.3.2-cjs.1"
   dependencies:
-    "@octokit/types": "npm:^9.3.1"
+    "@octokit/types": "npm:^13.8.0"
   peerDependencies:
-    "@octokit/core": ">=3"
-  checksum: 10c0/836372c4d6a2c373d5b838385d419804147ff5aa99de09ea3b1a9b926dfc4994ef929455e163650dfbe3b02a22e1c1b6e4f54019c114e77aa2ada2abd193b4f5
-  languageName: node
-  linkType: hard
-
-"@octokit/plugin-rest-endpoint-methods@npm:^9.0.0":
-  version: 9.0.0
-  resolution: "@octokit/plugin-rest-endpoint-methods@npm:9.0.0"
-  dependencies:
-    "@octokit/types": "npm:^11.0.0"
-  peerDependencies:
-    "@octokit/core": ">=5"
-  checksum: 10c0/17219d5bb00022dd49145bb9068e3b5142e30956eeabeaf1b6389766b916bcd16c8c849484cd5db7b6888b080ae167ec71c14a22cfa7a511df0ddc0f7cc0e680
+    "@octokit/core": ^5
+  checksum: 10c0/810fe5cb1861386746bf0218ea969d87c56e553ff339490526483b4b66f53c4b4c6092034bec30c5d453172eb6f33e75b5748ade1b401b76774b5a994e2c10b0
   languageName: node
   linkType: hard
 
@@ -4570,7 +4444,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@octokit/plugin-throttling@npm:^5.2.2, @octokit/plugin-throttling@npm:^5.2.3":
+"@octokit/plugin-throttling@npm:^5.2.3":
   version: 5.2.3
   resolution: "@octokit/plugin-throttling@npm:5.2.3"
   dependencies:
@@ -4582,7 +4456,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@octokit/request-error@npm:^3.0.0, @octokit/request-error@npm:^3.0.3":
+"@octokit/request-error@npm:^3.0.0":
   version: 3.0.3
   resolution: "@octokit/request-error@npm:3.0.3"
   dependencies:
@@ -4593,18 +4467,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@octokit/request-error@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "@octokit/request-error@npm:5.0.0"
+"@octokit/request-error@npm:^5.1.1":
+  version: 5.1.1
+  resolution: "@octokit/request-error@npm:5.1.1"
   dependencies:
-    "@octokit/types": "npm:^11.0.0"
+    "@octokit/types": "npm:^13.1.0"
     deprecation: "npm:^2.0.0"
     once: "npm:^1.4.0"
-  checksum: 10c0/c681fede406b6338e22c8dcc57ab306558201e1f35545dde09a4d6edae279a874393081c5f28b165dbfc3f9367cc627050b06a87229904cfd2083b186e508c34
+  checksum: 10c0/dc9fc76ea5e4199273e4665ce9ddf345fe8f25578d9999c9a16f276298e61ee6fe0e6f5a6147b91ba3b34fdf5b9e6b7af6ae13d6333175e95b30c574088f7a2d
   languageName: node
   linkType: hard
 
-"@octokit/request@npm:^6.0.0, @octokit/request@npm:^6.2.3":
+"@octokit/request@npm:^6.0.0":
   version: 6.2.5
   resolution: "@octokit/request@npm:6.2.5"
   dependencies:
@@ -4618,28 +4492,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@octokit/request@npm:^8.0.1, @octokit/request@npm:^8.0.2":
-  version: 8.1.1
-  resolution: "@octokit/request@npm:8.1.1"
+"@octokit/request@npm:^8.4.1":
+  version: 8.4.1
+  resolution: "@octokit/request@npm:8.4.1"
   dependencies:
-    "@octokit/endpoint": "npm:^9.0.0"
-    "@octokit/request-error": "npm:^5.0.0"
-    "@octokit/types": "npm:^11.1.0"
-    is-plain-object: "npm:^5.0.0"
+    "@octokit/endpoint": "npm:^9.0.6"
+    "@octokit/request-error": "npm:^5.1.1"
+    "@octokit/types": "npm:^13.1.0"
     universal-user-agent: "npm:^6.0.0"
-  checksum: 10c0/07fa47fff16be4ff36599752e31d54713137e140fe5e4604cb77da6b466b1e5c2eb093a3151112637aac5d341922685de10f5a6589881177a1559d7597a63e15
+  checksum: 10c0/1a69dcb7336de708a296db9e9a58040e5b284a87495a63112f80eb0007da3fc96a9fadecb9e875fc63cf179c23a0f81031fbef2a6f610a219e45805ead03fcf3
   languageName: node
   linkType: hard
 
 "@octokit/rest@npm:^20.0.1":
-  version: 20.0.1
-  resolution: "@octokit/rest@npm:20.0.1"
+  version: 20.1.2
+  resolution: "@octokit/rest@npm:20.1.2"
   dependencies:
-    "@octokit/core": "npm:^5.0.0"
-    "@octokit/plugin-paginate-rest": "npm:^8.0.0"
+    "@octokit/core": "npm:^5.0.2"
+    "@octokit/plugin-paginate-rest": "npm:11.4.4-cjs.2"
     "@octokit/plugin-request-log": "npm:^4.0.0"
-    "@octokit/plugin-rest-endpoint-methods": "npm:^9.0.0"
-  checksum: 10c0/4a2e8a623750233b7387d2bc0a9097b0f6caf8b1200bf7a9782b525cf745a8d65f3803f67619a9e4822c50e11ebbb5097fc744a021b5beebcb24452d025a9428
+    "@octokit/plugin-rest-endpoint-methods": "npm:13.3.2-cjs.1"
+  checksum: 10c0/712e08c43c7af37c5c219f95ae289b3ac2646270be4e8a7141fa2aa9340ed8f7134f117c9467e89206c5a9797c49c8d2c039b884d4865bb3bde91bc5adb3c38c
   languageName: node
   linkType: hard
 
@@ -4650,7 +4523,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@octokit/types@npm:^11.0.0, @octokit/types@npm:^11.1.0":
+"@octokit/types@npm:^11.1.0":
   version: 11.1.0
   resolution: "@octokit/types@npm:11.1.0"
   dependencies:
@@ -4659,38 +4532,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@octokit/types@npm:^9.0.0, @octokit/types@npm:^9.2.2, @octokit/types@npm:^9.2.3, @octokit/types@npm:^9.3.1":
+"@octokit/types@npm:^13.0.0, @octokit/types@npm:^13.1.0, @octokit/types@npm:^13.7.0, @octokit/types@npm:^13.8.0":
+  version: 13.10.0
+  resolution: "@octokit/types@npm:13.10.0"
+  dependencies:
+    "@octokit/openapi-types": "npm:^24.2.0"
+  checksum: 10c0/f66a401b89d653ec28e5c1529abdb7965752db4d9d40fa54c80e900af4c6bf944af6bd0a83f5b4f1eecb72e3d646899dfb27ffcf272ac243552de7e3b97a038d
+  languageName: node
+  linkType: hard
+
+"@octokit/types@npm:^9.0.0, @octokit/types@npm:^9.2.3":
   version: 9.3.1
   resolution: "@octokit/types@npm:9.3.1"
   dependencies:
     "@octokit/openapi-types": "npm:^18.0.0"
   checksum: 10c0/afa2aa2ddc48e59409b3167bae17e881f30454a605d04f09d4da07ed7433094b7048e79b50468ed98934b592697fcdfda900cf51d65afa02b87c59b4945d90c1
-  languageName: node
-  linkType: hard
-
-"@octokit/webhooks-methods@npm:^3.0.0":
-  version: 3.0.3
-  resolution: "@octokit/webhooks-methods@npm:3.0.3"
-  checksum: 10c0/f000d7b3cb2523bc352a0f2cb9d6f6f19c499704f9273a7564cbb0a69545fe92fc35f8f18ddc45026d54275ecef5ea6c127a7a058a6af2852abd5055a838fc9f
-  languageName: node
-  linkType: hard
-
-"@octokit/webhooks-types@npm:6.11.0":
-  version: 6.11.0
-  resolution: "@octokit/webhooks-types@npm:6.11.0"
-  checksum: 10c0/4c99c79d56e6c0390b66aef8c59f49a7a04f9429c22c8e621fff7f591bd0685000551378c778f662e2208c07df81908115f267fac4dd3af39ef3923e2dcc1eb8
-  languageName: node
-  linkType: hard
-
-"@octokit/webhooks@npm:^10.0.0":
-  version: 10.9.1
-  resolution: "@octokit/webhooks@npm:10.9.1"
-  dependencies:
-    "@octokit/request-error": "npm:^3.0.0"
-    "@octokit/webhooks-methods": "npm:^3.0.0"
-    "@octokit/webhooks-types": "npm:6.11.0"
-    aggregate-error: "npm:^3.1.0"
-  checksum: 10c0/f6c23d92bfb2e4bf3edf3eada3cc74610ef3160f4b4e6addcfc3bfbfe72ea28ec58991c1812d9e02190a4fe6d9248b9a577c286221cd535c2bf5d738aae3844c
   languageName: node
   linkType: hard
 
@@ -6896,13 +6752,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/aws-lambda@npm:^8.10.83":
-  version: 8.10.117
-  resolution: "@types/aws-lambda@npm:8.10.117"
-  checksum: 10c0/434df32065388838ec5b0025db2d4cc15fa34eaafabf8260f169a3bc1ca2545b807d266f4e02dece4ab0e047213dce3b38eb51a73f49ca00411d172fba122db7
-  languageName: node
-  linkType: hard
-
 "@types/babel__core@npm:^7.0.0, @types/babel__core@npm:^7.1.0, @types/babel__core@npm:^7.1.14":
   version: 7.1.18
   resolution: "@types/babel__core@npm:7.1.18"
@@ -6960,13 +6809,6 @@ __metadata:
     "@types/connect": "npm:*"
     "@types/node": "npm:*"
   checksum: 10c0/c2dd533e1d4af958d656bdba7f376df68437d8dfb7e4522c88b6f3e6f827549e4be5bf0be68a5f1878accf5752ea37fba7e8a4b6dda53d0d122d77e27b69c750
-  languageName: node
-  linkType: hard
-
-"@types/btoa-lite@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "@types/btoa-lite@npm:1.0.0"
-  checksum: 10c0/ab354cfa11b683fcc97c66cd2199b0a630b771dc13e3f98783c9f15beba3bdf031b9925c924252473888da3737a07dec93971226e0310354e58f9e64a03a102f
   languageName: node
   linkType: hard
 
@@ -7361,15 +7203,6 @@ __metadata:
   version: 0.0.29
   resolution: "@types/json5@npm:0.0.29"
   checksum: 10c0/6bf5337bc447b706bb5b4431d37686aa2ea6d07cfd6f79cc31de80170d6ff9b1c7384a9c0ccbc45b3f512bae9e9f75c2e12109806a15331dc94e8a8db6dbb4ac
-  languageName: node
-  linkType: hard
-
-"@types/jsonwebtoken@npm:^9.0.0":
-  version: 9.0.2
-  resolution: "@types/jsonwebtoken@npm:9.0.2"
-  dependencies:
-    "@types/node": "npm:*"
-  checksum: 10c0/5af586c291b3e3341be844f76ce0de53e15f3cbc8dbc147f79ab3af4f5e2a2bf3499f3dcbfb85752f1f265d9a9362bbe8104d0173e24c6d8d7b23e41821e0dbe
   languageName: node
   linkType: hard
 
@@ -9723,7 +9556,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"aggregate-error@npm:^3.0.0, aggregate-error@npm:^3.1.0":
+"aggregate-error@npm:^3.0.0":
   version: 3.1.0
   resolution: "aggregate-error@npm:3.1.0"
   dependencies:
@@ -11558,24 +11391,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"btoa-lite@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "btoa-lite@npm:1.0.0"
-  checksum: 10c0/7a4f0568ae3c915464650f98fde7901ae07b13a333a614515a0c86876b3528670fafece28dfef9745d971a613bb83341823afb0c20c6f318b384c1e364b9eb95
-  languageName: node
-  linkType: hard
-
 "buffer-crc32@npm:~0.2.3":
   version: 0.2.13
   resolution: "buffer-crc32@npm:0.2.13"
   checksum: 10c0/cb0a8ddf5cf4f766466db63279e47761eb825693eeba6a5a95ee4ec8cb8f81ede70aa7f9d8aeec083e781d47154290eb5d4d26b3f7a465ec57fb9e7d59c47150
-  languageName: node
-  linkType: hard
-
-"buffer-equal-constant-time@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "buffer-equal-constant-time@npm:1.0.1"
-  checksum: 10c0/fb2294e64d23c573d0dd1f1e7a466c3e978fe94a4e0f8183937912ca374619773bef8e2aceb854129d2efecbbc515bbd0cc78d2734a3e3031edb0888531bbc8e
   languageName: node
   linkType: hard
 
@@ -14658,7 +14477,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"deprecation@npm:^2.0.0, deprecation@npm:^2.3.1":
+"deprecation@npm:^2.0.0":
   version: 2.3.1
   resolution: "deprecation@npm:2.3.1"
   checksum: 10c0/23d688ba66b74d09b908c40a76179418acbeeb0bfdf218c8075c58ad8d0c315130cb91aa3dffb623aa3a411a3569ce56c6460de6c8d69071c17fe6dd2442f032
@@ -15158,15 +14977,6 @@ __metadata:
     jsbn: "npm:~0.1.0"
     safer-buffer: "npm:^2.1.0"
   checksum: 10c0/6cf168bae1e2dad2e46561d9af9cbabfbf5ff592176ad4e9f0f41eaaf5fe5e10bb58147fe0a804de62b1ee9dad42c28810c88d652b21b6013c47ba8efa274ca1
-  languageName: node
-  linkType: hard
-
-"ecdsa-sig-formatter@npm:1.0.11":
-  version: 1.0.11
-  resolution: "ecdsa-sig-formatter@npm:1.0.11"
-  dependencies:
-    safe-buffer: "npm:^5.0.1"
-  checksum: 10c0/ebfbf19d4b8be938f4dd4a83b8788385da353d63307ede301a9252f9f7f88672e76f2191618fd8edfc2f24679236064176fab0b78131b161ee73daa37125408c
   languageName: node
   linkType: hard
 
@@ -17845,7 +17655,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fromentries@npm:^1.3.1, fromentries@npm:^1.3.2":
+"fromentries@npm:^1.3.2":
   version: 1.3.2
   resolution: "fromentries@npm:1.3.2"
   checksum: 10c0/63938819a86e39f490b0caa1f6b38b8ad04f41ccd2a1c144eb48a21f76e4dbc074bc62e97abb053c7c1f541ecc70cf0b8aaa98eed3fe02206db9b6f9bb9a6a47
@@ -22611,18 +22421,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsonwebtoken@npm:^9.0.0":
-  version: 9.0.0
-  resolution: "jsonwebtoken@npm:9.0.0"
-  dependencies:
-    jws: "npm:^3.2.2"
-    lodash: "npm:^4.17.21"
-    ms: "npm:^2.1.1"
-    semver: "npm:^7.3.8"
-  checksum: 10c0/60c30d90d8a69b8e7148306e0c299ac120dbde9c032add48d26df928fe349e952cf4b09f12d7942257681a936e3374e4d49280ab20f8a4578688c7f08d87f9bc
-  languageName: node
-  linkType: hard
-
 "jsprim@npm:^1.2.2":
   version: 1.4.2
   resolution: "jsprim@npm:1.4.2"
@@ -22685,27 +22483,6 @@ __metadata:
   version: 4.2.1
   resolution: "just-extend@npm:4.2.1"
   checksum: 10c0/ab01b807ae064eee016001df7e958fab9d878a6e2e32119f5f5a94e986daca9d940aa6176889f04c2658e6e3edd75000d7bab1a2376d473ccb20ae571f4b8cbc
-  languageName: node
-  linkType: hard
-
-"jwa@npm:^1.4.2":
-  version: 1.4.2
-  resolution: "jwa@npm:1.4.2"
-  dependencies:
-    buffer-equal-constant-time: "npm:^1.0.1"
-    ecdsa-sig-formatter: "npm:1.0.11"
-    safe-buffer: "npm:^5.0.1"
-  checksum: 10c0/210a544a42ca22203e8fc538835205155ba3af6a027753109f9258bdead33086bac3c25295af48ac1981f87f9c5f941bc8f70303670f54ea7dcaafb53993d92c
-  languageName: node
-  linkType: hard
-
-"jws@npm:^3.2.2":
-  version: 3.2.3
-  resolution: "jws@npm:3.2.3"
-  dependencies:
-    jwa: "npm:^1.4.2"
-    safe-buffer: "npm:^5.0.1"
-  checksum: 10c0/9fdf9d6783b1892ef413ef373cd351eacc847ba01deec6fbfea96830e93241863ccbee66f3b749fc2310c59b6db2209d3f4b52931c0c259b52b17de20715917f
   languageName: node
   linkType: hard
 
@@ -23697,13 +23474,6 @@ __metadata:
   version: 8.0.5
   resolution: "lru-cache@npm:8.0.5"
   checksum: 10c0/cd95a9c38497611c5a6453de39a881f6eb5865851a2a01b5f14104ff3fee515362a7b1e7de28606028f423802910ba05bdb8ae1aa7b0d54eae70c92f0cec10b2
-  languageName: node
-  linkType: hard
-
-"lru-cache@npm:^9.0.0":
-  version: 9.1.2
-  resolution: "lru-cache@npm:9.1.2"
-  checksum: 10c0/886811ab451332c899c230274e7e51507c15e5b3b18f0b39fb55f558978d58799a0b1a50e04d60a448d8c970ff4e6ee718bb119083ca88abb78930284f1e0900
   languageName: node
   linkType: hard
 
@@ -25943,22 +25713,6 @@ __metadata:
   version: 1.1.2
   resolution: "obuf@npm:1.1.2"
   checksum: 10c0/520aaac7ea701618eacf000fc96ae458e20e13b0569845800fc582f81b386731ab22d55354b4915d58171db00e79cfcd09c1638c02f89577ef092b38c65b7d81
-  languageName: node
-  linkType: hard
-
-"octokit@npm:^2.0.19":
-  version: 2.0.19
-  resolution: "octokit@npm:2.0.19"
-  dependencies:
-    "@octokit/app": "npm:^13.1.5"
-    "@octokit/core": "npm:^4.2.1"
-    "@octokit/oauth-app": "npm:^4.2.1"
-    "@octokit/plugin-paginate-rest": "npm:^6.1.0"
-    "@octokit/plugin-rest-endpoint-methods": "npm:^7.1.1"
-    "@octokit/plugin-retry": "npm:^4.1.3"
-    "@octokit/plugin-throttling": "npm:^5.2.2"
-    "@octokit/types": "npm:^9.2.2"
-  checksum: 10c0/ba9909ef2fb6da57c4a5d97cd3cc397914f073f9b3f3c8d42975128d459a3db3a241ffb9fea7bed140d561dd7a2447a513aae23e7528f3145db98320206c29f5
   languageName: node
   linkType: hard
 
@@ -33088,16 +32842,6 @@ __metadata:
     unist-util-is: "npm:^4.0.0"
     unist-util-visit-parents: "npm:^3.0.0"
   checksum: 10c0/7b11303d82271ca53a2ced2d56c87a689dd518596c99ff4a11cdff750f5cc5c0e4b64b146bd2363557cb29443c98713bfd1e8dc6d1c3f9d474b9eb1f23a60888
-  languageName: node
-  linkType: hard
-
-"universal-github-app-jwt@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "universal-github-app-jwt@npm:1.1.1"
-  dependencies:
-    "@types/jsonwebtoken": "npm:^9.0.0"
-    jsonwebtoken: "npm:^9.0.0"
-  checksum: 10c0/f735a3fa0c9156898d128f45237eefa598edfab2424428ccc12e4b7dd9d217ff91b5a2b7a9a1ed6a16fd7985723f0ae34d5efbd3f81ab203c83184b7675c970a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
packages/scanner used the full `octokit` metapackage for exactly one REST call: createCommitStatus() in integration/github/commitStatus.ts. That pulled octokit 2.0.19, whose transitive @octokit/webhooks 10.9.1 carries GHSA-pwfr-8pq7-x9qv (high, unauthenticated DoS).

The obvious fix -- bump to octokit 4 -- is not available to us. octokit 4 and 5 are "type": "module" with no require condition in their exports map, so they would break scanner's CommonJS build and the @yao-pkg/pkg native snapshot. octokit 3.x is still dual, but it is a dead end to park on.

Instead, drop the dependency. The call is now a plain fetch POST to /repos/{owner}/{repo}/statuses/{sha}. Global fetch was already in use in this package (src/rules/lib/openapiProvider.ts). Behaviour is unchanged apart from the failure path, which now throws a plain Error carrying status, statusText and body rather than octokit's RequestError; no caller inspects the error type. This removes 25 packages from the tree.

Also re-resolve @octokit/rest in packages/cli from 20.0.1 to 20.1.2. This is within the existing ^20.0.1 range, so no manifest change. 20.1.2 still publishes CJS -- it depends on the -cjs tagged plugin builds -- and pulls @octokit/core 5.2.2, which satisfies the patched floors for @octokit/request (>=8.4.1) and @octokit/request-error (>=5.1.1).

Net: 5 octokit advisories down to 3, and the high is cleared. The remainder are moderate ReDoS advisories reaching the tree only through @semantic-release/github 8.1.0, which is the newest 8.x, so there is no in-range fix for them.

Add test/integration/github/commitStatus.spec.ts covering the request shape, URL encoding, the non-2xx path, and validate-before-request. Note that nock 13 cannot intercept undici, so these stub globalThis fetch directly rather than using nock.

Assisted-by: Claude:claude-opus-5[1m]