### PR TITLE
fix(components): show server-supplied error messages on the sign-in form

### DIFF
--- a/packages/components/src/components/SignIn.vue
+++ b/packages/components/src/components/SignIn.vue
@@ -239,15 +239,13 @@ export default {
           this.error = '';
           this.submitted = true;
         } else if (response.status < 500 && response.status >= 400) {
-          this.email = '';
-          this.error = this.generateInvalidFieldMsg('email address');
+          const message = await this.serverMessage(response);
+          this.error = message || this.generateInvalidFieldMsg('email address');
         } else {
-          this.email = '';
           this.error = GENERIC_ERROR_MSG;
         }
       } catch (error) {
         this.error = GENERIC_ERROR_MSG;
-        this.email = '';
       } finally {
         this.pendingRequest = undefined;
       }
@@ -266,12 +264,13 @@ export default {
         if (response.status === 200) {
           const data = await response.json();
           this.$root.$emit('activate', data.api_key);
+        } else if (response.status < 500 && response.status >= 400) {
+          const message = await this.serverMessage(response);
+          this.verificationCode = '';
+          this.error = message || this.generateInvalidFieldMsg('verification code');
         } else {
           this.verificationCode = '';
-          this.error =
-            response.status < 500 && response.status >= 400
-              ? this.generateInvalidFieldMsg('verification code')
-              : (this.error = GENERIC_ERROR_MSG);
+          this.error = GENERIC_ERROR_MSG;
         }
       } catch (error) {
         this.error = GENERIC_ERROR_MSG;
@@ -279,6 +278,22 @@ export default {
       } finally {
         this.pendingRequest = undefined;
       }
+    },
+    // A 4xx may carry an explanation the user can act on — a denied email
+    // domain, say — which is always better than our guess at which field was
+    // wrong. The error code is deliberately ignored: the message is the part
+    // written for the user, and matching on codes would leave every code the
+    // server adds later falling back to a misleading "invalid field" message.
+    // Any other body shape yields undefined, so the caller keeps its wording.
+    async serverMessage(response) {
+      try {
+        const body = await response.json();
+        const message = body?.error?.message;
+        if (typeof message === 'string' && message.trim()) return message.trim();
+      } catch {
+        // Not JSON — nothing to show beyond what the caller already has.
+      }
+      return undefined;
     },
     addParamsToUrl(url, params) {
       Object.keys(params).forEach((key) => url.searchParams.append(key, params[key]));

--- a/packages/components/src/stories/SignIn.stories.js
+++ b/packages/components/src/stories/SignIn.stories.js
@@ -1,7 +1,7 @@
 import VSignIn from '@/components/SignIn.vue';
 
 export default {
-  title: 'Pages/VS Code',
+  title: 'Pages/VS Code/Sign In',
   component: VSignIn,
   parameters: {
     chromatic: {
@@ -52,3 +52,60 @@ SignInWithOrgConfigAlreadyApplied.args = {
   enableOrgConfig: true,
   orgConfigApplied: true,
 };
+
+// The response the activation API returns when the email domain is licensed
+// through a managed installation instead of individual accounts. Both
+// /api/activations and /api/activations/verify answer 403 with this body.
+const DENIAL_STATUS = 403;
+const DENIAL_BODY = {
+  error: {
+    code: 'sign_in_denied',
+    message:
+      'Sign-in is disabled for this email domain. Your organization licenses AppMap through a ' +
+      'managed installation; please contact your IT department for access.',
+  },
+};
+
+// Simulates the activation API by stubbing fetch for its two endpoints, so the
+// denial path can be exercised without a server. `routes` maps a path fragment
+// to the [status, body] the stub answers with.
+const StubbedApiTemplate =
+  (routes) =>
+  (args, { argTypes }) => ({
+    props: Object.keys(argTypes),
+    components: { VSignIn },
+    template: '<v-sign-in v-bind="$props" ref="vsCode" />',
+    created() {
+      this.originalFetch = window.fetch;
+      window.fetch = (input, init) => {
+        const url = String(input && input.url ? input.url : input);
+        // Longest match first, so /api/activations/verify wins over /api/activations.
+        const path = Object.keys(routes)
+          .sort((a, b) => b.length - a.length)
+          .find((fragment) => url.includes(fragment));
+        if (!path) return this.originalFetch(input, init);
+
+        const [status, body] = routes[path];
+        return Promise.resolve(
+          new Response(body === undefined ? null : JSON.stringify(body), {
+            status,
+            headers: { 'Content-Type': 'application/json' },
+          })
+        );
+      };
+    },
+    beforeDestroy() {
+      if (this.originalFetch) window.fetch = this.originalFetch;
+    },
+  });
+
+// Enter any email and activate: the server denies the domain.
+export const SignInDenied = StubbedApiTemplate({
+  '/api/activations': [DENIAL_STATUS, DENIAL_BODY],
+}).bind({});
+
+// The email is accepted, but the domain is denied when the code is verified.
+export const SignInDeniedAtVerification = StubbedApiTemplate({
+  '/api/activations': [201, undefined],
+  '/api/activations/verify': [DENIAL_STATUS, DENIAL_BODY],
+}).bind({});

--- a/packages/components/tests/e2e/specs/sidebarSignIn.spec.js
+++ b/packages/components/tests/e2e/specs/sidebarSignIn.spec.js
@@ -1,10 +1,15 @@
 describe('Sidebar activation page', () => {
   const INVALID_EMAIL_MSG = 'Invalid email address, please try again.';
   const GENERIC_ERROR_MSG = 'Something went wrong, please try again later.';
+  const DENIAL_MSG =
+    'Sign-in is disabled for this email domain. Your organization licenses AppMap through a ' +
+    'managed installation; please contact your IT department for access.';
   const TEST_EMAIL = 'fake@test.net';
 
   beforeEach(() => {
-    cy.visit('http://localhost:6006/iframe.html?args=&id=pages-vs-code--sign-in&viewMode=story');
+    cy.visit(
+      'http://localhost:6006/iframe.html?args=&id=pages-vs-code-sign-in--sign-in&viewMode=story'
+    );
   });
 
   it('displays a title', () => {
@@ -73,6 +78,33 @@ describe('Sidebar activation page', () => {
     cy.get('[data-cy="org-config-applied"]').should('not.exist');
   });
 
+  it('shows the message the server supplies when sign-in is denied', () => {
+    cy.intercept('POST', 'https://getappmap.com/api/activations*', {
+      statusCode: 403,
+      body: { error: { code: 'sign_in_denied', message: DENIAL_MSG } },
+    });
+    cy.get('#email-input').type(TEST_EMAIL);
+    cy.get('[data-cy="email-activation-button"]').click();
+    cy.get('.error').should('have.text', DENIAL_MSG);
+    cy.get('.finish-activation').should('not.exist');
+    // The address the message is about stays put, and stays correctable.
+    cy.get('#email-input').should('have.value', TEST_EMAIL);
+  });
+
+  it('shows the message the server supplies when verification is denied', () => {
+    cy.intercept('POST', 'https://getappmap.com/api/activations*', {
+      statusCode: 201,
+    });
+    cy.get('#email-input').type(TEST_EMAIL);
+    cy.get('[data-cy="email-activation-button"]').click();
+    cy.intercept('POST', 'https://getappmap.com/api/activations/verify*', {
+      statusCode: 403,
+      body: { error: { code: 'sign_in_denied', message: DENIAL_MSG } },
+    });
+    cy.get('#verification-code-input').type('123456').type('{enter}');
+    cy.get('.error').should('have.text', DENIAL_MSG);
+  });
+
   it('shows an error message with incorrect verification code', () => {
     cy.intercept('POST', 'https://getappmap.com/api/activations*', {
       statusCode: 201,
@@ -90,7 +122,7 @@ describe('Sidebar activation page', () => {
 describe('Sidebar activation page with organization configuration enabled', () => {
   beforeEach(() => {
     cy.visit(
-      'http://localhost:6006/iframe.html?args=&id=pages-vs-code--sign-in-with-org-config&viewMode=story'
+      'http://localhost:6006/iframe.html?args=&id=pages-vs-code-sign-in--sign-in-with-org-config&viewMode=story'
     );
   });
 
@@ -120,7 +152,7 @@ describe('Sidebar activation page with organization configuration enabled', () =
 describe('Sidebar activation page with organization configuration already applied', () => {
   beforeEach(() => {
     cy.visit(
-      'http://localhost:6006/iframe.html?args=&id=pages-vs-code--sign-in-with-org-config-already-applied&viewMode=story'
+      'http://localhost:6006/iframe.html?args=&id=pages-vs-code-sign-in--sign-in-with-org-config-already-applied&viewMode=story'
     );
   });
 

--- a/packages/components/tests/unit/SignIn.spec.js
+++ b/packages/components/tests/unit/SignIn.spec.js
@@ -32,6 +32,154 @@ describe('SignIn.vue', () => {
     expect(fetchStub.mock.calls.length).toBe(1);
   });
 
+  describe('server-supplied error messages', () => {
+    const DENIAL_MESSAGE =
+      'Sign-in is disabled for this email domain. Your organization licenses AppMap through a ' +
+      'managed installation; please contact your IT department for access.';
+    const GENERIC_ERROR_MSG = 'Something went wrong, please try again later.';
+
+    // A minimal Response stand-in. `body` is what json() resolves to; pass a
+    // rejecting json() to model a response that isn't JSON at all.
+    const respond = (status, body) => {
+      global.fetch = jest.fn(() =>
+        Promise.resolve({
+          status,
+          json: typeof body === 'function' ? body : () => Promise.resolve(body),
+        })
+      );
+    };
+
+    const denial = { error: { code: 'sign_in_denied', message: DENIAL_MESSAGE } };
+    const notJson = () => Promise.reject(new SyntaxError('Unexpected token < in JSON'));
+
+    const activate = async () => {
+      wrapper.vm.email = 'test@example.test';
+      await wrapper.vm.activateWithEmail();
+    };
+
+    const verify = async () => {
+      wrapper.vm.email = 'test@example.test';
+      wrapper.vm.verificationCode = '123456';
+      await wrapper.vm.completeActivation();
+    };
+
+    describe('when requesting an activation', () => {
+      it('displays the message the server supplies', async () => {
+        respond(403, denial);
+        await activate();
+        expect(wrapper.vm.error).toBe(DENIAL_MESSAGE);
+      });
+
+      it('stays on the activation screen so the message remains visible', async () => {
+        respond(403, denial);
+        await activate();
+        await wrapper.vm.$nextTick();
+        expect(wrapper.vm.submitted).toBe(false);
+        expect(wrapper.find('.error').text()).toBe(DENIAL_MESSAGE);
+      });
+
+      it('falls back to the field message when the response is not JSON', async () => {
+        respond(422, notJson);
+        await activate();
+        expect(wrapper.vm.error).toBe('Invalid email address, please try again.');
+      });
+
+      it('falls back to the field message when the body carries no message', async () => {
+        respond(422, { error: { code: 'unprocessable' } });
+        await activate();
+        expect(wrapper.vm.error).toBe('Invalid email address, please try again.');
+      });
+
+      it('falls back to the field message when the message is blank or not a string', async () => {
+        respond(422, { error: { message: '   ' } });
+        await activate();
+        expect(wrapper.vm.error).toBe('Invalid email address, please try again.');
+
+        respond(422, { error: { message: { nested: 'object' } } });
+        await activate();
+        expect(wrapper.vm.error).toBe('Invalid email address, please try again.');
+      });
+
+      it('does not surface a message from a server error', async () => {
+        respond(500, { error: { message: 'ActiveRecord::StatementInvalid in Activations' } });
+        await activate();
+        expect(wrapper.vm.error).toBe(GENERIC_ERROR_MSG);
+      });
+    });
+
+    describe('when verifying the code', () => {
+      it('displays the message the server supplies', async () => {
+        respond(403, denial);
+        await verify();
+        expect(wrapper.vm.error).toBe(DENIAL_MESSAGE);
+      });
+
+      it('falls back to the field message when the response is not JSON', async () => {
+        respond(422, notJson);
+        await verify();
+        expect(wrapper.vm.error).toBe('Invalid verification code, please try again.');
+      });
+
+      it('falls back to the field message when the body carries no message', async () => {
+        respond(422, { error: { code: 'unprocessable' } });
+        await verify();
+        expect(wrapper.vm.error).toBe('Invalid verification code, please try again.');
+      });
+
+      it('does not surface a message from a server error', async () => {
+        respond(500, { error: { message: 'ActiveRecord::StatementInvalid' } });
+        await verify();
+        expect(wrapper.vm.error).toBe(GENERIC_ERROR_MSG);
+      });
+    });
+  });
+
+  describe('the email input', () => {
+    const EMAIL = 'test@example.test';
+
+    const failWith = (fetchImpl) => {
+      global.fetch = jest.fn(fetchImpl);
+    };
+
+    const activate = async () => {
+      wrapper.vm.email = EMAIL;
+      await wrapper.vm.activateWithEmail();
+    };
+
+    it('keeps the address when the server denies it', async () => {
+      failWith(() =>
+        Promise.resolve({
+          status: 403,
+          json: () => Promise.resolve({ error: { message: 'Sign-in is disabled.' } }),
+        })
+      );
+      await activate();
+      await wrapper.vm.$nextTick();
+      expect(wrapper.vm.email).toBe(EMAIL);
+      expect(wrapper.find('#email-input').element.value).toBe(EMAIL);
+    });
+
+    it('keeps the address when the server errors', async () => {
+      failWith(() => Promise.resolve({ status: 500, json: () => Promise.resolve({}) }));
+      await activate();
+      expect(wrapper.vm.email).toBe(EMAIL);
+    });
+
+    it('keeps the address when the request fails outright', async () => {
+      failWith(() => Promise.reject(new TypeError('Failed to fetch')));
+      await activate();
+      expect(wrapper.vm.email).toBe(EMAIL);
+    });
+
+    it('is cleared by "try again" from the verification screen', async () => {
+      wrapper.vm.email = EMAIL;
+      wrapper.vm.submitted = true;
+      wrapper.vm.reset();
+      expect(wrapper.vm.email).toBe('');
+      expect(wrapper.vm.submitted).toBe(false);
+    });
+  });
+
   describe('organization configuration', () => {
     it('does not show the prompt unless enabled by the host', () => {
       expect(wrapper.find('[data-cy="org-config-prompt"]').exists()).toBe(false);


### PR DESCRIPTION
The activation endpoints can answer a 4xx with a body of the form {"error": {"code": ..., "message": ...}}, explaining in the user's terms why the request was rejected. The form discarded it and always displayed its own guess -- "Invalid email address, please try again." -- which is misleading whenever the request failed for any reason other than a malformed field, and leaves the user with no idea what to do next.

Prefer the server's message when a 4xx carries one. The error code is deliberately ignored: the message is the part written for the user, and matching on codes would leave every code the server adds later falling back to the misleading wording. Every other shape keeps the existing text -- a non-JSON body, a missing, blank or non-string message, and any 5xx, whose body is an internal error or a proxy's HTML rather than anything worth showing.

Also stop clearing the email input on error. Making the user retype an address after a network blip serves no purpose, and blanking the field hides the very address the message is about. The verification code still clears, and "try again" still resets both.

The two new Storybook stories drive these paths through a stubbed fetch, so the error handling can be exercised without a server.

Assisted-by: Claude:claude-opus-5[1m]